### PR TITLE
[Security] Rename SDK review types

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -1791,6 +1791,11 @@ model CSharpSecurityAssessmentStatusResult
 @@clientName(PricingsAPI.Enforce, "SecurityPolicyEnforce", "csharp");
 @@clientName(PricingsAPI.Extension, "SecurityConnectorExtension", "csharp");
 @@clientName(
+  PricingsAPI.Inherited,
+  "SecurityCenterPricingInheritance",
+  "csharp"
+);
+@@clientName(
   PricingsAPI.IsEnabled,
   "SecurityCenterExtensionIsEnabled",
   "csharp"
@@ -1823,6 +1828,16 @@ model CSharpSecurityAssessmentStatusResult
 @@clientName(
   SecuritySolutionsAPI.ConnectionType,
   "SecurityCenterConnectionType",
+  "csharp"
+);
+@@clientName(
+  HealthReportsAPI.StatusName,
+  "SecurityCenterHealthStatus",
+  "csharp"
+);
+@@clientName(
+  GovernanceAPI.OperationResultStatus,
+  "SecurityCenterOperationResultStatus",
   "csharp"
 );
 @@clientName(SecurityStandardsAPI.Effect, "SecurityCenterEffect", "csharp");

--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -1796,6 +1796,11 @@ model CSharpSecurityAssessmentStatusResult
   "csharp"
 );
 @@clientName(
+  PricingsAPI.ResourcesCoverageStatus,
+  "SecurityCenterResourcesCoverageStatus",
+  "csharp"
+);
+@@clientName(
   PricingsAPI.IsEnabled,
   "SecurityCenterExtensionIsEnabled",
   "csharp"
@@ -1826,6 +1831,11 @@ model CSharpSecurityAssessmentStatusResult
 );
 @@clientName(AlertsAPI.BundleType.DNS, "Dns", "csharp");
 @@clientName(
+  DefenderForStorageAPI.AutomatedResponseType,
+  "MalwareScanningAutomatedResponseType",
+  "csharp"
+);
+@@clientName(
   SecuritySolutionsAPI.ConnectionType,
   "SecurityCenterConnectionType",
   "csharp"
@@ -1840,6 +1850,21 @@ model CSharpSecurityAssessmentStatusResult
   "SecurityCenterOperationResultStatus",
   "csharp"
 );
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanOperationStatus,
+  "SqlVulnerabilityAssessmentScanOperationStatus",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.attestationComplianceState,
+  "StandardAssignmentAttestationComplianceState",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.StandardType,
+  "SecurityStandardType",
+  "csharp"
+);
 @@clientName(SecurityStandardsAPI.Effect, "SecurityCenterEffect", "csharp");
 @@clientName(SecurityStandardsAPI.StandardSupportedCloud.AWS, "Aws", "csharp");
 @@clientName(SecurityStandardsAPI.StandardSupportedCloud.GCP, "Gcp", "csharp");
@@ -1850,6 +1875,16 @@ model CSharpSecurityAssessmentStatusResult
 );
 @@clientName(StandardsAPI.StandardSupportedClouds.AWS, "Aws", "csharp");
 @@clientName(StandardsAPI.StandardSupportedClouds.GCP, "Gcp", "csharp");
+@@clientName(
+  SecurityConnectorsDevOpsAPI.InventoryKind,
+  "IotSecurityInventoryKind",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.InventoryListKind,
+  "IotSecurityInventoryListKind",
+  "csharp"
+);
 @@clientName(
   HealthReportsAPI.environmentDetails,
   "SecurityConnectorEnvironmentDetails",

--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -1797,6 +1797,18 @@ model CSharpSecurityAssessmentStatusResult
 );
 @@clientName(SecureScoreAPI.ControlType, "SecurityControlType", "csharp");
 @@clientName(SensitivitySettingsAPI.BuiltInInfoType.type, "Dns", "csharp");
+@@clientName(Common.SettingName.MCAS, "Mcas", "csharp");
+@@clientName(Common.SettingName.WDATP, "Wdatp", "csharp");
+@@clientName(
+  Common.SettingName.WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW,
+  "WdatpExcludeLinuxPublicPreview",
+  "csharp"
+);
+@@clientName(
+  Common.SettingName.WDATP_UNIFIED_SOLUTION,
+  "WdatpUnifiedSolution",
+  "csharp"
+);
 @@clientName(
   AlertsAPI.AlertSimulatorBundlesRequestProperties,
   "SecurityAlertSimulatorBundlesRequestProperties",
@@ -1814,11 +1826,15 @@ model CSharpSecurityAssessmentStatusResult
   "csharp"
 );
 @@clientName(SecurityStandardsAPI.Effect, "SecurityCenterEffect", "csharp");
+@@clientName(SecurityStandardsAPI.StandardSupportedCloud.AWS, "Aws", "csharp");
+@@clientName(SecurityStandardsAPI.StandardSupportedCloud.GCP, "Gcp", "csharp");
 @@clientName(
   SecurityStandardsAPI.ExemptionCategory,
   "SecurityExemptionCategory",
   "csharp"
 );
+@@clientName(StandardsAPI.StandardSupportedClouds.AWS, "Aws", "csharp");
+@@clientName(StandardsAPI.StandardSupportedClouds.GCP, "Gcp", "csharp");
 @@clientName(
   HealthReportsAPI.environmentDetails,
   "SecurityConnectorEnvironmentDetails",

--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -1369,7 +1369,7 @@ op privateLinkResourcesGetCustomization(
 );
 @@clientName(
   SecurityConnectorsAPI.GitlabScopeEnvironmentData,
-  "GitlabScopeEnvironmentInfo",
+  "GitLabScopeEnvironmentInfo",
   "csharp"
 );
 @@clientName(
@@ -1912,6 +1912,11 @@ model CSharpSecurityAssessmentStatusResult
   "SecurityConnectorIdentity",
   "csharp"
 );
+@@clientName(
+  Azure.ResourceManager.CommonTypes.ResourceIdentityType,
+  "SecurityConnectorIdentityType",
+  "csharp"
+);
 @@clientName(Common.ResourceDetails, "SecurityCenterResourceDetails", "csharp");
 @@clientName(
   HealthReportsAPI.resourceDetails,
@@ -1927,6 +1932,11 @@ model CSharpSecurityAssessmentStatusResult
 @@clientName(
   DefenderForStorageAPI.BlobScanResultsOptions,
   "BlobScanResultsConfig",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.GetSensitivitySettingsResponsePropertiesMipInformation,
+  "SensitivitySettingsMipInformation",
   "csharp"
 );
 @@alternateType(


### PR DESCRIPTION
Follow-up for Azure/azure-sdk-for-net#59180. Renames SecurityCenter generated SDK types flagged by management SDK review: ResourceIdentityType, GitlabScopeEnvironmentInfo, and GetSensitivitySettingsResponsePropertiesMipInformation.