### PR TITLE
Add C# names for Network IDPS enum members

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -1601,20 +1601,20 @@ union ProvisioningStateUnion {
   "java"
 );
 
-@@clientName(FirewallPolicyIDPSSignatureDirection.`0`, "Zero", "go");
-@@clientName(FirewallPolicyIDPSSignatureDirection.`1`, "One", "go");
-@@clientName(FirewallPolicyIDPSSignatureDirection.`2`, "Two", "go");
-@@clientName(FirewallPolicyIDPSSignatureDirection.`3`, "Three", "go");
-@@clientName(FirewallPolicyIDPSSignatureDirection.`4`, "Four", "go");
-@@clientName(FirewallPolicyIDPSSignatureDirection.`5`, "Five", "go");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`0`, "Zero", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`1`, "One", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`2`, "Two", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`3`, "Three", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`4`, "Four", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureDirection.`5`, "Five", "go,csharp");
 
-@@clientName(FirewallPolicyIDPSSignatureMode.`0`, "Zero", "go");
-@@clientName(FirewallPolicyIDPSSignatureMode.`1`, "One", "go");
-@@clientName(FirewallPolicyIDPSSignatureMode.`2`, "Two", "go");
+@@clientName(FirewallPolicyIDPSSignatureMode.`0`, "Zero", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureMode.`1`, "One", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureMode.`2`, "Two", "go,csharp");
 
-@@clientName(FirewallPolicyIDPSSignatureSeverity.`1`, "One", "go");
-@@clientName(FirewallPolicyIDPSSignatureSeverity.`2`, "Two", "go");
-@@clientName(FirewallPolicyIDPSSignatureSeverity.`3`, "Three", "go");
+@@clientName(FirewallPolicyIDPSSignatureSeverity.`1`, "One", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureSeverity.`2`, "Two", "go,csharp");
+@@clientName(FirewallPolicyIDPSSignatureSeverity.`3`, "Three", "go,csharp");
 
 @@clientLocation(
   BastionHosts.deleteBastionShareableLink,

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -2098,9 +2098,19 @@ op replaceprivateDnsZoneGroupsList(
   "java"
 );
 @@clientName(
+  FirewallPolicyIDPSQuerySortOrder,
+  "FirewallPolicyIdpsQuerySortOrder",
+  "csharp"
+);
+@@clientName(
   FirewallPolicyIDPSSignatureDirection,
   "FirewallPolicyIdpsSignatureDirection",
   "java"
+);
+@@clientName(
+  FirewallPolicyIDPSSignatureDirection,
+  "FirewallPolicyIdpsSignatureDirection",
+  "csharp"
 );
 @@clientName(
   FirewallPolicyIDPSSignatureMode,
@@ -2108,9 +2118,19 @@ op replaceprivateDnsZoneGroupsList(
   "java"
 );
 @@clientName(
+  FirewallPolicyIDPSSignatureMode,
+  "FirewallPolicyIdpsSignatureMode",
+  "csharp"
+);
+@@clientName(
   FirewallPolicyIDPSSignatureSeverity,
   "FirewallPolicyIdpsSignatureSeverity",
   "java"
+);
+@@clientName(
+  FirewallPolicyIDPSSignatureSeverity,
+  "FirewallPolicyIdpsSignatureSeverity",
+  "csharp"
 );
 @@clientName(Microsoft.Network.IdpsQueryObject, "IdpsQueryObject", "java");
 @@clientName(


### PR DESCRIPTION
## Description

Adds C# client names for Network IDPS numeric enum members by extending the existing Go member customizations to `go,csharp`. This preserves the TypeSpec enum member identifiers so the Swagger output is not changed, while allowing .NET to generate the GA member names (`Zero`, `One`, etc.) instead of `_0`, `_1`, etc.

This builds on Azure/azure-rest-api-specs#44230, which adds C# client names for the affected IDPS enum type names.
