### PR TITLE
Modify stewardship guidance to NOT schedule meeting

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -838,7 +838,7 @@ const rulesPri0dataPlane = [
     anyRequiredLabels: ["APIStewardshipBoard-SignedOff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
-      `Send an email to azureapirbcore@microsoft.com with your PR link for offline review.`,
+      `Send an email to ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link for offline review.`,
   },
 ];
 

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -838,8 +838,7 @@ const rulesPri0dataPlane = [
     anyRequiredLabels: ["APIStewardshipBoard-SignedOff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
-      `Schedule the review by following ` +
-      `${href("aka.ms/azsdk/onboarding/restapischedule", "https://aka.ms/azsdk/onboarding/restapischedule")}.`,
+      `Send an email to azureapirbcore@microsoft.com with your PR link for offline review.,
   },
 ];
 

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -838,7 +838,7 @@ const rulesPri0dataPlane = [
     anyRequiredLabels: ["APIStewardshipBoard-SignedOff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
-      `Send an email to azureapirbcore@microsoft.com with your PR link for offline review.,
+      `Send an email to azureapirbcore@microsoft.com with your PR link for offline review.`,
   },
 ];
 


### PR DESCRIPTION
Quick fix into the stewardship guidance, so service teams do NOT schedule a meeting, but start an offline review.

This is necessary after changes in the stewardship makes meeting impossible to reach quorum. Discussed with @heaths from the board.

Once our main documentation is updated to be offline first, we will adjust the message. But we'd like to stop the bleeding of service teams scheduling review, that we have to cancel.