### PR TITLE
Add csharp customizations for Education migration

### DIFF
--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -44,4 +44,4 @@ using Microsoft.Education;
 @@access(Microsoft.Education.Operations.list, Access.internal, "csharp");
 
 @@clientName(GrantType, "EducationGrantType", "csharp");
-@@clientName(GrantDetails, "EducationGrantDetails", "csharp");
+@@clientName(GrantStatus, "EducationGrantStatus", "csharp");

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -33,3 +33,7 @@ using Microsoft.Education;
 );
 @@clientName(RedeemRequest, "EducationRedeemContent", "csharp");
 @@clientName(CommonTypes.Operation, "EducationOperationInfo", "csharp");
+// The provider operations-list method is ARM infrastructure; make the whole operation
+// internal so its method and envelope models stay off the public surface instead of
+// redefining common-types operation models publicly.
+@@access(Microsoft.Education.Operations.list, Access.internal, "csharp");

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -21,6 +21,11 @@ using Microsoft.Education;
 );
 @@clientLocation(redeemInvitationCode, "ManagementClient", "go");
 
+@@clientName(Amount, "EducationAmount", "csharp");
+
+@@alternateType(LabProperties.maxStudentCount, int32, "csharp");
+@@alternateType(InviteCodeGenerateRequest.maxStudentCount, int32, "csharp");
+
 // C# management SDK customizations for the Education onboarding.
 // common-types v3 types.json models Resource.id as a plain string; map it to
 // armResourceIdentifier so generated ResourceData ctors take a ResourceIdentifier.

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -42,3 +42,6 @@ using Microsoft.Education;
 // internal so its method and envelope models stay off the public surface instead of
 // redefining common-types operation models publicly.
 @@access(Microsoft.Education.Operations.list, Access.internal, "csharp");
+
+@@clientName(GrantType, "EducationGrantType", "csharp");
+@@clientName(GrantDetails, "EducationGrantDetails", "csharp");

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -2,6 +2,8 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
+using Azure.Core;
+using Azure.ResourceManager;
 using Microsoft.Education;
 
 @@clientName(
@@ -18,3 +20,16 @@ using Microsoft.Education;
   Lifecycle.Read
 );
 @@clientLocation(redeemInvitationCode, "ManagementClient", "go");
+
+// C# management SDK customizations for the Education onboarding.
+// common-types v3 types.json models Resource.id as a plain string; map it to
+// armResourceIdentifier so generated ResourceData ctors take a ResourceIdentifier.
+@@alternateType(CommonTypes.Resource.id, armResourceIdentifier, "csharp");
+// Rename models whose names collide with reserved Azure SDK suffixes (AZC0030/AZC0033).
+@@clientName(
+  InviteCodeGenerateRequest,
+  "EducationInviteCodeGenerateContent",
+  "csharp"
+);
+@@clientName(RedeemRequest, "EducationRedeemContent", "csharp");
+@@clientName(CommonTypes.Operation, "EducationOperationInfo", "csharp");

--- a/specification/education/resource-manager/Microsoft.Education/Education/tspconfig.yaml
+++ b/specification/education/resource-manager/Microsoft.Education/Education/tspconfig.yaml
@@ -39,6 +39,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Education"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Adds C# management SDK customizations for onboarding **Azure.ResourceManager.Education** (new service, API version 2021-12-01-preview) via TypeSpec.

### Changes
- `tspconfig.yaml`: add `@azure-typespec/http-client-csharp-mgmt` emitter block (`namespace: Azure.ResourceManager.Education`).
- `client.tsp` (all decorators `"csharp"`-scoped):
  - `@@alternateType(CommonTypes.Resource.id, armResourceIdentifier)` — common-types v3 models `id` as a plain string.
  - `@@clientName` renames to satisfy AZC0030/AZC0033 (`InviteCodeGenerateRequest`→`EducationInviteCodeGenerateContent`, `RedeemRequest`→`EducationRedeemContent`, `Operation`→`EducationOperationInfo`).
  - `@@access(Microsoft.Education.Operations.list, Access.internal)` — keep the provider operations-list infra off the public C# surface.

### Notes
- `back-compatible.tsp` is left untouched; all C# customizations live in `client.tsp`.
- Draft — paired with the SDK PR in Azure/azure-sdk-for-net.
