### PR TITLE
Move EvaluatorGenerationJobs tag under Evaluations parent

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -181,7 +181,7 @@
     },
     {
       "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
+      "parent": "Evaluations",
       "summary": "Evaluator generation jobs"
     },
     {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -94,7 +94,7 @@ tags:
     parent: Platform APIs
     summary: Agent optimization jobs
   - name: EvaluatorGenerationJobs
-    parent: Platform APIs
+    parent: Evaluations
     summary: Evaluator generation jobs
   - name: Evaluations
   - name: Evals

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -184,7 +184,7 @@
     },
     {
       "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
+      "parent": "Evaluations",
       "summary": "Evaluator generation jobs"
     },
     {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -95,7 +95,7 @@ tags:
     parent: Platform APIs
     summary: Agent optimization jobs
   - name: EvaluatorGenerationJobs
-    parent: Platform APIs
+    parent: Evaluations
     summary: Evaluator generation jobs
   - name: Evaluations
   - name: Evals

--- a/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
@@ -68,7 +68,7 @@ using OpenAPI;
   },
   #{
     name: "EvaluatorGenerationJobs",
-    parent: "Platform APIs",
+    parent: "Evaluations",
     summary: "Evaluator generation jobs",
   },
   #{ name: "Evaluations" },


### PR DESCRIPTION
Updates the `EvaluatorGenerationJobs` tag's `parent` from `Platform APIs` to `Evaluations` in `specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp` and regenerates the OpenAPI3 outputs (`v1` and `virtual-public-preview`, both yaml and json).

This is a documentation/OpenAPI tag-grouping change only; no operations, models, or API versions are affected.