### PR TITLE
[feat] Agents version AB experimentation

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -29,5 +29,6 @@ import "./src/skills/routes.tsp";
 import "./src/toolboxes/routes.tsp";
 import "./src/data_generation_jobs/routes.tsp";
 import "./src/agents-optimization/routes.tsp";
+import "./src/experiments/routes.tsp";
 import "./tag-definitions.tsp";
 import "./src/common/error.range.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6933,7 +6933,7 @@
       "post": {
         "operationId": "Experiments_create",
         "summary": "Create an experiment",
-        "description": "Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.",
+        "description": "Creates an experiment in the 'created' state. Call the :start action to begin routing traffic.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7207,6 +7207,69 @@
             }
           },
           "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:start": {
+      "post": {
+        "operationId": "Experiments_start",
+        "summary": "Start an experiment",
+        "description": "Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to start.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The experiment was started successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "default": {
             "description": "Server error",
             "content": {
               "application/json": {
@@ -25387,6 +25450,7 @@
           {
             "type": "string",
             "enum": [
+              "created",
               "running",
               "stopped",
               "promoted"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6929,6 +6929,614 @@
         }
       }
     },
+    "/experiments": {
+      "post": {
+        "operationId": "Experiments_create",
+        "summary": "Create an experiment",
+        "description": "Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The experiment was created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExperimentRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Experiments_list",
+        "summary": "List experiments",
+        "description": "Returns the list of all experiments.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Experiment"
+                      },
+                      "description": "The requested list of experiments."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of experiments."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}": {
+      "get": {
+        "operationId": "Experiments_get",
+        "summary": "Get an experiment",
+        "description": "Retrieves the experiment by id.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:stop": {
+      "post": {
+        "operationId": "Experiments_stop",
+        "summary": "Stop an experiment",
+        "description": "Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to stop.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The experiment was stopped successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:promote": {
+      "post": {
+        "operationId": "Experiments_promote",
+        "summary": "Promote an experiment",
+        "description": "Promotes the winning variant. The agent's version selector is replaced with a single 100% rule for the winner.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to promote.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The experiment was promoted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteExperimentRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}/scorecards": {
+      "get": {
+        "operationId": "Experiments_listScorecards",
+        "summary": "List scorecards",
+        "description": "Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Scorecard"
+                      },
+                      "description": "The list of scorecards."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}/scorecards/{scorecard_id}": {
+      "delete": {
+        "operationId": "Experiments_deleteScorecard",
+        "summary": "Delete a scorecard",
+        "description": "Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scorecard_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the scorecard to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The scorecard was deleted successfully."
+          },
+          "default": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
     "/indexes": {
       "get": {
         "operationId": "Indexes_listLatest",
@@ -24517,6 +25125,537 @@
             "Evaluations=V1Preview"
           ]
         }
+      },
+      "Experiment": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "state",
+          "display_name",
+          "variants",
+          "experiment_steps",
+          "assignment_properties",
+          "metrics"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the experiment.",
+            "readOnly": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/ExperimentType"
+          },
+          "state": {
+            "$ref": "#/components/schemas/ExperimentState"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "A human-readable display name for the experiment."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the experiment."
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent this experiment targets. Required for agents_safe_rollout type."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The list of variants participating in the experiment."
+          },
+          "experiment_steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentStep"
+            },
+            "description": "The list of experiment steps with traffic allocation details. Materialized by the service.",
+            "readOnly": true
+          },
+          "assignment_properties": {
+            "$ref": "#/components/schemas/ExperimentAssignmentProperties"
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "The list of metrics (evaluation rules or inline evaluators) attached to the experiment."
+          },
+          "scheduled_start_at": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The scheduled start time for the experiment (Unix timestamp). Null if started immediately."
+          },
+          "scheduled_end_at": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The scheduled end time for the experiment (Unix timestamp). Null if no end is scheduled."
+          }
+        },
+        "description": "Represents an experiment that binds version routing to a lifecycle for A/B testing."
+      },
+      "ExperimentAssignmentProperties": {
+        "type": "object",
+        "required": [
+          "salt",
+          "assignment_unit"
+        ],
+        "properties": {
+          "salt": {
+            "type": "string",
+            "description": "An immutable bucketing seed minted when the experiment starts. Re-salting re-randomizes every bucket.",
+            "readOnly": true
+          },
+          "assignment_unit": {
+            "type": "string",
+            "description": "The unit used for sticky bucketing (e.g. conversationId).",
+            "readOnly": true
+          }
+        },
+        "description": "Properties controlling how traffic is assigned to variants."
+      },
+      "ExperimentBucketRange": {
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The inclusive start of the bucket range (0-based)."
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The exclusive end of the bucket range."
+          }
+        },
+        "description": "A contiguous range of hash buckets assigned to a variant."
+      },
+      "ExperimentMetric": {
+        "type": "object",
+        "required": [
+          "id",
+          "direction",
+          "aggregation",
+          "source"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The metric identifier, unique within the experiment."
+          },
+          "direction": {
+            "$ref": "#/components/schemas/ExperimentMetricDirection"
+          },
+          "aggregation": {
+            "$ref": "#/components/schemas/ExperimentMetricAggregation"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ExperimentMetricSource"
+          },
+          "guardrail": {
+            "$ref": "#/components/schemas/ExperimentMetricGuardrail"
+          }
+        },
+        "description": "A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails."
+      },
+      "ExperimentMetricDirection": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "increase",
+              "decrease"
+            ]
+          }
+        ],
+        "description": "The desired direction for a metric value."
+      },
+      "ExperimentMetricAggregationType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "average",
+              "percentile",
+              "rate"
+            ]
+          }
+        ],
+        "description": "The aggregation function for a metric."
+      },
+      "ExperimentMetricAggregation": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ExperimentMetricAggregationType"
+          },
+          "percentile": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The percentile value (e.g. 95). Required when type is 'percentile'."
+          }
+        },
+        "description": "Aggregation configuration for a metric."
+      },
+      "ExperimentMetricSourceType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "continuous_evaluation_rule",
+              "evaluator",
+              "trace_metric"
+            ]
+          }
+        ],
+        "description": "The type of metric source."
+      },
+      "ExperimentMetricSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ExperimentMetricSourceType"
+          },
+          "rule_id": {
+            "type": "string",
+            "description": "The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'."
+          },
+          "evaluator_name": {
+            "type": "string",
+            "description": "The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'."
+          },
+          "name": {
+            "type": "string",
+            "description": "The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'."
+          }
+        },
+        "description": "The source of a metric value, discriminated by type."
+      },
+      "ExperimentMetricGuardrail": {
+        "type": "object",
+        "properties": {
+          "max_delta_percent": {
+            "type": "number",
+            "format": "double",
+            "description": "Maximum allowed relative delta as a percentage."
+          },
+          "max_absolute": {
+            "type": "number",
+            "format": "double",
+            "description": "Maximum allowed absolute value."
+          },
+          "state": {
+            "type": "string",
+            "description": "The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.",
+            "readOnly": true
+          }
+        },
+        "description": "Guardrail threshold for a metric."
+      },
+      "ExperimentState": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "running",
+              "stopped",
+              "promoted"
+            ]
+          }
+        ],
+        "description": "The lifecycle state of the experiment."
+      },
+      "ExperimentStep": {
+        "type": "object",
+        "required": [
+          "id",
+          "variant_traffic_maps"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this experiment step."
+          },
+          "started_at": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The Unix timestamp (seconds) when this step started."
+          },
+          "stopped_at": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The Unix timestamp (seconds) when this step stopped. Null if still running."
+          },
+          "variant_traffic_maps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariantTrafficMap"
+            },
+            "description": "The traffic allocation for each variant in this step."
+          }
+        },
+        "description": "A step in the experiment with traffic allocation details."
+      },
+      "ExperimentType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ]
+          }
+        ],
+        "description": "The discriminated experiment kind."
+      },
+      "ExperimentVariant": {
+        "type": "object",
+        "required": [
+          "id",
+          "role"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The variant identifier. For agents_safe_rollout this is the agent version number."
+          },
+          "role": {
+            "$ref": "#/components/schemas/ExperimentVariantRole"
+          },
+          "traffic_percentage": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses."
+          }
+        },
+        "description": "A variant participating in the experiment."
+      },
+      "ExperimentVariantRole": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "control",
+              "treatment"
+            ]
+          }
+        ],
+        "description": "The role of a variant in the experiment."
+      },
+      "ExperimentVariantTrafficMap": {
+        "type": "object",
+        "required": [
+          "variant_id",
+          "percentage",
+          "bucket_ranges"
+        ],
+        "properties": {
+          "variant_id": {
+            "type": "string",
+            "description": "The variant identifier this traffic map applies to."
+          },
+          "percentage": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The traffic percentage for this variant."
+          },
+          "bucket_ranges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentBucketRange"
+            },
+            "description": "The hash bucket ranges assigned to this variant."
+          }
+        },
+        "description": "Traffic allocation map for a single variant within an experiment step."
+      },
+      "CreateExperimentRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "display_name",
+          "variants"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ExperimentType"
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent this experiment targets. Required for agents_safe_rollout type."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "A human-readable display name for the experiment."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the experiment."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment."
+          }
+        },
+        "description": "Request body for creating an experiment."
+      },
+      "PromoteExperimentRequest": {
+        "type": "object",
+        "required": [
+          "winner_variant_id"
+        ],
+        "properties": {
+          "winner_variant_id": {
+            "type": "string",
+            "description": "The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version."
+          }
+        },
+        "description": "Request body for promoting an experiment."
+      },
+      "ScorecardState": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ready",
+              "computing",
+              "failed"
+            ]
+          }
+        ],
+        "description": "The state of a scorecard."
+      },
+      "ScorecardRow": {
+        "type": "object",
+        "required": [
+          "metric_id",
+          "label",
+          "control_value",
+          "treatment_value",
+          "delta",
+          "p_value"
+        ],
+        "properties": {
+          "metric_id": {
+            "type": "string",
+            "description": "The metric identifier this row corresponds to."
+          },
+          "label": {
+            "type": "string",
+            "description": "A human-readable label for the metric."
+          },
+          "control_value": {
+            "type": "number",
+            "format": "double",
+            "description": "The metric value for the control variant."
+          },
+          "treatment_value": {
+            "type": "number",
+            "format": "double",
+            "description": "The metric value for the treatment variant."
+          },
+          "delta": {
+            "type": "number",
+            "format": "double",
+            "description": "The absolute delta between treatment and control."
+          },
+          "p_value": {
+            "type": "number",
+            "format": "double",
+            "description": "The p-value for statistical significance."
+          },
+          "guardrail": {
+            "type": "boolean",
+            "description": "Whether this row corresponds to a guardrail metric."
+          }
+        },
+        "description": "A single row in a scorecard table — one metric comparison between control and treatment."
+      },
+      "Scorecard": {
+        "type": "object",
+        "required": [
+          "id",
+          "experiment_id",
+          "state",
+          "artifact_uri",
+          "rows"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the scorecard.",
+            "readOnly": true
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment this scorecard belongs to."
+          },
+          "state": {
+            "$ref": "#/components/schemas/ScorecardState"
+          },
+          "artifact_uri": {
+            "type": "string",
+            "description": "The URI to the scorecard artifact in the user's blob storage."
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScorecardRow"
+            },
+            "description": "The metric comparison rows."
+          }
+        },
+        "description": "A generated scorecard artifact — a table comparing metric values between variants."
       },
       "ExternalAgentDefinition": {
         "type": "object",
@@ -56008,6 +57147,16 @@
             "items": {
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment identifier bound to this selector. Minted and managed by the Experiments Service; read-only for developers. When set, the selector is write-locked.",
+            "readOnly": true
+          },
+          "salt": {
+            "type": "string",
+            "description": "An immutable bucketing seed used for deterministic sticky routing. Minted by the Experiments Service; read-only for developers.",
+            "readOnly": true
           }
         }
       },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -25225,6 +25225,10 @@
             "type": "string",
             "description": "The name of the agent this experiment targets. Required for agents_safe_rollout type."
           },
+          "duration": {
+            "type": "string",
+            "description": "The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted."
+          },
           "variants": {
             "type": "array",
             "items": {
@@ -25249,6 +25253,13 @@
               "$ref": "#/components/schemas/ExperimentMetric"
             },
             "description": "The list of metrics (evaluation rules or inline evaluators) attached to the experiment."
+          },
+          "started_at": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The Unix timestamp (seconds) when the experiment was started. Null if not yet started.",
+            "readOnly": true
           },
           "scheduled_start_at": {
             "type": "integer",
@@ -25308,30 +25319,37 @@
       "ExperimentMetric": {
         "type": "object",
         "required": [
-          "id",
-          "direction",
-          "aggregation",
+          "name",
+          "definition"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The caller-defined metric name, unique within the experiment."
+          },
+          "desired_direction": {
+            "$ref": "#/components/schemas/ExperimentMetricDirection"
+          },
+          "definition": {
+            "$ref": "#/components/schemas/ExperimentMetricDefinition"
+          }
+        },
+        "description": "A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from."
+      },
+      "ExperimentMetricDefinition": {
+        "type": "object",
+        "required": [
           "source"
         ],
         "properties": {
-          "id": {
-            "type": "string",
-            "description": "The metric identifier, unique within the experiment."
-          },
-          "direction": {
-            "$ref": "#/components/schemas/ExperimentMetricDirection"
-          },
-          "aggregation": {
-            "$ref": "#/components/schemas/ExperimentMetricAggregation"
-          },
           "source": {
             "$ref": "#/components/schemas/ExperimentMetricSource"
           },
-          "guardrail": {
-            "$ref": "#/components/schemas/ExperimentMetricGuardrail"
+          "aggregation": {
+            "$ref": "#/components/schemas/ExperimentMetricAggregation"
           }
         },
-        "description": "A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails."
+        "description": "The definition of a metric — wraps the data source and optional aggregation."
       },
       "ExperimentMetricDirection": {
         "anyOf": [
@@ -25391,7 +25409,7 @@
             "enum": [
               "continuous_evaluation_rule",
               "evaluator",
-              "trace_metric"
+              "traces"
             ]
           }
         ],
@@ -25416,32 +25434,12 @@
           },
           "name": {
             "type": "string",
-            "description": "The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'."
+            "description": "The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'."
           }
         },
         "description": "The source of a metric value, discriminated by type."
       },
-      "ExperimentMetricGuardrail": {
-        "type": "object",
-        "properties": {
-          "max_delta_percent": {
-            "type": "number",
-            "format": "double",
-            "description": "Maximum allowed relative delta as a percentage."
-          },
-          "max_absolute": {
-            "type": "number",
-            "format": "double",
-            "description": "Maximum allowed absolute value."
-          },
-          "state": {
-            "type": "string",
-            "description": "The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.",
-            "readOnly": true
-          }
-        },
-        "description": "Guardrail threshold for a metric."
-      },
+
       "ExperimentState": {
         "anyOf": [
           {
@@ -25593,6 +25591,10 @@
             "type": "string",
             "description": "A human-readable description of the experiment."
           },
+          "duration": {
+            "type": "string",
+            "description": "The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted."
+          },
           "variants": {
             "type": "array",
             "items": {
@@ -25642,31 +25644,31 @@
       "ScorecardRow": {
         "type": "object",
         "required": [
-          "metric_id",
+          "metric_name",
           "label",
-          "control_value",
-          "treatment_value",
+          "desired_direction",
+          "control_stats",
+          "treatment_stats",
           "delta",
           "p_value"
         ],
         "properties": {
-          "metric_id": {
+          "metric_name": {
             "type": "string",
-            "description": "The metric identifier this row corresponds to."
+            "description": "The metric name this row corresponds to."
           },
           "label": {
             "type": "string",
             "description": "A human-readable label for the metric."
           },
-          "control_value": {
-            "type": "number",
-            "format": "double",
-            "description": "The metric value for the control variant."
+          "desired_direction": {
+            "$ref": "#/components/schemas/ExperimentMetricDirection"
           },
-          "treatment_value": {
-            "type": "number",
-            "format": "double",
-            "description": "The metric value for the treatment variant."
+          "control_stats": {
+            "$ref": "#/components/schemas/ScorecardVariantStats"
+          },
+          "treatment_stats": {
+            "$ref": "#/components/schemas/ScorecardVariantStats"
           },
           "delta": {
             "type": "number",
@@ -25677,13 +25679,35 @@
             "type": "number",
             "format": "double",
             "description": "The p-value for statistical significance."
-          },
-          "guardrail": {
-            "type": "boolean",
-            "description": "Whether this row corresponds to a guardrail metric."
           }
         },
         "description": "A single row in a scorecard table — one metric comparison between control and treatment."
+      },
+      "ScorecardVariantStats": {
+        "type": "object",
+        "required": [
+          "count",
+          "average",
+          "std_dev"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of observations."
+          },
+          "average": {
+            "type": "number",
+            "format": "double",
+            "description": "The arithmetic mean of the metric values."
+          },
+          "std_dev": {
+            "type": "number",
+            "format": "double",
+            "description": "The standard deviation of the metric values."
+          }
+        },
+        "description": "Summary statistics for a variant in a scorecard row."
       },
       "Scorecard": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -180,6 +180,11 @@
       "summary": "Agent optimization jobs"
     },
     {
+      "name": "Experiments",
+      "parent": "Platform APIs",
+      "summary": "Experiment lifecycle for A/B version traffic-split"
+    },
+    {
       "name": "EvaluatorGenerationJobs",
       "parent": "Platform APIs",
       "summary": "Evaluator generation jobs"
@@ -6960,7 +6965,7 @@
         ],
         "responses": {
           "201": {
-            "description": "The experiment was created successfully.",
+            "description": "The request has succeeded and a new resource has been created as a result.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7001,7 +7006,8 @@
                 "$ref": "#/components/schemas/CreateExperimentRequest"
               }
             }
-          }
+          },
+          "description": "The experiment to create."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -7012,7 +7018,7 @@
       "get": {
         "operationId": "Experiments_list",
         "summary": "List experiments",
-        "description": "Returns the list of all experiments.",
+        "description": "Returns a cursor-paged list of experiments.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7042,7 +7048,7 @@
             "name": "order",
             "in": "query",
             "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc`\nfor descending order.",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
             "schema": {
               "$ref": "#/components/schemas/PageOrder"
             },
@@ -7052,7 +7058,7 @@
             "name": "after",
             "in": "query",
             "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
             "schema": {
               "type": "string"
             },
@@ -7062,7 +7068,7 @@
             "name": "before",
             "in": "query",
             "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
             "schema": {
               "type": "string"
             },
@@ -7096,7 +7102,7 @@
                       "items": {
                         "$ref": "#/components/schemas/Experiment"
                       },
-                      "description": "The requested list of experiments."
+                      "description": "The requested list of items."
                     },
                     "first_id": {
                       "type": "string",
@@ -7111,7 +7117,7 @@
                       "description": "A value indicating whether there are additional values available not captured in this list."
                     }
                   },
-                  "description": "The response data for a requested list of experiments."
+                  "description": "The response data for a requested list of items."
                 }
               }
             }
@@ -7225,13 +7231,11 @@
             "Experiments=V1Preview"
           ]
         }
-      }
-    },
-    "/experiments/{experiment_id}:start": {
-      "post": {
-        "operationId": "Experiments_start",
-        "summary": "Start an experiment",
-        "description": "Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.",
+      },
+      "patch": {
+        "operationId": "Experiments_update",
+        "summary": "Update an experiment",
+        "description": "Applies a partial update to an experiment. Only experiments still in the 'created' state may be updated; omitted fields are left unchanged.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7249,18 +7253,25 @@
             "name": "experiment_id",
             "in": "path",
             "required": true,
-            "description": "The unique identifier of the experiment to start.",
+            "description": "The unique identifier of the experiment to update.",
             "schema": {
               "type": "string"
             }
           },
           {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           }
         ],
         "responses": {
           "200": {
-            "description": "The experiment was started successfully.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7269,7 +7280,98 @@
               }
             }
           },
-          "default": {
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchExperimentRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Experiments_delete",
+        "summary": "Delete an experiment",
+        "description": "Deletes a non-running experiment and its scorecard artifacts.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
             "description": "Server error",
             "content": {
               "application/json": {
@@ -7290,11 +7392,11 @@
         }
       }
     },
-    "/experiments/{experiment_id}:stop": {
-      "post": {
-        "operationId": "Experiments_stop",
-        "summary": "Stop an experiment",
-        "description": "Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.",
+    "/experiments/{experiment_id}/scorecards": {
+      "get": {
+        "operationId": "Experiments_listScorecards",
+        "summary": "List scorecards",
+        "description": "Returns a cursor-paged list of generated scorecards for an experiment. Each entry is a lightweight summary; use Get scorecard to retrieve the full metric rows.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7312,7 +7414,164 @@
             "name": "experiment_id",
             "in": "path",
             "required": true,
-            "description": "The unique identifier of the experiment to stop.",
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ScorecardSummary"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}/scorecards/{scorecard_id}": {
+      "get": {
+        "operationId": "Experiments_getScorecard",
+        "summary": "Get a scorecard",
+        "description": "Retrieves a generated scorecard by id, including its full metric rows.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scorecard_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the scorecard.",
             "schema": {
               "type": "string"
             }
@@ -7330,14 +7589,94 @@
         ],
         "responses": {
           "200": {
-            "description": "The experiment was stopped successfully.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Experiment"
+                  "$ref": "#/components/schemas/Scorecard"
                 }
               }
             }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Experiments_deleteScorecard",
+        "summary": "Delete a scorecard",
+        "description": "Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scorecard_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the scorecard to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "4XX": {
             "description": "Client error",
@@ -7410,7 +7749,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The experiment was promoted successfully.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7451,7 +7790,8 @@
                 "$ref": "#/components/schemas/PromoteExperimentRequest"
               }
             }
-          }
+          },
+          "description": "The promotion request."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -7460,11 +7800,11 @@
         }
       }
     },
-    "/experiments/{experiment_id}/scorecards": {
-      "get": {
-        "operationId": "Experiments_listScorecards",
-        "summary": "List scorecards",
-        "description": "Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.",
+    "/experiments/{experiment_id}:start": {
+      "post": {
+        "operationId": "Experiments_start",
+        "summary": "Start an experiment",
+        "description": "Starts a created experiment. The service mints the salt, materializes traffic steps, and begins sticky-per-conversation routing.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7482,13 +7822,20 @@
             "name": "experiment_id",
             "in": "path",
             "required": true,
-            "description": "The unique identifier of the experiment.",
+            "description": "The unique identifier of the experiment to start.",
             "schema": {
               "type": "string"
             }
           },
           {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           }
         ],
         "responses": {
@@ -7497,24 +7844,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Scorecard"
-                      },
-                      "description": "The list of scorecards."
-                    }
-                  }
+                  "$ref": "#/components/schemas/Experiment"
                 }
               }
             }
           },
-          "default": {
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
             "description": "Server error",
             "content": {
               "application/json": {
@@ -7535,11 +7880,11 @@
         }
       }
     },
