### PR TITLE
Add SIG soft-delete GET/LIST fields for gallery image versions (2026-03-03)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/communityGalleryExamples/CommunityGalleryImageVersion_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/communityGalleryExamples/CommunityGalleryImageVersion_Get.json
@@ -23,7 +23,9 @@
           "artifactTags": {
             "ShareTag-CommunityGallery": "CommunityGallery"
           },
-          "disclaimer": "https://test-uri.com"
+          "disclaimer": "https://test-uri.com",
+          "consumptionEndTime": "2026-04-20T09:12:28Z",
+          "imageState": "SoftDeleted"
         },
         "location": "myLocation",
         "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/communityGalleryExamples/CommunityGalleryImageVersion_List.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/communityGalleryExamples/CommunityGalleryImageVersion_List.json
@@ -24,7 +24,8 @@
               "artifactTags": {
                 "ShareTag-CommunityGallery": "CommunityGallery"
               },
-              "disclaimer": "https://test-uri.com"
+              "disclaimer": "https://test-uri.com",
+              "imageState": "Active"
             },
             "location": "myLocation",
             "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/GallerySoftDeletedResource_ListByArtifactName.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/GallerySoftDeletedResource_ListByArtifactName.json
@@ -19,7 +19,9 @@
             "properties": {
               "resourceArmId": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGalleryName/images/myGalleryImageName/versions/1.0.0",
               "softDeletedTime": "2024-10-17T13:01:05+00:00",
-              "softDeletedArtifactType": "Images"
+              "softDeletedArtifactType": "Images",
+              "consumptionEndTime": "2024-11-16T13:01:05+00:00",
+              "hardDeletionTargetTime": "2024-11-23T13:01:05+00:00"
             }
           }
         ],

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/sharedGalleryExamples/SharedGalleryImageVersion_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/sharedGalleryExamples/SharedGalleryImageVersion_Get.json
@@ -22,7 +22,9 @@
           },
           "artifactTags": {
             "ShareTag-Official1PGallery": "Official1PGallery"
-          }
+          },
+          "consumptionEndTime": "2026-04-20T09:12:28Z",
+          "imageState": "SoftDeleted"
         },
         "location": "myLocation",
         "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/sharedGalleryExamples/SharedGalleryImageVersions_List.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/sharedGalleryExamples/SharedGalleryImageVersions_List.json
@@ -23,7 +23,8 @@
               },
               "artifactTags": {
                 "ShareTag-Official1PGallery": "Official1PGallery"
-              }
+              },
+              "imageState": "Active"
             },
             "location": "myLocation",
             "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -1824,7 +1824,7 @@ model GallerySoftDeletedResourceProperties {
   softDeletedTime?: string;
 
   /**
-   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.
+   * The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.
    */
   @added(Versions.v2026_03_03)
   @visibility(Lifecycle.Read)
@@ -2440,7 +2440,7 @@ union GalleryImageVersionState {
   Active: "Active",
 
   /**
-   * The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be referenced by the latest version.
+   * The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be resolved as the latest version.
    */
   SoftDeleted: "SoftDeleted",
 }
