### PR TITLE
Require client-sdk linter ruleset when client emitter options are present

### DIFF
--- a/.github/shared/test/examples.js
+++ b/.github/shared/test/examples.js
@@ -19,6 +19,7 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"
+    - "@azure-tools/typespec-azure-rulesets/client-sdk"
 options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"

--- a/eng/tools/typespec-validation/src/rules/linter-ruleset.ts
+++ b/eng/tools/typespec-validation/src/rules/linter-ruleset.ts
@@ -13,6 +13,22 @@ const deprecatedRulesets = new Map<string, string>([
   ],
 ]);
 
+// Ruleset required when any client (language) emitter has options defined
+const clientSdkRuleset = "@azure-tools/typespec-azure-rulesets/client-sdk";
+
+// Known client (language) emitters. When any of these has options defined in tspconfig.yaml,
+// the client-sdk ruleset must be enabled. Excludes non-client emitters such as
+// "@azure-tools/typespec-autorest" (swagger) and "@azure-tools/typespec-client-generator-cli".
+const clientEmitters = [
+  "@azure-tools/typespec-csharp",
+  "@azure-typespec/http-client-csharp",
+  "@azure-typespec/http-client-csharp-mgmt",
+  "@azure-tools/typespec-python",
+  "@azure-tools/typespec-java",
+  "@azure-tools/typespec-ts",
+  "@azure-tools/typespec-go",
+];
+
 export class LinterRulesetRule implements Rule {
   readonly name = "LinterRuleset";
 
@@ -88,6 +104,28 @@ export class LinterRulesetRule implements Rule {
         "linter:\n" +
         "  extends:\n" +
         `    - "${requiredRuleset}"`;
+    }
+
+    // If any client (language) emitter has options defined, the client-sdk ruleset is required.
+    const emittersWithOptions = clientEmitters.filter(
+      (emitter) => config?.options?.[emitter] !== undefined,
+    );
+    if (emittersWithOptions.length > 0 && !linterExtends?.includes(clientSdkRuleset)) {
+      success = false;
+      if (errorOutput) {
+        errorOutput += "\n\n";
+      }
+      errorOutput +=
+        "tspconfig.yaml defines options for the following client emitter(s):\n" +
+        "\n" +
+        emittersWithOptions.map((emitter) => `    - "${emitter}"`).join("\n") +
+        "\n" +
+        "\n" +
+        "so it must define the following property:\n" +
+        "\n" +
+        "linter:\n" +
+        "  extends:\n" +
+        `    - "${clientSdkRuleset}"`;
     }
 
     return {

--- a/eng/tools/typespec-validation/test/linter-ruleset.test.ts
+++ b/eng/tools/typespec-validation/test/linter-ruleset.test.ts
@@ -129,4 +129,65 @@ linter:
 
     assert(!result.success);
   });
+
+  it("succeeds with client emitter options and client-sdk ruleset", async function () {
+    readTspConfigSpy.mockImplementation(() =>
+      Promise.resolve(`
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+    - "@azure-tools/typespec-azure-rulesets/client-sdk"
+options:
+  "@azure-tools/typespec-python":
+    package-dir: "azure-contoso-widgetmanager"
+`),
+    );
+    const result = await new LinterRulesetRule().execute("specification/foo/data-plane/Foo");
+    assert(result.success);
+  });
+
+  it("fails with client emitter options but missing client-sdk ruleset", async function () {
+    readTspConfigSpy.mockImplementation(() =>
+      Promise.resolve(`
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-csharp":
+    package-dir: "Azure.Template.Contoso"
+`),
+    );
+    const result = await new LinterRulesetRule().execute("specification/foo/data-plane/Foo");
+    assert(!result.success);
+  });
+
+  it("succeeds with no client emitter options (client-sdk not required)", async function () {
+    readTspConfigSpy.mockImplementation(() =>
+      Promise.resolve(`
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+`),
+    );
+    const result = await new LinterRulesetRule().execute("specification/foo/data-plane/Foo");
+    assert(result.success);
+  });
+
+  it("succeeds with only non-client emitter options (client-sdk not required)", async function () {
+    readTspConfigSpy.mockImplementation(() =>
+      Promise.resolve(`
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "data-plane"
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/foo/Foo.Shared/"
+`),
+    );
+    const result = await new LinterRulesetRule().execute("specification/foo/data-plane/Foo");
+    assert(result.success);
+  });
 });


### PR DESCRIPTION
## Summary

Extends the TypeSpec Validation (TSV) `LinterRuleset` rule so that when a `tspconfig.yaml` defines `options` for **any known client (language) emitter**, the `linter.extends` list must include the new `@azure-tools/typespec-azure-rulesets/client-sdk` ruleset.

> Note: the `client-sdk` ruleset package does not exist yet — this PR only prepares the enforcement logic. The rule checks for the ruleset string in `linter.extends`; whether `tsp compile` can resolve the ruleset is handled separately by the `Compile` rule.

## Details

- **`eng/tools/typespec-validation/src/rules/linter-ruleset.ts`** — added a `clientSdkRuleset` constant and a `clientEmitters` allowlist (`typespec-csharp`, `http-client-csharp`, `http-client-csharp-mgmt`, `typespec-python`, `typespec-java`, `typespec-ts`, `typespec-go`). If any listed emitter has `options` defined but `linter.extends` omits the `client-sdk` ruleset, the rule fails with a clear error naming the offending emitter(s). This is additive to the existing data-plane/resource-manager check.
- **`.github/shared/test/examples.js`** — added `client-sdk` to the shared `contosoTspConfig`'s `linter.extends` (it defines client emitter options, so it would otherwise fail the new rule).
- **`eng/tools/typespec-validation/test/linter-ruleset.test.ts`** — added tests: client options + ruleset (pass), client options missing ruleset (fail), no client options (not required), autorest/TCGC-cli-only options (not required).

The swagger emitter (`@azure-tools/typespec-autorest`) and `@azure-tools/typespec-client-generator-cli` are intentionally **not** in the allowlist.

## Impact

This is a hard failure: specs that define client emitter options but do not yet list the `client-sdk` ruleset will start failing TSV once this merges. A repo-wide follow-up to add the ruleset to existing tspconfig files may be needed.

## Validation

- `npm run build` ✓
- `npm run test:ci` (241 tests passed) ✓
- `npm run lint` / `npm run format:check` ✓
