### PR TITLE
Add CSharp client names for Network IDPS types

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -2098,9 +2098,19 @@ op replaceprivateDnsZoneGroupsList(
   "java"
 );
 @@clientName(
+  FirewallPolicyIDPSQuerySortOrder,
+  "FirewallPolicyIdpsQuerySortOrder",
+  "csharp"
+);
+@@clientName(
   FirewallPolicyIDPSSignatureDirection,
   "FirewallPolicyIdpsSignatureDirection",
   "java"
+);
+@@clientName(
+  FirewallPolicyIDPSSignatureDirection,
+  "FirewallPolicyIdpsSignatureDirection",
+  "csharp"
 );
 @@clientName(
   FirewallPolicyIDPSSignatureMode,
@@ -2108,9 +2118,19 @@ op replaceprivateDnsZoneGroupsList(
   "java"
 );
 @@clientName(
+  FirewallPolicyIDPSSignatureMode,
+  "FirewallPolicyIdpsSignatureMode",
+  "csharp"
+);
+@@clientName(
   FirewallPolicyIDPSSignatureSeverity,
   "FirewallPolicyIdpsSignatureSeverity",
   "java"
+);
+@@clientName(
+  FirewallPolicyIDPSSignatureSeverity,
+  "FirewallPolicyIdpsSignatureSeverity",
+  "csharp"
 );
 @@clientName(Microsoft.Network.IdpsQueryObject, "IdpsQueryObject", "java");
 @@clientName(


### PR DESCRIPTION
Adds C# client names for Network IDPS types so .NET generation uses the existing `Idps` casing instead of producing duplicate public API types that differ only by casing.

Affected types:
- `FirewallPolicyIDPSQuerySortOrder`
- `FirewallPolicyIDPSSignatureDirection`
- `FirewallPolicyIDPSSignatureMode`
- `FirewallPolicyIDPSSignatureSeverity`

---
🤖 arcturus-copilot