### PR TITLE
[dynatrace] Add python client name customization to avoid SDK breaking

### DIFF
--- a/specification/dynatrace/Dynatrace.Management/client.tsp
+++ b/specification/dynatrace/Dynatrace.Management/client.tsp
@@ -5,6 +5,13 @@ using Azure.Core;
 using Azure.ClientGenerator.Core;
 using Dynatrace.Observability;
 
+// Preserve the existing Python SDK client name to avoid breaking changes
+@@clientName(
+  Dynatrace.Observability,
+  "DynatraceObservabilityMgmtClient",
+  "python"
+);
+
 @@clientName(EnvironmentInfo.landingURL, "landingUrl", "java");
 
 // Removing below operations as these are not currently supported in the backend


### PR DESCRIPTION
## Summary

Adds a Python client-name customization for the `Dynatrace.Observability` (Microsoft.Dynatrace) TypeSpec so the generated Python SDK keeps its existing client class name.

## What changed

Added to `specification/dynatrace/Dynatrace.Management/client.tsp`:

`@@clientName(Dynatrace.Observability, "DynatraceObservabilityMgmtClient", "python");`

## Why

The current released `azure-mgmt-dynatrace` Python SDK exposes the client as `DynatraceObservabilityMgmtClient`. Without this override, regenerating from TypeSpec derives the client name from the namespace and produces a different name, which is a breaking change for Python users. Pinning the Python client name preserves backward compatibility.

## Validation

- `tsp compile` completes successfully with the change.