-    "/experiments/{experiment_id}/scorecards/{scorecard_id}": {
-      "delete": {
-        "operationId": "Experiments_deleteScorecard",
-        "summary": "Delete a scorecard",
-        "description": "Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.",
+    "/experiments/{experiment_id}:stop": {
+      "post": {
+        "operationId": "Experiments_stop",
+        "summary": "Stop an experiment",
+        "description": "Stops a running experiment. Routing collapses to the control variant.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7557,29 +7902,44 @@
             "name": "experiment_id",
             "in": "path",
             "required": true,
-            "description": "The unique identifier of the experiment.",
+            "description": "The unique identifier of the experiment to stop.",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "scorecard_id",
-            "in": "path",
+            "name": "api-version",
+            "in": "query",
             "required": true,
-            "description": "The unique identifier of the scorecard to delete.",
+            "description": "The API version to use for this operation.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+            },
+            "explode": false
           }
         ],
         "responses": {
-          "204": {
-            "description": "The scorecard was deleted successfully."
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
           },
-          "default": {
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
             "description": "Server error",
             "content": {
               "application/json": {
@@ -13007,16 +13367,6 @@
                       "type": "string",
                       "description": "The model deployment to use for the creation of this response."
                     },
-                    "reasoning": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Reasoning"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "background": {
                       "anyOf": [
                         {
@@ -13139,6 +13489,16 @@
                         "$ref": "#/components/schemas/OpenAI.OutputItem"
                       },
                       "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.Reasoning"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "instructions": {
                       "anyOf": [
@@ -13361,16 +13721,6 @@
                     "type": "string",
                     "description": "The model deployment to use for the creation of this response."
                   },
-                  "reasoning": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Reasoning"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "background": {
                     "anyOf": [
                       {
@@ -13423,7 +13773,18 @@
                         "type": "null"
                       }
                     ],
+                    "deprecated": true,
                     "default": "disabled"
+                  },
+                  "reasoning": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.Reasoning"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "input": {
                     "$ref": "#/components/schemas/OpenAI.InputParam"
@@ -18680,6 +19041,32 @@
         ],
         "description": "Agentic identity credential definition"
       },
+      "AgentsSafeRolloutExperiment": {
+        "type": "object",
+        "required": [
+          "type",
+          "target_agent"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ],
+            "description": "The A/B safe-rollout experiment kind."
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent whose versions participate in the rollout."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Experiment"
+          }
+        ],
+        "description": "An experiment that safely rolls traffic between versions of one agent."
+      },
       "ApiErrorResponse": {
         "type": "object",
         "required": [
@@ -21684,6 +22071,32 @@
           ]
         }
       },
+      "CreateAgentsSafeRolloutExperimentRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "target_agent"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ],
+            "description": "The A/B safe-rollout experiment kind."
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent targeted by the experiment."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateExperimentRequest"
+          }
+        ],
+        "description": "Request body for creating an agents_safe_rollout experiment."
+      },
       "CreateEvalRequest": {
         "type": "object",
         "required": [
@@ -21816,6 +22229,66 @@
           }
         },
         "title": "CreateEvalRunRequest"
+      },
+      "CreateExperimentRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "display_name",
+          "variants"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The discriminated experiment kind."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "A human-readable display name for the experiment."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the experiment."
+          },
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The experiment duration in days. Drives only the service-managed scorecard refresh horizon; it does not end the experiment. Defaults to 7 when omitted."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "Optional list of metrics to attach to the experiment."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "Optional scheduled evaluation configuration."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agents_safe_rollout": "#/components/schemas/CreateAgentsSafeRolloutExperimentRequest"
+          }
+        },
+        "description": "Request body for creating an experiment."
       },
       "CreateSkillVersionFromFilesBody": {
         "type": "object",
@@ -24923,6 +25396,40 @@
           ]
         }
       },
+      "EvaluatorMetricSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "evaluator"
+            ],
+            "description": "The evaluator source kind."
+          },
+          "evaluator_name": {
+            "type": "string",
+            "description": "The evaluator name."
+          },
+          "evaluator_version": {
+            "type": "string",
+            "description": "The evaluator version to pin."
+          },
+          "parameters": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Additional evaluator parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExperimentMetricSource"
+          }
+        ],
+        "description": "A metric sourced from an evaluator (a judge that scores agent output)."
+      },
       "EvaluatorMetricType": {
         "anyOf": [
           {
@@ -25197,9 +25704,10 @@
           "state",
           "display_name",
           "variants",
+          "metrics",
           "experiment_steps",
           "assignment_properties",
-          "metrics"
+          "created_at"
         ],
         "properties": {
           "id": {
@@ -25208,10 +25716,21 @@
             "readOnly": true
           },
           "type": {
-            "$ref": "#/components/schemas/ExperimentType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The discriminated experiment kind."
           },
           "state": {
-            "$ref": "#/components/schemas/ExperimentState"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentState"
+              }
+            ],
+            "description": "The lifecycle state of the experiment.",
+            "readOnly": true
           },
           "display_name": {
             "type": "string",
@@ -25221,13 +25740,10 @@
             "type": "string",
             "description": "A human-readable description of the experiment."
           },
-          "target_agent": {
-            "type": "string",
-            "description": "The name of the agent this experiment targets. Required for agents_safe_rollout type."
-          },
-          "duration": {
-            "type": "string",
-            "description": "The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted."
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The experiment duration in days. Drives only the service-managed scorecard refresh horizon (how long scorecards keep refreshing after start); it does not end the experiment — the experiment ends only when the caller stops or promotes it. Defaults to 7 when omitted."
           },
           "variants": {
             "type": "array",
@@ -25235,6 +25751,21 @@
               "$ref": "#/components/schemas/ExperimentVariant"
             },
             "description": "The list of variants participating in the experiment."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "The list of metrics attached to the experiment."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "Configuration and service-managed resources for scheduled evaluation."
           },
           "experiment_steps": {
             "type": "array",
@@ -25245,36 +25776,55 @@
             "readOnly": true
           },
           "assignment_properties": {
-            "$ref": "#/components/schemas/ExperimentAssignmentProperties"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentAssignmentProperties"
+              }
+            ],
+            "description": "Properties controlling how traffic is assigned to variants.",
+            "readOnly": true
           },
-          "metrics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExperimentMetric"
-            },
-            "description": "The list of metrics (evaluation rules or inline evaluators) attached to the experiment."
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when the experiment was created.",
+            "readOnly": true
           },
           "started_at": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The Unix timestamp (seconds) when the experiment was started. Null if not yet started.",
             "readOnly": true
           },
-          "scheduled_start_at": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true,
-            "description": "The scheduled start time for the experiment (Unix timestamp). Null if started immediately."
-          },
-          "scheduled_end_at": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true,
-            "description": "The scheduled end time for the experiment (Unix timestamp). Null if no end is scheduled."
+          "end_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The actual end time (Unix seconds), set when the experiment is stopped or promoted. Null while the experiment is created or running.",
+            "readOnly": true
           }
         },
-        "description": "Represents an experiment that binds version routing to a lifecycle for A/B testing."
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agents_safe_rollout": "#/components/schemas/AgentsSafeRolloutExperiment"
+          }
+        },
+        "description": "A materialized experiment that binds version routing to a lifecycle for A/B testing."
       },
       "ExperimentAssignmentProperties": {
         "type": "object",
@@ -25316,6 +25866,26 @@
         },
         "description": "A contiguous range of hash buckets assigned to a variant."
       },
+      "ExperimentEvaluation": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The deployed model used by evaluator-backed metrics."
+          },
+          "eval_id": {
+            "type": "string",
+            "description": "The service-managed evaluation group identifier.",
+            "readOnly": true
+          },
+          "schedule_id": {
+            "type": "string",
+            "description": "The service-managed schedule identifier.",
+            "readOnly": true
+          }
+        },
+        "description": "Configuration and service-managed resources for scheduled experiment evaluation."
+      },
       "ExperimentMetric": {
         "type": "object",
         "required": [
@@ -25328,13 +25898,60 @@
             "description": "The caller-defined metric name, unique within the experiment."
           },
           "desired_direction": {
-            "$ref": "#/components/schemas/ExperimentMetricDirection"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDirection"
+              }
+            ],
+            "description": "The desired direction for this metric. Optional; if omitted, the service infers from the evaluator defaults."
           },
           "definition": {
-            "$ref": "#/components/schemas/ExperimentMetricDefinition"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDefinition"
+              }
+            ],
+            "description": "The metric definition including data source and optional aggregation."
           }
         },
         "description": "A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from."
+      },
+      "ExperimentMetricAggregation": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricAggregationType"
+              }
+            ],
+            "description": "The aggregation function."
+          },
+          "percentile": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The percentile value (e.g. 95). Required when type is 'percentile'."
+          }
+        },
+        "description": "Aggregation configuration for a metric."
+      },
+      "ExperimentMetricAggregationType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "average",
+              "percentile"
+            ]
+          }
+        ],
+        "description": "The aggregation function for a metric."
       },
       "ExperimentMetricDefinition": {
         "type": "object",
@@ -25343,10 +25960,20 @@
         ],
         "properties": {
           "source": {
-            "$ref": "#/components/schemas/ExperimentMetricSource"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSource"
+              }
+            ],
+            "description": "The source of the metric data."
           },
           "aggregation": {
-            "$ref": "#/components/schemas/ExperimentMetricAggregation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricAggregation"
+              }
+            ],
+            "description": "Optional aggregation configuration. If omitted, the service uses the evaluator's default aggregation."
           }
         },
         "description": "The definition of a metric — wraps the data source and optional aggregation."
@@ -25360,44 +25987,36 @@
             "type": "string",
             "enum": [
               "increase",
-              "decrease"
+              "decrease",
+              "neutral"
             ]
           }
         ],
         "description": "The desired direction for a metric value."
       },
-      "ExperimentMetricAggregationType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "average",
-              "percentile",
-              "rate"
-            ]
-          }
-        ],
-        "description": "The aggregation function for a metric."
-      },
-      "ExperimentMetricAggregation": {
+      "ExperimentMetricSource": {
         "type": "object",
         "required": [
           "type"
         ],
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/ExperimentMetricAggregationType"
-          },
-          "percentile": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The percentile value (e.g. 95). Required when type is 'percentile'."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSourceType"
+              }
+            ],
+            "description": "The type of metric source."
           }
         },
-        "description": "Aggregation configuration for a metric."
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "evaluator": "#/components/schemas/EvaluatorMetricSource",
+            "traces": "#/components/schemas/TracesMetricSource"
+          }
+        },
+        "description": "The source of a metric value, discriminated by type."
       },
       "ExperimentMetricSourceType": {
         "anyOf": [
@@ -25407,7 +26026,6 @@
           {
             "type": "string",
             "enum": [
-              "continuous_evaluation_rule",
               "evaluator",
               "traces"
             ]
@@ -25415,31 +26033,6 @@
         ],
         "description": "The type of metric source."
       },
-      "ExperimentMetricSource": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/ExperimentMetricSourceType"
-          },
-          "rule_id": {
-            "type": "string",
-            "description": "The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'."
-          },
-          "evaluator_name": {
-            "type": "string",
-            "description": "The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'."
-          },
-          "name": {
-            "type": "string",
-            "description": "The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'."
-          }
-        },
-        "description": "The source of a metric value, discriminated by type."
-      },
-
       "ExperimentState": {
         "anyOf": [
           {
@@ -25469,15 +26062,25 @@
             "description": "The identifier for this experiment step."
           },
           "started_at": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The Unix timestamp (seconds) when this step started."
           },
           "stopped_at": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The Unix timestamp (seconds) when this step stopped. Null if still running."
           },
           "variant_traffic_maps": {
@@ -25516,12 +26119,22 @@
             "description": "The variant identifier. For agents_safe_rollout this is the agent version number."
           },
           "role": {
-            "$ref": "#/components/schemas/ExperimentVariantRole"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentVariantRole"
+              }
+            ],
+            "description": "The role of this variant in the experiment."
           },
           "traffic_percentage": {
             "type": "integer",
             "format": "int32",
-            "description": "The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses."
+            "description": "The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead)."
+          },
+          "required_sample_size": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The minimum number of observations required before this variant's scorecard results are considered reliable. Defaults to 100 when omitted."
           }
         },
         "description": "A variant participating in the experiment."
@@ -25567,183 +26180,6 @@
           }
         },
         "description": "Traffic allocation map for a single variant within an experiment step."
-      },
-      "CreateExperimentRequest": {
-        "type": "object",
-        "required": [
-          "type",
-          "display_name",
-          "variants"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/ExperimentType"
-          },
-          "target_agent": {
-            "type": "string",
-            "description": "The name of the agent this experiment targets. Required for agents_safe_rollout type."
-          },
-          "display_name": {
-            "type": "string",
-            "description": "A human-readable display name for the experiment."
-          },
-          "description": {
-            "type": "string",
-            "description": "A human-readable description of the experiment."
-          },
-          "duration": {
-            "type": "string",
-            "description": "The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted."
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExperimentVariant"
-            },
-            "description": "The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100."
-          },
-          "metrics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExperimentMetric"
-            },
-            "description": "Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment."
-          }
-        },
-        "description": "Request body for creating an experiment."
-      },
-      "PromoteExperimentRequest": {
-        "type": "object",
-        "required": [
-          "winner_variant_id"
-        ],
-        "properties": {
-          "winner_variant_id": {
-            "type": "string",
-            "description": "The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version."
-          }
-        },
-        "description": "Request body for promoting an experiment."
-      },
-      "ScorecardState": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "ready",
-              "computing",
-              "failed"
-            ]
-          }
-        ],
-        "description": "The state of a scorecard."
-      },
-      "ScorecardRow": {
-        "type": "object",
-        "required": [
-          "metric_name",
-          "label",
-          "desired_direction",
-          "control_stats",
-          "treatment_stats",
-          "delta",
-          "p_value"
-        ],
-        "properties": {
-          "metric_name": {
-            "type": "string",
-            "description": "The metric name this row corresponds to."
-          },
-          "label": {
-            "type": "string",
-            "description": "A human-readable label for the metric."
-          },
-          "desired_direction": {
-            "$ref": "#/components/schemas/ExperimentMetricDirection"
-          },
-          "control_stats": {
-            "$ref": "#/components/schemas/ScorecardVariantStats"
-          },
-          "treatment_stats": {
-            "$ref": "#/components/schemas/ScorecardVariantStats"
-          },
-          "delta": {
-            "type": "number",
-            "format": "double",
-            "description": "The absolute delta between treatment and control."
-          },
-          "p_value": {
-            "type": "number",
-            "format": "double",
-            "description": "The p-value for statistical significance."
-          }
-        },
-        "description": "A single row in a scorecard table — one metric comparison between control and treatment."
-      },
-      "ScorecardVariantStats": {
-        "type": "object",
-        "required": [
-          "count",
-          "average",
-          "std_dev"
-        ],
-        "properties": {
-          "count": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The number of observations."
-          },
-          "average": {
-            "type": "number",
-            "format": "double",
-            "description": "The arithmetic mean of the metric values."
-          },
-          "std_dev": {
-            "type": "number",
-            "format": "double",
-            "description": "The standard deviation of the metric values."
-          }
-        },
-        "description": "Summary statistics for a variant in a scorecard row."
-      },
-      "Scorecard": {
-        "type": "object",
-        "required": [
-          "id",
-          "experiment_id",
-          "state",
-          "artifact_uri",
-          "rows"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the scorecard.",
-            "readOnly": true
-          },
-          "experiment_id": {
-            "type": "string",
-            "description": "The experiment this scorecard belongs to."
-          },
-          "state": {
-            "$ref": "#/components/schemas/ScorecardState"
-          },
-          "artifact_uri": {
-            "type": "string",
-            "description": "The URI to the scorecard artifact in the user's blob storage."
-          },
-          "rows": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ScorecardRow"
-            },
-            "description": "The metric comparison rows."
-          }
-        },
-        "description": "A generated scorecard artifact — a table comparing metric values between variants."
       },
       "ExternalAgentDefinition": {
         "type": "object",
@@ -27364,7 +27800,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\n  provided."
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n  `tunnel_id` must be provided."
           },
           "connector_id": {
             "type": "string",
@@ -27378,7 +27814,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url` or `connector_id` must be provided. Learn more about service\n  connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\n  about service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided."
           },
           "authorization": {
             "type": "string",
@@ -44152,7 +44593,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\n  provided."
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n  `tunnel_id` must be provided."
           },
           "connector_id": {
             "type": "string",
@@ -44166,7 +44607,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url` or `connector_id` must be provided. Learn more about service\n  connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\n  about service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided."
           },
           "authorization": {
             "type": "string",
@@ -47018,6 +47464,21 @@
               }
             ]
           },
+          "context": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "current_turn",
+                  "all_turns"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "generate_summary": {
             "anyOf": [
               {
@@ -47181,16 +47642,6 @@
             "type": "string",
             "description": "The model deployment to use for the creation of this response."
           },
-          "reasoning": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "background": {
             "anyOf": [
               {
@@ -47313,6 +47764,16 @@
               "$ref": "#/components/schemas/OpenAI.OutputItem"
             },
             "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Reasoning"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "instructions": {
             "anyOf": [
@@ -53485,6 +53946,55 @@
           }
         }
       },
+      "PatchExperimentRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The experiment kind. Must match the existing experiment."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "The new display name. Left unchanged when omitted."
+          },
+          "description": {
+            "type": "string",
+            "description": "The new description. Left unchanged when omitted."
+          },
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The new duration in days. Left unchanged when omitted."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The replacement variant list. When provided it fully replaces the existing variants and must satisfy the same rules as on create."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "The replacement metric list. When provided it fully replaces the existing metrics."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "The replacement scheduled evaluation configuration. Left unchanged when omitted."
+          }
+        },
+        "description": "Request body for patching an experiment. Only experiments still in the 'created' state may be\nupdated; omitted fields are left unchanged. Type-specific identity (e.g. agents_safe_rollout\ntarget_agent) is immutable and cannot be changed here."
+      },
       "PendingUploadRequest": {
         "type": "object",
         "required": [
@@ -53568,6 +54078,19 @@
             "MemoryStores=V1Preview"
           ]
         }
+      },
+      "PromoteExperimentRequest": {
+        "type": "object",
+        "required": [
+          "winner_variant_id"
+        ],
+        "properties": {
+          "winner_variant_id": {
+            "type": "string",
+            "description": "The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version."
+          }
+        },
+        "description": "Request body for promoting an experiment."
       },
       "PromotionInfo": {
         "type": "object",
@@ -55180,6 +55703,381 @@
             "Schedules=V1Preview"
           ]
         }
+      },
+      "Scorecard": {
+        "type": "object",
+        "required": [
+          "id",
+          "experiment_id",
+          "control_variant_id",
+          "treatment_variant_ids",
+          "window_start",
+          "window_end",
+          "created_at",
+          "state",
+          "rows"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the scorecard."
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment this scorecard belongs to."
+          },
+          "control_variant_id": {
+            "type": "string",
+            "description": "The control (baseline) variant used by this scorecard."
+          },
+          "treatment_variant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The treatment variants compared against the control in this scorecard."
+          },
+          "window_start": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "window_end": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this scorecard was generated."
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardState"
+              }
+            ],
+            "description": "The state of the scorecard."
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardError"
+              }
+            ],
+            "description": "Failure detail when the state is 'failed'. Null otherwise."
+          },
+          "metadata": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here."
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScorecardRow"
+            },
+            "description": "The metric comparison rows."
+          }
+        },
+        "description": "A generated scorecard artifact — a table comparing metric values between variants."
+      },
+      "ScorecardError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable, machine-readable failure category (e.g. 'compute_failed', 'internal_error', 'publish_failed')."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable (truncated) failure description."
+          }
+        },
+        "description": "Structured failure detail for a scorecard whose state is 'failed'."
+      },
+      "ScorecardMetricLevel": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "turn",
+              "conversation"
+            ]
+          }
+        ],
+        "description": "The granularity a scorecard metric is measured at."
+      },
+      "ScorecardPairComparison": {
+        "type": "object",
+        "required": [
+          "delta",
+          "p_value",
+          "treatment_effect"
+        ],
+        "properties": {
+          "delta": {
+            "type": "number",
+            "format": "double",
+            "description": "The signed delta: this variant's average minus the control's."
+          },
+          "p_value": {
+            "type": "number",
+            "format": "double",
+            "description": "The p-value for significance vs. the control."
+          },
+          "relative_difference": {
+            "anyOf": [
+              {
+                "type": "number",
+                "format": "double"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The relative difference vs. the control, or null when the control average is zero."
+          },
+          "treatment_effect": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardTreatmentEffect"
+              }
+            ],
+            "description": "The qualitative treatment effect vs. the control, classified from the p-value and thresholds."
+          }
+        },
+        "description": "A treatment variant's comparison against the scorecard's control for one metric."
+      },
+      "ScorecardRow": {
+        "type": "object",
+        "required": [
+          "metric_name",
+          "level",
+          "category",
+          "desired_direction",
+          "variants"
+        ],
+        "properties": {
+          "metric_name": {
+            "type": "string",
+            "description": "The metric name this row corresponds to."
+          },
+          "level": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardMetricLevel"
+              }
+            ],
+            "description": "The granularity this metric is measured at (turn or conversation)."
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSourceType"
+              }
+            ],
+            "description": "The kind of source this metric is derived from (evaluator or traces)."
+          },
+          "desired_direction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDirection"
+              }
+            ],
+            "description": "The desired direction for this metric."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScorecardVariantResult"
+            },
+            "description": "One result per variant (control plus every treatment) for this metric."
+          }
+        },
+        "description": "A single row in a scorecard table — one metric compared across every variant."
+      },
+      "ScorecardState": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ready",
+              "computing",
+              "failed"
+            ]
+          }
+        ],
+        "description": "The state of a scorecard."
+      },
+      "ScorecardSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "experiment_id",
+          "control_variant_id",
+          "treatment_variant_ids",
+          "window_start",
+          "window_end",
+          "created_at",
+          "state",
+          "metric_count"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the scorecard."
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment this scorecard belongs to."
+          },
+          "control_variant_id": {
+            "type": "string",
+            "description": "The control (baseline) variant used by this scorecard."
+          },
+          "treatment_variant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The treatment variants compared against the control in this scorecard."
+          },
+          "window_start": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "window_end": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this scorecard was generated."
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardState"
+              }
+            ],
+            "description": "The state of the scorecard."
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardError"
+              }
+            ],
+            "description": "Failure detail when the state is 'failed'. Null otherwise."
+          },
+          "metadata": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here."
+          },
+          "metric_count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of metric rows in the full scorecard."
+          }
+        },
+        "description": "Lightweight scorecard projection returned by list operations. The full metric rows are available only from the individual scorecard resource."
+      },
+      "ScorecardTreatmentEffect": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "improved",
+              "degraded",
+              "changed",
+              "inconclusive",
+              "insufficient_data",
+              "no_samples",
+              "unknown"
+            ]
+          }
+        ],
+        "description": "The qualitative outcome of a metric's treatment-vs-control comparison."
+      },
+      "ScorecardVariantResult": {
+        "type": "object",
+        "required": [
+          "variant_id",
+          "count",
+          "average",
+          "std_dev"
+        ],
+        "properties": {
+          "variant_id": {
+            "type": "string",
+            "description": "The variant identifier (for agents_safe_rollout this is the agent version number)."
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of observations."
+          },
+          "average": {
+            "type": "number",
+            "format": "double",
+            "description": "The arithmetic mean of the metric values."
+          },
+          "std_dev": {
+            "type": "number",
+            "format": "double",
+            "description": "The standard deviation of the metric values."
+          },
+          "comparison": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardPairComparison"
+              }
+            ],
+            "description": "This variant's comparison against the scorecard's control. Null for the control variant."
+          }
+        },
+        "description": "One variant's result for a metric row: its raw aggregates plus, for treatment variants, the comparison against the control."
       },
       "SessionDirectoryEntry": {
         "type": "object",
@@ -56828,6 +57726,35 @@
             "Evaluations=V1Preview"
           ]
         }
