### PR TITLE
Enable Compute provisioning emitter

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -73,8 +73,6 @@ namespace ComputeCombine;
 // ── C# type renames for backward compatibility (migration from AutoRest) ──
 
 // C# naming fixes for Azure.ResourceManager.Compute 1.15.0 stable API review.
-@@clientName(ComputeGallery.Gallery, "ComputeGallery", "csharp");
-@@clientName(ComputeDisk.Snapshot, "ComputeSnapshot", "csharp");
 @@clientName(ConfidentialVMVersion, "ConfidentialVmVersion", "csharp");
 @@clientName(
   DiskSecurityProfile.confidentialVMVersion,

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -73,6 +73,8 @@ namespace ComputeCombine;
 // ── C# type renames for backward compatibility (migration from AutoRest) ──
 
 // C# naming fixes for Azure.ResourceManager.Compute 1.15.0 stable API review.
+@@clientName(ComputeGallery.Gallery, "ComputeGallery", "csharp");
+@@clientName(ComputeDisk.Snapshot, "ComputeSnapshot", "csharp");
 @@clientName(ConfidentialVMVersion, "ConfidentialVmVersion", "csharp");
 @@clientName(
   DiskSecurityProfile.confidentialVMVersion,

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -16,7 +16,11 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2026-03-01"
+    api-version:
+      Compute: "2026-03-01"
+      ComputeDisk: "2026-03-02"
+      ComputeGallery: "2025-12-03"
+      ComputeSku: "2021-07-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -16,11 +16,7 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version:
-      Compute: "2026-03-01"
-      ComputeDisk: "2026-03-02"
-      ComputeGallery: "2025-12-03"
-      ComputeSku: "2021-07-01"
+    api-version: "2026-03-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -13,6 +13,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Compute"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-11-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -16,7 +16,11 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2025-11-01"
+    api-version:
+      Compute: "2026-03-01"
+      ComputeDisk: "2026-03-02"
+      ComputeGallery: "2025-12-03"
+      ComputeSku: "2021-07-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -16,11 +16,6 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version:
-      Compute: "2026-03-01"
-      ComputeDisk: "2026-03-02"
-      ComputeGallery: "2025-12-03"
-      ComputeSku: "2021-07-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"


### PR DESCRIPTION
Enable the C# TypeSpec provisioning emitter for Compute so Azure.Provisioning.Compute can migrate from reflection-based generation.