### PR TITLE
Remove Compute CSharp API version pinning

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -483,6 +483,26 @@ namespace ComputeCombine;
   "csharp"
 );
 @@clientName(
+  ComputeGallery.SharedGalleryInvites.gallerySharingAccept,
+  "AcceptGallerySharing",
+  "csharp"
+);
+@@clientName(
+  ComputeGallery.SharedGalleryInvites.gallerySharingReject,
+  "RejectGallerySharing",
+  "csharp"
+);
+@@clientName(
+  ComputeGallery.TenantLevelSharedGalleryInvites.tenantLevelGallerySharingAccept,
+  "AcceptTenantLevelGallerySharing",
+  "csharp"
+);
+@@clientName(
+  ComputeGallery.TenantLevelSharedGalleryInvites.tenantLevelGallerySharingReject,
+  "RejectTenantLevelGallerySharing",
+  "csharp"
+);
+@@clientName(
   ComputeGallery.Galleries.listByArtifactName,
   "GetSoftDeletedResourcesByArtifactName",
   "csharp"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -13,11 +13,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version:
-      Compute: "2025-11-01"
-      ComputeDisk: "2025-01-02"
-      ComputeGallery: "2025-03-03"
-      ComputeSku: "2021-07-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"


### PR DESCRIPTION
Removes the C#-specific API-version pinning that was used for the Azure.ResourceManager.Compute 1.15.0 migration/release.

This allows the next Compute SDK generation to use the latest TypeSpec service versions from the spec.