### PR TITLE
Rename Monitor performance counters Otel property

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
@@ -628,6 +628,11 @@ namespace Microsoft.InsightsCombinedClient;
   "csharp"
 );
 @@clientName(
+  DataCollectionApi.DataSourcesSpec.performanceCountersOTel,
+  "PerformanceCountersOtel",
+  "csharp"
+);
+@@clientName(
   DataCollectionApi.DataFlow.captureOverflow,
   "ShouldCaptureOverflow",
   "csharp"


### PR DESCRIPTION
Fixes the C# API naming review feedback from Azure/azure-sdk-for-net#59738 by renaming the generated Monitor `performanceCountersOTel` property to `PerformanceCountersOtel` via `@@clientName`.

Companion SDK PR will update `tsp-location.yaml` and regenerate `Azure.ResourceManager.Monitor`.