### PR TITLE
Add VoiceLive data-plane stable 2026-07-15 API version

### DIFF
--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -137,6 +137,7 @@ union ReasoningEffort {
 }
 
 /** Base for session configuration in the response. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
 @usage(ResponseUsage)
 model ResponseSession is RequestSession {
   ...SessionBase;
@@ -146,6 +147,12 @@ model ResponseSession is RequestSession {
 
   /** The unique identifier for the session. */
   id?: string;
+
+  /** Expiration time for the session. This value is set by the server and cannot be changed with `session.update`. */
+  #suppress "@microsoft/azure-openapi-validator/IntegerTypeMustHaveFormat" "The unixtime format is present, but the legacy rule only allows int32 or int64."
+  @added(Versions.v2026_07_15)
+  @encode(DateTimeKnownEncoding.unixTimestamp, int64)
+  expires_at?: utcDateTime;
 }
 
 /** Supported OpenAI voice names (string enum). */
@@ -725,11 +732,19 @@ model EouDetection {
       | "semantic_detection_v1_multilingual"
       | string
   )
+  @typeChangedFrom(
+    Versions.v2026_07_15,
+
+      | "semantic_detection_v1"
+      | "semantic_detection_v1_en"
+      | "semantic_detection_v1_multilingual"
+      | "smart_end_of_turn_detection"
+      | string
+  )
   `model`:
     | "semantic_detection_v1"
     | "semantic_detection_v1_en"
     | "semantic_detection_v1_multilingual"
-    | "smart_end_of_turn_detection"
     | string;
 }
 
