### PR TITLE
Switch PAT to GitHub Apps

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -178,6 +178,9 @@ stages:
             Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
           displayName: "Validate and update SDK repository commitish"
 
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
+        - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
           Paths:
@@ -195,7 +198,7 @@ stages:
               WorkingDirectory: $(SdkRepoDirectory)
           SkipCheckoutNone: true
           ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
-            TokenToUseForAuth: $(azuresdk-github-pat)
+            TokenToUseForAuth: $(GH_TOKEN)
             PreserveAuthToken: true
 
       - task: UseNode@1
@@ -290,6 +293,8 @@ stages:
           CustomCondition: and(succeededOrFailed(), ne(variables['StagedArtifactsFolder'], ''))
 
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
         - pwsh: |
             $sdkPrBranchName = "$(PrBranch)-$(Build.BuildId)"
             $sdkRepoBranch = '${{ parameters.SdkRepoBranch }}'
@@ -348,7 +353,7 @@ stages:
               -BaseBranch "main"
               -PROwner "$(SdkRepoOwner)"
               -PRBranch "$(SdkPullRequestSourceBranch)"
-              -AuthToken "$(azuresdk-github-pat)"
+              -AuthToken "$(GH_TOKEN)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
               -OpenAsDraft $${{ not(endsWith(parameters.TriggerSource, '-release')) }}

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -179,7 +179,23 @@ stages:
           displayName: "Validate and update SDK repository commitish"
 
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
+        - checkout: self
+          displayName: 'Sparse checkout eng/common/scripts for GitHub login'
+          path: s/_login_scripts
+          sparseCheckoutDirectories: eng/common/scripts
+          fetchDepth: 1
+
+        - pwsh: |
+            $source = "$(Build.SourcesDirectory)/_login_scripts/eng"
+            $dest = "$(Agent.TempDirectory)"
+            Copy-Item -Recurse -Force $source $dest
+            Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/*" -ErrorAction SilentlyContinue
+            Remove-Item -Recurse -Force "$(Build.SourcesDirectory)/.git" -ErrorAction SilentlyContinue
+          displayName: Copy and clean repo checkout folder
+        
         - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+          parameters:
+            ScriptDirectory: "$(Agent.TempDirectory)/eng/common/scripts"
 
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -1,4 +1,5 @@
 parameters:
+  # Sample change used to exercise API documentation preview validation.
   "service-dir":
     default: "sdk/contosowidgetmanager"
   "dependencies":


### PR DESCRIPTION
This pull request updates the Azure Pipelines archetype spec-gen SDK YAML template to improve GitHub authentication handling and standardize the use of authentication tokens. The main changes involve switching from the `azuresdk-github-pat` variable to `GH_TOKEN` for GitHub authentication and ensuring the login step is explicitly included where needed.

Authentication improvements:

* Replaced all uses of the `azuresdk-github-pat` variable with `GH_TOKEN` for GitHub authentication in steps that require repository access or pull request creation. [[1]](diffhunk://#diff-adfcc31953a117e028add8b1de68500eafc81f7b8475a5a4822f818a701cfc73L198-R201) [[2]](diffhunk://#diff-adfcc31953a117e028add8b1de68500eafc81f7b8475a5a4822f818a701cfc73L351-R356)

Pipeline step updates:

* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template to relevant pipeline stages to ensure proper GitHub login when running in internal projects or when creating pull requests. [[1]](diffhunk://#diff-adfcc31953a117e028add8b1de68500eafc81f7b8475a5a4822f818a701cfc73R181-R183) [[2]](diffhunk://#diff-adfcc31953a117e028add8b1de68500eafc81f7b8475a5a4822f818a701cfc73R296-R297)