### PR TITLE
[HorizonDB] Change private endpoint connection update from PATCH to PUT

### DIFF
--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/client.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/client.tsp
@@ -9,11 +9,6 @@ using Azure.ClientGenerator.Core;
   "HorizonDBPrivateEndpointConnection",
   "csharp"
 );
-@@clientName(
-  Azure.ResourceManager.PrivateEndpointConnectionUpdate,
-  "HorizonDBPrivateEndpointConnectionPatch",
-  "csharp"
-);
 @@clientName(Microsoft.HorizonDb, "HorizonDBMgmtClient", "csharp");
 @@clientName(
   Microsoft.HorizonDb.CreateModeCluster,
@@ -187,11 +182,6 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   Azure.ResourceManager.PrivateEndpointConnectionProperties,
   "HorizonDBPrivateEndpointConnectionProperties",
-  "csharp"
-);
-@@clientName(
-  Azure.ResourceManager.PrivateEndpointConnectionUpdate.properties,
-  "HorizonDBPrivateEndpointConnectionPatchProperties",
   "csharp"
 );
 @@clientName(

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/examples/2026-01-20-preview/PrivateEndpointConnections_Update.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/examples/2026-01-20-preview/PrivateEndpointConnections_Update.json
@@ -7,7 +7,7 @@
     "clusterName": "examplecluster",
     "privateEndpointConnectionName": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
     "api-version": "2026-01-20-preview",
-    "properties": {
+    "resource": {
       "properties": {
         "privateLinkServiceConnectionState": {
           "description": "Approved by johndoe@contoso.com",
@@ -17,25 +17,9 @@
     }
   },
   "responses": {
-    "200": {
-      "body": {
-        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.HorizonDb/clusters/examplecluster/privateEndpointConnections/exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
-        "name": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
-        "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections",
-        "properties": {
-          "privateEndpoint": {
-            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.Network/privateEndpoints/examplePrivateEndpoint"
-          },
-          "privateLinkServiceConnectionState": {
-            "status": "Approved",
-            "description": "Approved by johndoe@contoso.com"
-          },
-          "provisioningState": "Succeeded"
-        }
-      }
-    },
     "202": {
       "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?api-version=2026-01-20-preview",
         "Location": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/operationResults/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb?api-version=2026-01-20-preview"
       }
     }

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/examples/2026-01-20-preview/PrivateEndpointConnections_Update.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/examples/2026-01-20-preview/PrivateEndpointConnections_Update.json
@@ -17,10 +17,21 @@
     }
   },
   "responses": {
-    "202": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?api-version=2026-01-20-preview",
-        "Location": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/operationResults/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb?api-version=2026-01-20-preview"
+    "200": {
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.HorizonDb/clusters/examplecluster/privateEndpointConnections/exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "name": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.Network/privateEndpoints/examplePrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": "Approved by johndoe@contoso.com"
+          },
+          "provisioningState": "Succeeded"
+        }
       }
     }
   }

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/examples/PrivateEndpointConnections_Update.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/examples/PrivateEndpointConnections_Update.json
@@ -7,7 +7,7 @@
     "clusterName": "examplecluster",
     "privateEndpointConnectionName": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
     "api-version": "2026-01-20-preview",
