### PR TITLE
Update parameter wiring

### DIFF
--- a/eng/pipelines/templates/steps/set-sha-check.yml
+++ b/eng/pipelines/templates/steps/set-sha-check.yml
@@ -64,4 +64,4 @@ steps:
     displayName: ${{ parameters.DisplayName }}
     condition: ${{ parameters.Condition }}
     env:
-      GH_TOKEN: $(GH_TOKEN)
+      GH_TOKEN: ${{ coalesce(parameters.GitHubToken, '$(GH_TOKEN)') }}


### PR DESCRIPTION
This pull request makes a small update to the `set-sha-check.yml` pipeline template to improve how the GitHub token is set in the step environment. Now, the pipeline will use a provided `GitHubToken` parameter if available, and fall back to the default `GH_TOKEN` variable if not.

* Improved token selection logic in the `env` block of `set-sha-check.yml` to use the `GitHubToken` parameter if provided, otherwise defaulting to `GH_TOKEN`.