### PR TITLE
fix: exclude tool_configs from ToolFields to prevent deprecated bleed

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18682,14 +18682,6 @@
               "azure_ai_search"
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -20277,14 +20269,6 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           }
         },
         "allOf": [
@@ -24478,14 +24462,6 @@
               }
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "vector_store_ids": {
             "type": "array",
             "items": {
@@ -25721,14 +25697,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           }
         },
         "allOf": [
@@ -50810,14 +50778,6 @@
               "openapi"
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "openapi": {
             "allOf": [
               {
@@ -55369,14 +55329,6 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12306,12 +12306,6 @@ components:
           type: string
           enum:
             - azure_ai_search
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -13365,12 +13359,6 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -16450,12 +16438,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -17272,12 +17254,6 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An MCP tool stored in a toolbox.
@@ -34894,12 +34870,6 @@ components:
           type: string
           enum:
             - openapi
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -37938,12 +37908,6 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -22105,14 +22105,6 @@
               "azure_ai_search"
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -23700,14 +23692,6 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           }
         },
         "allOf": [
@@ -28959,14 +28943,6 @@
               }
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "vector_store_ids": {
             "type": "array",
             "items": {
@@ -30275,14 +30251,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           }
         },
         "allOf": [
@@ -55481,14 +55449,6 @@
               "openapi"
             ]
           },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
-          },
           "openapi": {
             "allOf": [
               {
@@ -60239,14 +60199,6 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
-          },
-          "tool_configs": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
-            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14595,12 +14595,6 @@ components:
           type: string
           enum:
             - azure_ai_search
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -15654,12 +15648,6 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -19470,12 +19458,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -20338,12 +20320,6 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An MCP tool stored in a toolbox.
@@ -38044,12 +38020,6 @@ components:
           type: string
           enum:
             - openapi
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -41221,12 +41191,6 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
-        tool_configs:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: Deprecated. This property is deprecated and will be removed in a future version.
-          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -64,7 +64,7 @@ model WithFieldsOptional<Source, Keys extends string> {
  * Spreads tool-specific fields from `Source`, excluding fields owned by `ToolboxTool`.
  */
 alias ToolFields<Source> = {
-  ...OmitProperties<Source, "name" | "description" | "type">;
+  ...OmitProperties<Source, "name" | "description" | "type" | "tool_configs">;
 };
 
 alias ToolboxCodeInterpreterToolType = "code_interpreter";


### PR DESCRIPTION
## Summary
This PR fixes a regression where deprecated tool_configs could leak into ToolboxTool subtypes through a spread of ToolFields<OpenAI.MCPTool>. (https://github.com/Azure/azure-rest-api-specs/pull/44208)

## Root Cause
ToolFields<Source> intentionally omitted name, description, and type, but it did not omit tool_configs.  
When patched agent-side Tools were spread into ToolboxTool subtypes via ...ToolFields<OpenAI.MCPTool>, the deprecated tool_configs from the source type was brought along and could override the ToolboxTool base definition.


ToolboxTool already defines a non-deprecated tool_configs, so this spread behavior was incorrect and caused the deprecated field shape to bleed through.

## Fix
- Updated ToolFields so tool_configs is also omitted from the spread source.
- Preserved ToolboxTool as the single source of truth for the non-deprecated tool_configs definition.
- Prevented accidental override of ToolboxTool base fields when composing subtypes.

## Behavior Change
- ToolboxTool subtypes now inherit the intended non-deprecated tool_configs from ToolboxTool.
- Deprecated tool_configs from patched agent-side Tools no longer propagates through ToolFields spreads.

## Validation
- Confirmed generated/tool type shapes no longer include the deprecated override path from ToolFields<OpenAI.MCPTool>.
- Confirmed ToolboxTool subtypes resolve to the base non-deprecated tool_configs definition.

## Risk
Low.  
Change is narrowly scoped to field composition/omit behavior and removes an unintended override path rather than introducing a new schema surface.