### PR TITLE
Mark agent draft version features as preview with AgentsDraft=V1Previ…

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -805,7 +805,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         },
         "tags": [
@@ -2644,7 +2645,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         },
         "tags": [
@@ -2728,13 +2730,35 @@
             "explode": false
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsDraft=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "include_drafts",
             "in": "query",
             "required": false,
             "description": "(Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).",
             "schema": {
               "type": "boolean",
+              "x-ms-foundry-meta": {
+                "conditional_previews": [
+                  "AgentsDraft=V1Preview"
+                ]
+              },
               "default": false
+            },
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
             },
             "explode": false
           },
@@ -2809,7 +2833,12 @@
         },
         "tags": [
           "Agent Versions"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsDraft=V1Preview"
+          ]
+        }
       }
     },
     "/agents/{agent_name}/versions/{agent_version}": {
@@ -17279,7 +17308,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -17287,7 +17317,8 @@
         "type": "string",
         "enum": [
           "WorkflowAgents=V1Preview",
-          "ExternalAgents=V1Preview"
+          "ExternalAgents=V1Preview",
+          "AgentsDraft=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
       },
@@ -17866,6 +17897,11 @@
           "draft": {
             "type": "boolean",
             "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           },
           "status": {
@@ -20701,7 +20737,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },
@@ -20716,6 +20753,11 @@
           "draft": {
             "type": "boolean",
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           },
           "agent_endpoint": {
@@ -20738,7 +20780,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -20873,7 +20916,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },
@@ -20888,13 +20932,19 @@
           "draft": {
             "type": "boolean",
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -55053,7 +55103,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -806,7 +806,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         },
         "tags": [
@@ -2646,7 +2646,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         },
         "tags": [
@@ -2737,7 +2737,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -2750,14 +2750,14 @@
               "type": "boolean",
               "x-ms-foundry-meta": {
                 "conditional_previews": [
-                  "AgentsDraft=V1Preview"
+                  "DraftAgents=V1Preview"
                 ]
               },
               "default": false
             },
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "explode": false
@@ -2836,7 +2836,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       }
@@ -17309,7 +17309,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -17318,7 +17318,7 @@
         "enum": [
           "WorkflowAgents=V1Preview",
           "ExternalAgents=V1Preview",
-          "AgentsDraft=V1Preview"
+          "DraftAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
       },
@@ -17899,7 +17899,7 @@
             "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -20738,7 +20738,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -20755,7 +20755,7 @@
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -20781,7 +20781,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -20917,7 +20917,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -20934,7 +20934,7 @@
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -20944,7 +20944,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -55104,7 +55104,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -516,6 +516,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
       tags:
         - Agents
       requestBody:
@@ -1798,6 +1799,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -1863,13 +1865,27 @@ paths:
           schema:
             type: string
           explode: false
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsDraft=V1Preview
         - name: include_drafts
           in: query
           required: false
           description: (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).
           schema:
             type: boolean
+            x-ms-foundry-meta:
+              conditional_previews:
+                - AgentsDraft=V1Preview
             default: false
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           explode: false
         - name: api-version
           in: query
@@ -1918,6 +1934,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Versions
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsDraft=V1Preview
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
@@ -11389,11 +11408,13 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
         - WorkflowAgents=V1Preview
         - ExternalAgents=V1Preview
+        - AgentsDraft=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
     AgentEndpointAuthorizationScheme:
       type: object
@@ -11771,6 +11792,9 @@ components:
         draft:
           type: boolean
           description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
         status:
           allOf:
@@ -13674,6 +13698,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -13681,6 +13706,9 @@ components:
         draft:
           type: boolean
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
         agent_endpoint:
           allOf:
@@ -13694,6 +13722,7 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     CreateAgentSessionRequest:
       type: object
       required:
@@ -13807,6 +13836,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -13814,11 +13844,15 @@ components:
         draft:
           type: boolean
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     CreateEvalRequest:
       type: object
       required:
@@ -37739,6 +37773,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -516,7 +516,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -1799,7 +1799,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -1872,7 +1872,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         - name: include_drafts
           in: query
           required: false
@@ -1881,11 +1881,11 @@ paths:
             type: boolean
             x-ms-foundry-meta:
               conditional_previews:
-                - AgentsDraft=V1Preview
+                - DraftAgents=V1Preview
             default: false
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           explode: false
         - name: api-version
           in: query
@@ -1936,7 +1936,7 @@ paths:
         - Agent Versions
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
@@ -11408,13 +11408,13 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
         - WorkflowAgents=V1Preview
         - ExternalAgents=V1Preview
-        - AgentsDraft=V1Preview
+        - DraftAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
     AgentEndpointAuthorizationScheme:
       type: object
@@ -11794,7 +11794,7 @@ components:
           description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
         status:
           allOf:
@@ -13698,7 +13698,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -13708,7 +13708,7 @@ components:
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
         agent_endpoint:
           allOf:
@@ -13722,7 +13722,7 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     CreateAgentSessionRequest:
       type: object
       required:
@@ -13836,7 +13836,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -13846,13 +13846,13 @@ components:
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     CreateEvalRequest:
       type: object
       required:
@@ -37773,7 +37773,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -809,7 +809,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         },
         "tags": [
@@ -3010,7 +3010,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         },
         "tags": [
@@ -3101,7 +3101,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -3114,14 +3114,14 @@
               "type": "boolean",
               "x-ms-foundry-meta": {
                 "conditional_previews": [
-                  "AgentsDraft=V1Preview"
+                  "DraftAgents=V1Preview"
                 ]
               },
               "default": false
             },
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "explode": false
@@ -3200,7 +3200,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       }
@@ -20455,7 +20455,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -20464,7 +20464,7 @@
         "enum": [
           "WorkflowAgents=V1Preview",
           "ExternalAgents=V1Preview",
-          "AgentsDraft=V1Preview",
+          "DraftAgents=V1Preview",
           "HostedAgents=V1Preview",
           "ContainerAgents=V1Preview"
         ],