@@ -2479,7 +2479,7 @@ model SharedGalleryImageVersionProperties {
   artifactTags?: Record<string>;
 
   /**
-   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
+   * The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
    */
   @added(Versions.v2026_03_03)
   @visibility(Lifecycle.Read)
@@ -2773,7 +2773,7 @@ model CommunityGalleryImageVersionProperties {
   artifactTags?: Record<string>;
 
   /**
-   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
+   * The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
    */
   @added(Versions.v2026_03_03)
   @visibility(Lifecycle.Read)

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -1822,6 +1822,20 @@ model GallerySoftDeletedResourceProperties {
    * The timestamp for when the resource is soft-deleted. In dateTime offset format.
    */
   softDeletedTime?: string;
+
+  /**
+   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  consumptionEndTime?: utcDateTime;
+
+  /**
+   * The timestamp at which a soft-deleted gallery image version is permanently (hard) deleted and can no longer be recovered. In dateTime offset format.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  hardDeletionTargetTime?: utcDateTime;
 }
 
 /**
@@ -2414,6 +2428,24 @@ model SharedGalleryImageVersionList
 @@identifiers(SharedGalleryImageVersionList.value, #[]);
 
 /**
+ * The state of a gallery image version, derived from its soft-delete status.
+ */
+@added(Versions.v2026_03_03)
+union GalleryImageVersionState {
+  string,
+
+  /**
+   * The gallery image version is active and available for use.
+   */
+  Active: "Active",
+
+  /**
+   * The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be referenced by the latest version.
+   */
+  SoftDeleted: "SoftDeleted",
+}
+
+/**
  * Describes the properties of a gallery image version.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
@@ -2445,6 +2477,20 @@ model SharedGalleryImageVersionProperties {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
   artifactTags?: Record<string>;
+
+  /**
+   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  consumptionEndTime?: utcDateTime;
+
+  /**
+   * The state of the gallery image version, derived from its soft-delete status.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  imageState?: GalleryImageVersionState;
 }
 
 /**
@@ -2725,6 +2771,20 @@ model CommunityGalleryImageVersionProperties {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
   artifactTags?: Record<string>;
+
+  /**
+   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  consumptionEndTime?: utcDateTime;
+
+  /**
+   * The state of the gallery image version, derived from its soft-delete status.
+   */
+  @added(Versions.v2026_03_03)
+  @visibility(Lifecycle.Read)
+  imageState?: GalleryImageVersionState;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -2479,7 +2479,7 @@ model SharedGalleryImageVersionProperties {
   artifactTags?: Record<string>;
 
   /**
-   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.
+   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
    */
   @added(Versions.v2026_03_03)
   @visibility(Lifecycle.Read)
@@ -2773,7 +2773,7 @@ model CommunityGalleryImageVersionProperties {
   artifactTags?: Record<string>;
 
   /**
-   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.
+   * The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.
    */
   @added(Versions.v2026_03_03)
   @visibility(Lifecycle.Read)

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -5140,7 +5140,7 @@
         "consumptionEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
+          "description": "The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
           "readOnly": true
         },
         "imageState": {
@@ -6340,7 +6340,7 @@
           {
             "name": "SoftDeleted",
             "value": "SoftDeleted",
-            "description": "The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be referenced by the latest version."
+            "description": "The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be resolved as the latest version."
           }
         ]
       }
@@ -7069,7 +7069,7 @@
         "consumptionEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.",
+          "description": "The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.",
           "readOnly": true
         },
         "hardDeletionTargetTime": {
@@ -7809,7 +7809,7 @@
         "consumptionEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
+          "description": "The timestamp after which a soft-deleted gallery image version is no longer consumable for VM/VMSS creation or VMSS scale out. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
           "readOnly": true
         },
         "imageState": {

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -5136,6 +5136,17 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "consumptionEndTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.",
+          "readOnly": true
+        },
+        "imageState": {
+          "$ref": "#/definitions/GalleryImageVersionState",
+          "description": "The state of the gallery image version, derived from its soft-delete status.",
+          "readOnly": true
         }
       }
     },
@@ -6310,6 +6321,30 @@
         }
       ]
     },
+    "GalleryImageVersionState": {
+      "type": "string",
+      "description": "The state of a gallery image version, derived from its soft-delete status.",
+      "enum": [
+        "Active",
+        "SoftDeleted"
+      ],
+      "x-ms-enum": {
+        "name": "GalleryImageVersionState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "The gallery image version is active and available for use."
+          },
+          {
+            "name": "SoftDeleted",
+            "value": "SoftDeleted",
+            "description": "The gallery image version has been soft-deleted. It is available for use only when a specific version is requested, and it will not be referenced by the latest version."
+          }
+        ]
+      }
+    },
     "GalleryImageVersionStorageProfile": {
       "type": "object",
       "description": "This is the storage profile of a Gallery Image Version.",
@@ -7030,6 +7065,18 @@
         "softDeletedTime": {
           "type": "string",
           "description": "The timestamp for when the resource is soft-deleted. In dateTime offset format."
+        },
+        "consumptionEndTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period. In dateTime offset format.",
+          "readOnly": true
+        },
+        "hardDeletionTargetTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp at which a soft-deleted gallery image version is permanently (hard) deleted and can no longer be recovered. In dateTime offset format.",
+          "readOnly": true
         }
       }
     },
@@ -7758,6 +7805,17 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "consumptionEndTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.",
+          "readOnly": true
+        },
+        "imageState": {
+          "$ref": "#/definitions/GalleryImageVersionState",
+          "description": "The state of the gallery image version, derived from its soft-delete status.",
+          "readOnly": true
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -5140,7 +5140,7 @@
         "consumptionEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.",
+          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
           "readOnly": true
         },
         "imageState": {
@@ -7809,7 +7809,7 @@
         "consumptionEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the delete-requested time plus the retention period, and is null for active gallery image versions.",
+          "description": "The timestamp at which a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed. It is calculated from the soft-deleted time plus the retention period, and is not present for active gallery image versions. In dateTime offset format.",
           "readOnly": true
         },
         "imageState": {

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/communityGalleryExamples/CommunityGalleryImageVersion_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/communityGalleryExamples/CommunityGalleryImageVersion_Get.json
@@ -23,7 +23,9 @@
           "artifactTags": {
             "ShareTag-CommunityGallery": "CommunityGallery"
           },
-          "disclaimer": "https://test-uri.com"
+          "disclaimer": "https://test-uri.com",
+          "consumptionEndTime": "2026-04-20T09:12:28Z",
+          "imageState": "SoftDeleted"
         },
         "location": "myLocation",
         "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/communityGalleryExamples/CommunityGalleryImageVersion_List.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/communityGalleryExamples/CommunityGalleryImageVersion_List.json
