### PR TITLE
[sql] Pin api-version 2025-01-01 for Java in tspconfig

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/tspconfig.yaml
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/tspconfig.yaml
@@ -17,6 +17,7 @@ options:
     emitter-output-dir: "{output-dir}/sdk/sqlmanagement/{namespace}"
     enable-wire-path-attribute: true
   "@azure-tools/typespec-java":
+    api-version: "2025-01-01"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-sql"
     namespace: "com.azure.resourcemanager.sql"
     flavor: "azure"


### PR DESCRIPTION
Pins `api-version: 2025-01-01` for the `@azure-tools/typespec-java` emitter in the sql tspconfig, so the Java SDK (azure-resourcemanager-sql) is generated against the stable 2025-01-01 API version.

Related Java SDK PR: https://github.com/Azure/azure-sdk-for-java/pull/49142