@@ -798,6 +813,7 @@ model AzureSemanticDetectionMultilingual extends EouDetection {
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(RequestUsage)
 model SmartEndOfTurnDetection extends EouDetection {
   `model`: "smart_end_of_turn_detection";

--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -31,6 +31,7 @@ union ClientEventType {
 
   /** Sent by the client to initiate a WebRTC session with an SDP offer. */
   @added(Versions.v2026_06_01_preview)
+  @removed(Versions.v2026_07_15)
   rtc_call_sdp_create: "rtc.call.sdp.create",
 
   /** Streamed delta of input text content being appended to an item. */
@@ -159,17 +160,21 @@ union ServerEventType {
 
   /** Returned when the WebRTC SDP negotiation completes successfully. */
   @added(Versions.v2026_06_01_preview)
+  @removed(Versions.v2026_07_15)
   rtc_call_sdp_created: "rtc.call.sdp.created",
 
   /** Returned when a WebRTC call operation fails. */
   @added(Versions.v2026_06_01_preview)
+  @removed(Versions.v2026_07_15)
   rtc_call_error: "rtc.call.error",
 
   /** Output audio buffer playback started. */
   @added(Versions.v2026_06_01_preview)
+  @removed(Versions.v2026_07_15)
   output_audio_buffer_started: "output_audio_buffer.started",
 
   /** Output audio buffer playback stopped. */
   @added(Versions.v2026_06_01_preview)
+  @removed(Versions.v2026_07_15)
   output_audio_buffer_stopped: "output_audio_buffer.stopped",
 }

--- a/specification/ai/data-plane/VoiceLive/main.tsp
+++ b/specification/ai/data-plane/VoiceLive/main.tsp
@@ -25,4 +25,7 @@ enum Versions {
 
   /** Version 2026-06-01-preview. */
   v2026_06_01_preview: "2026-06-01-preview",
+
+  /** Version 2026-07-15. */
+  v2026_07_15: "2026-07-15",
 }

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -1284,7 +1284,7 @@ model ResponseCreateParams {
   @added(Versions.v2026_04_10)
   interim_response?: InterimResponseConfig;
 
-  /** Input data to invoke the hosted agent. This feature is in preview. */
+  /** Input data to invoke the hosted agent. */
   #suppress "@azure-tools/typespec-azure-core/no-unknown" "Opaque passthrough: values are user-provided input forwarded to the hosted agent, whose schema is not defined by this API."
   #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Opaque passthrough JSON from hosted agent; values are not limited to strings."
   @added(Versions.v2026_06_01_preview)
@@ -1773,6 +1773,7 @@ model ClientEventOutputAudioBufferClear extends ClientEvent {
 /** Sent by the client to initiate a WebRTC session with an SDP offer. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(RequestUsage)
 model ClientEventRtcCallSdpCreate extends ClientEvent {
   /** The event type, must be `rtc.call.sdp.create`. */
@@ -1788,6 +1789,7 @@ model ClientEventRtcCallSdpCreate extends ClientEvent {
 /** Returned when the WebRTC SDP negotiation completes successfully. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(ResponseUsage)
 model ServerEventRtcCallSdpCreated extends ServerEvent {
   /** The event type, must be `rtc.call.sdp.created`. */
@@ -1805,6 +1807,7 @@ model ServerEventRtcCallSdpCreated extends ServerEvent {
 /** Error details for RTC call errors. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(ResponseUsage)
 model RtcCallErrorDetails {
   /** The error category: `invalid_request_error` or `server_error`. */
@@ -1820,6 +1823,7 @@ model RtcCallErrorDetails {
 /** Returned when a WebRTC call operation fails. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(ResponseUsage)
 model ServerEventRtcCallError extends ServerEvent {
   /** The event type, must be `rtc.call.error`. */
@@ -1840,6 +1844,7 @@ model ServerEventRtcCallError extends ServerEvent {
 /** Returned when model audio output starts playing. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(ResponseUsage)
 model ServerEventOutputAudioBufferStarted extends ServerEvent {
   /** The event type, must be `output_audio_buffer.started`. */
@@ -1852,6 +1857,7 @@ model ServerEventOutputAudioBufferStarted extends ServerEvent {
 /** Returned when model audio output finishes playing. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // snake_case to remain close to OpenAI style.
 @added(Versions.v2026_06_01_preview)
+@removed(Versions.v2026_07_15)
 @usage(ResponseUsage)
 model ServerEventOutputAudioBufferStopped extends ServerEvent {
   /** The event type, must be `output_audio_buffer.stopped`. */

--- a/specification/ai/data-plane/VoiceLive/readme.md
+++ b/specification/ai/data-plane/VoiceLive/readme.md
@@ -8,13 +8,22 @@ This is the AutoRest configuration file for VoiceLive.
 
 ### Basic Information
 
-This is a TypeSpec project so we only want to readme to default the default tag and point to the outputted swagger file.
+This is a TypeSpec project so this readme only points to the outputted swagger files.
 This is used for some tools such as doc generation and swagger apiview generation it isn't used for SDK code gen as we
-use the native TypeSpec code generation configured in the tspconfig.yaml file.
+use the native TypeSpec code generation configured in the tspconfig.yaml file. The default (latest)
+API version is controlled by the `@azure-tools/typespec-autorest` emitter in tspconfig.yaml.
 
 ```yaml
 openapi-type: data-plane
-tag: package-2026-06-01-preview
+```
+
+### Tag: package-2026-07-15
+
+These settings apply only when `--tag=package-2026-07-15` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-07-15'
+input-file:
+  - stable/2026-07-15/VoiceLive.json
 ```
 
 ### Tag: package-2026-06-01-preview
@@ -60,4 +69,8 @@ directive:
   - suppress: OAV133
     from: VoiceLive.json
     reason: OpenAI and Azure require two different discriminators.
+  - suppress: IntegerTypeMustHaveFormat
+    from: VoiceLive.json
+    where: $.definitions.ResponseSession.properties.expires_at
+    reason: OpenAI Realtime uses the "unixtime" format, which this legacy rule does not recognize.
 ```

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "VoiceLive",
-    "version": "2026-06-01-preview",
+    "version": "2026-07-15",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"
@@ -1547,29 +1547,6 @@
       ],
       "x-ms-discriminator-value": "response.create"
     },
-    "ClientEventRtcCallSdpCreate": {
-      "type": "object",
-      "description": "Sent by the client to initiate a WebRTC session with an SDP offer.",
-      "properties": {
-        "sdp_offer": {
-          "type": "string",
-          "description": "The SDP offer from the client for WebRTC negotiation."
-        },
-        "session": {
-          "$ref": "#/definitions/RequestSession",
-          "description": "Optional initial session configuration. If provided, applied before the session is established."
-        }
-      },
-      "required": [
-        "sdp_offer"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ClientEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "rtc.call.sdp.create"
-    },
     "ClientEventSessionAvatarConnect": {
       "type": "object",
       "description": "Sent when the client connects and provides its SDP (Session Description Protocol)\n\nfor avatar-related media negotiation.",
@@ -1629,7 +1606,6 @@
         "session.avatar.connect",
         "mcp_approval_response",
         "output_audio_buffer.clear",
-        "rtc.call.sdp.create",
         "input_text.delta",
         "input_text.done"
       ],
@@ -1709,11 +1685,6 @@
             "name": "output_audio_buffer_clear",
             "value": "output_audio_buffer.clear",
             "description": "Client request to clear the avatar output buffer."
-          },
-          {
-            "name": "rtc_call_sdp_create",
-            "value": "rtc.call.sdp.create",
-            "description": "Sent by the client to initiate a WebRTC session with an SDP offer."
           },
           {
             "name": "input_text_delta",
@@ -1830,8 +1801,7 @@
           "enum": [
             "semantic_detection_v1",
             "semantic_detection_v1_en",
-            "semantic_detection_v1_multilingual",
-            "smart_end_of_turn_detection"
+            "semantic_detection_v1_multilingual"
           ],
           "x-ms-enum": {
             "modelAsString": true
@@ -3935,6 +3905,11 @@
         "id": {
           "type": "string",
           "description": "The unique identifier for the session."
+        },
+        "expires_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "Expiration time for the session. This value is set by the server and cannot be changed with `session.update`."
         }
       }
     },
@@ -4030,28 +4005,6 @@
         }
       ],
       "x-ms-discriminator-value": "web_search_call"
-    },
-    "RtcCallErrorDetails": {
-      "type": "object",
-      "description": "Error details for RTC call errors.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The error category: `invalid_request_error` or `server_error`."
-        },
-        "code": {
-          "type": "string",
-          "description": "A machine-readable error code."
-        },
-        "message": {
-          "type": "string",
-          "description": "A human-readable error description."
-        }
-      },
-      "required": [
-        "type",
-        "message"
-      ]
     },
     "Scene": {
       "type": "object",
@@ -4512,38 +4465,6 @@
         }
       ],
       "x-ms-discriminator-value": "output_audio_buffer.cleared"
-    },
-    "ServerEventOutputAudioBufferStarted": {
-      "type": "object",
-      "description": "Returned when model audio output starts playing.",
-      "properties": {
-        "response_id": {
-          "type": "string",
-          "description": "The ID of the response whose audio started playing."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "output_audio_buffer.started"
-    },
-    "ServerEventOutputAudioBufferStopped": {
-      "type": "object",
-      "description": "Returned when model audio output finishes playing.",
-      "properties": {
-        "response_id": {
-          "type": "string",
-          "description": "The ID of the response whose audio stopped playing."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "output_audio_buffer.stopped"
     },
     "ServerEventResponseAnimationBlendshapeDelta": {
       "type": "object",
@@ -5734,57 +5655,6 @@
       ],
       "x-ms-discriminator-value": "response.web_search_call.searching"
     },
-    "ServerEventRtcCallError": {
-      "type": "object",
-      "description": "Returned when a WebRTC call operation fails.",
-      "properties": {
-        "operation": {
-          "type": "string",
-          "description": "The operation that caused the error (e.g., `rtc.call.sdp.create`)."
-        },
-        "rtc_call_id": {
-          "type": "string",
-          "description": "The RTC call identifier, if available."
-        },
-        "error": {
-          "$ref": "#/definitions/RtcCallErrorDetails",
-          "description": "The error details."
-        }
-      },
-      "required": [
-        "error"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "rtc.call.error"
-    },
-    "ServerEventRtcCallSdpCreated": {
-      "type": "object",
-      "description": "Returned when the WebRTC SDP negotiation completes successfully.",
-      "properties": {
-        "rtc_call_id": {
-          "type": "string",
-          "description": "The unique identifier for this RTC call session."
-        },
-        "sdp_answer": {
-          "type": "string",
-          "description": "The SDP answer from the server for WebRTC negotiation."
-        }
-      },
-      "required": [
-        "rtc_call_id",
-        "sdp_answer"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "rtc.call.sdp.created"
-    },
     "ServerEventSessionAvatarConnecting": {
       "type": "object",
       "description": "Sent when the server is in the process of establishing an avatar media connection and provides its SDP answer.",
@@ -5931,11 +5801,7 @@
         "response.file_search_call.completed",
         "output_audio_buffer.cleared",
         "response.audio_transcript.annotation.added",
-        "response.invocation.delta",
-        "rtc.call.sdp.created",
-        "rtc.call.error",
-        "output_audio_buffer.started",
-        "output_audio_buffer.stopped"
+        "response.invocation.delta"
       ],
       "x-ms-enum": {
         "name": "ServerEventType",
@@ -6176,26 +6042,6 @@
             "name": "response_invocation_delta",
             "value": "response.invocation.delta",
             "description": "Invocation passthrough delta from hosted agent."
-          },
-          {
-            "name": "rtc_call_sdp_created",
-            "value": "rtc.call.sdp.created",
-            "description": "Returned when the WebRTC SDP negotiation completes successfully."
-          },
-          {
-            "name": "rtc_call_error",
-            "value": "rtc.call.error",
-            "description": "Returned when a WebRTC call operation fails."
-          },
-          {
-            "name": "output_audio_buffer_started",
-            "value": "output_audio_buffer.started",
-            "description": "Output audio buffer playback started."
-          },
-          {
-            "name": "output_audio_buffer_stopped",
-            "value": "output_audio_buffer.stopped",
-            "description": "Output audio buffer playback stopped."
           }
         ]
       }
@@ -6321,28 +6167,6 @@
           }
         ]
       }
