### PR TITLE
Fix SecurityCenter IoT list model casing for .NET

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/IoTSecurityAPI/back-compatible.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/IoTSecurityAPI/back-compatible.tsp
@@ -26,6 +26,11 @@ using Common;
   IoTSecuritySolutionAnalyticsModels.list,
   "IotSecuritySolutionAnalytics"
 );
+@@clientName(
+  IoTSecuritySolutionAnalyticsModelList,
+  "IotSecuritySolutionAnalyticsModelList",
+  "csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(IoTSecuritySolutionAnalyticsModel.properties);
 
@@ -41,6 +46,11 @@ using Common;
   IoTSecurityAggregatedAlerts.dismiss,
   "IotSecuritySolutionsAnalyticsAggregatedAlert"
 );
+@@clientName(
+  IoTSecurityAggregatedAlertList,
+  "IotSecurityAggregatedAlertList",
+  "csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(IoTSecurityAggregatedAlert.properties);
 
@@ -51,6 +61,11 @@ using Common;
 @@clientLocation(
   IoTSecurityAggregatedRecommendations.list,
   "IotSecuritySolutionsAnalyticsRecommendation"
+);
+@@clientName(
+  IoTSecurityAggregatedRecommendationList,
+  "IotSecurityAggregatedRecommendationList",
+  "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(IoTSecurityAggregatedRecommendation.properties);
@@ -78,5 +93,6 @@ using Common;
   IoTSecuritySolutionModels.listBySubscription,
   "IotSecuritySolution"
 );
+@@clientName(IoTSecuritySolutionsList, "IotSecuritySolutionsList", "csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(IoTSecuritySolutionModel.properties);

--- a/specification/security/resource-manager/Microsoft.Security/Security/IoTSecurityAPI/back-compatible.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/IoTSecurityAPI/back-compatible.tsp
@@ -26,11 +26,6 @@ using Common;
   IoTSecuritySolutionAnalyticsModels.list,
   "IotSecuritySolutionAnalytics"
 );
-@@clientName(
-  IoTSecuritySolutionAnalyticsModelList,
-  "IotSecuritySolutionAnalyticsModelList",
-  "csharp"
-);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(IoTSecuritySolutionAnalyticsModel.properties);
 


### PR DESCRIPTION
## Summary
- Add C#-scoped client-name customizations for SecurityCenter IoT list models.
- Normalize generated .NET list model names to `IotSecurity*List` to avoid case-only duplicate APIs during MPG migration.

## Validation
- Regenerated Azure.ResourceManager.SecurityCenter locally with `RegenSdkLocal.ps1`.
- Built Azure.ResourceManager.SecurityCenter successfully.
- Exported API listings successfully.
