### PR TITLE
[powerbidedicated] Add python client name customization (PowerBIDedicatedMgmtClient)

### DIFF
--- a/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/client.tsp
+++ b/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/client.tsp
@@ -6,6 +6,12 @@ using Azure.Core;
 using Azure.ResourceManager.Foundations;
 using Microsoft.PowerBIDedicated;
 
+@@clientName(
+  Microsoft.PowerBIDedicated,
+  "PowerBIDedicatedMgmtClient",
+  "python"
+);
+
 @@clientName(Capacities.getDetails, "get", "csharp");
 @@clientName(
   CheckCapacityNameAvailabilityParameters,


### PR DESCRIPTION
## Summary

Sets the Python client name for the `Microsoft.PowerBIDedicated` TypeSpec.

## What changed

Added to `specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/client.tsp`:

`@@clientName(Microsoft.PowerBIDedicated, "PowerBIDedicatedMgmtClient", "python");`

## Note

This intentionally renames the generated Python client to `PowerBIDedicatedMgmtClient`. The currently released `azure-mgmt-powerbidedicated` exposes the client as `PowerBIDedicated`, so this is a deliberate client rename.

## Validation

- `tsp format` applied.
- `tsp compile` completes successfully with the change.