@@ -21288,7 +21288,7 @@
             "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -24308,7 +24308,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -24325,7 +24325,7 @@
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -24351,7 +24351,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -24487,7 +24487,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },
@@ -24504,7 +24504,7 @@
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             },
             "default": false
@@ -24514,7 +24514,7 @@
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
             "ExternalAgents=V1Preview",
-            "AgentsDraft=V1Preview"
+            "DraftAgents=V1Preview"
           ]
         }
       },
@@ -59948,7 +59948,7 @@
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
                 "ExternalAgents=V1Preview",
-                "AgentsDraft=V1Preview"
+                "DraftAgents=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -808,7 +808,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         },
         "tags": [
@@ -3008,7 +3009,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         },
         "tags": [
@@ -3092,13 +3094,35 @@
             "explode": false
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsDraft=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "include_drafts",
             "in": "query",
             "required": false,
             "description": "(Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).",
             "schema": {
               "type": "boolean",
+              "x-ms-foundry-meta": {
+                "conditional_previews": [
+                  "AgentsDraft=V1Preview"
+                ]
+              },
               "default": false
+            },
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
             },
             "explode": false
           },
@@ -3173,7 +3197,12 @@
         },
         "tags": [
           "Agent Versions"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsDraft=V1Preview"
+          ]
+        }
       }
     },
     "/agents/{agent_name}/versions/{agent_version}": {
@@ -20425,7 +20454,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -20434,6 +20464,7 @@
         "enum": [
           "WorkflowAgents=V1Preview",
           "ExternalAgents=V1Preview",
+          "AgentsDraft=V1Preview",
           "HostedAgents=V1Preview",
           "ContainerAgents=V1Preview"
         ],
@@ -21255,6 +21286,11 @@
           "draft": {
             "type": "boolean",
             "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           },
           "status": {
@@ -24271,7 +24307,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },
@@ -24286,6 +24323,11 @@
           "draft": {
             "type": "boolean",
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           },
           "agent_endpoint": {
@@ -24308,7 +24350,8 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -24443,7 +24486,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },
@@ -24458,13 +24502,19 @@
           "draft": {
             "type": "boolean",
             "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "AgentsDraft=V1Preview"
+              ]
+            },
             "default": false
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "WorkflowAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "ExternalAgents=V1Preview",
+            "AgentsDraft=V1Preview"
           ]
         }
       },
@@ -59897,7 +59947,8 @@
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "WorkflowAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "ExternalAgents=V1Preview",
+                "AgentsDraft=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -517,6 +517,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
       tags:
         - Agents
       requestBody:
@@ -2054,6 +2055,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -2119,13 +2121,27 @@ paths:
           schema:
             type: string
           explode: false
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsDraft=V1Preview
         - name: include_drafts
           in: query
           required: false
           description: (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).
           schema:
             type: boolean
+            x-ms-foundry-meta:
+              conditional_previews:
+                - AgentsDraft=V1Preview
             default: false
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           explode: false
         - name: api-version
           in: query
@@ -2174,6 +2190,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Versions
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsDraft=V1Preview
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
@@ -13483,11 +13502,13 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
         - WorkflowAgents=V1Preview
         - ExternalAgents=V1Preview
+        - AgentsDraft=V1Preview
         - HostedAgents=V1Preview
         - ContainerAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
@@ -14039,6 +14060,9 @@ components:
         draft:
           type: boolean
           description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
         status:
           allOf:
@@ -16064,6 +16088,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -16071,6 +16096,9 @@ components:
         draft:
           type: boolean
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
         agent_endpoint:
           allOf:
@@ -16084,6 +16112,7 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     CreateAgentSessionRequest:
       type: object
       required:
@@ -16197,6 +16226,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -16204,11 +16234,15 @@ components:
         draft:
           type: boolean
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - AgentsDraft=V1Preview
           default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
+          - AgentsDraft=V1Preview
     CreateEvalRequest:
       type: object
       required:
@@ -41005,6 +41039,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
+              - AgentsDraft=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -517,7 +517,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -2055,7 +2055,7 @@ paths:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -2128,7 +2128,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         - name: include_drafts
           in: query
           required: false
@@ -2137,11 +2137,11 @@ paths:
             type: boolean
             x-ms-foundry-meta:
               conditional_previews:
