### PR TITLE
[BillingTrust] Add .NET client rename for GenerateUploadTokenResponse (AZC0030)

### DIFF
--- a/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/client.tsp
+++ b/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/client.tsp
@@ -5,3 +5,4 @@ using Microsoft.BillingTrust;
 using Azure.ClientGenerator.Core;
 
 @@clientName(ProvisioningState, "BillingTrustProvisioningState", "csharp");
+@@clientName(GenerateUploadTokenResponse, "GenerateUploadTokenResult", "csharp");

--- a/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/client.tsp
+++ b/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/client.tsp
@@ -5,4 +5,8 @@ using Microsoft.BillingTrust;
 using Azure.ClientGenerator.Core;
 
 @@clientName(ProvisioningState, "BillingTrustProvisioningState", "csharp");
-@@clientName(GenerateUploadTokenResponse, "GenerateUploadTokenResult", "csharp");
+@@clientName(
+  GenerateUploadTokenResponse,
+  "GenerateUploadTokenResult",
+  "csharp"
+);


### PR DESCRIPTION
## Summary

Adds a .NET-only client rename for the `GenerateUploadTokenResponse` model to satisfy the Azure .NET SDK analyzer rule **AZC0030** (model names must not end in `Response`).

## Why

The .NET SDK generation for `Azure.ResourceManager.Billing.Trust` failed with:

```
error AZC0030: Model name 'GenerateUploadTokenResponse' ends with 'Response'.
We suggest renaming it to '...Result'.
```

This is a .NET-specific SDK guideline (`Response` is reserved for HTTP response wrappers). Python, Java, JavaScript, and Go SDKs generated successfully — only .NET enforces this rule.

## Change

`client.tsp` only:
```typespec
@@clientName(GenerateUploadTokenResponse, "GenerateUploadTokenResult", "csharp");
```

- **Client-only change** — does not modify the wire contract, `openapi.json`, or any other language SDK.
- Verified locally: `tsp compile` succeeds and `openapi.json` is unchanged.
- Follows the same `@@clientName`/csharp pattern already used for `ProvisioningState`.

## Related
- Release Plan: [#35167](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=35167)
- Original spec PR: #43896 (merged)
- .NET SDK PR to be regenerated: Azure/azure-sdk-for-net#60598