+      },
+      "TracesMetricSource": {
+        "type": "object",
+        "required": [
+          "type",
+          "attribute_names"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "traces"
+            ],
+            "description": "The traces source kind."
+          },
+          "attribute_names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Trace attribute names the metric value is read from. Each attribute must be numeric, or boolean (coerced to 1/0). When more than one is given, the per-event value is the sum of the attributes; a missing attribute contributes 0 (partial rows are kept), and the event value is null only when every listed attribute is null."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExperimentMetricSource"
+          }
+        ],
+        "description": "A metric sourced from trace/event attributes."
       },
       "TracesPreviewEvalRunDataSource": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4604,6 +4604,383 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+  /experiments:
+    post:
+      operationId: Experiments_create
+      summary: Create an experiment
+      description: Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The experiment was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExperimentRequest'
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    get:
+      operationId: Experiments_list
+      summary: List experiments
+      description: Returns the list of all experiments.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Experiment'
+                    description: The requested list of experiments.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of experiments.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:
+    get:
+      operationId: Experiments_get
+      summary: Get an experiment
+      description: Retrieves the experiment by id.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:stop:
+    post:
+      operationId: Experiments_stop
+      summary: Stop an experiment
+      description: Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to stop.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The experiment was stopped successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:promote:
+    post:
+      operationId: Experiments_promote
+      summary: Promote an experiment
+      description: Promotes the winning variant. The agent's version selector is replaced with a single 100% rule for the winner.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to promote.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The experiment was promoted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromoteExperimentRequest'
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards:
+    get:
+      operationId: Experiments_listScorecards
+      summary: List scorecards
+      description: Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Scorecard'
+                    description: The list of scorecards.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards/{scorecard_id}:
+    delete:
+      operationId: Experiments_deleteScorecard
+      summary: Delete a scorecard
+      description: Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: scorecard_id
+          in: path
+          required: true
+          description: The unique identifier of the scorecard to delete.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: The scorecard was deleted successfully.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
   /indexes:
     get:
       operationId: Indexes_listLatest
@@ -16459,6 +16836,380 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    Experiment:
+      type: object
+      required:
+        - id
+        - type
+        - state
+        - display_name
+        - variants
+        - experiment_steps
+        - assignment_properties
+        - metrics
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the experiment.
+          readOnly: true
+        type:
+          $ref: '#/components/schemas/ExperimentType'
+        state:
+          $ref: '#/components/schemas/ExperimentState'
+        display_name:
+          type: string
+          description: A human-readable display name for the experiment.
+        description:
+          type: string
+          description: A human-readable description of the experiment.
+        target_agent:
+          type: string
+          description: The name of the agent this experiment targets. Required for agents_safe_rollout type.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The list of variants participating in the experiment.
+        experiment_steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentStep'
+          description: The list of experiment steps with traffic allocation details. Materialized by the service.
+          readOnly: true
+        assignment_properties:
+          $ref: '#/components/schemas/ExperimentAssignmentProperties'
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: The list of metrics (evaluation rules or inline evaluators) attached to the experiment.
+        scheduled_start_at:
+          type: integer
+          format: int32
+          nullable: true
+          description: The scheduled start time for the experiment (Unix timestamp). Null if started immediately.
+        scheduled_end_at:
+          type: integer
+          format: int32
+          nullable: true
+          description: The scheduled end time for the experiment (Unix timestamp). Null if no end is scheduled.
+      description: Represents an experiment that binds version routing to a lifecycle for A/B testing.
+    ExperimentAssignmentProperties:
+      type: object
+      required:
+        - salt
+        - assignment_unit
+      properties:
+        salt:
+          type: string
+          description: An immutable bucketing seed minted when the experiment starts. Re-salting re-randomizes every bucket.
+          readOnly: true
+        assignment_unit:
+          type: string
+          description: The unit used for sticky bucketing (e.g. conversationId).
+          readOnly: true
+      description: Properties controlling how traffic is assigned to variants.
+    ExperimentBucketRange:
+      type: object
+      required:
+        - start
+        - end
+      properties:
+        start:
+          type: integer
+          format: int32
+          description: The inclusive start of the bucket range (0-based).
+        end:
+          type: integer
+          format: int32
+          description: The exclusive end of the bucket range.
+      description: A contiguous range of hash buckets assigned to a variant.
+    ExperimentMetric:
+      type: object
+      required:
+        - id
+        - direction
+        - aggregation
+        - source
+      properties:
+        id:
+          type: string
+          description: The metric identifier, unique within the experiment.
+        direction:
+          $ref: '#/components/schemas/ExperimentMetricDirection'
+        aggregation:
+          $ref: '#/components/schemas/ExperimentMetricAggregation'
+        source:
+          $ref: '#/components/schemas/ExperimentMetricSource'
+        guardrail:
+          $ref: '#/components/schemas/ExperimentMetricGuardrail'
+      description: A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails.
+    ExperimentMetricDirection:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - increase
+            - decrease
+      description: The desired direction for a metric value.
+    ExperimentMetricAggregationType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - average
+            - percentile
+            - rate
+      description: The aggregation function for a metric.
+    ExperimentMetricAggregation:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          $ref: '#/components/schemas/ExperimentMetricAggregationType'
+        percentile:
+          type: integer
+          format: int32
+          description: The percentile value (e.g. 95). Required when type is 'percentile'.
+      description: Aggregation configuration for a metric.
+    ExperimentMetricSourceType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - continuous_evaluation_rule
+            - evaluator
+            - trace_metric
+      description: The type of metric source.
+    ExperimentMetricSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          $ref: '#/components/schemas/ExperimentMetricSourceType'
+        rule_id:
+          type: string
+          description: The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'.
+        evaluator_name:
+          type: string
+          description: The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.
+        name:
+          type: string
+          description: The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'.
+      description: The source of a metric value, discriminated by type.
+    ExperimentMetricGuardrail:
+      type: object
+      properties:
+        max_delta_percent:
+          type: number
+          format: double
+          description: Maximum allowed relative delta as a percentage.
+        max_absolute:
+          type: number
+          format: double
+          description: Maximum allowed absolute value.
+        state:
+          type: string
+          description: The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.
+          readOnly: true
+      description: Guardrail threshold for a metric.
+    ExperimentState:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - running
+            - stopped
+            - promoted
+      description: The lifecycle state of the experiment.
+    ExperimentStep:
+      type: object
+      required:
+        - id
+        - variant_traffic_maps
+      properties:
+        id:
+          type: string
+          description: The identifier for this experiment step.
+        started_at:
+          type: integer
+          format: int32
+          nullable: true
+          description: The Unix timestamp (seconds) when this step started.
+        stopped_at:
+          type: integer
+          format: int32
+          nullable: true
+          description: The Unix timestamp (seconds) when this step stopped. Null if still running.
+        variant_traffic_maps:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariantTrafficMap'
+          description: The traffic allocation for each variant in this step.
+      description: A step in the experiment with traffic allocation details.
+    ExperimentType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agents_safe_rollout
+      description: The discriminated experiment kind.
+    ExperimentVariant:
+      type: object
+      required:
+        - id
+        - role
+      properties:
+        id:
+          type: string
+          description: The variant identifier. For agents_safe_rollout this is the agent version number.
+        role:
+          $ref: '#/components/schemas/ExperimentVariantRole'
+        traffic_percentage:
+          type: integer
+          format: int32
+          description: The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses.
+      description: A variant participating in the experiment.
+    ExperimentVariantRole:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - control
+            - treatment
+      description: The role of a variant in the experiment.
+    ExperimentVariantTrafficMap:
+      type: object
+      required:
+        - variant_id
+        - percentage
+        - bucket_ranges
+      properties:
+        variant_id:
+          type: string
+          description: The variant identifier this traffic map applies to.
+        percentage:
+          type: integer
+          format: int32
+          description: The traffic percentage for this variant.
+        bucket_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentBucketRange'
+          description: The hash bucket ranges assigned to this variant.
+      description: Traffic allocation map for a single variant within an experiment step.
+    CreateExperimentRequest:
+      type: object
+      required:
+        - type
+        - display_name
+        - variants
+      properties:
+        type:
+          $ref: '#/components/schemas/ExperimentType'
+        target_agent:
+          type: string
+          description: The name of the agent this experiment targets. Required for agents_safe_rollout type.
+        display_name:
+          type: string
+          description: A human-readable display name for the experiment.
+        description:
+          type: string
+          description: A human-readable description of the experiment.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment.
+      description: Request body for creating an experiment.
+    PromoteExperimentRequest:
+      type: object
+      required:
+        - winner_variant_id
+      properties:
+        winner_variant_id:
+          type: string
+          description: The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version.
+      description: Request body for promoting an experiment.
+    ScorecardState:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ready
+            - computing
+            - failed
+      description: The state of a scorecard.
+    ScorecardRow:
+      type: object
+      required:
+        - metric_id
+        - label
+        - control_value
+        - treatment_value
+        - delta
+        - p_value
+      properties:
+        metric_id:
+          type: string
+          description: The metric identifier this row corresponds to.
+        label:
+          type: string
+          description: A human-readable label for the metric.
+        control_value:
+          type: number
+          format: double
+          description: The metric value for the control variant.
+        treatment_value:
+          type: number
+          format: double
+          description: The metric value for the treatment variant.
+        delta:
+          type: number
+          format: double
+          description: The absolute delta between treatment and control.
+        p_value:
+          type: number
+          format: double
+          description: The p-value for statistical significance.
+        guardrail:
+          type: boolean
+          description: Whether this row corresponds to a guardrail metric.
+      description: A single row in a scorecard table — one metric comparison between control and treatment.
+    Scorecard:
+      type: object
+      required:
+        - id
+        - experiment_id
+        - state
+        - artifact_uri
+        - rows
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the scorecard.
+          readOnly: true
+        experiment_id:
+          type: string
+          description: The experiment this scorecard belongs to.
+        state:
+          $ref: '#/components/schemas/ScorecardState'
+        artifact_uri:
+          type: string
+          description: The URI to the scorecard artifact in the user's blob storage.
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScorecardRow'
+          description: The metric comparison rows.
+      description: A generated scorecard artifact — a table comparing metric values between variants.
     ExternalAgentDefinition:
       type: object
       required:
@@ -38316,6 +39067,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
+        experiment_id:
+          type: string
+          description: The experiment identifier bound to this selector. Minted and managed by the Experiments Service; read-only for developers. When set, the selector is write-locked.
+          readOnly: true
+        salt:
+          type: string
+          description: An immutable bucketing seed used for deterministic sticky routing. Minted by the Experiments Service; read-only for developers.
+          readOnly: true
     VersionSelectorType:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -16910,6 +16910,9 @@ components:
         target_agent:
           type: string
           description: The name of the agent this experiment targets. Required for agents_safe_rollout type.
+        duration:
+          type: string
+          description: The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.
         variants:
           type: array
           items:
@@ -16928,6 +16931,12 @@ components:
           items:
             $ref: '#/components/schemas/ExperimentMetric'
           description: The list of metrics (evaluation rules or inline evaluators) attached to the experiment.
+        started_at:
+          type: integer
+          format: int32
+          nullable: true
+          description: The Unix timestamp (seconds) when the experiment was started. Null if not yet started.
+          readOnly: true
         scheduled_start_at:
           type: integer
           format: int32
@@ -16972,23 +16981,27 @@ components:
     ExperimentMetric:
       type: object
       required:
-        - id
-        - direction
-        - aggregation
+        - name
+        - definition
+      properties:
+        name:
+          type: string
+          description: The caller-defined metric name, unique within the experiment.
+        desired_direction:
+          $ref: '#/components/schemas/ExperimentMetricDirection'
+        definition:
+          $ref: '#/components/schemas/ExperimentMetricDefinition'
+      description: A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from.
+    ExperimentMetricDefinition:
+      type: object
+      required:
         - source
       properties:
-        id:
-          type: string
-          description: The metric identifier, unique within the experiment.
-        direction:
-          $ref: '#/components/schemas/ExperimentMetricDirection'
-        aggregation:
-          $ref: '#/components/schemas/ExperimentMetricAggregation'
         source:
           $ref: '#/components/schemas/ExperimentMetricSource'
-        guardrail:
-          $ref: '#/components/schemas/ExperimentMetricGuardrail'
-      description: A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails.
+        aggregation:
+          $ref: '#/components/schemas/ExperimentMetricAggregation'
+      description: The definition of a metric — wraps the data source and optional aggregation.
     ExperimentMetricDirection:
       anyOf:
         - type: string
@@ -17025,7 +17038,7 @@ components:
           enum:
             - continuous_evaluation_rule
             - evaluator
-            - trace_metric
+            - traces
       description: The type of metric source.
     ExperimentMetricSource:
       type: object
@@ -17042,24 +17055,8 @@ components:
           description: The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.
         name:
           type: string
-          description: The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'.
+          description: The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'.
       description: The source of a metric value, discriminated by type.
-    ExperimentMetricGuardrail:
-      type: object
-      properties:
-        max_delta_percent:
-          type: number
-          format: double
-          description: Maximum allowed relative delta as a percentage.
-        max_absolute:
-          type: number
-          format: double
-          description: Maximum allowed absolute value.
-        state:
-          type: string
-          description: The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.
-          readOnly: true
-      description: Guardrail threshold for a metric.
     ExperimentState:
       anyOf:
         - type: string
@@ -17164,6 +17161,9 @@ components:
         description:
           type: string
           description: A human-readable description of the experiment.
+        duration:
+          type: string
+          description: The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.
         variants:
           type: array
           items:
@@ -17196,27 +17196,26 @@ components:
     ScorecardRow:
       type: object
       required:
-        - metric_id
+        - metric_name
         - label
-        - control_value
-        - treatment_value
+        - desired_direction
+        - control_stats
+        - treatment_stats
         - delta
         - p_value
       properties:
-        metric_id:
+        metric_name:
           type: string
-          description: The metric identifier this row corresponds to.
+          description: The metric name this row corresponds to.
         label:
           type: string
           description: A human-readable label for the metric.
-        control_value:
-          type: number
-          format: double
-          description: The metric value for the control variant.
-        treatment_value:
-          type: number
-          format: double
-          description: The metric value for the treatment variant.
+        desired_direction:
+          $ref: '#/components/schemas/ExperimentMetricDirection'
+        control_stats:
+          $ref: '#/components/schemas/ScorecardVariantStats'
+        treatment_stats:
+          $ref: '#/components/schemas/ScorecardVariantStats'
         delta:
           type: number
           format: double
@@ -17225,10 +17224,27 @@ components:
           type: number
           format: double
           description: The p-value for statistical significance.
-        guardrail:
-          type: boolean
-          description: Whether this row corresponds to a guardrail metric.
       description: A single row in a scorecard table — one metric comparison between control and treatment.
+    ScorecardVariantStats:
+      type: object
+      required:
+        - count
+        - average
+        - std_dev
+      properties:
+        count:
+          type: integer
+          format: int32
+          description: The number of observations.
+        average:
+          type: number
+          format: double
+          description: The arithmetic mean of the metric values.
+        std_dev:
+          type: number
+          format: double
+          description: The standard deviation of the metric values.
+      description: Summary statistics for a variant in a scorecard row.
     Scorecard:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4608,7 +4608,7 @@ paths:
     post:
       operationId: Experiments_create
       summary: Create an experiment
-      description: Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.
+      description: Creates an experiment in the 'created' state. Call the :start action to begin routing traffic.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4770,6 +4770,51 @@ paths:
       responses:
         '200':
           description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:start:
+    post:
+      operationId: Experiments_start
+      summary: Start an experiment
+      description: Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to start.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The experiment was started successfully.
           content:
             application/json:
               schema:
@@ -17020,6 +17065,7 @@ components:
         - type: string
         - type: string
           enum:
+            - created
             - running
             - stopped
             - promoted

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -93,6 +93,9 @@ tags:
   - name: AgentOptimizationJobs
     parent: Platform APIs
     summary: Agent optimization jobs
+  - name: Experiments
+    parent: Platform APIs
+    summary: Experiment lifecycle for A/B version traffic-split
   - name: EvaluatorGenerationJobs
     parent: Platform APIs
     summary: Evaluator generation jobs
@@ -4627,13 +4630,19 @@ paths:
           explode: false
       responses:
         '201':
-          description: The experiment was created successfully.
+          description: The request has succeeded and a new resource has been created as a result.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Experiment'
-        default:
-          description: An unexpected error response.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4646,13 +4655,14 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateExperimentRequest'
+        description: The experiment to create.
       x-ms-foundry-meta:
         conditional_previews:
           - Experiments=V1Preview
     get:
       operationId: Experiments_list
       summary: List experiments
