### PR TITLE
Skip Python package validation for private spec repo

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -34,6 +34,7 @@ import { detectChangedSpecConfigFiles } from "./spec-helpers.ts";
 import { type CommandResult, type ExecutionReport, type SpecGenSdkCmdInput } from "./types.ts";
 import {
   execAsync,
+  isPrivateSpecRepo,
   resetGitRepo,
   runCommandWithOutput,
   runSpecGenSdkCommand,
@@ -382,7 +383,10 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
 
       try {
         executionReport = getExecutionReport(commandInput);
-        if (commandInput.sdkLanguage === "azure-sdk-for-python") {
+        if (
+          commandInput.sdkLanguage === "azure-sdk-for-python" &&
+          !isPrivateSpecRepo(commandInput.specRepoHttpsUrl)
+        ) {
           const pythonPackageValidation = await validatePythonPackagesOnPyPI(
             executionReport.packages,
           );

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -57,6 +57,14 @@ export function getArgumentValue(args: string[], flag: string, defaultValue: str
   return index !== -1 && args[index + 1] ? args[index + 1] : defaultValue;
 }
 
+export function isPrivateSpecRepo(specRepoHttpsUrl: string): boolean {
+  const normalizedUrl = specRepoHttpsUrl
+    .toLowerCase()
+    .replace(/\.git$/, "")
+    .replace(/\/$/, "");
+  return normalizedUrl.endsWith("-pr");
+}
+
 /*
  * Get the relative path from the specification folder
  */

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -366,7 +366,7 @@ describe("generateSdkForSpecPr", () => {
       sdkRepoName: "azure-sdk-for-python-pr",
       sdkLanguage: SdkName.Python,
       specCommitSha: "",
-      specRepoHttpsUrl: "",
+      specRepoHttpsUrl: "https://github.com/Azure/azure-rest-api-specs",
     };
     const mockChangedSpecs = [
       {
@@ -421,6 +421,67 @@ describe("generateSdkForSpecPr", () => {
     expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
       mockCommandInput,
       "failed",
+      false,
+      true,
+      false,
+      "",
+      [],
+      true,
+    );
+  });
+
+  test("should skip Python PR validation for private spec repo", async () => {
+    const mockCommandInput = {
+      localSdkRepoPath: "path/to/local/repo",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "spec-pull-request",
+      sdkRepoName: "azure-sdk-for-python-pr",
+      sdkLanguage: SdkName.Python,
+      specCommitSha: "",
+      specRepoHttpsUrl: "https://github.com/Azure/azure-rest-api-specs-pr",
+    };
+    const mockChangedSpecs = [
+      {
+        specs: [
+          "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/examples/Employees_Get.json",
+        ],
+        typespecProject: "specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml",
+        readmeMd: "specification/contosowidgetmanager/resource-manager/readme.md",
+      },
+    ];
+    const mockExecutionReport = {
+      executionResult: "succeeded",
+      packages: [{ packageName: "azure-mgmt-newwidget" }],
+      vsoLogPath: "path/to/log",
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
+    vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
+    vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
+      mockExecutionReport as ExecutionReport,
+    );
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
+    vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
+    vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    const pypiValidationSpy = vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI");
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const { statusCode, executionResult } = await generateSdkForSpecPr();
+
+    expect(statusCode).toBe(0);
+    expect(executionResult).toBe("succeeded");
+    expect(pypiValidationSpy).not.toHaveBeenCalled();
+    expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
+      mockCommandInput,
+      "succeeded",
       false,
       true,
       false,


### PR DESCRIPTION
## Summary
- Skip PyPI package-name validation for Python SDK generation when the spec repo URL points to a private '-pr' repo
- Add coverage for private spec repo skip behavior