-    },
-    "SmartEndOfTurnDetection": {
-      "type": "object",
-      "description": "Audio-based end-of-turn detection. Operates directly on the input audio\nstream rather than text. Use `threshold_level` and `timeout_ms` to tune\ndetection.",
-      "properties": {
-        "threshold_level": {
-          "$ref": "#/definitions/EouThresholdLevel",
-          "description": "Threshold level setting. One of `low`, `medium`, `high`, or `default`."
-        },
-        "timeout_ms": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Timeout in milliseconds.",
-          "minimum": 0
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/EouDetection"
-        }
-      ],
-      "x-ms-discriminator-value": "smart_end_of_turn_detection"
     },
     "StaticInterimResponseConfig": {
       "type": "object",


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

This PR adds the new stable `2026-07-15` version of the VoiceLive data-plane API. It graduates the API from the `2026-06-01-preview` line to a stable release, carrying forward the preview features the service intends to ship in GA while dropping the ones that are not yet ready.

Summary of changes:

- **New stable version `2026-07-15`** added to the `Versions` enum and generated as `stable/2026-07-15/VoiceLive.json`.
- **Added:** `ResponseSession.expires_at` (int64) — a server-set session expiration timestamp. Its description follows OpenAI's public Realtime API wording; it cannot be changed via `session.update`. Typed `int64` to avoid a Year 2038 epoch-seconds overflow.
- **Graduated from preview into stable:** `parallel_tool_calls`, azure-realtime native voices (`AzureRealtimeNativeVoice` / `AzureRealtimeNativeVoiceName` and the `Voice` union member), input-text streaming (`input_text.delta` / `input_text.done`), invocation streaming (`ServerEventResponseInvocationDelta` + `invoke_input`), and client-side echo-cancellation reference config (`EchoCancellationReferenceSource`, `AudioEchoCancellation.reference_source` / `channels`, graduated in #44475).
- **Held back from stable** (remain preview-only via `@removed(Versions.v2026_07_15)`): WebRTC calling (`rtc.call.sdp.create/created/error`, `output_audio_buffer.started/stopped` and their models) and smart end-of-turn detection (`SmartEndOfTurnDetection`).

New/retained fields are version-gated with `@added` decorators so earlier released versions are unchanged. The generated OpenAPI was produced with `tsp compile` and compiles with no warnings.

## Changelog

### `2026-07-15` vs `2026-06-01-preview` (previous preview)

**Added**
- `ResponseSession.expires_at` (int64) — server-set session expiration timestamp.

**Removed** (preview-only, not graduated to stable — see "Still in preview" below)
- WebRTC calling: `ClientEventRtcCallSdpCreate`, `ServerEventRtcCallSdpCreated`, `ServerEventRtcCallError`, `RtcCallErrorDetails`, `ServerEventOutputAudioBufferStarted`, `ServerEventOutputAudioBufferStopped` (events `rtc.call.sdp.create`, `rtc.call.sdp.created`, `rtc.call.error`, `output_audio_buffer.started`, `output_audio_buffer.stopped`).
- Smart end-of-turn detection: `SmartEndOfTurnDetection`.

**Retained from preview** (graduated to stable): `parallel_tool_calls`, azure-realtime native voices, input-text streaming (`input_text.delta` / `input_text.done`), and client-side echo-cancellation reference config (`EchoCancellationReferenceSource`, `AudioEchoCancellation.reference_source` / `channels`).

### `2026-07-15` vs `2026-04-10` (previous stable)

**Added**
- `ResponseSession.expires_at`.
- `parallel_tool_calls` (default `true`).
- Azure-realtime native voices: `AzureRealtimeNativeVoice`, `AzureRealtimeNativeVoiceName`, plus the `Voice` union member.
- Input-text streaming: `ClientEventInputTextDelta`, `ClientEventInputTextDone`.
- Invocation streaming: `ServerEventResponseInvocationDelta` (event `response.invocation.delta`) and the `invoke_input` field.
- Client-side echo-cancellation reference config: `EchoCancellationReferenceSource` union, `AudioEchoCancellation.reference_source`, `AudioEchoCancellation.channels`.

**Removed:** none. Everything dropped in `2026-07-15` was preview-only, so it never existed in stable `2026-04-10`.

### Still in preview (available in `2026-06-01-preview`, intentionally not in stable `2026-07-15`)

- **WebRTC calling:** client event `rtc.call.sdp.create`; server events `rtc.call.sdp.created`, `rtc.call.error`, `output_audio_buffer.started`, `output_audio_buffer.stopped`; models `ClientEventRtcCallSdpCreate`, `ServerEventRtcCallSdpCreated`, `ServerEventRtcCallError`, `RtcCallErrorDetails`, `ServerEventOutputAudioBufferStarted`, `ServerEventOutputAudioBufferStopped`.
- **Smart end-of-turn detection:** `SmartEndOfTurnDetection`.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## API Info: The Basics

Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue: N/A

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release

### Change Scope

<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous API Spec document (if applicable), and the root paths that have been updated. </sup>
* Design Document: N/A
* Previous API Spec Doc: `specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json`
* Updated paths: `specification/ai/data-plane/VoiceLive/` (new `stable/2026-07-15/VoiceLive.json`)

### Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

### Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[Swagger-Suppression-Process](https://aka.ms/pr-suppressions) 
to get approval.

### Release planner

A [release plan](https://aka.ms/azsdkdocs/release-plans) should have been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azsdk/onboarding/restapischedule).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling

 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)

### Guidelines & Specifications

 * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links

 * [Schedule a data plane REST API spec review](https://aka.ms/azsdk/onboarding/restapischedule)

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories) 
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
fix https://github.com/Azure/azure-rest-api-specs/issues/44570