### PR TITLE
[edgeorder] Add python client name customization to avoid SDK breaking

### DIFF
--- a/specification/edgeorder/resource-manager/Microsoft.EdgeOrder/EdgeOrder/client.tsp
+++ b/specification/edgeorder/resource-manager/Microsoft.EdgeOrder/EdgeOrder/client.tsp
@@ -4,6 +4,9 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.EdgeOrder;
 
+// Preserve the existing Python SDK client name to avoid breaking changes
+@@clientName(Microsoft.EdgeOrder, "EdgeOrderManagementClient", "python");
+
 // csharp
 @@clientName(AddressUpdateParameter, "EdgeOrderAddressPatch", "csharp");
 @@clientName(


### PR DESCRIPTION
## Summary

Adds a Python client-name customization for the `Microsoft.EdgeOrder` TypeSpec so the generated Python SDK keeps its existing client class name.

## What changed

Added to `specification/edgeorder/resource-manager/Microsoft.EdgeOrder/EdgeOrder/client.tsp`:

`@@clientName(Microsoft.EdgeOrder, "EdgeOrderManagementClient", "python");`

## Why

The current released `azure-mgmt-edgeorder` Python SDK exposes the client as `EdgeOrderManagementClient`. Without this override, regenerating from TypeSpec derives the client name from the namespace and produces a different name, which is a breaking change for Python users. Pinning the Python client name preserves backward compatibility.

## Validation

- `tsp format` reports no changes needed.
- `tsp compile` completes successfully with the change.