-      description: Returns the list of all experiments.
+      description: Returns a cursor-paged list of experiments.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4677,7 +4687,7 @@ paths:
           in: query
           required: false
           description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc`
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
             for descending order.
           schema:
             $ref: '#/components/schemas/PageOrder'
@@ -4685,14 +4695,20 @@ paths:
         - name: after
           in: query
           required: false
-          description: A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
           schema:
             type: string
           explode: false
         - name: before
           in: query
           required: false
-          description: A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
           schema:
             type: string
           explode: false
@@ -4718,7 +4734,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Experiment'
-                    description: The requested list of experiments.
+                    description: The requested list of items.
                   first_id:
                     type: string
                     description: The first ID represented in this list.
@@ -4728,9 +4744,15 @@ paths:
                   has_more:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of experiments.
-        default:
-          description: An unexpected error response.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4774,8 +4796,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Experiment'
-        default:
-          description: An unexpected error response.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4785,11 +4813,10 @@ paths:
       x-ms-foundry-meta:
         conditional_previews:
           - Experiments=V1Preview
-  /experiments/{experiment_id}:start:
-    post:
-      operationId: Experiments_start
-      summary: Start an experiment
-      description: Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.
+    patch:
+      operationId: Experiments_update
+      summary: Update an experiment
+      description: Applies a partial update to an experiment. Only experiments still in the 'created' state may be updated; omitted fields are left unchanged.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4802,7 +4829,7 @@ paths:
         - name: experiment_id
           in: path
           required: true
-          description: The unique identifier of the experiment to start.
+          description: The unique identifier of the experiment to update.
           schema:
             type: string
         - name: api-version
@@ -4814,27 +4841,38 @@ paths:
           explode: false
       responses:
         '200':
-          description: The experiment was started successfully.
+          description: The request has succeeded.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Experiment'
-        default:
-          description: An unexpected error response.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Experiments
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/PatchExperimentRequest'
       x-ms-foundry-meta:
         conditional_previews:
           - Experiments=V1Preview
-  /experiments/{experiment_id}:stop:
-    post:
-      operationId: Experiments_stop
-      summary: Stop an experiment
-      description: Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.
+    delete:
+      operationId: Experiments_delete
+      summary: Delete an experiment
+      description: Deletes a non-running experiment and its scorecard artifacts.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4847,7 +4885,170 @@ paths:
         - name: experiment_id
           in: path
           required: true
-          description: The unique identifier of the experiment to stop.
+          description: The unique identifier of the experiment to delete.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards:
+    get:
+      operationId: Experiments_listScorecards
+      summary: List scorecards
+      description: Returns a cursor-paged list of generated scorecards for an experiment. Each entry is a lightweight summary; use Get scorecard to retrieve the full metric rows.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScorecardSummary'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards/{scorecard_id}:
+    get:
+      operationId: Experiments_getScorecard
+      summary: Get a scorecard
+      description: Retrieves a generated scorecard by id, including its full metric rows.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: scorecard_id
+          in: path
+          required: true
+          description: The unique identifier of the scorecard.
           schema:
             type: string
         - name: api-version
@@ -4859,13 +5060,71 @@ paths:
           explode: false
       responses:
         '200':
-          description: The experiment was stopped successfully.
+          description: The request has succeeded.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Experiment'
-        default:
-          description: An unexpected error response.
+                $ref: '#/components/schemas/Scorecard'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    delete:
+      operationId: Experiments_deleteScorecard
+      summary: Delete a scorecard
+      description: Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: scorecard_id
+          in: path
+          required: true
+          description: The unique identifier of the scorecard to delete.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4904,13 +5163,19 @@ paths:
           explode: false
       responses:
         '200':
-          description: The experiment was promoted successfully.
+          description: The request has succeeded.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Experiment'
-        default:
-          description: An unexpected error response.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4923,14 +5188,15 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PromoteExperimentRequest'
+        description: The promotion request.
       x-ms-foundry-meta:
         conditional_previews:
           - Experiments=V1Preview
-  /experiments/{experiment_id}/scorecards:
-    get:
-      operationId: Experiments_listScorecards
-      summary: List scorecards
-      description: Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.
+  /experiments/{experiment_id}:start:
+    post:
+      operationId: Experiments_start
+      summary: Start an experiment
+      description: Starts a created experiment. The service mints the salt, materializes traffic steps, and begins sticky-per-conversation routing.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4943,7 +5209,7 @@ paths:
         - name: experiment_id
           in: path
           required: true
-          description: The unique identifier of the experiment.
+          description: The unique identifier of the experiment to start.
           schema:
             type: string
         - name: api-version
@@ -4959,17 +5225,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Scorecard'
-                    description: The list of scorecards.
-        default:
-          description: An unexpected error response.
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -4979,11 +5243,11 @@ paths:
       x-ms-foundry-meta:
         conditional_previews:
           - Experiments=V1Preview
-  /experiments/{experiment_id}/scorecards/{scorecard_id}:
-    delete:
-      operationId: Experiments_deleteScorecard
-      summary: Delete a scorecard
-      description: Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.
+  /experiments/{experiment_id}:stop:
+    post:
+      operationId: Experiments_stop
+      summary: Stop an experiment
+      description: Stops a running experiment. Routing collapses to the control variant.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4996,13 +5260,7 @@ paths:
         - name: experiment_id
           in: path
           required: true
-          description: The unique identifier of the experiment.
-          schema:
-            type: string
-        - name: scorecard_id
-          in: path
-          required: true
-          description: The unique identifier of the scorecard to delete.
+          description: The unique identifier of the experiment to stop.
           schema:
             type: string
         - name: api-version
@@ -5013,10 +5271,20 @@ paths:
             type: string
           explode: false
       responses:
-        '204':
-          description: The scorecard was deleted successfully.
-        default:
-          description: An unexpected error response.
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
           content:
             application/json:
               schema:
@@ -8573,10 +8841,6 @@ paths:
                   model:
                     type: string
                     description: The model deployment to use for the creation of this response.
-                  reasoning:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Reasoning'
-                      - type: 'null'
                   background:
                     anyOf:
                       - type: boolean
@@ -8655,6 +8919,10 @@ paths:
                         assuming it's an `assistant` message with the content generated by
                         the model, you might consider using the `output_text` property where
                         supported in SDKs.
+                  reasoning:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      - type: 'null'
                   instructions:
                     anyOf:
                       - type: string
@@ -8778,10 +9046,6 @@ paths:
                 model:
                   type: string
                   description: The model deployment to use for the creation of this response.
-                reasoning:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Reasoning'
-                    - type: 'null'
                 background:
                   anyOf:
                     - type: boolean
@@ -8807,7 +9071,12 @@ paths:
                         - auto
                         - disabled
                     - type: 'null'
+                  deprecated: true
                   default: disabled
+                reasoning:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.Reasoning'
+                    - type: 'null'
                 input:
                   $ref: '#/components/schemas/OpenAI.InputParam'
                 include:
@@ -12282,6 +12551,23 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Agentic identity credential definition
+    AgentsSafeRolloutExperiment:
+      type: object
+      required:
+        - type
+        - target_agent
+      properties:
+        type:
+          type: string
+          enum:
+            - agents_safe_rollout
+          description: The A/B safe-rollout experiment kind.
+        target_agent:
+          type: string
+          description: The name of the agent whose versions participate in the rollout.
+      allOf:
+        - $ref: '#/components/schemas/Experiment'
+      description: An experiment that safely rolls traffic between versions of one agent.
     ApiErrorResponse:
       type: object
       required:
@@ -14314,6 +14600,23 @@ components:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
           - DraftAgents=V1Preview
+    CreateAgentsSafeRolloutExperimentRequest:
+      type: object
+      required:
+        - type
+        - target_agent
+      properties:
+        type:
+          type: string
+          enum:
+            - agents_safe_rollout
+          description: The A/B safe-rollout experiment kind.
+        target_agent:
+          type: string
+          description: The name of the agent targeted by the experiment.
+      allOf:
+        - $ref: '#/components/schemas/CreateExperimentRequest'
+      description: Request body for creating an agents_safe_rollout experiment.
     CreateEvalRequest:
       type: object
       required:
@@ -14386,6 +14689,46 @@ components:
           description: The level at which evaluation is performed. Defaults to 'turn' if not specified.
           default: turn
       title: CreateEvalRunRequest
+    CreateExperimentRequest:
+      type: object
+      required:
+        - type
+        - display_name
+        - variants
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The discriminated experiment kind.
+        display_name:
+          type: string
+          description: A human-readable display name for the experiment.
+        description:
+          type: string
+          description: A human-readable description of the experiment.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The experiment duration in days. Drives only the service-managed scorecard refresh horizon; it does not end the experiment. Defaults to 7 when omitted.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: Optional list of metrics to attach to the experiment.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: Optional scheduled evaluation configuration.
+      discriminator:
+        propertyName: type
+        mapping:
+          agents_safe_rollout: '#/components/schemas/CreateAgentsSafeRolloutExperimentRequest'
+      description: Request body for creating an experiment.
     CreateSkillVersionFromFilesBody:
       type: object
       properties:
@@ -16703,6 +17046,29 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    EvaluatorMetricSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - evaluator
+          description: The evaluator source kind.
+        evaluator_name:
+          type: string
+          description: The evaluator name.
+        evaluator_version:
+          type: string
+          description: The evaluator version to pin.
+        parameters:
+          type: object
+          unevaluatedProperties: {}
+          description: Additional evaluator parameters.
+      allOf:
+        - $ref: '#/components/schemas/ExperimentMetricSource'
+      description: A metric sourced from an evaluator (a judge that scores agent output).
     EvaluatorMetricType:
       anyOf:
         - type: string
@@ -16889,35 +17255,48 @@ components:
         - state
         - display_name
         - variants
+        - metrics
         - experiment_steps
         - assignment_properties
-        - metrics
+        - created_at
       properties:
         id:
           type: string
           description: The unique identifier of the experiment.
           readOnly: true
         type:
-          $ref: '#/components/schemas/ExperimentType'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The discriminated experiment kind.
         state:
-          $ref: '#/components/schemas/ExperimentState'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentState'
+          description: The lifecycle state of the experiment.
+          readOnly: true
         display_name:
           type: string
           description: A human-readable display name for the experiment.
         description:
           type: string
           description: A human-readable description of the experiment.
-        target_agent:
-          type: string
-          description: The name of the agent this experiment targets. Required for agents_safe_rollout type.
-        duration:
-          type: string
-          description: The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The experiment duration in days. Drives only the service-managed scorecard refresh horizon (how long scorecards keep refreshing after start); it does not end the experiment — the experiment ends only when the caller stops or promotes it. Defaults to 7 when omitted.
         variants:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentVariant'
           description: The list of variants participating in the experiment.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: The list of metrics attached to the experiment.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: Configuration and service-managed resources for scheduled evaluation.
         experiment_steps:
           type: array
           items:
@@ -16925,29 +17304,32 @@ components:
           description: The list of experiment steps with traffic allocation details. Materialized by the service.
           readOnly: true
         assignment_properties:
-          $ref: '#/components/schemas/ExperimentAssignmentProperties'
-        metrics:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExperimentMetric'
-          description: The list of metrics (evaluation rules or inline evaluators) attached to the experiment.
+          allOf:
+            - $ref: '#/components/schemas/ExperimentAssignmentProperties'
+          description: Properties controlling how traffic is assigned to variants.
+          readOnly: true
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when the experiment was created.
+          readOnly: true
         started_at:
-          type: integer
-          format: int32
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
           description: The Unix timestamp (seconds) when the experiment was started. Null if not yet started.
           readOnly: true
-        scheduled_start_at:
-          type: integer
-          format: int32
-          nullable: true
-          description: The scheduled start time for the experiment (Unix timestamp). Null if started immediately.
-        scheduled_end_at:
-          type: integer
-          format: int32
-          nullable: true
-          description: The scheduled end time for the experiment (Unix timestamp). Null if no end is scheduled.
-      description: Represents an experiment that binds version routing to a lifecycle for A/B testing.
+        end_at:
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
+          description: The actual end time (Unix seconds), set when the experiment is stopped or promoted. Null while the experiment is created or running.
+          readOnly: true
+      discriminator:
+        propertyName: type
+        mapping:
+          agents_safe_rollout: '#/components/schemas/AgentsSafeRolloutExperiment'
+      description: A materialized experiment that binds version routing to a lifecycle for A/B testing.
     ExperimentAssignmentProperties:
       type: object
       required:
@@ -16978,6 +17360,21 @@ components:
           format: int32
           description: The exclusive end of the bucket range.
       description: A contiguous range of hash buckets assigned to a variant.
+    ExperimentEvaluation:
+      type: object
+      properties:
+        model:
+          type: string
+          description: The deployed model used by evaluator-backed metrics.
+        eval_id:
+          type: string
+          description: The service-managed evaluation group identifier.
+          readOnly: true
+        schedule_id:
+          type: string
+          description: The service-managed schedule identifier.
+          readOnly: true
+      description: Configuration and service-managed resources for scheduled experiment evaluation.
     ExperimentMetric:
       type: object
       required:
@@ -16988,19 +17385,49 @@ components:
           type: string
           description: The caller-defined metric name, unique within the experiment.
         desired_direction:
-          $ref: '#/components/schemas/ExperimentMetricDirection'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDirection'
+          description: The desired direction for this metric. Optional; if omitted, the service infers from the evaluator defaults.
         definition:
-          $ref: '#/components/schemas/ExperimentMetricDefinition'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDefinition'
+          description: The metric definition including data source and optional aggregation.
       description: A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from.
+    ExperimentMetricAggregation:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricAggregationType'
+          description: The aggregation function.
+        percentile:
+          type: integer
+          format: int32
+          description: The percentile value (e.g. 95). Required when type is 'percentile'.
+      description: Aggregation configuration for a metric.
+    ExperimentMetricAggregationType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - average
+            - percentile
+      description: The aggregation function for a metric.
     ExperimentMetricDefinition:
       type: object
       required:
         - source
       properties:
         source:
-          $ref: '#/components/schemas/ExperimentMetricSource'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSource'
+          description: The source of the metric data.
         aggregation:
-          $ref: '#/components/schemas/ExperimentMetricAggregation'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricAggregation'
+          description: Optional aggregation configuration. If omitted, the service uses the evaluator's default aggregation.
       description: The definition of a metric — wraps the data source and optional aggregation.
     ExperimentMetricDirection:
       anyOf:
@@ -17009,54 +17436,31 @@ components:
           enum:
             - increase
             - decrease
+            - neutral
       description: The desired direction for a metric value.
-    ExperimentMetricAggregationType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - average
-            - percentile
-            - rate
-      description: The aggregation function for a metric.
-    ExperimentMetricAggregation:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/ExperimentMetricAggregationType'
-        percentile:
-          type: integer
-          format: int32
-          description: The percentile value (e.g. 95). Required when type is 'percentile'.
-      description: Aggregation configuration for a metric.
-    ExperimentMetricSourceType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - continuous_evaluation_rule
-            - evaluator
-            - traces
-      description: The type of metric source.
     ExperimentMetricSource:
       type: object
       required:
         - type
       properties:
         type:
-          $ref: '#/components/schemas/ExperimentMetricSourceType'
-        rule_id:
-          type: string
-          description: The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'.
-        evaluator_name:
-          type: string
-          description: The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.
-        name:
-          type: string
-          description: The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'.
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSourceType'
+          description: The type of metric source.
+      discriminator:
+        propertyName: type
+        mapping:
+          evaluator: '#/components/schemas/EvaluatorMetricSource'
+          traces: '#/components/schemas/TracesMetricSource'
       description: The source of a metric value, discriminated by type.
+    ExperimentMetricSourceType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - evaluator
+            - traces
+      description: The type of metric source.
     ExperimentState:
       anyOf:
         - type: string
@@ -17077,14 +17481,14 @@ components:
           type: string
           description: The identifier for this experiment step.
         started_at:
-          type: integer
-          format: int32
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
           description: The Unix timestamp (seconds) when this step started.
         stopped_at:
-          type: integer
-          format: int32
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
           description: The Unix timestamp (seconds) when this step stopped. Null if still running.
         variant_traffic_maps:
           type: array
@@ -17109,11 +17513,17 @@ components:
           type: string
           description: The variant identifier. For agents_safe_rollout this is the agent version number.
         role:
-          $ref: '#/components/schemas/ExperimentVariantRole'
+          allOf:
+            - $ref: '#/components/schemas/ExperimentVariantRole'
+          description: The role of this variant in the experiment.
         traffic_percentage:
           type: integer
           format: int32
-          description: The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses.
+          description: The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead).
+        required_sample_size:
+          type: integer
+          format: int32
+          description: The minimum number of observations required before this variant's scorecard results are considered reliable. Defaults to 100 when omitted.
       description: A variant participating in the experiment.
     ExperimentVariantRole:
       anyOf:
@@ -17143,135 +17553,6 @@ components:
             $ref: '#/components/schemas/ExperimentBucketRange'
           description: The hash bucket ranges assigned to this variant.
       description: Traffic allocation map for a single variant within an experiment step.
-    CreateExperimentRequest:
-      type: object
-      required:
-        - type
-        - display_name
-        - variants
-      properties:
-        type:
-          $ref: '#/components/schemas/ExperimentType'
-        target_agent:
-          type: string
-          description: The name of the agent this experiment targets. Required for agents_safe_rollout type.
-        display_name:
-          type: string
-          description: A human-readable display name for the experiment.
-        description:
-          type: string
-          description: A human-readable description of the experiment.
-        duration:
-          type: string
-          description: The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.
-        variants:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExperimentVariant'
-          description: The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.
-        metrics:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExperimentMetric'
-          description: Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment.
-      description: Request body for creating an experiment.
-    PromoteExperimentRequest:
-      type: object
-      required:
-        - winner_variant_id
-      properties:
-        winner_variant_id:
-          type: string
-          description: The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version.
-      description: Request body for promoting an experiment.
-    ScorecardState:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - ready
-            - computing
-            - failed
-      description: The state of a scorecard.
-    ScorecardRow:
-      type: object
-      required:
-        - metric_name
-        - label
-        - desired_direction
-        - control_stats
-        - treatment_stats
-        - delta
-        - p_value
-      properties:
-        metric_name:
-          type: string
-          description: The metric name this row corresponds to.
-        label:
-          type: string
-          description: A human-readable label for the metric.
-        desired_direction:
-          $ref: '#/components/schemas/ExperimentMetricDirection'
-        control_stats:
-          $ref: '#/components/schemas/ScorecardVariantStats'
-        treatment_stats:
-          $ref: '#/components/schemas/ScorecardVariantStats'
-        delta:
-          type: number
-          format: double
-          description: The absolute delta between treatment and control.
-        p_value:
-          type: number
-          format: double
-          description: The p-value for statistical significance.
-      description: A single row in a scorecard table — one metric comparison between control and treatment.
-    ScorecardVariantStats:
-      type: object
-      required:
-        - count
-        - average
-        - std_dev
-      properties:
-        count:
-          type: integer
-          format: int32
-          description: The number of observations.
-        average:
-          type: number
-          format: double
-          description: The arithmetic mean of the metric values.
-        std_dev:
-          type: number
-          format: double
-          description: The standard deviation of the metric values.
-      description: Summary statistics for a variant in a scorecard row.
-    Scorecard:
-      type: object
-      required:
-        - id
-        - experiment_id
-        - state
-        - artifact_uri
-        - rows
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the scorecard.
-          readOnly: true
-        experiment_id:
-          type: string
-          description: The experiment this scorecard belongs to.
-        state:
-          $ref: '#/components/schemas/ScorecardState'
-        artifact_uri:
-          type: string
-          description: The URI to the scorecard artifact in the user's blob storage.
-        rows:
-          type: array
-          items:
-            $ref: '#/components/schemas/ScorecardRow'
-          description: The metric comparison rows.
-      description: A generated scorecard artifact — a table comparing metric values between variants.
     ExternalAgentDefinition:
       type: object
       required:
@@ -18321,8 +18602,8 @@ components:
           type: string
           format: uri
           description: |-
-            The URL for the MCP server. One of `server_url` or `connector_id` must be
-              provided.
+            The URL for the MCP server. One of `server_url`, `connector_id`, or
+              `tunnel_id` must be provided.
         connector_id:
           type: string
           enum:
@@ -18336,8 +18617,8 @@ components:
             - connector_sharepoint
           description: |-
             Identifier for service connectors, like those available in ChatGPT. One of
-              `server_url` or `connector_id` must be provided. Learn more about service
-              connectors [here](/docs/guides/tools-remote-mcp#connectors).
+              `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more
+              about service connectors [here](/docs/guides/tools-remote-mcp#connectors).
               Currently supported `connector_id` values are:
               - Dropbox: `connector_dropbox`
               - Gmail: `connector_gmail`
@@ -18347,6 +18628,12 @@ components:
               - Outlook Calendar: `connector_outlookcalendar`
               - Outlook Email: `connector_outlookemail`
               - SharePoint: `connector_sharepoint`
+        tunnel_id:
+          type: string
+          pattern: ^tunnel_[a-z0-9]{32}$
+          description: |-
+            The Secure MCP Tunnel ID to use instead of a direct server URL. One of
+              `server_url`, `connector_id`, or `tunnel_id` must be provided.
         authorization:
           type: string
           description: |-
@@ -29755,8 +30042,8 @@ components:
           type: string
           format: uri
           description: |-
-            The URL for the MCP server. One of `server_url` or `connector_id` must be
-              provided.
+            The URL for the MCP server. One of `server_url`, `connector_id`, or
+              `tunnel_id` must be provided.
         connector_id:
           type: string
           enum:
@@ -29770,8 +30057,8 @@ components:
             - connector_sharepoint
           description: |-
             Identifier for service connectors, like those available in ChatGPT. One of
-              `server_url` or `connector_id` must be provided. Learn more about service
-              connectors [here](/docs/guides/tools-remote-mcp#connectors).
+              `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more
+              about service connectors [here](/docs/guides/tools-remote-mcp#connectors).
               Currently supported `connector_id` values are:
               - Dropbox: `connector_dropbox`
               - Gmail: `connector_gmail`
@@ -29781,6 +30068,12 @@ components:
               - Outlook Calendar: `connector_outlookcalendar`
               - Outlook Email: `connector_outlookemail`
               - SharePoint: `connector_sharepoint`
+        tunnel_id:
+          type: string
+          pattern: ^tunnel_[a-z0-9]{32}$
+          description: |-
+            The Secure MCP Tunnel ID to use instead of a direct server URL. One of
+              `server_url`, `connector_id`, or `tunnel_id` must be provided.
         authorization:
           type: string
           description: |-
@@ -31738,6 +32031,14 @@ components:
                 - concise
                 - detailed
             - type: 'null'
+        context:
+          anyOf:
+            - type: string
+              enum:
+                - auto
+                - current_turn
+                - all_turns
+            - type: 'null'
         generate_summary:
           anyOf:
             - type: string
@@ -31853,10 +32154,6 @@ components:
         model:
           type: string
           description: The model deployment to use for the creation of this response.
-        reasoning:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
         background:
           anyOf:
             - type: boolean
@@ -31935,6 +32232,10 @@ components:
               assuming it's an `assistant` message with the content generated by
               the model, you might consider using the `output_text` property where
               supported in SDKs.
+        reasoning:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.Reasoning'
+            - type: 'null'
         instructions:
           anyOf:
             - type: string
@@ -36633,6 +36934,41 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentCardUpdate'
           description: Optional agent card for the agent
+    PatchExperimentRequest:
+      type: object
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The experiment kind. Must match the existing experiment.
+        display_name:
+          type: string
+          description: The new display name. Left unchanged when omitted.
+        description:
+          type: string
+          description: The new description. Left unchanged when omitted.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The new duration in days. Left unchanged when omitted.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The replacement variant list. When provided it fully replaces the existing variants and must satisfy the same rules as on create.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: The replacement metric list. When provided it fully replaces the existing metrics.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: The replacement scheduled evaluation configuration. Left unchanged when omitted.
+      description: |-
+        Request body for patching an experiment. Only experiments still in the 'created' state may be
+        updated; omitted fields are left unchanged. Type-specific identity (e.g. agents_safe_rollout
+        target_agent) is immutable and cannot be changed here.
     PendingUploadRequest:
       type: object
       required:
@@ -36689,6 +37025,15 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - MemoryStores=V1Preview
+    PromoteExperimentRequest:
+      type: object
+      required:
+        - winner_variant_id
+      properties:
+        winner_variant_id:
+          type: string
+          description: The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version.
+      description: Request body for promoting an experiment.
     PromotionInfo:
       type: object
       required:
@@ -37728,6 +38073,248 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    Scorecard:
+      type: object
+      required:
+        - id
+        - experiment_id
+        - control_variant_id
+        - treatment_variant_ids
+        - window_start
+        - window_end
+        - created_at
+        - state
+        - rows
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the scorecard.
+        experiment_id:
+          type: string
+          description: The experiment this scorecard belongs to.
+        control_variant_id:
+          type: string
+          description: The control (baseline) variant used by this scorecard.
+        treatment_variant_ids:
+          type: array
+          items:
+            type: string
+          description: The treatment variants compared against the control in this scorecard.
+        window_start:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        window_end:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when this scorecard was generated.
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardState'
+          description: The state of the scorecard.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardError'
+          description: Failure detail when the state is 'failed'. Null otherwise.
+        metadata:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here.
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScorecardRow'
+          description: The metric comparison rows.
+      description: A generated scorecard artifact — a table comparing metric values between variants.
+    ScorecardError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Stable, machine-readable failure category (e.g. 'compute_failed', 'internal_error', 'publish_failed').
+        message:
+          type: string
+          description: Human-readable (truncated) failure description.
+      description: Structured failure detail for a scorecard whose state is 'failed'.
+    ScorecardMetricLevel:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - turn
+            - conversation
+      description: The granularity a scorecard metric is measured at.
+    ScorecardPairComparison:
+      type: object
+      required:
+        - delta
+        - p_value
+        - treatment_effect
+      properties:
+        delta:
+          type: number
+          format: double
+          description: "The signed delta: this variant's average minus the control's."
+        p_value:
+          type: number
+          format: double
+          description: The p-value for significance vs. the control.
+        relative_difference:
+          anyOf:
+            - type: number
+              format: double
+            - type: 'null'
+          description: The relative difference vs. the control, or null when the control average is zero.
+        treatment_effect:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardTreatmentEffect'
+          description: The qualitative treatment effect vs. the control, classified from the p-value and thresholds.
+      description: A treatment variant's comparison against the scorecard's control for one metric.
+    ScorecardRow:
+      type: object
+      required:
+        - metric_name
+        - level
+        - category
+        - desired_direction
+        - variants
+      properties:
+        metric_name:
+          type: string
+          description: The metric name this row corresponds to.
+        level:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardMetricLevel'
+          description: The granularity this metric is measured at (turn or conversation).
+        category:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSourceType'
+          description: The kind of source this metric is derived from (evaluator or traces).
+        desired_direction:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDirection'
+          description: The desired direction for this metric.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScorecardVariantResult'
+          description: One result per variant (control plus every treatment) for this metric.
+      description: A single row in a scorecard table — one metric compared across every variant.
+    ScorecardState:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ready
+            - computing
+            - failed
+      description: The state of a scorecard.
+    ScorecardSummary:
+      type: object
+      required:
+        - id
+        - experiment_id
+        - control_variant_id
+        - treatment_variant_ids
+        - window_start
+        - window_end
+        - created_at
+        - state
+        - metric_count
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the scorecard.
+        experiment_id:
+          type: string
+          description: The experiment this scorecard belongs to.
+        control_variant_id:
+          type: string
+          description: The control (baseline) variant used by this scorecard.
+        treatment_variant_ids:
+          type: array
+          items:
+            type: string
+          description: The treatment variants compared against the control in this scorecard.
+        window_start:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        window_end:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when this scorecard was generated.
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardState'
+          description: The state of the scorecard.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardError'
+          description: Failure detail when the state is 'failed'. Null otherwise.
+        metadata:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here.
+        metric_count:
+          type: integer
+          format: int32
+          description: The number of metric rows in the full scorecard.
+      description: Lightweight scorecard projection returned by list operations. The full metric rows are available only from the individual scorecard resource.
+    ScorecardTreatmentEffect:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - improved
+            - degraded
+            - changed
+            - inconclusive
+            - insufficient_data
+            - no_samples
+            - unknown
+      description: The qualitative outcome of a metric's treatment-vs-control comparison.
+    ScorecardVariantResult:
+      type: object
+      required:
+        - variant_id
+        - count
+        - average
+        - std_dev
+      properties:
+        variant_id:
+          type: string
+          description: The variant identifier (for agents_safe_rollout this is the agent version number).
+        count:
+          type: integer
+          format: int32
+          description: The number of observations.
+        average:
+          type: number
+          format: double
+          description: The arithmetic mean of the metric values.
+        std_dev:
+          type: number
+          format: double
+          description: The standard deviation of the metric values.
+        comparison:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardPairComparison'
+          description: This variant's comparison against the scorecard's control. Null for the control variant.
+      description: "One variant's result for a metric row: its raw aggregates plus, for treatment variants, the comparison against the control."
     SessionDirectoryEntry:
       type: object
       required:
@@ -38849,6 +39436,25 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    TracesMetricSource:
+      type: object
+      required:
+        - type
+        - attribute_names
+      properties:
+        type:
+          type: string
+          enum:
+            - traces
+          description: The traces source kind.
+        attribute_names:
+          type: array
+          items:
+            type: string
+          description: Trace attribute names the metric value is read from. Each attribute must be numeric, or boolean (coerced to 1/0). When more than one is given, the per-event value is the sum of the attributes; a missing attribute contributes 0 (partial rows are kept), and the event value is null only when every listed attribute is null.
+      allOf:
+        - $ref: '#/components/schemas/ExperimentMetricSource'
+      description: A metric sourced from trace/event attributes.
     TracesPreviewEvalRunDataSource:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -183,6 +183,11 @@
       "summary": "Agent optimization jobs"
     },
     {
+      "name": "Experiments",
+      "parent": "Platform APIs",
+      "summary": "Experiment lifecycle for A/B version traffic-split"
+    },
+    {
       "name": "EvaluatorGenerationJobs",
       "parent": "Platform APIs",
       "summary": "Evaluator generation jobs"
@@ -9595,6 +9600,1032 @@
         }
       }
     },
+    "/experiments": {
+      "post": {
+        "operationId": "Experiments_create",
+        "summary": "Create an experiment",
+        "description": "Creates an experiment in the 'created' state. Call the :start action to begin routing traffic.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExperimentRequest"
+              }
+            }
+          },
+          "description": "The experiment to create."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Experiments_list",
+        "summary": "List experiments",
+        "description": "Returns a cursor-paged list of experiments.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Experiment"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}": {
+      "get": {
+        "operationId": "Experiments_get",
+        "summary": "Get an experiment",
+        "description": "Retrieves the experiment by id.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "patch": {
+        "operationId": "Experiments_update",
+        "summary": "Update an experiment",
+        "description": "Applies a partial update to an experiment. Only experiments still in the 'created' state may be updated; omitted fields are left unchanged.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to update.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchExperimentRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Experiments_delete",
+        "summary": "Delete an experiment",
+        "description": "Deletes a non-running experiment and its scorecard artifacts.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}/scorecards": {
+      "get": {
+        "operationId": "Experiments_listScorecards",
+        "summary": "List scorecards",
+        "description": "Returns a cursor-paged list of generated scorecards for an experiment. Each entry is a lightweight summary; use Get scorecard to retrieve the full metric rows.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ScorecardSummary"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}/scorecards/{scorecard_id}": {
+      "get": {
+        "operationId": "Experiments_getScorecard",
+        "summary": "Get a scorecard",
+        "description": "Retrieves a generated scorecard by id, including its full metric rows.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scorecard_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the scorecard.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scorecard"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Experiments_deleteScorecard",
+        "summary": "Delete a scorecard",
+        "description": "Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scorecard_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the scorecard to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:promote": {
+      "post": {
+        "operationId": "Experiments_promote",
+        "summary": "Promote an experiment",
+        "description": "Promotes the winning variant. The agent's version selector is replaced with a single 100% rule for the winner.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to promote.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteExperimentRequest"
+              }
+            }
+          },
+          "description": "The promotion request."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:start": {
+      "post": {
+        "operationId": "Experiments_start",
+        "summary": "Start an experiment",
+        "description": "Starts a created experiment. The service mints the salt, materializes traffic steps, and begins sticky-per-conversation routing.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to start.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
+    "/experiments/{experiment_id}:stop": {
+      "post": {
+        "operationId": "Experiments_stop",
+        "summary": "Stop an experiment",
+        "description": "Stops a running experiment. Routing collapses to the control variant.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Experiments=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the experiment to stop.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Experiment"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Experiments"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Experiments=V1Preview"
+          ]
+        }
+      }
+    },
     "/indexes": {
       "get": {
         "operationId": "Indexes_listLatest",
@@ -15254,16 +16285,6 @@
                       "type": "string",
                       "description": "The model deployment to use for the creation of this response."
                     },
-                    "reasoning": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Reasoning"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "background": {
                       "anyOf": [
                         {
@@ -15386,6 +16407,16 @@
                         "$ref": "#/components/schemas/OpenAI.OutputItem"
                       },
                       "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.Reasoning"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "instructions": {
                       "anyOf": [
@@ -15620,16 +16651,6 @@
                     "type": "string",
                     "description": "The model deployment to use for the creation of this response."
                   },
-                  "reasoning": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Reasoning"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "background": {
                     "anyOf": [
                       {
@@ -15682,7 +16703,18 @@
                         "type": "null"
                       }
                     ],
+                    "deprecated": true,
                     "default": "disabled"
+                  },
+                  "reasoning": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.Reasoning"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "input": {
                     "$ref": "#/components/schemas/OpenAI.InputParam"
@@ -21411,6 +22443,32 @@
         ],
         "description": "Agentic identity credential definition"
       },
+      "AgentsSafeRolloutExperiment": {
+        "type": "object",
+        "required": [
+          "type",
+          "target_agent"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ],
+            "description": "The A/B safe-rollout experiment kind."
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent whose versions participate in the rollout."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Experiment"
+          }
+        ],
+        "description": "An experiment that safely rolls traffic between versions of one agent."
+      },
       "ApiErrorResponse": {
         "type": "object",
         "required": [
@@ -24588,6 +25646,32 @@
           ]
         }
       },
+      "CreateAgentsSafeRolloutExperimentRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "target_agent"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ],
+            "description": "The A/B safe-rollout experiment kind."
+          },
+          "target_agent": {
+            "type": "string",
+            "description": "The name of the agent targeted by the experiment."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateExperimentRequest"
+          }
+        ],
+        "description": "Request body for creating an agents_safe_rollout experiment."
+      },
       "CreateEvalRequest": {
         "type": "object",
         "required": [
@@ -24720,6 +25804,66 @@
           }
         },
         "title": "CreateEvalRunRequest"
+      },
+      "CreateExperimentRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "display_name",
+          "variants"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The discriminated experiment kind."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "A human-readable display name for the experiment."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the experiment."
+          },
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The experiment duration in days. Drives only the service-managed scorecard refresh horizon; it does not end the experiment. Defaults to 7 when omitted."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "Optional list of metrics to attach to the experiment."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "Optional scheduled evaluation configuration."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agents_safe_rollout": "#/components/schemas/CreateAgentsSafeRolloutExperimentRequest"
+          }
+        },
+        "description": "Request body for creating an experiment."
       },
       "CreateOrUpdateManagedAgentIdentityBlueprintRequest": {
         "type": "object",
@@ -28828,6 +29972,40 @@
           ]
         }
       },
+      "EvaluatorMetricSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "evaluator"
+            ],
+            "description": "The evaluator source kind."
+          },
+          "evaluator_name": {
+            "type": "string",
+            "description": "The evaluator name."
+          },
+          "evaluator_version": {
+            "type": "string",
+            "description": "The evaluator version to pin."
+          },
+          "parameters": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Additional evaluator parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExperimentMetricSource"
+          }
+        ],
+        "description": "A metric sourced from an evaluator (a judge that scores agent output)."
+      },
       "EvaluatorMetricType": {
         "anyOf": [
           {
@@ -29093,6 +30271,491 @@
             "Evaluations=V1Preview"
           ]
         }
+      },
+      "Experiment": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "state",
+          "display_name",
+          "variants",
+          "metrics",
+          "experiment_steps",
+          "assignment_properties",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the experiment.",
+            "readOnly": true
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The discriminated experiment kind."
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentState"
+              }
+            ],
+            "description": "The lifecycle state of the experiment.",
+            "readOnly": true
+          },
+          "display_name": {
+            "type": "string",
+            "description": "A human-readable display name for the experiment."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the experiment."
+          },
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The experiment duration in days. Drives only the service-managed scorecard refresh horizon (how long scorecards keep refreshing after start); it does not end the experiment — the experiment ends only when the caller stops or promotes it. Defaults to 7 when omitted."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The list of variants participating in the experiment."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "The list of metrics attached to the experiment."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "Configuration and service-managed resources for scheduled evaluation."
+          },
+          "experiment_steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentStep"
+            },
+            "description": "The list of experiment steps with traffic allocation details. Materialized by the service.",
+            "readOnly": true
+          },
+          "assignment_properties": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentAssignmentProperties"
+              }
+            ],
+            "description": "Properties controlling how traffic is assigned to variants.",
+            "readOnly": true
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when the experiment was created.",
+            "readOnly": true
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when the experiment was started. Null if not yet started.",
+            "readOnly": true
+          },
+          "end_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The actual end time (Unix seconds), set when the experiment is stopped or promoted. Null while the experiment is created or running.",
+            "readOnly": true
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agents_safe_rollout": "#/components/schemas/AgentsSafeRolloutExperiment"
+          }
+        },
+        "description": "A materialized experiment that binds version routing to a lifecycle for A/B testing."
+      },
+      "ExperimentAssignmentProperties": {
+        "type": "object",
+        "required": [
+          "salt",
+          "assignment_unit"
+        ],
+        "properties": {
+          "salt": {
+            "type": "string",
+            "description": "An immutable bucketing seed minted when the experiment starts. Re-salting re-randomizes every bucket.",
+            "readOnly": true
+          },
+          "assignment_unit": {
+            "type": "string",
+            "description": "The unit used for sticky bucketing (e.g. conversationId).",
+            "readOnly": true
+          }
+        },
+        "description": "Properties controlling how traffic is assigned to variants."
+      },
+      "ExperimentBucketRange": {
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The inclusive start of the bucket range (0-based)."
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The exclusive end of the bucket range."
+          }
+        },
+        "description": "A contiguous range of hash buckets assigned to a variant."
+      },
+      "ExperimentEvaluation": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The deployed model used by evaluator-backed metrics."
+          },
+          "eval_id": {
+            "type": "string",
+            "description": "The service-managed evaluation group identifier.",
+            "readOnly": true
+          },
+          "schedule_id": {
+            "type": "string",
+            "description": "The service-managed schedule identifier.",
+            "readOnly": true
+          }
+        },
+        "description": "Configuration and service-managed resources for scheduled experiment evaluation."
+      },
+      "ExperimentMetric": {
+        "type": "object",
+        "required": [
+          "name",
+          "definition"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The caller-defined metric name, unique within the experiment."
+          },
+          "desired_direction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDirection"
+              }
+            ],
+            "description": "The desired direction for this metric. Optional; if omitted, the service infers from the evaluator defaults."
+          },
+          "definition": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDefinition"
+              }
+            ],
+            "description": "The metric definition including data source and optional aggregation."
+          }
+        },
+        "description": "A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from."
+      },
+      "ExperimentMetricAggregation": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricAggregationType"
+              }
+            ],
+            "description": "The aggregation function."
+          },
+          "percentile": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The percentile value (e.g. 95). Required when type is 'percentile'."
+          }
+        },
+        "description": "Aggregation configuration for a metric."
+      },
+      "ExperimentMetricAggregationType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "average",
+              "percentile"
+            ]
+          }
+        ],
+        "description": "The aggregation function for a metric."
+      },
+      "ExperimentMetricDefinition": {
+        "type": "object",
+        "required": [
+          "source"
+        ],
+        "properties": {
+          "source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSource"
+              }
+            ],
+            "description": "The source of the metric data."
+          },
+          "aggregation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricAggregation"
+              }
+            ],
+            "description": "Optional aggregation configuration. If omitted, the service uses the evaluator's default aggregation."
+          }
+        },
+        "description": "The definition of a metric — wraps the data source and optional aggregation."
+      },
+      "ExperimentMetricDirection": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "increase",
+              "decrease",
+              "neutral"
+            ]
+          }
+        ],
+        "description": "The desired direction for a metric value."
+      },
+      "ExperimentMetricSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSourceType"
+              }
+            ],
+            "description": "The type of metric source."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "evaluator": "#/components/schemas/EvaluatorMetricSource",
+            "traces": "#/components/schemas/TracesMetricSource"
+          }
+        },
+        "description": "The source of a metric value, discriminated by type."
+      },
+      "ExperimentMetricSourceType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "evaluator",
+              "traces"
+            ]
+          }
+        ],
+        "description": "The type of metric source."
+      },
+      "ExperimentState": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "created",
+              "running",
+              "stopped",
+              "promoted"
+            ]
+          }
+        ],
+        "description": "The lifecycle state of the experiment."
+      },
+      "ExperimentStep": {
+        "type": "object",
+        "required": [
+          "id",
+          "variant_traffic_maps"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this experiment step."
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this step started."
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this step stopped. Null if still running."
+          },
+          "variant_traffic_maps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariantTrafficMap"
+            },
+            "description": "The traffic allocation for each variant in this step."
+          }
+        },
+        "description": "A step in the experiment with traffic allocation details."
+      },
+      "ExperimentType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agents_safe_rollout"
+            ]
+          }
+        ],
+        "description": "The discriminated experiment kind."
+      },
+      "ExperimentVariant": {
+        "type": "object",
+        "required": [
+          "id",
+          "role"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The variant identifier. For agents_safe_rollout this is the agent version number."
+          },
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentVariantRole"
+              }
+            ],
+            "description": "The role of this variant in the experiment."
+          },
+          "traffic_percentage": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead)."
+          },
+          "required_sample_size": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The minimum number of observations required before this variant's scorecard results are considered reliable. Defaults to 100 when omitted."
+          }
+        },
+        "description": "A variant participating in the experiment."
+      },
+      "ExperimentVariantRole": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "control",
+              "treatment"
+            ]
+          }
+        ],
+        "description": "The role of a variant in the experiment."
+      },
+      "ExperimentVariantTrafficMap": {
+        "type": "object",
+        "required": [
+          "variant_id",
+          "percentage",
+          "bucket_ranges"
+        ],
+        "properties": {
+          "variant_id": {
+            "type": "string",
+            "description": "The variant identifier this traffic map applies to."
+          },
+          "percentage": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The traffic percentage for this variant."
+          },
+          "bucket_ranges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentBucketRange"
+            },
+            "description": "The hash bucket ranges assigned to this variant."
+          }
+        },
+        "description": "Traffic allocation map for a single variant within an experiment step."
       },
       "ExternalAgentDefinition": {
         "type": "object",
@@ -30786,7 +32449,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\n  provided."
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n  `tunnel_id` must be provided."
           },
           "connector_id": {
             "type": "string",
@@ -30800,7 +32463,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url` or `connector_id` must be provided. Learn more about service\n  connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\n  about service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided."
           },
           "authorization": {
             "type": "string",
@@ -47666,7 +49334,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\n  provided."
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n  `tunnel_id` must be provided."
           },
           "connector_id": {
             "type": "string",
@@ -47680,7 +49348,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url` or `connector_id` must be provided. Learn more about service\n  connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\n  about service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n  Currently supported `connector_id` values are:\n  - Dropbox: `connector_dropbox`\n  - Gmail: `connector_gmail`\n  - Google Calendar: `connector_googlecalendar`\n  - Google Drive: `connector_googledrive`\n  - Microsoft Teams: `connector_microsoftteams`\n  - Outlook Calendar: `connector_outlookcalendar`\n  - Outlook Email: `connector_outlookemail`\n  - SharePoint: `connector_sharepoint`"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n  `server_url`, `connector_id`, or `tunnel_id` must be provided."
           },
           "authorization": {
             "type": "string",
@@ -50543,6 +52216,21 @@
               }
             ]
           },
+          "context": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "current_turn",
+                  "all_turns"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "generate_summary": {
             "anyOf": [
               {
@@ -50706,16 +52394,6 @@
             "type": "string",
             "description": "The model deployment to use for the creation of this response."
           },
-          "reasoning": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "background": {
             "anyOf": [
               {
@@ -50838,6 +52516,16 @@
               "$ref": "#/components/schemas/OpenAI.OutputItem"
             },
             "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Reasoning"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "instructions": {
             "anyOf": [
@@ -57087,6 +58775,55 @@
           }
         }
       },
+      "PatchExperimentRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentType"
+              }
+            ],
+            "description": "The experiment kind. Must match the existing experiment."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "The new display name. Left unchanged when omitted."
+          },
+          "description": {
+            "type": "string",
+            "description": "The new description. Left unchanged when omitted."
+          },
+          "duration_in_days": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The new duration in days. Left unchanged when omitted."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentVariant"
+            },
+            "description": "The replacement variant list. When provided it fully replaces the existing variants and must satisfy the same rules as on create."
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExperimentMetric"
+            },
+            "description": "The replacement metric list. When provided it fully replaces the existing metrics."
+          },
+          "evaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentEvaluation"
+              }
+            ],
+            "description": "The replacement scheduled evaluation configuration. Left unchanged when omitted."
+          }
+        },
+        "description": "Request body for patching an experiment. Only experiments still in the 'created' state may be\nupdated; omitted fields are left unchanged. Type-specific identity (e.g. agents_safe_rollout\ntarget_agent) is immutable and cannot be changed here."
+      },
       "PendingUploadRequest": {
         "type": "object",
         "required": [
@@ -57170,6 +58907,19 @@
             "MemoryStores=V1Preview"
           ]
         }
+      },
+      "PromoteExperimentRequest": {
+        "type": "object",
+        "required": [
+          "winner_variant_id"
+        ],
+        "properties": {
+          "winner_variant_id": {
+            "type": "string",
+            "description": "The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version."
+          }
+        },
+        "description": "Request body for promoting an experiment."
       },
       "PromotionInfo": {
         "type": "object",
@@ -58817,6 +60567,381 @@
             "Schedules=V1Preview"
           ]
         }
+      },
+      "Scorecard": {
+        "type": "object",
+        "required": [
+          "id",
+          "experiment_id",
+          "control_variant_id",
+          "treatment_variant_ids",
+          "window_start",
+          "window_end",
+          "created_at",
+          "state",
+          "rows"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the scorecard."
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment this scorecard belongs to."
+          },
+          "control_variant_id": {
+            "type": "string",
+            "description": "The control (baseline) variant used by this scorecard."
+          },
+          "treatment_variant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The treatment variants compared against the control in this scorecard."
+          },
+          "window_start": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "window_end": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this scorecard was generated."
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardState"
+              }
+            ],
+            "description": "The state of the scorecard."
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardError"
+              }
+            ],
+            "description": "Failure detail when the state is 'failed'. Null otherwise."
+          },
+          "metadata": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here."
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScorecardRow"
+            },
+            "description": "The metric comparison rows."
+          }
+        },
+        "description": "A generated scorecard artifact — a table comparing metric values between variants."
+      },
+      "ScorecardError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable, machine-readable failure category (e.g. 'compute_failed', 'internal_error', 'publish_failed')."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable (truncated) failure description."
+          }
+        },
+        "description": "Structured failure detail for a scorecard whose state is 'failed'."
+      },
+      "ScorecardMetricLevel": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "turn",
+              "conversation"
+            ]
+          }
+        ],
+        "description": "The granularity a scorecard metric is measured at."
+      },
+      "ScorecardPairComparison": {
+        "type": "object",
+        "required": [
+          "delta",
+          "p_value",
+          "treatment_effect"
+        ],
+        "properties": {
+          "delta": {
+            "type": "number",
+            "format": "double",
+            "description": "The signed delta: this variant's average minus the control's."
+          },
+          "p_value": {
+            "type": "number",
+            "format": "double",
+            "description": "The p-value for significance vs. the control."
+          },
+          "relative_difference": {
+            "anyOf": [
+              {
+                "type": "number",
+                "format": "double"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The relative difference vs. the control, or null when the control average is zero."
+          },
+          "treatment_effect": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardTreatmentEffect"
+              }
+            ],
+            "description": "The qualitative treatment effect vs. the control, classified from the p-value and thresholds."
+          }
+        },
+        "description": "A treatment variant's comparison against the scorecard's control for one metric."
+      },
+      "ScorecardRow": {
+        "type": "object",
+        "required": [
+          "metric_name",
+          "level",
+          "category",
+          "desired_direction",
+          "variants"
+        ],
+        "properties": {
+          "metric_name": {
+            "type": "string",
+            "description": "The metric name this row corresponds to."
+          },
+          "level": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardMetricLevel"
+              }
+            ],
+            "description": "The granularity this metric is measured at (turn or conversation)."
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricSourceType"
+              }
+            ],
+            "description": "The kind of source this metric is derived from (evaluator or traces)."
+          },
+          "desired_direction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExperimentMetricDirection"
+              }
+            ],
+            "description": "The desired direction for this metric."
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScorecardVariantResult"
+            },
+            "description": "One result per variant (control plus every treatment) for this metric."
+          }
+        },
+        "description": "A single row in a scorecard table — one metric compared across every variant."
+      },
+      "ScorecardState": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ready",
+              "computing",
+              "failed"
+            ]
+          }
+        ],
+        "description": "The state of a scorecard."
+      },
+      "ScorecardSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "experiment_id",
+          "control_variant_id",
+          "treatment_variant_ids",
+          "window_start",
+          "window_end",
+          "created_at",
+          "state",
+          "metric_count"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the scorecard."
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment this scorecard belongs to."
+          },
+          "control_variant_id": {
+            "type": "string",
+            "description": "The control (baseline) variant used by this scorecard."
+          },
+          "treatment_variant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The treatment variants compared against the control in this scorecard."
+          },
+          "window_start": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "window_end": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds)."
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The Unix timestamp (seconds) when this scorecard was generated."
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardState"
+              }
+            ],
+            "description": "The state of the scorecard."
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardError"
+              }
+            ],
+            "description": "Failure detail when the state is 'failed'. Null otherwise."
+          },
+          "metadata": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here."
+          },
+          "metric_count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of metric rows in the full scorecard."
+          }
+        },
+        "description": "Lightweight scorecard projection returned by list operations. The full metric rows are available only from the individual scorecard resource."
+      },
+      "ScorecardTreatmentEffect": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "improved",
+              "degraded",
+              "changed",
+              "inconclusive",
+              "insufficient_data",
+              "no_samples",
+              "unknown"
+            ]
+          }
+        ],
+        "description": "The qualitative outcome of a metric's treatment-vs-control comparison."
+      },
+      "ScorecardVariantResult": {
+        "type": "object",
+        "required": [
+          "variant_id",
+          "count",
+          "average",
+          "std_dev"
+        ],
+        "properties": {
+          "variant_id": {
+            "type": "string",
+            "description": "The variant identifier (for agents_safe_rollout this is the agent version number)."
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of observations."
+          },
+          "average": {
+            "type": "number",
+            "format": "double",
+            "description": "The arithmetic mean of the metric values."
+          },
+          "std_dev": {
+            "type": "number",
+            "format": "double",
+            "description": "The standard deviation of the metric values."
+          },
+          "comparison": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardPairComparison"
+              }
+            ],
+            "description": "This variant's comparison against the scorecard's control. Null for the control variant."
+          }
+        },
+        "description": "One variant's result for a metric row: its raw aggregates plus, for treatment variants, the comparison against the control."
       },
       "SessionDirectoryEntry": {
         "type": "object",
@@ -60551,6 +62676,35 @@
           ]
         }
       },
+      "TracesMetricSource": {
+        "type": "object",
+        "required": [
+          "type",
+          "attribute_names"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "traces"
+            ],
+            "description": "The traces source kind."
+          },
+          "attribute_names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Trace attribute names the metric value is read from. Each attribute must be numeric, or boolean (coerced to 1/0). When more than one is given, the per-event value is the sum of the attributes; a missing attribute contributes 0 (partial rows are kept), and the event value is null only when every listed attribute is null."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExperimentMetricSource"
+          }
+        ],
+        "description": "A metric sourced from trace/event attributes."
+      },
       "TracesPreviewEvalRunDataSource": {
         "type": "object",
         "required": [
@@ -60983,6 +63137,16 @@
             "items": {
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
+          },
+          "experiment_id": {
+            "type": "string",
+            "description": "The experiment identifier bound to this selector. Minted and managed by the Experiments Service; read-only for developers. When set, the selector is write-locked.",
+            "readOnly": true
+          },
+          "salt": {
+            "type": "string",
+            "description": "An immutable bucketing seed used for deterministic sticky routing. Minted by the Experiments Service; read-only for developers.",
+            "readOnly": true
           }
         }
       },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -94,6 +94,9 @@ tags:
   - name: AgentOptimizationJobs
     parent: Platform APIs
     summary: Agent optimization jobs
+  - name: Experiments
+    parent: Platform APIs
+    summary: Experiment lifecycle for A/B version traffic-split
   - name: EvaluatorGenerationJobs
     parent: Platform APIs
     summary: Evaluator generation jobs
@@ -6367,6 +6370,693 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+  /experiments:
+    post:
+      operationId: Experiments_create
+      summary: Create an experiment
+      description: Creates an experiment in the 'created' state. Call the :start action to begin routing traffic.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExperimentRequest'
+        description: The experiment to create.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    get:
+      operationId: Experiments_list
+      summary: List experiments
+      description: Returns a cursor-paged list of experiments.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Experiment'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:
+    get:
+      operationId: Experiments_get
+      summary: Get an experiment
+      description: Retrieves the experiment by id.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    patch:
+      operationId: Experiments_update
+      summary: Update an experiment
+      description: Applies a partial update to an experiment. Only experiments still in the 'created' state may be updated; omitted fields are left unchanged.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to update.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/PatchExperimentRequest'
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    delete:
+      operationId: Experiments_delete
+      summary: Delete an experiment
+      description: Deletes a non-running experiment and its scorecard artifacts.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to delete.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards:
+    get:
+      operationId: Experiments_listScorecards
+      summary: List scorecards
+      description: Returns a cursor-paged list of generated scorecards for an experiment. Each entry is a lightweight summary; use Get scorecard to retrieve the full metric rows.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScorecardSummary'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}/scorecards/{scorecard_id}:
+    get:
+      operationId: Experiments_getScorecard
+      summary: Get a scorecard
+      description: Retrieves a generated scorecard by id, including its full metric rows.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: scorecard_id
+          in: path
+          required: true
+          description: The unique identifier of the scorecard.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scorecard'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+    delete:
+      operationId: Experiments_deleteScorecard
+      summary: Delete a scorecard
+      description: Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment.
+          schema:
+            type: string
+        - name: scorecard_id
+          in: path
+          required: true
+          description: The unique identifier of the scorecard to delete.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:promote:
+    post:
+      operationId: Experiments_promote
+      summary: Promote an experiment
+      description: Promotes the winning variant. The agent's version selector is replaced with a single 100% rule for the winner.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to promote.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromoteExperimentRequest'
+        description: The promotion request.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:start:
+    post:
+      operationId: Experiments_start
+      summary: Start an experiment
+      description: Starts a created experiment. The service mints the salt, materializes traffic steps, and begins sticky-per-conversation routing.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to start.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
+  /experiments/{experiment_id}:stop:
+    post:
+      operationId: Experiments_stop
+      summary: Stop an experiment
+      description: Stops a running experiment. Routing collapses to the control variant.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Experiments=V1Preview
+        - name: experiment_id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to stop.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Experiments
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Experiments=V1Preview
   /indexes:
     get:
       operationId: Indexes_listLatest
@@ -10080,10 +10770,6 @@ paths:
                   model:
                     type: string
                     description: The model deployment to use for the creation of this response.
-                  reasoning:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Reasoning'
-                      - type: 'null'
                   background:
                     anyOf:
                       - type: boolean
@@ -10162,6 +10848,10 @@ paths:
                         assuming it's an `assistant` message with the content generated by
                         the model, you might consider using the `output_text` property where
                         supported in SDKs.
+                  reasoning:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      - type: 'null'
                   instructions:
                     anyOf:
                       - type: string
@@ -10298,10 +10988,6 @@ paths:
                 model:
                   type: string
                   description: The model deployment to use for the creation of this response.
-                reasoning:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Reasoning'
-                    - type: 'null'
                 background:
                   anyOf:
                     - type: boolean
@@ -10327,7 +11013,12 @@ paths:
                         - auto
                         - disabled
                     - type: 'null'
+                  deprecated: true
                   default: disabled
+                reasoning:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.Reasoning'
+                    - type: 'null'
                 input:
                   $ref: '#/components/schemas/OpenAI.InputParam'
                 include:
@@ -14135,6 +14826,23 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Agentic identity credential definition
+    AgentsSafeRolloutExperiment:
+      type: object
+      required:
+        - type
+        - target_agent
+      properties:
+        type:
+          type: string
+          enum:
+            - agents_safe_rollout
+          description: The A/B safe-rollout experiment kind.
+        target_agent:
+          type: string
+          description: The name of the agent whose versions participate in the rollout.
+      allOf:
+        - $ref: '#/components/schemas/Experiment'
+      description: An experiment that safely rolls traffic between versions of one agent.
     ApiErrorResponse:
       type: object
       required:
@@ -16285,6 +16993,23 @@ components:
           - WorkflowAgents=V1Preview
           - ExternalAgents=V1Preview
           - DraftAgents=V1Preview
+    CreateAgentsSafeRolloutExperimentRequest:
+      type: object
+      required:
+        - type
+        - target_agent
+      properties:
+        type:
+          type: string
+          enum:
+            - agents_safe_rollout
+          description: The A/B safe-rollout experiment kind.
+        target_agent:
+          type: string
+          description: The name of the agent targeted by the experiment.
+      allOf:
+        - $ref: '#/components/schemas/CreateExperimentRequest'
+      description: Request body for creating an agents_safe_rollout experiment.
     CreateEvalRequest:
       type: object
       required:
@@ -16357,6 +17082,46 @@ components:
           description: The level at which evaluation is performed. Defaults to 'turn' if not specified.
           default: turn
       title: CreateEvalRunRequest
+    CreateExperimentRequest:
+      type: object
+      required:
+        - type
+        - display_name
+        - variants
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The discriminated experiment kind.
+        display_name:
+          type: string
+          description: A human-readable display name for the experiment.
+        description:
+          type: string
+          description: A human-readable description of the experiment.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The experiment duration in days. Drives only the service-managed scorecard refresh horizon; it does not end the experiment. Defaults to 7 when omitted.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: Optional list of metrics to attach to the experiment.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: Optional scheduled evaluation configuration.
+      discriminator:
+        propertyName: type
+        mapping:
+          agents_safe_rollout: '#/components/schemas/CreateAgentsSafeRolloutExperimentRequest'
+      description: Request body for creating an experiment.
     CreateOrUpdateManagedAgentIdentityBlueprintRequest:
       type: object
       required:
@@ -19358,6 +20123,29 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    EvaluatorMetricSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - evaluator
+          description: The evaluator source kind.
+        evaluator_name:
+          type: string
+          description: The evaluator name.
+        evaluator_version:
+          type: string
+          description: The evaluator version to pin.
+        parameters:
+          type: object
+          unevaluatedProperties: {}
+          description: Additional evaluator parameters.
+      allOf:
+        - $ref: '#/components/schemas/ExperimentMetricSource'
+      description: A metric sourced from an evaluator (a judge that scores agent output).
     EvaluatorMetricType:
       anyOf:
         - type: string
@@ -19536,6 +20324,312 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    Experiment:
+      type: object
+      required:
+        - id
+        - type
+        - state
+        - display_name
+        - variants
+        - metrics
+        - experiment_steps
+        - assignment_properties
+        - created_at
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the experiment.
+          readOnly: true
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The discriminated experiment kind.
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentState'
+          description: The lifecycle state of the experiment.
+          readOnly: true
+        display_name:
+          type: string
+          description: A human-readable display name for the experiment.
+        description:
+          type: string
+          description: A human-readable description of the experiment.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The experiment duration in days. Drives only the service-managed scorecard refresh horizon (how long scorecards keep refreshing after start); it does not end the experiment — the experiment ends only when the caller stops or promotes it. Defaults to 7 when omitted.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The list of variants participating in the experiment.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: The list of metrics attached to the experiment.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: Configuration and service-managed resources for scheduled evaluation.
+        experiment_steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentStep'
+          description: The list of experiment steps with traffic allocation details. Materialized by the service.
+          readOnly: true
+        assignment_properties:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentAssignmentProperties'
+          description: Properties controlling how traffic is assigned to variants.
+          readOnly: true
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when the experiment was created.
+          readOnly: true
+        started_at:
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
+          description: The Unix timestamp (seconds) when the experiment was started. Null if not yet started.
+          readOnly: true
+        end_at:
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
+          description: The actual end time (Unix seconds), set when the experiment is stopped or promoted. Null while the experiment is created or running.
+          readOnly: true
+      discriminator:
+        propertyName: type
+        mapping:
+          agents_safe_rollout: '#/components/schemas/AgentsSafeRolloutExperiment'
+      description: A materialized experiment that binds version routing to a lifecycle for A/B testing.
+    ExperimentAssignmentProperties:
+      type: object
+      required:
+        - salt
+        - assignment_unit
+      properties:
+        salt:
+          type: string
+          description: An immutable bucketing seed minted when the experiment starts. Re-salting re-randomizes every bucket.
+          readOnly: true
+        assignment_unit:
+          type: string
+          description: The unit used for sticky bucketing (e.g. conversationId).
+          readOnly: true
+      description: Properties controlling how traffic is assigned to variants.
+    ExperimentBucketRange:
+      type: object
+      required:
+        - start
+        - end
+      properties:
+        start:
+          type: integer
+          format: int32
+          description: The inclusive start of the bucket range (0-based).
+        end:
+          type: integer
+          format: int32
+          description: The exclusive end of the bucket range.
+      description: A contiguous range of hash buckets assigned to a variant.
+    ExperimentEvaluation:
+      type: object
+      properties:
+        model:
+          type: string
+          description: The deployed model used by evaluator-backed metrics.
+        eval_id:
+          type: string
+          description: The service-managed evaluation group identifier.
+          readOnly: true
+        schedule_id:
+          type: string
+          description: The service-managed schedule identifier.
+          readOnly: true
+      description: Configuration and service-managed resources for scheduled experiment evaluation.
+    ExperimentMetric:
+      type: object
+      required:
+        - name
+        - definition
+      properties:
+        name:
+          type: string
+          description: The caller-defined metric name, unique within the experiment.
+        desired_direction:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDirection'
+          description: The desired direction for this metric. Optional; if omitted, the service infers from the evaluator defaults.
+        definition:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDefinition'
+          description: The metric definition including data source and optional aggregation.
+      description: A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from.
+    ExperimentMetricAggregation:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricAggregationType'
+          description: The aggregation function.
+        percentile:
+          type: integer
+          format: int32
+          description: The percentile value (e.g. 95). Required when type is 'percentile'.
+      description: Aggregation configuration for a metric.
+    ExperimentMetricAggregationType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - average
+            - percentile
+      description: The aggregation function for a metric.
+    ExperimentMetricDefinition:
+      type: object
+      required:
+        - source
+      properties:
+        source:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSource'
+          description: The source of the metric data.
+        aggregation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricAggregation'
+          description: Optional aggregation configuration. If omitted, the service uses the evaluator's default aggregation.
+      description: The definition of a metric — wraps the data source and optional aggregation.
+    ExperimentMetricDirection:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - increase
+            - decrease
+            - neutral
+      description: The desired direction for a metric value.
+    ExperimentMetricSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSourceType'
+          description: The type of metric source.
+      discriminator:
+        propertyName: type
+        mapping:
+          evaluator: '#/components/schemas/EvaluatorMetricSource'
+          traces: '#/components/schemas/TracesMetricSource'
+      description: The source of a metric value, discriminated by type.
+    ExperimentMetricSourceType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - evaluator
+            - traces
+      description: The type of metric source.
+    ExperimentState:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - created
+            - running
+            - stopped
+            - promoted
+      description: The lifecycle state of the experiment.
+    ExperimentStep:
+      type: object
+      required:
+        - id
+        - variant_traffic_maps
+      properties:
+        id:
+          type: string
+          description: The identifier for this experiment step.
+        started_at:
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
+          description: The Unix timestamp (seconds) when this step started.
+        stopped_at:
+          anyOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+            - type: 'null'
+          description: The Unix timestamp (seconds) when this step stopped. Null if still running.
+        variant_traffic_maps:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariantTrafficMap'
+          description: The traffic allocation for each variant in this step.
+      description: A step in the experiment with traffic allocation details.
+    ExperimentType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agents_safe_rollout
+      description: The discriminated experiment kind.
+    ExperimentVariant:
+      type: object
+      required:
+        - id
+        - role
+      properties:
+        id:
+          type: string
+          description: The variant identifier. For agents_safe_rollout this is the agent version number.
+        role:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentVariantRole'
+          description: The role of this variant in the experiment.
+        traffic_percentage:
+          type: integer
+          format: int32
+          description: The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead).
+        required_sample_size:
+          type: integer
+          format: int32
+          description: The minimum number of observations required before this variant's scorecard results are considered reliable. Defaults to 100 when omitted.
+      description: A variant participating in the experiment.
+    ExperimentVariantRole:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - control
+            - treatment
+      description: The role of a variant in the experiment.
+    ExperimentVariantTrafficMap:
+      type: object
+      required:
+        - variant_id
+        - percentage
+        - bucket_ranges
+      properties:
+        variant_id:
+          type: string
+          description: The variant identifier this traffic map applies to.
+        percentage:
+          type: integer
+          format: int32
+          description: The traffic percentage for this variant.
+        bucket_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentBucketRange'
+          description: The hash bucket ranges assigned to this variant.
+      description: Traffic allocation map for a single variant within an experiment step.
     ExternalAgentDefinition:
       type: object
       required:
@@ -20631,8 +21725,8 @@ components:
           type: string
           format: uri
           description: |-
-            The URL for the MCP server. One of `server_url` or `connector_id` must be
-              provided.
+            The URL for the MCP server. One of `server_url`, `connector_id`, or
+              `tunnel_id` must be provided.
         connector_id:
           type: string
           enum:
@@ -20646,8 +21740,8 @@ components:
             - connector_sharepoint
           description: |-
             Identifier for service connectors, like those available in ChatGPT. One of
-              `server_url` or `connector_id` must be provided. Learn more about service
-              connectors [here](/docs/guides/tools-remote-mcp#connectors).
+              `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more
+              about service connectors [here](/docs/guides/tools-remote-mcp#connectors).
               Currently supported `connector_id` values are:
               - Dropbox: `connector_dropbox`
               - Gmail: `connector_gmail`
@@ -20657,6 +21751,12 @@ components:
               - Outlook Calendar: `connector_outlookcalendar`
               - Outlook Email: `connector_outlookemail`
               - SharePoint: `connector_sharepoint`
+        tunnel_id:
+          type: string
+          pattern: ^tunnel_[a-z0-9]{32}$
+          description: |-
+            The Secure MCP Tunnel ID to use instead of a direct server URL. One of
+              `server_url`, `connector_id`, or `tunnel_id` must be provided.
         authorization:
           type: string
           description: |-
@@ -32129,8 +33229,8 @@ components:
           type: string
           format: uri
           description: |-
-            The URL for the MCP server. One of `server_url` or `connector_id` must be
-              provided.
+            The URL for the MCP server. One of `server_url`, `connector_id`, or
+              `tunnel_id` must be provided.
         connector_id:
           type: string
           enum:
@@ -32144,8 +33244,8 @@ components:
             - connector_sharepoint
           description: |-
             Identifier for service connectors, like those available in ChatGPT. One of
-              `server_url` or `connector_id` must be provided. Learn more about service
-              connectors [here](/docs/guides/tools-remote-mcp#connectors).
+              `server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more
+              about service connectors [here](/docs/guides/tools-remote-mcp#connectors).
               Currently supported `connector_id` values are:
               - Dropbox: `connector_dropbox`
               - Gmail: `connector_gmail`
@@ -32155,6 +33255,12 @@ components:
               - Outlook Calendar: `connector_outlookcalendar`
               - Outlook Email: `connector_outlookemail`
               - SharePoint: `connector_sharepoint`
+        tunnel_id:
+          type: string
+          pattern: ^tunnel_[a-z0-9]{32}$
+          description: |-
+            The Secure MCP Tunnel ID to use instead of a direct server URL. One of
+              `server_url`, `connector_id`, or `tunnel_id` must be provided.
         authorization:
           type: string
           description: |-
@@ -34117,6 +35223,14 @@ components:
                 - concise
                 - detailed
             - type: 'null'
+        context:
+          anyOf:
+            - type: string
+              enum:
+                - auto
+                - current_turn
+                - all_turns
+            - type: 'null'
         generate_summary:
           anyOf:
             - type: string
@@ -34232,10 +35346,6 @@ components:
         model:
           type: string
           description: The model deployment to use for the creation of this response.
-        reasoning:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
         background:
           anyOf:
             - type: boolean
@@ -34314,6 +35424,10 @@ components:
               assuming it's an `assistant` message with the content generated by
               the model, you might consider using the `output_text` property where
               supported in SDKs.
+        reasoning:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.Reasoning'
+            - type: 'null'
         instructions:
           anyOf:
             - type: string
@@ -39072,6 +40186,41 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentCardUpdate'
           description: Optional agent card for the agent
+    PatchExperimentRequest:
+      type: object
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentType'
+          description: The experiment kind. Must match the existing experiment.
+        display_name:
+          type: string
+          description: The new display name. Left unchanged when omitted.
+        description:
+          type: string
+          description: The new description. Left unchanged when omitted.
+        duration_in_days:
+          type: integer
+          format: int32
+          description: The new duration in days. Left unchanged when omitted.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+          description: The replacement variant list. When provided it fully replaces the existing variants and must satisfy the same rules as on create.
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentMetric'
+          description: The replacement metric list. When provided it fully replaces the existing metrics.
+        evaluation:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentEvaluation'
+          description: The replacement scheduled evaluation configuration. Left unchanged when omitted.
+      description: |-
+        Request body for patching an experiment. Only experiments still in the 'created' state may be
+        updated; omitted fields are left unchanged. Type-specific identity (e.g. agents_safe_rollout
+        target_agent) is immutable and cannot be changed here.
     PendingUploadRequest:
       type: object
       required:
@@ -39128,6 +40277,15 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - MemoryStores=V1Preview
+    PromoteExperimentRequest:
+      type: object
+      required:
+        - winner_variant_id
+      properties:
+        winner_variant_id:
+          type: string
+          description: The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version.
+      description: Request body for promoting an experiment.
     PromotionInfo:
       type: object
       required:
@@ -40190,6 +41348,248 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    Scorecard:
+      type: object
+      required:
+        - id
+        - experiment_id
+        - control_variant_id
+        - treatment_variant_ids
+        - window_start
+        - window_end
+        - created_at
+        - state
+        - rows
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the scorecard.
+        experiment_id:
+          type: string
+          description: The experiment this scorecard belongs to.
+        control_variant_id:
+          type: string
+          description: The control (baseline) variant used by this scorecard.
+        treatment_variant_ids:
+          type: array
+          items:
+            type: string
+          description: The treatment variants compared against the control in this scorecard.
+        window_start:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        window_end:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when this scorecard was generated.
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardState'
+          description: The state of the scorecard.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardError'
+          description: Failure detail when the state is 'failed'. Null otherwise.
+        metadata:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here.
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScorecardRow'
+          description: The metric comparison rows.
+      description: A generated scorecard artifact — a table comparing metric values between variants.
+    ScorecardError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Stable, machine-readable failure category (e.g. 'compute_failed', 'internal_error', 'publish_failed').
+        message:
+          type: string
+          description: Human-readable (truncated) failure description.
+      description: Structured failure detail for a scorecard whose state is 'failed'.
+    ScorecardMetricLevel:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - turn
+            - conversation
+      description: The granularity a scorecard metric is measured at.
+    ScorecardPairComparison:
+      type: object
+      required:
+        - delta
+        - p_value
+        - treatment_effect
+      properties:
+        delta:
+          type: number
+          format: double
+          description: "The signed delta: this variant's average minus the control's."
+        p_value:
+          type: number
+          format: double
+          description: The p-value for significance vs. the control.
+        relative_difference:
+          anyOf:
+            - type: number
+              format: double
+            - type: 'null'
+          description: The relative difference vs. the control, or null when the control average is zero.
+        treatment_effect:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardTreatmentEffect'
+          description: The qualitative treatment effect vs. the control, classified from the p-value and thresholds.
+      description: A treatment variant's comparison against the scorecard's control for one metric.
+    ScorecardRow:
+      type: object
+      required:
+        - metric_name
+        - level
+        - category
+        - desired_direction
+        - variants
+      properties:
+        metric_name:
+          type: string
+          description: The metric name this row corresponds to.
+        level:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardMetricLevel'
+          description: The granularity this metric is measured at (turn or conversation).
+        category:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricSourceType'
+          description: The kind of source this metric is derived from (evaluator or traces).
+        desired_direction:
+          allOf:
+            - $ref: '#/components/schemas/ExperimentMetricDirection'
+          description: The desired direction for this metric.
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScorecardVariantResult'
+          description: One result per variant (control plus every treatment) for this metric.
+      description: A single row in a scorecard table — one metric compared across every variant.
+    ScorecardState:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ready
+            - computing
+            - failed
+      description: The state of a scorecard.
+    ScorecardSummary:
+      type: object
+      required:
+        - id
+        - experiment_id
+        - control_variant_id
+        - treatment_variant_ids
+        - window_start
+        - window_end
+        - created_at
+        - state
+        - metric_count
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the scorecard.
+        experiment_id:
+          type: string
+          description: The experiment this scorecard belongs to.
+        control_variant_id:
+          type: string
+          description: The control (baseline) variant used by this scorecard.
+        treatment_variant_ids:
+          type: array
+          items:
+            type: string
+          description: The treatment variants compared against the control in this scorecard.
+        window_start:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        window_end:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds).
+        created_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (seconds) when this scorecard was generated.
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardState'
+          description: The state of the scorecard.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardError'
+          description: Failure detail when the state is 'failed'. Null otherwise.
+        metadata:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here.
+        metric_count:
+          type: integer
+          format: int32
+          description: The number of metric rows in the full scorecard.
+      description: Lightweight scorecard projection returned by list operations. The full metric rows are available only from the individual scorecard resource.
+    ScorecardTreatmentEffect:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - improved
+            - degraded
+            - changed
+            - inconclusive
+            - insufficient_data
+            - no_samples
+            - unknown
+      description: The qualitative outcome of a metric's treatment-vs-control comparison.
+    ScorecardVariantResult:
+      type: object
+      required:
+        - variant_id
+        - count
+        - average
+        - std_dev
+      properties:
+        variant_id:
+          type: string
+          description: The variant identifier (for agents_safe_rollout this is the agent version number).
+        count:
+          type: integer
+          format: int32
+          description: The number of observations.
+        average:
+          type: number
+          format: double
+          description: The arithmetic mean of the metric values.
+        std_dev:
+          type: number
+          format: double
+          description: The standard deviation of the metric values.
+        comparison:
+          allOf:
+            - $ref: '#/components/schemas/ScorecardPairComparison'
+          description: This variant's comparison against the scorecard's control. Null for the control variant.
+      description: "One variant's result for a metric row: its raw aggregates plus, for treatment variants, the comparison against the control."
     SessionDirectoryEntry:
       type: object
       required:
@@ -41365,6 +42765,25 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
+    TracesMetricSource:
+      type: object
+      required:
+        - type
+        - attribute_names
+      properties:
+        type:
+          type: string
+          enum:
+            - traces
+          description: The traces source kind.
+        attribute_names:
+          type: array
+          items:
+            type: string
+          description: Trace attribute names the metric value is read from. Each attribute must be numeric, or boolean (coerced to 1/0). When more than one is given, the per-event value is the sum of the attributes; a missing attribute contributes 0 (partial rows are kept), and the event value is null only when every listed attribute is null.
+      allOf:
+        - $ref: '#/components/schemas/ExperimentMetricSource'
+      description: A metric sourced from trace/event attributes.
     TracesPreviewEvalRunDataSource:
       type: object
       required:
@@ -41662,6 +43081,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
+        experiment_id:
+          type: string
+          description: The experiment identifier bound to this selector. Minted and managed by the Experiments Service; read-only for developers. When set, the selector is write-locked.
+          readOnly: true
+        salt:
+          type: string
+          description: An immutable bucketing seed used for deterministic sticky routing. Minted by the Experiments Service; read-only for developers.
+          readOnly: true
     VersionSelectorType:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -33,7 +33,9 @@ model CreateAgentVersionRequest {
   @doc("(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
+    #{
+      conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview],
+    }
   )
   draft?: boolean = false;
 }
@@ -190,7 +192,9 @@ model AgentVersionObject {
   @doc("Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
+    #{
+      conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview],
+    }
   )
   draft?: boolean = false;
 
@@ -561,6 +565,14 @@ union VersionSelectorType {
 
 model VersionSelector {
   version_selection_rules: VersionSelectionRule[];
+
+  @doc("The experiment identifier bound to this selector. Minted and managed by the Experiments Service; read-only for developers. When set, the selector is write-locked.")
+  @visibility(Lifecycle.Read)
+  experiment_id?: string;
+
+  @doc("An immutable bucketing seed used for deterministic sticky routing. Minted by the Experiments Service; read-only for developers.")
+  @visibility(Lifecycle.Read)
+  salt?: string;
 }
 
 @discriminator("type")

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -77,9 +77,10 @@ op FoundryDataPlaneOperation<
   Params extends Reflection.Model,
   Response,
   ErrorResponse = ApiErrorResponse
->(...Params, ...FoundryDataPlaneApiVersionParameter):
-  | Response
-  | AzureRangeErrorResponse<ErrorResponse>;
+>(
+  ...Params,
+  ...FoundryDataPlaneApiVersionParameter,
+): Response | AzureRangeErrorResponse<ErrorResponse>;
 
 // ---- Feature opt-in keys & preview headers ----
 
@@ -88,8 +89,10 @@ union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
   draft_agents_v1_preview: "DraftAgents=V1Preview",
+
   @removed(Versions.v1)
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
+
   @removed(Versions.v1)
   container_agents_v1_preview: "ContainerAgents=V1Preview",
 }
@@ -105,11 +108,10 @@ union FoundryFeaturesOptInKeys {
   data_generation_jobs_v1_preview: "DataGenerationJobs=V1Preview",
   models_v1_preview: "Models=V1Preview",
   agents_optimization_v2_preview: "AgentsOptimization=V2Preview",
+  experiments_v1_preview: "Experiments=V1Preview",
 }
 
-alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends
-  | FoundryFeaturesOptInKeys
-  | AgentDefinitionOptInKeys> = {
+alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends FoundryFeaturesOptInKeys | AgentDefinitionOptInKeys> = {
   /**
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
@@ -117,9 +119,7 @@ alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends
   foundry_features: RequiredPreviewOptInHeader;
 };
 
-alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader extends
-  | FoundryFeaturesOptInKeys
-  | AgentDefinitionOptInKeys> = {
+alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader extends FoundryFeaturesOptInKeys | AgentDefinitionOptInKeys> = {
   /**
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
@@ -533,9 +533,7 @@ op deleteJob<TJob extends TypeSpec.Reflection.Model> is FoundryDataPlaneOperatio
 /** Delete a job (preview). Returns 204 No Content. */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Job templates are project-standard operations"
 @delete
-op deleteJobPreview<AreaPreviewLabel extends
-  | FoundryFeaturesOptInKeys
-  | AgentDefinitionOptInKeys> is FoundryDataPlanePreviewOperation<
+op deleteJobPreview<AreaPreviewLabel extends FoundryFeaturesOptInKeys | AgentDefinitionOptInKeys> is FoundryDataPlanePreviewOperation<
   AreaPreviewLabel,
   {
     /** The ID of the job to delete. */

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
@@ -89,8 +89,8 @@ union ExperimentMetricSourceType {
   /** An inline evaluator definition that the service materializes into a continuous evaluation rule. */
   evaluator: "evaluator",
 
-  /** A trace-level metric (e.g. latency, error rate). */
-  trace_metric: "trace_metric",
+  /** A trace-level metric (e.g. latency_ms, error rate). */
+  traces: "traces",
 }
 
 /** The state of a scorecard. */
@@ -190,63 +190,65 @@ model ExperimentMetricSource {
   @doc("The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.")
   evaluator_name?: string;
 
-  @doc("The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'.")
+  @doc("The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'.")
   name?: string;
 }
 
-/** Guardrail threshold for a metric. Metrics with guardrails are monitored for safety bounds. */
-model ExperimentMetricGuardrail {
-  @doc("Maximum allowed relative delta as a percentage. If the treatment deviates by more than this, the guardrail is breached.")
-  max_delta_percent?: float64;
-
-  @doc("Maximum allowed absolute value. If the treatment exceeds this, the guardrail is breached.")
-  max_absolute?: float64;
-
-  @doc("The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.")
-  @visibility(Lifecycle.Read)
-  state?: string;
-}
-
-/** A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails. */
-model ExperimentMetric {
-  @doc("The metric identifier, unique within the experiment.")
-  id: string;
-
-  @doc("The desired direction for this metric.")
-  direction: ExperimentMetricDirection;
-
-  @doc("The aggregation configuration.")
-  aggregation: ExperimentMetricAggregation;
-
+/** The definition of a metric — wraps the data source and optional aggregation. */
+model ExperimentMetricDefinition {
   @doc("The source of the metric data.")
   source: ExperimentMetricSource;
 
-  @doc("Optional guardrail threshold. Metrics with guardrails are monitored for safety bounds.")
-  guardrail?: ExperimentMetricGuardrail;
+  @doc("Optional aggregation configuration. If omitted, the service uses the evaluator's default aggregation.")
+  aggregation?: ExperimentMetricAggregation;
+}
+
+/** A metric attached to the experiment — defines what to measure, how to aggregate, and where the data comes from. */
+model ExperimentMetric {
+  @doc("The caller-defined metric name, unique within the experiment.")
+  name: string;
+
+  @doc("The desired direction for this metric. Optional; if omitted, the service infers from the evaluator defaults.")
+  desired_direction?: ExperimentMetricDirection;
+
+  @doc("The metric definition including data source and optional aggregation.")
+  definition: ExperimentMetricDefinition;
+}
+
+/** Summary statistics for a variant in a scorecard row. */
+model ScorecardVariantStats {
+  @doc("The number of observations.")
+  count: int32;
+
+  @doc("The arithmetic mean of the metric values.")
+  average: float64;
+
+  @doc("The standard deviation of the metric values.")
+  std_dev: float64;
 }
 
 /** A single row in a scorecard table — one metric comparison between control and treatment. */
 model ScorecardRow {
-  @doc("The metric identifier this row corresponds to.")
-  metric_id: string;
+  @doc("The metric name this row corresponds to.")
+  metric_name: string;
 
   @doc("A human-readable label for the metric.")
   label: string;
 
-  @doc("The metric value for the control variant.")
-  control_value: float64;
+  @doc("The desired direction for this metric.")
+  desired_direction: ExperimentMetricDirection;
 
-  @doc("The metric value for the treatment variant.")
-  treatment_value: float64;
+  @doc("Summary statistics for the control variant.")
+  control_stats: ScorecardVariantStats;
+
+  @doc("Summary statistics for the treatment variant.")
+  treatment_stats: ScorecardVariantStats;
 
   @doc("The absolute delta between treatment and control.")
   delta: float64;
 
   @doc("The p-value for statistical significance.")
   p_value: float64;
-
-  @doc("Whether this row corresponds to a guardrail metric.")
-  guardrail?: boolean;
 }
 
 /** A generated scorecard artifact — a table comparing metric values between variants. */
@@ -289,6 +291,9 @@ model Experiment {
   @doc("The name of the agent this experiment targets. Required for agents_safe_rollout type.")
   target_agent?: string;
 
+  @doc("The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.")
+  duration?: string;
+
   @doc("The list of variants participating in the experiment.")
   variants: ExperimentVariant[];
 
@@ -301,6 +306,10 @@ model Experiment {
 
   @doc("The list of metrics (evaluation rules or inline evaluators) attached to the experiment.")
   metrics: ExperimentMetric[];
+
+  @doc("The Unix timestamp (seconds) when the experiment was started. Null if not yet started.")
+  @visibility(Lifecycle.Read)
+  started_at?: FoundryTimestamp | null;
 
   @doc("The scheduled start time for the experiment. Null if started immediately.")
   scheduled_start_at?: FoundryTimestamp | null;
@@ -322,6 +331,9 @@ model CreateExperimentRequest {
 
   @doc("A human-readable description of the experiment.")
   description?: string;
+
+  @doc("The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.")
+  duration?: string;
 
   @doc("The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.")
   variants: ExperimentVariant[];

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
@@ -30,6 +30,9 @@ union ExperimentType {
 union ExperimentState {
   string,
 
+  /** The experiment has been created but not yet started. */
+  created: "created",
+
   /** The experiment is actively routing traffic. */
   running: "running",
 

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
@@ -1,0 +1,334 @@
+// Models for the Experiments data-plane surface.
+// Provides experiment lifecycle for A/B version traffic-split on agents.
+
+import "../common/models.tsp";
+import "../common/servicepatterns.tsp";
+import "../agents/models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+
+namespace Azure.AI.Projects;
+
+const ExperimentsRequiredPreviews = #{
+  conditional_previews: #[FoundryFeaturesOptInKeys.experiments_v1_preview],
+};
+
+// ---------------------------------------------------------------------------
+// Enums / unions
+// ---------------------------------------------------------------------------
+
+/** The discriminated experiment kind. */
+union ExperimentType {
+  string,
+
+  /** A/B experiment across agent versions with sticky-per-conversation routing. */
+  agents_safe_rollout: "agents_safe_rollout",
+}
+
+/** The lifecycle state of the experiment. */
+union ExperimentState {
+  string,
+
+  /** The experiment is actively routing traffic. */
+  running: "running",
+
+  /** The experiment has been stopped; routing collapsed to control. */
+  stopped: "stopped",
+
+  /** The winning variant has been promoted. */
+  promoted: "promoted",
+}
+
+/** The role of a variant in the experiment. */
+union ExperimentVariantRole {
+  string,
+
+  /** The baseline variant (receives the majority of traffic). */
+  control: "control",
+
+  /** The candidate variant being tested. */
+  treatment: "treatment",
+}
+
+/** The desired direction for a metric value. */
+union ExperimentMetricDirection {
+  string,
+
+  /** Higher values are better. */
+  increase: "increase",
+
+  /** Lower values are better. */
+  decrease: "decrease",
+}
+
+/** The aggregation function for a metric. */
+union ExperimentMetricAggregationType {
+  string,
+
+  /** Arithmetic mean. */
+  average: "average",
+
+  /** Percentile (requires the `percentile` parameter). */
+  percentile: "percentile",
+
+  /** Rate (count of occurrences / total). */
+  rate: "rate",
+}
+
+/** The type of metric source. */
+union ExperimentMetricSourceType {
+  string,
+
+  /** References an existing continuous evaluation rule by its schedule ID. */
+  continuous_evaluation_rule: "continuous_evaluation_rule",
+
+  /** An inline evaluator definition that the service materializes into a continuous evaluation rule. */
+  evaluator: "evaluator",
+
+  /** A trace-level metric (e.g. latency, error rate). */
+  trace_metric: "trace_metric",
+}
+
+/** The state of a scorecard. */
+union ScorecardState {
+  string,
+
+  /** The scorecard is ready and can be read. */
+  ready: "ready",
+
+  /** The scorecard is still being computed. */
+  computing: "computing",
+
+  /** The scorecard computation failed. */
+  failed: "failed",
+}
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+/** A variant participating in the experiment. */
+model ExperimentVariant {
+  @doc("The variant identifier. For agents_safe_rollout this is the agent version number.")
+  id: string;
+
+  @doc("The role of this variant in the experiment.")
+  role: ExperimentVariantRole;
+
+  @doc("The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead).")
+  traffic_percentage?: int32;
+}
+
+/** A contiguous range of hash buckets assigned to a variant. */
+model ExperimentBucketRange {
+  @doc("The inclusive start of the bucket range (0-based).")
+  start: int32;
+
+  @doc("The exclusive end of the bucket range.")
+  end: int32;
+}
+
+/** Traffic allocation map for a single variant within an experiment step. */
+model ExperimentVariantTrafficMap {
+  @doc("The variant identifier this traffic map applies to.")
+  variant_id: string;
+
+  @doc("The traffic percentage for this variant.")
+  percentage: int32;
+
+  @doc("The hash bucket ranges assigned to this variant.")
+  bucket_ranges: ExperimentBucketRange[];
+}
+
+/** A step in the experiment with traffic allocation details. */
+model ExperimentStep {
+  @doc("The identifier for this experiment step.")
+  id: string;
+
+  @doc("The Unix timestamp (seconds) when this step started.")
+  started_at?: FoundryTimestamp | null;
+
+  @doc("The Unix timestamp (seconds) when this step stopped. Null if still running.")
+  stopped_at?: FoundryTimestamp | null;
+
+  @doc("The traffic allocation for each variant in this step.")
+  variant_traffic_maps: ExperimentVariantTrafficMap[];
+}
+
+/** Properties controlling how traffic is assigned to variants. */
+model ExperimentAssignmentProperties {
+  @doc("An immutable bucketing seed minted when the experiment starts. Re-salting re-randomizes every bucket.")
+  @visibility(Lifecycle.Read)
+  salt: string;
+
+  @doc("The unit used for sticky bucketing (e.g. conversationId).")
+  @visibility(Lifecycle.Read)
+  assignment_unit: string;
+}
+
+/** Aggregation configuration for a metric. */
+model ExperimentMetricAggregation {
+  @doc("The aggregation function.")
+  type: ExperimentMetricAggregationType;
+
+  @doc("The percentile value (e.g. 95). Required when type is 'percentile'.")
+  percentile?: int32;
+}
+
+/** The source of a metric value, discriminated by type. */
+model ExperimentMetricSource {
+  @doc("The type of metric source.")
+  type: ExperimentMetricSourceType;
+
+  @doc("The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'.")
+  rule_id?: string;
+
+  @doc("The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.")
+  evaluator_name?: string;
+
+  @doc("The trace metric name (e.g. 'latency_ms'). Required when type is 'trace_metric'.")
+  name?: string;
+}
+
+/** Guardrail threshold for a metric. Metrics with guardrails are monitored for safety bounds. */
+model ExperimentMetricGuardrail {
+  @doc("Maximum allowed relative delta as a percentage. If the treatment deviates by more than this, the guardrail is breached.")
+  max_delta_percent?: float64;
+
+  @doc("Maximum allowed absolute value. If the treatment exceeds this, the guardrail is breached.")
+  max_absolute?: float64;
+
+  @doc("The current guardrail state (e.g. 'monitoring', 'breached'). Service-managed.")
+  @visibility(Lifecycle.Read)
+  state?: string;
+}
+
+/** A metric attached to the experiment — defines what to measure, how to aggregate, where the data comes from, and optional guardrails. */
+model ExperimentMetric {
+  @doc("The metric identifier, unique within the experiment.")
+  id: string;
+
+  @doc("The desired direction for this metric.")
+  direction: ExperimentMetricDirection;
+
+  @doc("The aggregation configuration.")
+  aggregation: ExperimentMetricAggregation;
+
+  @doc("The source of the metric data.")
+  source: ExperimentMetricSource;
+
+  @doc("Optional guardrail threshold. Metrics with guardrails are monitored for safety bounds.")
+  guardrail?: ExperimentMetricGuardrail;
+}
+
+/** A single row in a scorecard table — one metric comparison between control and treatment. */
+model ScorecardRow {
+  @doc("The metric identifier this row corresponds to.")
+  metric_id: string;
+
+  @doc("A human-readable label for the metric.")
+  label: string;
+
+  @doc("The metric value for the control variant.")
+  control_value: float64;
+
+  @doc("The metric value for the treatment variant.")
+  treatment_value: float64;
+
+  @doc("The absolute delta between treatment and control.")
+  delta: float64;
+
+  @doc("The p-value for statistical significance.")
+  p_value: float64;
+
+  @doc("Whether this row corresponds to a guardrail metric.")
+  guardrail?: boolean;
+}
+
+/** A generated scorecard artifact — a table comparing metric values between variants. */
+model Scorecard {
+  @doc("The unique identifier of the scorecard.")
+  @visibility(Lifecycle.Read)
+  id: string;
+
+  @doc("The experiment this scorecard belongs to.")
+  experiment_id: string;
+
+  @doc("The state of the scorecard.")
+  state: ScorecardState;
+
+  @doc("The URI to the scorecard artifact in the user's blob storage.")
+  artifact_uri: string;
+
+  @doc("The metric comparison rows.")
+  rows: ScorecardRow[];
+}
+
+/** Represents an experiment that binds version routing to a lifecycle for A/B testing. */
+model Experiment {
+  @doc("The unique identifier of the experiment.")
+  @visibility(Lifecycle.Read)
+  id: string;
+
+  @doc("The discriminated experiment kind.")
+  type: ExperimentType;
+
+  @doc("The lifecycle state of the experiment.")
+  state: ExperimentState;
+
+  @doc("A human-readable display name for the experiment.")
+  display_name: string;
+
+  @doc("A human-readable description of the experiment.")
+  description?: string;
+
+  @doc("The name of the agent this experiment targets. Required for agents_safe_rollout type.")
+  target_agent?: string;
+
+  @doc("The list of variants participating in the experiment.")
+  variants: ExperimentVariant[];
+
+  @doc("The list of experiment steps with traffic allocation details. Materialized by the service.")
+  @visibility(Lifecycle.Read)
+  experiment_steps: ExperimentStep[];
+
+  @doc("Properties controlling how traffic is assigned to variants.")
+  assignment_properties: ExperimentAssignmentProperties;
+
+  @doc("The list of metrics (evaluation rules or inline evaluators) attached to the experiment.")
+  metrics: ExperimentMetric[];
+
+  @doc("The scheduled start time for the experiment. Null if started immediately.")
+  scheduled_start_at?: FoundryTimestamp | null;
+
+  @doc("The scheduled end time for the experiment. Null if no end is scheduled.")
+  scheduled_end_at?: FoundryTimestamp | null;
+}
+
+/** Request body for creating an experiment. */
+model CreateExperimentRequest {
+  @doc("The discriminated experiment kind.")
+  type: ExperimentType;
+
+  @doc("The name of the agent this experiment targets. Required for agents_safe_rollout type.")
+  target_agent?: string;
+
+  @doc("A human-readable display name for the experiment.")
+  display_name: string;
+
+  @doc("A human-readable description of the experiment.")
+  description?: string;
+
+  @doc("The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.")
+  variants: ExperimentVariant[];
+
+  @doc("Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment.")
+  metrics?: ExperimentMetric[];
+}
+
+/** Request body for promoting an experiment. */
+model PromoteExperimentRequest {
+  @doc("The variant id (agent version) to promote as the winner. The agent's version selector is replaced with a single 100% rule for this version.")
+  winner_variant_id: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/models.tsp
@@ -63,6 +63,9 @@ union ExperimentMetricDirection {
 
   /** Lower values are better. */
   decrease: "decrease",
+
+  /** The metric has no preferred direction. */
+  neutral: "neutral",
 }
 
 /** The aggregation function for a metric. */
@@ -74,19 +77,13 @@ union ExperimentMetricAggregationType {
 
   /** Percentile (requires the `percentile` parameter). */
   percentile: "percentile",
-
-  /** Rate (count of occurrences / total). */
-  rate: "rate",
 }
 
 /** The type of metric source. */
 union ExperimentMetricSourceType {
   string,
 
-  /** References an existing continuous evaluation rule by its schedule ID. */
-  continuous_evaluation_rule: "continuous_evaluation_rule",
-
-  /** An inline evaluator definition that the service materializes into a continuous evaluation rule. */
+  /** An inline evaluator definition that the service materializes into a scheduled evaluation rule. */
   evaluator: "evaluator",
 
   /** A trace-level metric (e.g. latency_ms, error rate). */
@@ -107,6 +104,43 @@ union ScorecardState {
   failed: "failed",
 }
 
+/** The granularity a scorecard metric is measured at. */
+union ScorecardMetricLevel {
+  string,
+
+  /** The metric is measured per agent turn. */
+  turn: "turn",
+
+  /** The metric is measured per conversation. */
+  conversation: "conversation",
+}
+
+/** The qualitative outcome of a metric's treatment-vs-control comparison. */
+union ScorecardTreatmentEffect {
+  string,
+
+  /** Significant change in the desired direction. */
+  improved: "improved",
+
+  /** Significant change against the desired direction. */
+  degraded: "degraded",
+
+  /** Significant change on a neutral-direction metric (no preferred direction). */
+  changed: "changed",
+
+  /** Not statistically significant at the metric's threshold. */
+  inconclusive: "inconclusive",
+
+  /** Below the metric's minimum sample size. */
+  insufficient_data: "insufficient_data",
+
+  /** Neither variant produced any samples. */
+  no_samples: "no_samples",
+
+  /** The comparison could not be classified (e.g. no p-value). */
+  `unknown`: "unknown",
+}
+
 // ---------------------------------------------------------------------------
 // Models
 // ---------------------------------------------------------------------------
@@ -121,6 +155,9 @@ model ExperimentVariant {
 
   @doc("The percentage of traffic to route to this variant. Required on create; may be omitted in materialized responses (use experiment_steps instead).")
   traffic_percentage?: int32;
+
+  @doc("The minimum number of observations required before this variant's scorecard results are considered reliable. Defaults to 100 when omitted.")
+  required_sample_size?: int32;
 }
 
 /** A contiguous range of hash buckets assigned to a variant. */
@@ -180,18 +217,34 @@ model ExperimentMetricAggregation {
 }
 
 /** The source of a metric value, discriminated by type. */
+@discriminator("type")
 model ExperimentMetricSource {
   @doc("The type of metric source.")
   type: ExperimentMetricSourceType;
+}
 
-  @doc("The schedule ID of a continuous evaluation rule. Required when type is 'continuous_evaluation_rule'.")
-  rule_id?: string;
+/** A metric sourced from an evaluator (a judge that scores agent output). */
+model EvaluatorMetricSource extends ExperimentMetricSource {
+  @doc("The evaluator source kind.")
+  type: ExperimentMetricSourceType.evaluator;
 
-  @doc("The built-in evaluator name (e.g. 'builtin.groundedness'). Required when type is 'evaluator'.")
+  @doc("The evaluator name.")
   evaluator_name?: string;
 
-  @doc("The trace metric name (e.g. 'latency_ms'). Required when type is 'traces'.")
-  name?: string;
+  @doc("The evaluator version to pin.")
+  evaluator_version?: string;
+
+  @doc("Additional evaluator parameters.")
+  parameters?: Record<unknown>;
+}
+
+/** A metric sourced from trace/event attributes. */
+model TracesMetricSource extends ExperimentMetricSource {
+  @doc("The traces source kind.")
+  type: ExperimentMetricSourceType.traces;
+
+  @doc("Trace attribute names the metric value is read from. Each attribute must be numeric, or boolean (coerced to 1/0). When more than one is given, the per-event value is the sum of the attributes; a missing attribute contributes 0 (partial rows are kept), and the event value is null only when every listed attribute is null.")
+  attribute_names: string[];
 }
 
 /** The definition of a metric — wraps the data source and optional aggregation. */
@@ -215,8 +268,35 @@ model ExperimentMetric {
   definition: ExperimentMetricDefinition;
 }
 
-/** Summary statistics for a variant in a scorecard row. */
-model ScorecardVariantStats {
+/** Structured failure detail for a scorecard whose state is 'failed'. */
+model ScorecardError {
+  @doc("Stable, machine-readable failure category (e.g. 'compute_failed', 'internal_error', 'publish_failed').")
+  code: string;
+
+  @doc("Human-readable (truncated) failure description.")
+  message: string;
+}
+
+/** A treatment variant's comparison against the scorecard's control for one metric. */
+model ScorecardPairComparison {
+  @doc("The signed delta: this variant's average minus the control's.")
+  delta: float64;
+
+  @doc("The p-value for significance vs. the control.")
+  p_value: float64;
+
+  @doc("The relative difference vs. the control, or null when the control average is zero.")
+  relative_difference?: float64 | null;
+
+  @doc("The qualitative treatment effect vs. the control, classified from the p-value and thresholds.")
+  treatment_effect: ScorecardTreatmentEffect;
+}
+
+/** One variant's result for a metric row: its raw aggregates plus, for treatment variants, the comparison against the control. */
+model ScorecardVariantResult {
+  @doc("The variant identifier (for agents_safe_rollout this is the agent version number).")
+  variant_id: string;
+
   @doc("The number of observations.")
   count: int32;
 
@@ -225,52 +305,94 @@ model ScorecardVariantStats {
 
   @doc("The standard deviation of the metric values.")
   std_dev: float64;
+
+  @doc("This variant's comparison against the scorecard's control. Null for the control variant.")
+  comparison?: ScorecardPairComparison;
 }
 
-/** A single row in a scorecard table — one metric comparison between control and treatment. */
+/** A single row in a scorecard table — one metric compared across every variant. */
 model ScorecardRow {
   @doc("The metric name this row corresponds to.")
   metric_name: string;
 
-  @doc("A human-readable label for the metric.")
-  label: string;
+  @doc("The granularity this metric is measured at (turn or conversation).")
+  level: ScorecardMetricLevel;
+
+  @doc("The kind of source this metric is derived from (evaluator or traces).")
+  category: ExperimentMetricSourceType;
 
   @doc("The desired direction for this metric.")
   desired_direction: ExperimentMetricDirection;
 
-  @doc("Summary statistics for the control variant.")
-  control_stats: ScorecardVariantStats;
-
-  @doc("Summary statistics for the treatment variant.")
-  treatment_stats: ScorecardVariantStats;
-
-  @doc("The absolute delta between treatment and control.")
-  delta: float64;
-
-  @doc("The p-value for statistical significance.")
-  p_value: float64;
+  @doc("One result per variant (control plus every treatment) for this metric.")
+  variants: ScorecardVariantResult[];
 }
 
-/** A generated scorecard artifact — a table comparing metric values between variants. */
-model Scorecard {
+/** Fields shared by the scorecard summary and detail representations. */
+model ScorecardBase {
   @doc("The unique identifier of the scorecard.")
-  @visibility(Lifecycle.Read)
   id: string;
 
   @doc("The experiment this scorecard belongs to.")
   experiment_id: string;
 
+  @doc("The control (baseline) variant used by this scorecard.")
+  control_variant_id: string;
+
+  @doc("The treatment variants compared against the control in this scorecard.")
+  treatment_variant_ids: string[];
+
+  @doc("The inclusive start of the observation window this scorecard was computed over, as a Unix timestamp (seconds).")
+  window_start: FoundryTimestamp;
+
+  @doc("The exclusive end of the observation window this scorecard was computed over, as a Unix timestamp (seconds).")
+  window_end: FoundryTimestamp;
+
+  @doc("The Unix timestamp (seconds) when this scorecard was generated.")
+  created_at: FoundryTimestamp;
+
   @doc("The state of the scorecard.")
   state: ScorecardState;
 
-  @doc("The URI to the scorecard artifact in the user's blob storage.")
-  artifact_uri: string;
+  @doc("Failure detail when the state is 'failed'. Null otherwise.")
+  error?: ScorecardError;
+
+  @doc("Optional open key-value metadata for forward-compatible extension (e.g. compute window, template version). First-class data stays in typed fields, not here.")
+  metadata?: Record<string>;
+}
+
+/** Lightweight scorecard projection returned by list operations. The full metric rows are available only from the individual scorecard resource. */
+model ScorecardSummary {
+  ...ScorecardBase;
+
+  @doc("The number of metric rows in the full scorecard.")
+  metric_count: int32;
+}
+
+/** A generated scorecard artifact — a table comparing metric values between variants. */
+model Scorecard {
+  ...ScorecardBase;
 
   @doc("The metric comparison rows.")
   rows: ScorecardRow[];
 }
 
-/** Represents an experiment that binds version routing to a lifecycle for A/B testing. */
+/** Configuration and service-managed resources for scheduled experiment evaluation. */
+model ExperimentEvaluation {
+  @doc("The deployed model used by evaluator-backed metrics.")
+  `model`?: string;
+
+  @doc("The service-managed evaluation group identifier.")
+  @visibility(Lifecycle.Read)
+  eval_id?: string;
+
+  @doc("The service-managed schedule identifier.")
+  @visibility(Lifecycle.Read)
+  schedule_id?: string;
+}
+
+/** A materialized experiment that binds version routing to a lifecycle for A/B testing. */
+@discriminator("type")
 model Experiment {
   @doc("The unique identifier of the experiment.")
   @visibility(Lifecycle.Read)
@@ -280,6 +402,7 @@ model Experiment {
   type: ExperimentType;
 
   @doc("The lifecycle state of the experiment.")
+  @visibility(Lifecycle.Read)
   state: ExperimentState;
 
   @doc("A human-readable display name for the experiment.")
@@ -288,43 +411,53 @@ model Experiment {
   @doc("A human-readable description of the experiment.")
   description?: string;
 
-  @doc("The name of the agent this experiment targets. Required for agents_safe_rollout type.")
-  target_agent?: string;
-
-  @doc("The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.")
-  duration?: string;
+  @doc("The experiment duration in days. Drives only the service-managed scorecard refresh horizon (how long scorecards keep refreshing after start); it does not end the experiment — the experiment ends only when the caller stops or promotes it. Defaults to 7 when omitted.")
+  duration_in_days?: int32;
 
   @doc("The list of variants participating in the experiment.")
   variants: ExperimentVariant[];
+
+  @doc("The list of metrics attached to the experiment.")
+  metrics: ExperimentMetric[];
+
+  @doc("Configuration and service-managed resources for scheduled evaluation.")
+  evaluation?: ExperimentEvaluation;
 
   @doc("The list of experiment steps with traffic allocation details. Materialized by the service.")
   @visibility(Lifecycle.Read)
   experiment_steps: ExperimentStep[];
 
   @doc("Properties controlling how traffic is assigned to variants.")
+  @visibility(Lifecycle.Read)
   assignment_properties: ExperimentAssignmentProperties;
 
-  @doc("The list of metrics (evaluation rules or inline evaluators) attached to the experiment.")
-  metrics: ExperimentMetric[];
+  @doc("The Unix timestamp (seconds) when the experiment was created.")
+  @visibility(Lifecycle.Read)
+  created_at: FoundryTimestamp;
 
   @doc("The Unix timestamp (seconds) when the experiment was started. Null if not yet started.")
   @visibility(Lifecycle.Read)
   started_at?: FoundryTimestamp | null;
 
-  @doc("The scheduled start time for the experiment. Null if started immediately.")
-  scheduled_start_at?: FoundryTimestamp | null;
+  @doc("The actual end time (Unix seconds), set when the experiment is stopped or promoted. Null while the experiment is created or running.")
+  @visibility(Lifecycle.Read)
+  end_at?: FoundryTimestamp | null;
+}
 
-  @doc("The scheduled end time for the experiment. Null if no end is scheduled.")
-  scheduled_end_at?: FoundryTimestamp | null;
+/** An experiment that safely rolls traffic between versions of one agent. */
+model AgentsSafeRolloutExperiment extends Experiment {
+  @doc("The A/B safe-rollout experiment kind.")
+  type: ExperimentType.agents_safe_rollout;
+
+  @doc("The name of the agent whose versions participate in the rollout.")
+  target_agent: string;
 }
 
 /** Request body for creating an experiment. */
+@discriminator("type")
 model CreateExperimentRequest {
   @doc("The discriminated experiment kind.")
   type: ExperimentType;
-
-  @doc("The name of the agent this experiment targets. Required for agents_safe_rollout type.")
-  target_agent?: string;
 
   @doc("A human-readable display name for the experiment.")
   display_name: string;
@@ -332,14 +465,54 @@ model CreateExperimentRequest {
   @doc("A human-readable description of the experiment.")
   description?: string;
 
-  @doc("The ISO 8601 duration for the experiment (e.g. 'P3D' for 3 days). Defaults to P3D when omitted.")
-  duration?: string;
+  @doc("The experiment duration in days. Drives only the service-managed scorecard refresh horizon; it does not end the experiment. Defaults to 7 when omitted.")
+  duration_in_days?: int32;
 
   @doc("The list of variants. Each variant id is an agent version number. Exactly one must have role 'control'. traffic_percentage must sum to 100.")
   variants: ExperimentVariant[];
 
-  @doc("Optional list of metrics (evaluation rules or inline evaluators) to attach to the experiment.")
+  @doc("Optional list of metrics to attach to the experiment.")
   metrics?: ExperimentMetric[];
+
+  @doc("Optional scheduled evaluation configuration.")
+  evaluation?: ExperimentEvaluation;
+}
+
+/** Request body for creating an agents_safe_rollout experiment. */
+model CreateAgentsSafeRolloutExperimentRequest extends CreateExperimentRequest {
+  @doc("The A/B safe-rollout experiment kind.")
+  type: ExperimentType.agents_safe_rollout;
+
+  @doc("The name of the agent targeted by the experiment.")
+  target_agent: string;
+}
+
+/**
+ * Request body for patching an experiment. Only experiments still in the 'created' state may be
+ * updated; omitted fields are left unchanged. Type-specific identity (e.g. agents_safe_rollout
+ * target_agent) is immutable and cannot be changed here.
+ */
+model PatchExperimentRequest {
+  @doc("The experiment kind. Must match the existing experiment.")
+  type: ExperimentType;
+
+  @doc("The new display name. Left unchanged when omitted.")
+  display_name?: string;
+
+  @doc("The new description. Left unchanged when omitted.")
+  description?: string;
+
+  @doc("The new duration in days. Left unchanged when omitted.")
+  duration_in_days?: int32;
+
+  @doc("The replacement variant list. When provided it fully replaces the existing variants and must satisfy the same rules as on create.")
+  variants?: ExperimentVariant[];
+
+  @doc("The replacement metric list. When provided it fully replaces the existing metrics.")
+  metrics?: ExperimentMetric[];
+
+  @doc("The replacement scheduled evaluation configuration. Left unchanged when omitted.")
+  evaluation?: ExperimentEvaluation;
 }
 
 /** Request body for promoting an experiment. */

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
@@ -1,0 +1,132 @@
+// Routes for the Experiments data-plane surface.
+// Provides experiment lifecycle for A/B version traffic-split on agents.
+
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Experiment CRUD + lifecycle actions
+// ---------------------------------------------------------------------------
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
+@tag("Experiments")
+interface Experiments {
+  @summary("Create an experiment")
+  @doc("Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.")
+  @route("experiments")
+  @post
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  create is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    CreateExperimentRequest,
+    {
+      @statusCode statusCode: 201;
+      @body body: Experiment;
+    }
+  >;
+
+  @summary("Get an experiment")
+  @doc("Retrieves the experiment by id.")
+  @route("experiments/{experiment_id}")
+  @get
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  get is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment.")
+      @path
+      experiment_id: string;
+    },
+    Experiment
+  >;
+
+  @summary("List experiments")
+  @doc("Returns the list of all experiments.")
+  @route("experiments")
+  @get
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  list is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      ...CursorPaginationParams;
+    },
+    OpenAIPage<Experiment>
+  >;
+
+  @summary("Stop an experiment")
+  @doc("Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.")
+  @route("experiments/{experiment_id}:stop")
+  @post
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  stop is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment to stop.")
+      @path
+      experiment_id: string;
+    },
+    Experiment
+  >;
+
+  @summary("Promote an experiment")
+  @doc("Promotes the winning variant. The agent's version selector is replaced with a single 100% rule for the winner.")
+  @route("experiments/{experiment_id}:promote")
+  @post
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  promote is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment to promote.")
+      @path
+      experiment_id: string;
+
+      @doc("The promotion request.")
+      @body
+      body: PromoteExperimentRequest;
+    },
+    Experiment
+  >;
+
+  @summary("List scorecards")
+  @doc("Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.")
+  @route("experiments/{experiment_id}/scorecards")
+  @get
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  listScorecards is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment.")
+      @path
+      experiment_id: string;
+    },
+    {
+      @doc("The list of scorecards.")
+      data: Scorecard[];
+    }
+  >;
+
+  @summary("Delete a scorecard")
+  @doc("Deletes the scorecard record and its user-blob artifact. Does not stop or mutate the experiment itself.")
+  @route("experiments/{experiment_id}/scorecards/{scorecard_id}")
+  @delete
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  deleteScorecard is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment.")
+      @path
+      experiment_id: string;
+
+      @doc("The unique identifier of the scorecard to delete.")
+      @path
+      scorecard_id: string;
+    },
+    {
+      @statusCode statusCode: 204;
+    }
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
@@ -16,7 +16,7 @@ namespace Azure.AI.Projects;
 @tag("Experiments")
 interface Experiments {
   @summary("Create an experiment")
-  @doc("Creates an experiment. For an agents_safe_rollout experiment, the service mints experiment_id and salt, write-locks the agent's version selector, and starts sticky-per-conversation routing.")
+  @doc("Creates an experiment in the 'created' state. Call the :start action to begin routing traffic.")
   @route("experiments")
   @post
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
@@ -55,6 +55,21 @@ interface Experiments {
       ...CursorPaginationParams;
     },
     OpenAIPage<Experiment>
+  >;
+
+  @summary("Start an experiment")
+  @doc("Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.")
+  @route("experiments/{experiment_id}:start")
+  @post
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  start is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment to start.")
+      @path
+      experiment_id: string;
+    },
+    Experiment
   >;
 
   @summary("Stop an experiment")

--- a/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/experiments/routes.tsp
@@ -22,7 +22,11 @@ interface Experiments {
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
   create is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.experiments_v1_preview,
-    CreateExperimentRequest,
+    {
+      @doc("The experiment to create.")
+      @body
+      body: CreateExperimentRequest;
+    },
     {
       @statusCode statusCode: 201;
       @body body: Experiment;
@@ -45,20 +49,39 @@ interface Experiments {
   >;
 
   @summary("List experiments")
-  @doc("Returns the list of all experiments.")
+  @doc("Returns a cursor-paged list of experiments.")
   @route("experiments")
   @get
+  @list
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
   list is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.experiments_v1_preview,
     {
-      ...CursorPaginationParams;
+      ...CommonPageQueryParameters;
     },
-    OpenAIPage<Experiment>
+    AgentsPagedResult<Experiment>
+  >;
+
+  @summary("Update an experiment")
+  @doc("Applies a partial update to an experiment. Only experiments still in the 'created' state may be updated; omitted fields are left unchanged.")
+  @route("experiments/{experiment_id}")
+  @patch(#{ implicitOptionality: true })
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  update is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment to update.")
+      @path
+      experiment_id: string;
+
+      @header("Content-Type") contentType: "application/merge-patch+json";
+      ...PatchExperimentRequest;
+    },
+    Experiment
   >;
 
   @summary("Start an experiment")
-  @doc("Starts a created experiment. The service mints experiment_id and salt, write-locks the agent's version selector, and begins sticky-per-conversation routing.")
+  @doc("Starts a created experiment. The service mints the salt, materializes traffic steps, and begins sticky-per-conversation routing.")
   @route("experiments/{experiment_id}:start")
   @post
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
@@ -73,7 +96,7 @@ interface Experiments {
   >;
 
   @summary("Stop an experiment")
-  @doc("Stops a running experiment. Routing collapses to the control variant and the agent's version selector is unlocked for editing.")
+  @doc("Stops a running experiment. Routing collapses to the control variant.")
   @route("experiments/{experiment_id}:stop")
   @post
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
@@ -106,10 +129,28 @@ interface Experiments {
     Experiment
   >;
 
+  @summary("Delete an experiment")
+  @doc("Deletes a non-running experiment and its scorecard artifacts.")
+  @route("experiments/{experiment_id}")
+  @delete
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  delete is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
+    {
+      @doc("The unique identifier of the experiment to delete.")
+      @path
+      experiment_id: string;
+    },
+    {
+      @statusCode statusCode: 204;
+    }
+  >;
+
   @summary("List scorecards")
-  @doc("Returns the list of generated scorecards for an experiment. Each scorecard is a table comparing metric values between variants.")
+  @doc("Returns a cursor-paged list of generated scorecards for an experiment. Each entry is a lightweight summary; use Get scorecard to retrieve the full metric rows.")
   @route("experiments/{experiment_id}/scorecards")
   @get
+  @list
   @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
   listScorecards is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.experiments_v1_preview,
@@ -117,11 +158,29 @@ interface Experiments {
       @doc("The unique identifier of the experiment.")
       @path
       experiment_id: string;
+
+      ...CommonPageQueryParameters;
     },
+    AgentsPagedResult<ScorecardSummary>
+  >;
+
+  @summary("Get a scorecard")
+  @doc("Retrieves a generated scorecard by id, including its full metric rows.")
+  @route("experiments/{experiment_id}/scorecards/{scorecard_id}")
+  @get
+  @extension("x-ms-foundry-meta", ExperimentsRequiredPreviews)
+  getScorecard is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.experiments_v1_preview,
     {
-      @doc("The list of scorecards.")
-      data: Scorecard[];
-    }
+      @doc("The unique identifier of the experiment.")
+      @path
+      experiment_id: string;
+
+      @doc("The unique identifier of the scorecard.")
+      @path
+      scorecard_id: string;
+    },
+    Scorecard
   >;
 
   @summary("Delete a scorecard")

--- a/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
@@ -67,6 +67,11 @@ using OpenAPI;
     summary: "Agent optimization jobs",
   },
   #{
+    name: "Experiments",
+    parent: "Platform APIs",
+    summary: "Experiment lifecycle for A/B version traffic-split",
+  },
+  #{
     name: "EvaluatorGenerationJobs",
     parent: "Platform APIs",
     summary: "Evaluator generation jobs",


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.


<!-- 🚨🚨🚨 Replace this line with a summary and reason for these changes to your data plane API 🚨🚨🚨 -->

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## API Info: The Basics

Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue:

Is this review for (select one):

- [x] a private preview
- [ ] a public preview
- [ ] GA release

### Change Scope

This PR adds the **Experiments** and **Scorecards** API surface to the AI Foundry data-plane spec, enabling A/B experimentation on agents via traffic-split version selectors.

- **Design Document:** (internal) `foundrysdk_specs/specs/agents/optimization/agents_safe_rollout.md`
- **Previous API Spec Doc:** N/A (new API surface)
- **Updated paths:**
  - `POST /experiments` — Create an experiment (returns in `created` state)
  - `GET /experiments` — List experiments
  - `GET /experiments/{experiment_id}` — Get an experiment
  - `POST /experiments/{experiment_id}:start` — Start a created experiment
  - `POST /experiments/{experiment_id}:stop` — Stop a running experiment
  - `POST /experiments/{experiment_id}:promote` — Promote the winning variant
  - `GET /experiments/{experiment_id}/scorecards` — List scorecards
  - `DELETE /experiments/{experiment_id}/scorecards/{scorecard_id}` — Delete a scorecard

**New / Modified files:**

| Layer | File | Change |
|-------|------|--------|
| TypeSpec | `src/experiments/models.tsp` | **New** — Experiment, Scorecard, ExperimentMetric models and unions |
| TypeSpec | `src/experiments/routes.tsp` | **New** — CRUD + lifecycle (start/stop/promote) + scorecard endpoints |
| TypeSpec | `src/agents/models.tsp` | **Modified** — Added `experiment_id` (readOnly) and `salt` (readOnly) to `VersionSelector` |
| TypeSpec | `src/common/servicepatterns.tsp` | **Modified** — Added `experiments_v1_preview` feature flag |
| TypeSpec | `main.tsp` | **Modified** — Added `import "./src/experiments/routes.tsp"` |
| TypeSpec | `tag-definitions.tsp` | **Modified** — Added `Experiments` tag |
| OpenAPI3 JSON | `openapi3/v1/microsoft-foundry-openapi3.json` | **Modified** — All experiment/scorecard paths + schemas |
| OpenAPI3 YAML | `openapi3/v1/microsoft-foundry-openapi3.yaml` | **Modified** — All experiment/scorecard paths + schemas |

**Key models added:**
- `Experiment` — top-level resource with type, state (created/running/stopped/promoted), variants, steps, assignment, and metrics
- `ExperimentMetric` — Statsig-style metric: id, direction, aggregation (type + optional percentile), source (discriminated by continuous_evaluation_rule / evaluator / trace_metric), optional guardrail
- `Scorecard` / `ScorecardRow` — per-metric comparison between variants with state (ready/computing/failed)
- `VersionSelector` updated with readOnly `experiment_id` and `salt` fields

### Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff.

### Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[Swagger-Suppression-Process](https://aka.ms/pr-suppressions) 
to get approval.

### Release planner

A [release plan](https://aka.ms/azsdkdocs/release-plans) should have been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azsdk/onboarding/restapischedule).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling

 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)

### Guidelines & Specifications

 * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links

 * [Schedule a data plane REST API spec review](https://aka.ms/azsdk/onboarding/restapischedule)

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories) 
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
