### PR TITLE
Fix Java service-name casing to Compute BulkActions

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
     service-dir: "sdk/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-compute-bulkactions"
     namespace: "com.azure.resourcemanager.compute.bulkactions"
-    service-name: "Compute Bulkactions"
+    service-name: "Compute BulkActions"
     flavor: azure
   "@azure-tools/typespec-ts":
     service-dir: "sdk/compute"


### PR DESCRIPTION
Corrects the Java emitter `service-name` from `Compute Bulkactions` to `Compute BulkActions` in the Microsoft.Compute/Bulkactions tspconfig, aligning with the C# namespace `Azure.ResourceManager.Compute.BulkActions` and producing the correct human-readable title in the generated Java SDK CHANGELOG/README.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>