### PR TITLE
Enable Traffic Manager provisioning emitter

### DIFF
--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
@@ -15,6 +15,10 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.TrafficManager"
     api-version: "2022-04-01"
+  "@azure-typespec/http-client-csharp-provisioning":
+    emitter-output-dir: "{output-dir}/{service-dir}/Azure.Provisioning.TrafficManager"
+    namespace: "Azure.Provisioning.TrafficManager"
+    api-version: "2022-04-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-trafficmanager"
     namespace: "azure.mgmt.trafficmanager"


### PR DESCRIPTION
Enables the C# provisioning emitter for Traffic Manager so Azure.Provisioning.TrafficManager can be generated.\n\nSDK PR: pending