### PR TITLE
Add DataFactory provisioning emitter config

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/tspconfig.yaml
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/tspconfig.yaml
@@ -11,6 +11,10 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.DataFactory"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.DataFactory"
+    api-version: "2018-06-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-datafactory"
     namespace: "azure.mgmt.datafactory"


### PR DESCRIPTION
Adds the C# provisioning emitter configuration for DataFactory so Azure.Provisioning.DataFactory can migrate to the TypeSpec provisioning generator.