-                - AgentsDraft=V1Preview
+                - DraftAgents=V1Preview
             default: false
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           explode: false
         - name: api-version
           in: query
@@ -2192,7 +2192,7 @@ paths:
         - Agent Versions
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
@@ -13502,13 +13502,13 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
         - WorkflowAgents=V1Preview
         - ExternalAgents=V1Preview
-        - AgentsDraft=V1Preview
+        - DraftAgents=V1Preview
         - HostedAgents=V1Preview
         - ContainerAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
@@ -14062,7 +14062,7 @@ components:
           description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
         status:
           allOf:
@@ -16088,7 +16088,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -16098,7 +16098,7 @@ components:
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
         agent_endpoint:
           allOf:
@@ -16112,7 +16112,7 @@ components:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     CreateAgentSessionRequest:
       type: object
       required:
@@ -16226,7 +16226,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
@@ -16236,13 +16236,13 @@ components:
           description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
           x-ms-foundry-meta:
             conditional_previews:
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
           default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
-          - AgentsDraft=V1Preview
+          - DraftAgents=V1Preview
     CreateEvalRequest:
       type: object
       required:
@@ -41039,7 +41039,7 @@ components:
             conditional_previews:
               - WorkflowAgents=V1Preview
               - ExternalAgents=V1Preview
-              - AgentsDraft=V1Preview
+              - DraftAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -11,7 +11,7 @@ const AllConditionalAgentDefinitionPreviews = #{
   conditional_previews: #[
     AgentDefinitionOptInKeys.workflow_agents_v1_preview,
     AgentDefinitionOptInKeys.external_agents_v1_preview,
-    AgentDefinitionOptInKeys.agents_draft_v1_preview
+    AgentDefinitionOptInKeys.draft_agents_v1_preview
   ],
 };
 
@@ -33,7 +33,7 @@ model CreateAgentVersionRequest {
   @doc("(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
   )
   draft?: boolean = false;
 }
@@ -189,7 +189,7 @@ model AgentVersionObject {
   @doc("Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
   )
   draft?: boolean = false;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -10,7 +10,8 @@ namespace Azure.AI.Projects;
 const AllConditionalAgentDefinitionPreviews = #{
   conditional_previews: #[
     AgentDefinitionOptInKeys.workflow_agents_v1_preview,
-    AgentDefinitionOptInKeys.external_agents_v1_preview
+    AgentDefinitionOptInKeys.external_agents_v1_preview,
+    AgentDefinitionOptInKeys.agents_draft_v1_preview
   ],
 };
 
@@ -30,6 +31,10 @@ model CreateAgentVersionRequest {
   blueprint_reference?: AgentBlueprintReference;
 
   @doc("(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+  )
   draft?: boolean = false;
 }
 
@@ -182,6 +187,10 @@ model AgentVersionObject {
   definition: AgentDefinition;
 
   @doc("Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+  )
   draft?: boolean = false;
 
   @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -304,6 +304,10 @@ interface Agents {
   @route("/agents/{agent_name}/versions")
   @list
   @tag("Agent Versions")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+  )
   listAgentVersions is FoundryDataPlaneOperation<
     {
       /** The name of the agent to retrieve versions for. */
@@ -311,7 +315,13 @@ interface Agents {
 
       ...CommonPageQueryParameters;
 
+      ...WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.agents_draft_v1_preview>;
+
       /** (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned). */
+      @extension(
+        "x-ms-foundry-meta",
+        #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+      )
       @query include_drafts?: boolean = false;
     },
     AgentsPagedResult<AgentVersionObject>

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -306,7 +306,7 @@ interface Agents {
   @tag("Agent Versions")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
   )
   listAgentVersions is FoundryDataPlaneOperation<
     {
@@ -315,12 +315,12 @@ interface Agents {
 
       ...CommonPageQueryParameters;
 
-      ...WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.agents_draft_v1_preview>;
+      ...WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.draft_agents_v1_preview>;
 
       /** (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned). */
       @extension(
         "x-ms-foundry-meta",
-        #{ conditional_previews: #[AgentDefinitionOptInKeys.agents_draft_v1_preview] }
+        #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
       )
       @query include_drafts?: boolean = false;
     },

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -87,7 +87,7 @@ op FoundryDataPlaneOperation<
 union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
-  agents_draft_v1_preview: "AgentsDraft=V1Preview",
+  draft_agents_v1_preview: "DraftAgents=V1Preview",
   @removed(Versions.v1)
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   @removed(Versions.v1)

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -87,6 +87,7 @@ op FoundryDataPlaneOperation<
 union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
+  agents_draft_v1_preview: "AgentsDraft=V1Preview",
   @removed(Versions.v1)
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   @removed(Versions.v1)


### PR DESCRIPTION
…ew opt-in

Add agents_draft_v1_preview key to AgentDefinitionOptInKeys and apply x-ms-foundry-meta extensions to the draft property on CreateAgentVersionRequest, AgentVersionObject, and the include_drafts query param on listAgentVersions. The listAgentVersions operation also gains an optional Foundry-Features header.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
