### PR TITLE
[feature/foundry-release] Add Go SDK emitter configuration for AI Foundry

### DIFF
--- a/specification/ai-foundry/cspell.yaml
+++ b/specification/ai-foundry/cspell.yaml
@@ -12,6 +12,8 @@ words:
   #   easy-to-make typographic errors. If possible, add to a more targeted override, below.
   - agentic
   - AOAI
+  - azaiprojects
+  - byval
   - CSDL
   - evals
   - includable

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -94,6 +94,7 @@ namespace Azure.AI.Projects {
        * If not provided, the service assumes auto.
        */
       #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Copying existing union type."
+      @Azure.ClientGenerator.Core.alternateType(unknown, "go")
       container?: string | OpenAI.AutoCodeInterpreterToolParam,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-go-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-go-azure-ai-projects/client.tsp
@@ -1,0 +1,91 @@
+import "../common/custom-types.tsp";
+import "../common/service.tsp";
+import "../sdk-common/error.default.tsp";
+import "../connections/routes.tsp";
+import "../datasets/routes.tsp";
+import "../indexes/routes.tsp";
+import "../deployments/routes.tsp";
+import "../red-teams/routes.tsp";
+import "../evaluation-rules/routes.tsp";
+import "../evaluation-taxonomies/routes.tsp";
+import "../evaluators/routes.tsp";
+import "../insights/routes.tsp";
+import "../schedules/routes.tsp";
+import "../memory-stores/routes.tsp";
+import "../toolboxes/routes.tsp";
+
+using Azure.ClientGenerator.Core;
+namespace Azure.AI.Projects;
+
+// --------------------------------------------------------------------------------
+// Root client
+// --------------------------------------------------------------------------------
+@@clientName(Azure.AI.Projects, "Client");
+
+// For Go, keep feature opt-in headers as strings so request and fake-server header handling agree.
+@@alternateType(FoundryFeaturesOptInKeys, string);
+
+// For Go, keep the memory inputs light instead of expanding the full OpenAI input-item model graph.
+@@alternateType(OpenAI.InputItem, Record<unknown>);
+
+@@usage(MemoryStoreUpdateCompletedResult, Usage.output);
+@@access(MemoryStoreUpdateCompletedResult, Access.public);
+@@usage(MemoryStoreUpdateResponse, Usage.output);
+@@access(MemoryStoreUpdateResponse, Access.public);
+@@access(MemoryStoreSearchResponse, Access.public);
+
+@@clientName(MemoryStoreSearchResponse, "MemoryStoreSearchResult");
+@@clientName(MemoryStoreUpdateResponse, "MemoryStoreUpdateResult");
+@@clientName(DeleteMemoryStoreResponse, "DeleteMemoryStoreResult");
+@@clientName(MemoryStoreDeleteScopeResponse, "MemoryStoreDeleteScopeResult");
+@@clientName(MemorySearchOptions, "MemorySearchResultOptions");
+@@clientDoc(
+  MemoryStoreUpdateRequest.items,
+  "A list of messages to store in memory. Each item is represented as a map with keys such as `type`, `role`, and `content`, similar to OpenAI response input items. Only message items are currently processed; other item types are ignored.",
+  DocumentationMode.replace,
+  "go"
+);
+@@clientDoc(
+  MemoryStoreSearchRequest.items,
+  "A list of messages used to search for relevant memories. Each item is represented as a map with keys such as `type`, `role`, and `content`, similar to OpenAI response input items. Only message items are currently processed; other item types are ignored.",
+  DocumentationMode.replace,
+  "go"
+);
+
+// --------------------------------------------------------------------------------
+// Model and property names
+// --------------------------------------------------------------------------------
+
+// More accurate naming.
+@@clientName(AssetCredentialResponse, "DatasetCredential");
+@@clientName(SasCredential, "BlobReferenceSasCredential");
+
+// These OpenAI/toolbox properties use @oneOf or unnamed union shapes that typespec-go
+// cannot adapt yet. Keep the service wire shapes intact and expose broad Go types.
+@@alternateType(OpenAI.Filters, Record<unknown>);
+@@alternateType(OpenAI.MCPTool.allowed_tools, unknown);
+@@alternateType(OpenAI.MCPTool.require_approval, string);
+@@alternateType(OpenAI.NamespaceToolParam.tools, Record<unknown>[]);
+@@alternateType(FabricIQPreviewTool.require_approval, string);
+
+// Make these two internal, since SDKs hand-write a single public method with a boolean includeCredentials input parameter.
+@@access(Connections.get, Access.internal);
+@@access(Connections.getWithCredentials, Access.internal);
+
+// EvaluatorVersion datetime fields are typed as strings in the service model but carry ISO 8601 timestamps.
+@@alternateType(EvaluatorVersion.created_at, utcDateTime);
+@@alternateType(EvaluatorVersion.modified_at, utcDateTime);
+
+// Schedule trigger datetime fields are typed as strings in the service model but carry ISO 8601 timestamps.
+@@alternateType(RecurrenceTrigger.startTime, utcDateTime);
+@@alternateType(RecurrenceTrigger.endTime, utcDateTime);
+@@alternateType(OneTimeTrigger.triggerAt, utcDateTime);
+@@alternateType(CronTrigger.startTime, utcDateTime);
+@@alternateType(CronTrigger.endTime, utcDateTime);
+@@alternateType(ScheduleRun.triggerTime, utcDateTime);
+
+// --------------------------------------------------------------------------------
+// Schedules models
+// --------------------------------------------------------------------------------
+@@clientName(SchedulesCreateOrUpdateParams.resource, "Schedule");
+@@clientName(Schedule.id, "ScheduleID");

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-go-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-go-azure-ai-projects/tspconfig.yaml
@@ -1,0 +1,38 @@
+parameters:
+  "service-dir":
+    default: "sdk/ai"
+  "dependencies":
+    default: "@azure-tools/openai-typespec@1.19.0"
+options:
+  "@azure-tools/typespec-go":
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/azaiprojects"
+    service-dir: "sdk/ai"
+    emitter-output-dir: "{output-dir}/{service-dir}/azaiprojects"
+    generate-fakes: true
+    inject-spans: true
+    slice-elements-byval: true
+    flavor: azure
+imports:
+  - "@azure-tools/typespec-azure-core"
+  - "@azure-tools/typespec-azure-core/experimental"
+  - "@azure-tools/typespec-client-generator-core"
+  # Note: Imports for OpenAI types may use alternate views per tspconfig.yaml
+  - "@azure-tools/openai-typespec/models/evals"
+  - "@azure-tools/openai-typespec/models/responses"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+  disable:
+    "@azure-tools/typespec-azure-core/casing-style": "Since we have many names in the form XxxxAIXxxx"
+    "@azure-tools/typespec-azure-core/no-string-discriminator": "Use an extensible union instead of a plain string"
+    "@azure-tools/typespec-azure-core/bad-record-type": "We do want to use Record<unknown>, and not Record<string>. But this needs further investigation"
+    "@azure-tools/typespec-azure-core/use-standard-names": "PUT operations that return 200 should start with 'replace' or 'createOrReplace'"
+    "@azure-tools/typespec-azure-core/documentation-required": "Some OpenAI models do not contain docstrings."
+    "@azure-tools/typespec-azure-core/no-nullable": "Some OpenAI models still contain <> | null notation."
+    "@azure-tools/typespec-azure-core/no-closed-literal-union": "OpenAI incompliance"
+    "@azure-tools/typespec-azure-core/no-openapi": ".external-readonly uses OpenAI."
+    "@azure-tools/typespec-azure-core/no-multiple-discriminator": "OpenAI contains multiple discriminators."
+    "@azure-tools/typespec-azure-core/no-unknown": "unknowns are used in OpenAI package."
+    "@azure-tools/typespec-azure-core/no-query-explode": "Explode is used in OpenAI package."
+    "@azure-tools/typespec-client-generator-core/property-name-conflict": "OpenAI package has conflict."
+    "@azure-tools/typespec-azure-core/no-enum": "OpenAI uses enums."


### PR DESCRIPTION
This PR wires AI Foundry into the Go SDK generation path.

What changed:
- Adds the Go emitter configuration for the `azaiprojects` package, including fake generation, span injection, and by-value slice elements.
- Adds Go-specific client customizations in `client.go.tsp` so the generated SDK has friendlier names and shapes for memory stores, schedules, evaluator timestamps, credentials, and connection operations.

Validation:
- `npx tsp compile specification/ai-foundry/data-plane/Foundry`