### PR TITLE
[Network] Mitigate Java PolicySettings captcha property rename in client.tsp

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -5401,3 +5401,9 @@ op replaceprivateDnsZoneGroupsList(
   "GetDefaultSharedKey",
   "csharp"
 );
+
+@@clientName(
+  Microsoft.Network.PolicySettings.captchaExpirationInMins,
+  "captchaCookieExpirationInMins",
+  "java"
+);

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -5404,7 +5404,7 @@ op replaceprivateDnsZoneGroupsList(
 
 @@clientName(
   Microsoft.Network.PolicySettings.captchaCookieExpirationInMins,
-  "captchaCookieExpirationInMinsLegacy",
+  "captchaCookieExpirationInMinsRemoved",
   "java"
 );
 

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -5403,6 +5403,12 @@ op replaceprivateDnsZoneGroupsList(
 );
 
 @@clientName(
+  Microsoft.Network.PolicySettings.captchaCookieExpirationInMins,
+  "captchaCookieExpirationInMinsLegacy",
+  "java"
+);
+
+@@clientName(
   Microsoft.Network.PolicySettings.captchaExpirationInMins,
   "captchaCookieExpirationInMins",
   "java"


### PR DESCRIPTION
## Summary\n- add a Java @@clientName mapping in specification/network/resource-manager/Microsoft.Network/Network/client.tsp\n- map PolicySettings.captchaExpirationInMins back to captchaCookieExpirationInMins for Java\n\n## Why\nThis mitigates the Java breaking rename surfaced by Azure/azure-sdk-for-java#49665 while keeping the wire name in the 2025-07-01 spec.\n\n## Validation\n- confirmed change is scoped to client.tsp only