@@ -24,7 +24,8 @@
               "artifactTags": {
                 "ShareTag-CommunityGallery": "CommunityGallery"
               },
-              "disclaimer": "https://test-uri.com"
+              "disclaimer": "https://test-uri.com",
+              "imageState": "Active"
             },
             "location": "myLocation",
             "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/GallerySoftDeletedResource_ListByArtifactName.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/GallerySoftDeletedResource_ListByArtifactName.json
@@ -19,7 +19,9 @@
             "properties": {
               "resourceArmId": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGalleryName/images/myGalleryImageName/versions/1.0.0",
               "softDeletedTime": "2024-10-17T13:01:05+00:00",
-              "softDeletedArtifactType": "Images"
+              "softDeletedArtifactType": "Images",
+              "consumptionEndTime": "2024-11-16T13:01:05+00:00",
+              "hardDeletionTargetTime": "2024-11-23T13:01:05+00:00"
             }
           }
         ],

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/sharedGalleryExamples/SharedGalleryImageVersion_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/sharedGalleryExamples/SharedGalleryImageVersion_Get.json
@@ -22,7 +22,9 @@
           },
           "artifactTags": {
             "ShareTag-Official1PGallery": "Official1PGallery"
-          }
+          },
+          "consumptionEndTime": "2026-04-20T09:12:28Z",
+          "imageState": "SoftDeleted"
         },
         "location": "myLocation",
         "name": "myGalleryImageVersionName",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/sharedGalleryExamples/SharedGalleryImageVersions_List.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/sharedGalleryExamples/SharedGalleryImageVersions_List.json
@@ -23,7 +23,8 @@
               },
               "artifactTags": {
                 "ShareTag-Official1PGallery": "Official1PGallery"
-              }
+              },
+              "imageState": "Active"
             },
             "location": "myLocation",
             "name": "myGalleryImageVersionName",


### PR DESCRIPTION
## Summary

As part of the **SIG Soft Delete** feature, the GET/LIST responses for shared and community gallery image versions, and the soft-deleted artifacts LIST, now expose soft-delete metadata. This PR adds the corresponding **read-only** properties to the Compute Gallery (`Microsoft.Compute`) API in api-version **2026-03-03**.

All new members are gated with `@added(Versions.v2026_03_03)`, so they appear only in the `2026-03-03` contract and do not alter previously published api-versions. This follows the same pattern as PR #44214 (which added `retentionPeriodInDays` / `gracePeriodInDays` to `SoftDeletePolicy`).

## Changes

`ComputeGallery/models.tsp` (source of truth):

- **`SharedGalleryImageVersionProperties`** and **`CommunityGalleryImageVersionProperties`** — add `consumptionEndTime` (`utcDateTime`) and `imageState` (new extensible enum **`GalleryImageVersionState`**: `Active`, `SoftDeleted`).
- **`GallerySoftDeletedResourceProperties`** (`SoftDeletedResource_ListByArtifactName`) — add `consumptionEndTime` and `hardDeletionTargetTime` (`utcDateTime`).

Field meanings (sourced from the CAPS/PIR service models in `Compute-CPlat-PIR`):

- `consumptionEndTime` — when a soft-deleted gallery image version transitions to a simulated hard-deleted state and can no longer be consumed (delete-requested/soft-deleted time + retention period).
- `hardDeletionTargetTime` — when a soft-deleted gallery image version is permanently (hard) deleted.
- `imageState` — the state of the gallery image version derived from its soft-delete status.

Regenerated / updated:

- `stable/2026-03-03/GalleryRP.json` — regenerated via `tsp compile`.
- Examples updated to demonstrate the new fields:
  - GET examples show the `SoftDeleted` state (with `consumptionEndTime`).
  - LIST examples show the `Active` state (soft-deleted versions are hidden from LIST but retrievable via GET).
  - `GallerySoftDeletedResource_ListByArtifactName` shows `consumptionEndTime` + `hardDeletionTargetTime`.

## Validation

- `tsp compile .` passes.
- `azsdk_run_typespec_validation` succeeds.
- Diff is scoped to `2026-03-03` only; `2024-03-03` / `2025-03-03` / `2025-12-03` are unchanged.

## Notes

These are additive, read-only response fields — no breaking changes to the API contract.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>