### PR TITLE
Deviceupdate rename updates subclient

### DIFF
--- a/specification/deviceupdate/data-plane/duiothub/client.tsp
+++ b/specification/deviceupdate/data-plane/duiothub/client.tsp
@@ -11,20 +11,114 @@ using DeviceUpdateClient;
   "logCollectionId"
 );
 
-@@clientLocation(DeviceUpdateOperationGroup.listUpdates, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.importUpdate, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.getUpdate, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.deleteUpdate, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.listProviders, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.listNames, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.listVersions, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.listFiles, "DeviceUpdate");
-@@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdate");
+// The C# namespace is `Azure.IoT.DeviceUpdate`; a sub-client literally named
+// `DeviceUpdate` collides with the namespace's last segment, so the C# emitter
+// disambiguates by renaming the namespace to `Azure.IoT._DeviceUpdate`. Use
+// `DeviceUpdates` for C# only to avoid the collision; all other languages keep
+// the original `DeviceUpdate` name (no collision there, and it preserves the
+// already-shipped public client/operation-group name).
+@@clientLocation(
+  DeviceUpdateOperationGroup.listUpdates,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listUpdates,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.importUpdate,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.importUpdate,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.getUpdate,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.getUpdate,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.deleteUpdate,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.deleteUpdate,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listProviders,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listProviders,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listNames,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listNames,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listVersions,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listVersions,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listFiles,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.listFiles,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdates", "csharp");
+@@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdate", "!csharp");
 @@clientLocation(
   DeviceUpdateOperationGroup.listOperationStatuses,
-  "DeviceUpdate"
+  "DeviceUpdates",
+  "csharp"
 );
-@@clientLocation(DeviceUpdateOperationGroup.getOperationStatus, "DeviceUpdate");
+@@clientLocation(
+  DeviceUpdateOperationGroup.listOperationStatuses,
+  "DeviceUpdate",
+  "!csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.getOperationStatus,
+  "DeviceUpdates",
+  "csharp"
+);
+@@clientLocation(
+  DeviceUpdateOperationGroup.getOperationStatus,
+  "DeviceUpdate",
+  "!csharp"
+);
 
 @@clientLocation(
   DeviceManagementOperationGroup.listDeviceClasses,

--- a/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
+++ b/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
@@ -39,3 +39,6 @@ options:
     package-details:
       name: "@azure/iot-device-update"
     flavor: azure
+  "@azure-typespec/http-client-csharp":
+    namespace: "Azure.IoT.DeviceUpdate"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

## API Info: The Basics

This is a client-customization-only change (`client.tsp`) to the existing GA Device Update for IoT Hub data-plane spec. There are **no API surface changes** and **no changes to the generated swagger / wire contract**.

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release

## Change Scope

**Design Document:** N/A — no API surface changes. This PR only adjusts a client-side customization (`client.tsp`).

**What changed:** The C# namespace is `Azure.IoT.DeviceUpdate`. The `client.tsp` defines a sub-client named `DeviceUpdate` (via `@@clientLocation`), which is identical to the last segment of that namespace. As a result the C# emitter disambiguates by renaming the namespace to `Azure.IoT._DeviceUpdate` (leading underscore), which is the wrong public namespace.

This PR renames that sub-client to `DeviceUpdates` **for C# only**, using a scoped `@@clientLocation`:
- `"DeviceUpdates"` scoped to `"csharp"` — fixes the collision so the namespace generates correctly as `Azure.IoT.DeviceUpdate` (sub-client accessor `GetDeviceUpdatesClient()`).
- `"DeviceUpdate"` scoped to `"!csharp"` — all other languages keep the original name, preserving the already-shipped public client/operation-group names (`DeviceUpdateClient` in Java/Python/JS).

The `DeviceManagement` sub-client is unaffected.

**Updated paths:**
- [`specification/deviceupdate/data-plane/duiothub/client.tsp`](specification/deviceupdate/data-plane/duiothub/client.tsp)

### Viewing API changes

No swagger / OpenAPI changes are produced by this PR — it is a client-only customization. The `Generated ApiView` comment can be used to confirm there is no public REST API diff.

### Suppressing failures

No new suppressions are introduced by this PR.

### Release planner

This is a client-customization-only change to an existing GA spec — no new API surface is being added. Covered by the existing Device Update GA release; no separate SDK release plan required.
