### PR TITLE
[privatedns] Add python client name customization to avoid SDK breaking

### DIFF
--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
@@ -5,6 +5,7 @@ using Microsoft.Network;
 
 @@clientName(Microsoft.Network, "PrivateDnsManagementClient", "javascript");
 @@clientName(Microsoft.Network, "PrivateDnsManagementClient", "java");
+@@clientName(Microsoft.Network, "PrivateDnsManagementClient", "python");
 
 // Add .NET SDK config
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "Customize generated C# resource names for expanded Private DNS record-set resources."


### PR DESCRIPTION
## Summary

Adds a Python client-name customization for the PrivateDns (`Microsoft.Network`) TypeSpec so the generated Python SDK keeps its existing client class name.

## What changed

Added to `specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp`:

`@@clientName(Microsoft.Network, "PrivateDnsManagementClient", "python");`

This mirrors the existing `javascript` and `java` overrides already present in the file.

## Why

The current released `azure-mgmt-privatedns` Python SDK exposes the client as `PrivateDnsManagementClient`. Without this override, regenerating from TypeSpec derives the client name from the namespace (`Microsoft.Network`) and produces a different name, which is a breaking change for Python users. Pinning the Python client name preserves backward compatibility.

## Validation

- `tsp format` reports no changes needed.
- `tsp compile` completes successfully with the change.
