### PR TITLE
chore: upgrades openai typespec definitions to 1.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.14",
-        "@azure-tools/openai-typespec": "1.20.1",
+        "@azure-tools/openai-typespec": "1.21.0",
         "@azure-tools/spec-gen-sdk": "~0.9.1",
         "@azure-tools/specs-shared": "file:.github/shared",
         "@azure-tools/typespec-apiview": "0.7.2",
@@ -1636,9 +1636,9 @@
       "link": true
     },
     "node_modules/@azure-tools/openai-typespec": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.20.1.tgz",
-      "integrity": "sha512-9pXpSrRyvslAi3Wrwz5uIqoZ20xwWDpDEuuU+MjlAWJIFdv6FR5QnWJCT8xz74yLYLxITaY3UVO2KKNTxT6Vpw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-1.21.0.tgz",
+      "integrity": "sha512-wKHNsyXii+/ZJn/mqKC/ey+/Y+RoW7XGBQD5yNRhGKA3VRibLNIhn/0PGLEIZhWWsFp3okTvifhPDs/b0DmOTA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-rest-api-specs",
   "devDependencies": {
     "@autorest/openapi-to-typespec": "0.11.14",
-    "@azure-tools/openai-typespec": "1.20.1",
+    "@azure-tools/openai-typespec": "1.21.0",
     "@azure-tools/spec-gen-sdk": "~0.9.1",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",


### PR DESCRIPTION
Changelog https://github.com/microsoft/openai-openapi-pr/releases/tag/%40azure-tools%2Fopenai-typespec%401.21.0