### PR TITLE
Fix for java agents tspconfig.yaml file

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
@@ -25,24 +25,19 @@ options:
     flavor: azure
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
-      - "specification/ai-foundry/data-plane/Foundry/src/.external-readonly/"
-      - "specification/ai-foundry/data-plane/Foundry/src/agents/"
-      - "specification/ai-foundry/data-plane/Foundry/src/common/"
-      - "specification/ai-foundry/data-plane/Foundry/src/connections/"
-      - "specification/ai-foundry/data-plane/Foundry/src/datasets/"
-      - "specification/ai-foundry/data-plane/Foundry/src/indexes/"
-      - "specification/ai-foundry/data-plane/Foundry/src/deployments/"
-      - "specification/ai-foundry/data-plane/Foundry/src/red-teams/"
-      - "specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/"
-      - "specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/"
-      - "specification/ai-foundry/data-plane/Foundry/src/evaluation-taxonomies/"
-      - "specification/ai-foundry/data-plane/Foundry/src/evaluators/"
-      - "specification/ai-foundry/data-plane/Foundry/src/insights/"
-      - "specification/ai-foundry/data-plane/Foundry/src/schedules/"
-      - "specification/ai-foundry/data-plane/Foundry/src/memory-stores/"
-      - "specification/ai-foundry/data-plane/Foundry/src/conversations/"
-      - "specification/ai-foundry/data-plane/Foundry/src/responses/"
-      - "specification/ai-foundry/data-plane/Foundry/src/tools/"
+      - "specification/ai-foundry/data-plane/Foundry/src/agents"
+      - "specification/ai-foundry/data-plane/Foundry/src/agents-session-files"
+      - "specification/ai-foundry/data-plane/Foundry/src/agents-optimization"
+      - "specification/ai-foundry/data-plane/Foundry/src/common"
+      - "specification/ai-foundry/data-plane/Foundry/src/memory-stores"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-conversations"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-responses"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-evaluations"
+      - "specification/ai-foundry/data-plane/Foundry/src/red-teams"
+      - "specification/ai-foundry/data-plane/Foundry/src/sdk-common"
+      - "specification/ai-foundry/data-plane/Foundry/src/skills"
+      - "specification/ai-foundry/data-plane/Foundry/src/toolboxes"
+      - "specification/ai-foundry/data-plane/Foundry/src/tools"
   # Exports the @extension("x-ms-foundry-meta", ...) beta entities for the Java emitter consumption
   # - run `tsp-client sync` from package folder
   # - run `cd TempTypeSpecFiles && npm install --no-save typespec-extension-exporter`

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
@@ -4,7 +4,7 @@ parameters:
 options:
   "@azure-tools/typespec-java":
     api-version: "v1"
-    package-dir: "azure-ai-agents"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-ai-agents"
     namespace: "com.azure.ai.agents"
     service-name: "Agents"
     partial-update: true

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
@@ -16,6 +16,31 @@ options:
     rename-model:
       FilesFileDetails: SkillFileDetails
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/ai-foundry/data-plane/Foundry/src/sdk-common"
+      - "specification/ai-foundry/data-plane/Foundry/src/agents-session-files"
+      - "specification/ai-foundry/data-plane/Foundry/src/common"
+      - "specification/ai-foundry/data-plane/Foundry/src/connections"
+      - "specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs"
+      - "specification/ai-foundry/data-plane/Foundry/src/datasets"
+      - "specification/ai-foundry/data-plane/Foundry/src/deployments"
+      - "specification/ai-foundry/data-plane/Foundry/src/evaluation-rules"
+      - "specification/ai-foundry/data-plane/Foundry/src/evaluation-taxonomies"
+      - "specification/ai-foundry/data-plane/Foundry/src/evaluators"
+      - "specification/ai-foundry/data-plane/Foundry/src/indexes"
+      - "specification/ai-foundry/data-plane/Foundry/src/insights"
+      - "specification/ai-foundry/data-plane/Foundry/src/memory-stores"
+      - "specification/ai-foundry/data-plane/Foundry/src/models"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-conversations"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-evaluations"
+      - "specification/ai-foundry/data-plane/Foundry/src/openai-responses"
+      - "specification/ai-foundry/data-plane/Foundry/src/red-teams"
+      - "specification/ai-foundry/data-plane/Foundry/src/routines"
+      - "specification/ai-foundry/data-plane/Foundry/src/schedules"
+      - "specification/ai-foundry/data-plane/Foundry/src/skills"
+      - "specification/ai-foundry/data-plane/Foundry/src/toolboxes"
+      - "specification/ai-foundry/data-plane/Foundry/src/tools"
   # Exports the @extension("x-ms-foundry-meta", ...) beta entities for the Java emitter consumption
   # - run `tsp-client sync` from package folder
   # - run `cd TempTypeSpecFiles && npm install --no-save typespec-extension-exporter`


### PR DESCRIPTION
This pull request updates the Java SDK TypeSpec configuration to improve the organization of emitter output files.

Configuration update:

* Changed the output directory for the Java emitter by replacing the `package-dir` option with `emitter-output-dir` in `tspconfig.yaml`, ensuring generated files are placed in a structured path using `{output-dir}/{service-dir}/azure-ai-agents`.