-    "properties": {
+    "resource": {
       "properties": {
         "privateLinkServiceConnectionState": {
           "description": "Approved by johndoe@contoso.com",
@@ -17,25 +17,9 @@
     }
   },
   "responses": {
-    "200": {
-      "body": {
-        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.HorizonDb/clusters/examplecluster/privateEndpointConnections/exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
-        "name": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
-        "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections",
-        "properties": {
-          "privateEndpoint": {
-            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.Network/privateEndpoints/examplePrivateEndpoint"
-          },
-          "privateLinkServiceConnectionState": {
-            "status": "Approved",
-            "description": "Approved by johndoe@contoso.com"
-          },
-          "provisioningState": "Succeeded"
-        }
-      }
-    },
     "202": {
       "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?api-version=2026-01-20-preview",
         "Location": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/operationResults/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb?api-version=2026-01-20-preview"
       }
     }

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/examples/PrivateEndpointConnections_Update.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/examples/PrivateEndpointConnections_Update.json
@@ -17,10 +17,21 @@
     }
   },
   "responses": {
-    "202": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?api-version=2026-01-20-preview",
-        "Location": "https://management.azure.com/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.HorizonDb/locations/westus2/operationResults/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb?api-version=2026-01-20-preview"
+    "200": {
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.HorizonDb/clusters/examplecluster/privateEndpointConnections/exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "name": "exampleprivateendpointconnection.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/exampleresourcegroup/providers/Microsoft.Network/privateEndpoints/examplePrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": "Approved by johndoe@contoso.com"
+          },
+          "provisioningState": "Succeeded"
+        }
       }
     }
   }

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/openapi.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/openapi.json
@@ -1471,17 +1471,21 @@
           }
         ],
         "responses": {
-          "202": {
-            "description": "Resource operation accepted.",
+          "200": {
+            "description": "Resource 'PrivateEndpointConnectionResource' update operation succeeded",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnectionResource' create operation succeeded",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            },
             "headers": {
               "Azure-AsyncOperation": {
                 "type": "string",
-                "format": "uri",
                 "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
               },
               "Retry-After": {
                 "type": "integer",

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/openapi.json
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/preview/2026-01-20-preview/openapi.json
@@ -1431,12 +1431,12 @@
           }
         }
       },
-      "patch": {
+      "put": {
         "operationId": "HorizonDbPrivateEndpointConnections_Update",
         "tags": [
           "HorizonDbPrivateEndpointConnections"
         ],
-        "description": "Updates a private endpoint connection.",
+        "description": "Approves or rejects a private endpoint connection.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -1461,25 +1461,24 @@
             "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
           },
           {
-            "name": "properties",
+            "name": "resource",
             "in": "body",
-            "description": "The resource properties to be updated.",
+            "description": "Resource create parameters.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Azure.ResourceManager.PrivateEndpointConnectionUpdate"
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
             }
           }
         ],
         "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
-            }
-          },
           "202": {
-            "description": "Resource update request accepted.",
+            "description": "Resource operation accepted.",
             "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
               "Location": {
                 "type": "string",
                 "description": "The Location header contains the URL where the status of the long running operation can be checked."
@@ -1504,7 +1503,7 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
+          "final-state-via": "azure-async-operation",
           "final-state-schema": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
         },
         "x-ms-long-running-operation": true
@@ -2119,26 +2118,6 @@
     "Azure.Core.azureLocation": {
       "type": "string",
       "description": "Represents an Azure geography region where supported resource providers live."
-    },
-    "Azure.ResourceManager.PrivateEndpointConnectionUpdate": {
-      "type": "object",
-      "description": "PATCH model for private endpoint connections",
-      "properties": {
-        "properties": {
-          "type": "object",
-          "description": "The private endpoint connection properties",
-          "properties": {
-            "privateEndpoint": {
-              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpoint",
-              "description": "The private endpoint resource."
-            },
-            "privateLinkServiceConnectionState": {
-              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateLinkServiceConnectionState",
-              "description": "A collection of information about the state of the connection between service consumer and provider."
-            }
-          }
-        }
-      }
     },
     "CreateModeCluster": {
       "type": "string",

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/routes.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/routes.tsp
@@ -116,15 +116,9 @@ interface HorizonDbPrivateEndpointConnections {
   >;
 
   @doc("Approves or rejects a private endpoint connection.")
-  @Azure.Core.useFinalStateVia("azure-async-operation")
   update is HorizonDbPrivateEndpointOperations.CreateOrReplaceAsync<
     HorizonDbCluster,
-    PrivateEndpointConnectionResource,
-    Response = ArmAcceptedLroResponse<
-      "Resource operation accepted.",
-      ArmCombinedLroHeaders<FinalResult = PrivateEndpointConnectionResource> &
-        Azure.Core.Foundations.RetryAfterHeader
-    >
+    PrivateEndpointConnectionResource
   >;
 
   @doc("Deletes a private endpoint connection.")

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/routes.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/routes.tsp
@@ -115,10 +115,16 @@ interface HorizonDbPrivateEndpointConnections {
     PrivateEndpointConnectionResource
   >;
 
-  @doc("Updates a private endpoint connection.")
-  update is HorizonDbPrivateEndpointOperations.CustomPatchAsync<
+  @doc("Approves or rejects a private endpoint connection.")
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  update is HorizonDbPrivateEndpointOperations.CreateOrReplaceAsync<
     HorizonDbCluster,
-    PrivateEndpointConnectionResource
+    PrivateEndpointConnectionResource,
+    Response = ArmAcceptedLroResponse<
+      "Resource operation accepted.",
+      ArmCombinedLroHeaders<FinalResult = PrivateEndpointConnectionResource> &
+        Azure.Core.Foundations.RetryAfterHeader
+    >
   >;
 
   @doc("Deletes a private endpoint connection.")


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider.
  - [ ] Update existing version for a new feature.
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing OpenAPI spec to TypeSpec spec.
  - [x] Other, please clarify: Fix the HorizonDB private endpoint connection `update` operation to use **PUT** instead of **PATCH** (approve/reject), in the existing preview API version `2026-01-20-preview`. Discovered via the `azure-mgmt-horizondb` SDK.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [ ] I have reviewed the [Resource Provider guidelines](https://aka.ms/rpguidelines) (ARM RPC + REST guidelines). _(owner to confirm)_
- [ ] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. _(owner to confirm)_

## Description

The HorizonDB private endpoint connection (PEC) `update` operation was generated as **PATCH**, but it must be **PUT** — the HorizonDB backend PEC controller and the Azure CLI extension use `PUT` for approve/reject. Left as PATCH, SDK regeneration keeps reverting downstream consumers.

Addresses #44392. Follow-up to #44288 (which fixed the missing cluster name in the PEC route) and Azure/azure-sdk-for-python#47688. Updates the existing **preview** version `2026-01-20-preview` in place.

### Change

- `put` on the same cluster-scoped path; operationId unchanged: `HorizonDbPrivateEndpointConnections_Update`
- request body = full `PrivateEndpointConnection` (ARM common-types)
- canonical ARM async responses: **200 + 201** (both `PrivateEndpointConnection`) + `default`
- `x-ms-long-running-operation-options`: `final-state-via: azure-async-operation`, `final-state-schema: PrivateEndpointConnection`
- route stays cluster-scoped (unchanged)

TypeSpec: `CustomPatchAsync` → `CreateOrReplaceAsync` (`routes.tsp`). The now-unused `PrivateEndpointConnectionUpdate` ("Patch") C# client names are removed (`client.tsp`), and the example is updated to the 200 response shape.

> Note on shape: PostgreSQL Flexible Server models this as a 202-only PUT, but that shape trips ARM LintDiff (`PutResponseCodes`, `ProvisioningStateSpecifiedForLROPut`, `PutGetPatchResponseSchema`) for a new change; the canonical 200+201 async PUT is used instead (same verb, route, operationId, and result type).

### Validation

- `tsp compile` passes; `azsdk_run_typespec_validation` succeeds; local LintDiff reports **0 errors** (only the expected `PutInOperationName` warning).
- `Swagger BreakingChange` is expected and requires the breaking-change + versioning review to sign off — same path as #44288 (`PublishToCustomers`, `BreakingChange-Approved-BugFix`, `Versioning-Approved-BugFix`, `ARMSignedOff`).

### Downstream

After merge: regenerate `azure-mgmt-horizondb` and re-vendor into the Azure CLI extension, which currently hand-patches the vendored SDK to force `method="PUT"`.

## Additional information

<details>
<summary>Suppressing failures</summary>

No validation suppressions are used in this PR.

</details>
