### PR TITLE
Add lifecycleHookState to VMSS VM instance view (2026-04-01)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-04-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceView_WithLifecycleHookState.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-04-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceView_WithLifecycleHookState.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "vmScaleSetName": "myVirtualMachineScaleSet",
+    "instanceId": "0",
+    "api-version": "2026-04-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "platformUpdateDomain": 0,
+        "platformFaultDomain": 0,
+        "rdpThumbPrint": null,
+        "vmAgent": {
+          "vmAgentVersion": "Unknown",
+          "statuses": [
+            {
+              "code": "ProvisioningState/Unavailable",
+              "level": "Warning",
+              "displayStatus": "Not Ready",
+              "message": "VM status blob is found but not yet populated.",
+              "time": "2026-04-01T05:00:32+00:00"
+            }
+          ],
+          "extensionHandlers": null
+        },
+        "disks": [
+          {
+            "name": "myOSDisk",
+            "encryptionSettings": null,
+            "statuses": [
+              {
+                "code": "ProvisioningState/succeeded",
+                "level": "Info",
+                "displayStatus": "Provisioning succeeded",
+                "message": null,
+                "time": "2026-04-01T04:58:58.0882815+00:00"
+              }
+            ]
+          }
+        ],
+        "extensions": null,
+        "bootDiagnostics": null,
+        "statuses": [
+          {
+            "code": "ProvisioningState/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": null,
+            "time": "2026-04-01T04:59:58.1852966+00:00"
+          },
+          {
+            "code": "PowerState/running",
+            "level": "Info",
+            "displayStatus": "VM running",
+            "message": null,
+            "time": null
+          }
+        ],
+        "lifecycleHookState": "VMScaleSetVMDeleteStarting:waiting"
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetVMs_GetInstanceView",
+  "title": "Get instance view of a virtual machine from a VM scale set with an active lifecycle hook."
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -5295,7 +5295,7 @@ model VirtualMachineScaleSetVMInstanceView {
   interconnectInstanceView?: InterconnectInstanceView;
 
   /**
-   * The lifecycle hook state of the virtual machine scale set VM, in the form "<lifecycleHookType>:<state>" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of "waiting" or "proceeding". For example, "VMScaleSetVMDeleteStarting:waiting". This is not settable by the customer. It is set only by the platform.
+   * The lifecycle hook state of the virtual machine scale set VM, in the form "<lifecycleHookType>:<state>" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of "waiting" or "proceeding". For example, "VMScaleSetVMDeleteStarting:waiting". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform.
    */
   @added(Versions.v2026_04_01)
   lifecycleHookState?: string;

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -5295,9 +5295,10 @@ model VirtualMachineScaleSetVMInstanceView {
   interconnectInstanceView?: InterconnectInstanceView;
 
   /**
-   * The lifecycle hook state of the virtual machine scale set VM, in the form "<lifecycleHookType>:<state>" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of "waiting" or "proceeding". For example, "VMScaleSetVMDeleteStarting:waiting". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform.
+   * The lifecycle hook state of the virtual machine scale set VM, in the form "<lifecycleHookType>:<state>" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of "waiting" or "proceeding". For example, "VMScaleSetVMDeleteStarting:waiting". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform. Minimum api-version: 2026-04-01.
    */
   @added(Versions.v2026_04_01)
+  @visibility(Lifecycle.Read)
   lifecycleHookState?: string;
 }
 

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -5293,6 +5293,12 @@ model VirtualMachineScaleSetVMInstanceView {
   @added(Versions.v2026_03_01)
   @visibility(Lifecycle.Read)
   interconnectInstanceView?: InterconnectInstanceView;
+
+  /**
+   * The lifecycle hook state of the virtual machine scale set VM, in the form "<lifecycleHookType>:<state>" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of "waiting" or "proceeding". For example, "VMScaleSetVMDeleteStarting:waiting". This is not settable by the customer. It is set only by the platform.
+   */
+  @added(Versions.v2026_04_01)
+  lifecycleHookState?: string;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
@@ -23575,7 +23575,8 @@
         },
         "lifecycleHookState": {
           "type": "string",
-          "description": "The lifecycle hook state of the virtual machine scale set VM, in the form \"<lifecycleHookType>:<state>\" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of \"waiting\" or \"proceeding\". For example, \"VMScaleSetVMDeleteStarting:waiting\". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform."
+          "description": "The lifecycle hook state of the virtual machine scale set VM, in the form \"<lifecycleHookType>:<state>\" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of \"waiting\" or \"proceeding\". For example, \"VMScaleSetVMDeleteStarting:waiting\". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform. Minimum api-version: 2026-04-01.",
+          "readOnly": true
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
@@ -9404,6 +9404,9 @@
         "x-ms-examples": {
           "Get instance view of a virtual machine from a VM scale set placed on a dedicated host group through automatic placement.": {
             "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewAutoPlacedOnDedicatedHostGroup.json"
+          },
+          "Get instance view of a virtual machine from a VM scale set with an active lifecycle hook.": {
+            "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceView_WithLifecycleHookState.json"
           }
         }
       }

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
@@ -23575,7 +23575,7 @@
         },
         "lifecycleHookState": {
           "type": "string",
-          "description": "The lifecycle hook state of the virtual machine scale set VM, in the form \"<lifecycleHookType>:<state>\" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of \"waiting\" or \"proceeding\". For example, \"VMScaleSetVMDeleteStarting:waiting\". This is not settable by the customer. It is set only by the platform."
+          "description": "The lifecycle hook state of the virtual machine scale set VM, in the form \"<lifecycleHookType>:<state>\" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of \"waiting\" or \"proceeding\". For example, \"VMScaleSetVMDeleteStarting:waiting\". This property is null or absent when there is no active lifecycle hook event for the virtual machine scale set VM. This is not settable by the customer. It is set only by the platform."
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
@@ -23569,6 +23569,10 @@
           "$ref": "#/definitions/InterconnectInstanceView",
           "description": "The Interconnect runtime view of the Scale Set VM instance. Minimum api-version: 2026-03-01.",
           "readOnly": true
+        },
+        "lifecycleHookState": {
+          "type": "string",
+          "description": "The lifecycle hook state of the virtual machine scale set VM, in the form \"<lifecycleHookType>:<state>\" where the type is the lifecycle hook type (e.g. VMScaleSetVMCreateStarting, VMScaleSetVMDeleteStarting) and the state is one of \"waiting\" or \"proceeding\". For example, \"VMScaleSetVMDeleteStarting:waiting\". This is not settable by the customer. It is set only by the platform."
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceView_WithLifecycleHookState.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceView_WithLifecycleHookState.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "vmScaleSetName": "myVirtualMachineScaleSet",
+    "instanceId": "0",
+    "api-version": "2026-04-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "platformUpdateDomain": 0,
+        "platformFaultDomain": 0,
+        "rdpThumbPrint": null,
+        "vmAgent": {
+          "vmAgentVersion": "Unknown",
+          "statuses": [
+            {
+              "code": "ProvisioningState/Unavailable",
+              "level": "Warning",
+              "displayStatus": "Not Ready",
+              "message": "VM status blob is found but not yet populated.",
+              "time": "2026-04-01T05:00:32+00:00"
+            }
+          ],
+          "extensionHandlers": null
+        },
+        "disks": [
+          {
+            "name": "myOSDisk",
+            "encryptionSettings": null,
+            "statuses": [
+              {
+                "code": "ProvisioningState/succeeded",
+                "level": "Info",
+                "displayStatus": "Provisioning succeeded",
+                "message": null,
+                "time": "2026-04-01T04:58:58.0882815+00:00"
+              }
+            ]
+          }
+        ],
+        "extensions": null,
+        "bootDiagnostics": null,
+        "statuses": [
+          {
+            "code": "ProvisioningState/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": null,
+            "time": "2026-04-01T04:59:58.1852966+00:00"
+          },
+          {
+            "code": "PowerState/running",
+            "level": "Info",
+            "displayStatus": "VM running",
+            "message": null,
+            "time": null
+          }
+        ],
+        "lifecycleHookState": "VMScaleSetVMDeleteStarting:waiting"
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetVMs_GetInstanceView",
+  "title": "Get instance view of a virtual machine from a VM scale set with an active lifecycle hook."
+}


### PR DESCRIPTION
Adds the lifecycleHookState property to the VMSS VM instance view, gated to api-version 2026-04-01.

- Surfaces the platform-set composite value in the form `<lifecycleHookType>:<state>` (e.g. `VMScaleSetVMDeleteStarting:waiting`) where state is `waiting` or `proceeding`. Read-only / not settable by the customer.