### PR TITLE
[relay] Add python client name customization (RelayAPIMgmtClient) and remove obsolete ArmResource rename

### DIFF
--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/back-compatible.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/back-compatible.tsp
@@ -118,9 +118,3 @@ using Microsoft.Relay;
 
 // NamespacesOperationGroup operations
 @@clientLocation(NamespacesOperationGroup.checkNameAvailability, "Namespaces");
-
-@@clientName(
-  Azure.ResourceManager.CommonTypes.Resource,
-  "ArmResource",
-  "python"
-);

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
@@ -4,6 +4,8 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.Relay;
 
+@@clientName(Microsoft.Relay, "RelayAPIMgmtClient", "python");
+
 // Preserve existing "WcfRelays" client name (was "WCFRelays" in TypeSpec)
 @@clientName(WCFRelays, "WcfRelays", "java");
 


### PR DESCRIPTION
## Summary

Two Python client customizations for the Relay (`Microsoft.Relay`) TypeSpec.

## What changed

1. Added to `client.tsp`:

   `@@clientName(Microsoft.Relay, "RelayAPIMgmtClient", "python");`

2. Removed the obsolete `ArmResource` python rename from `back-compatible.tsp` (no longer needed):

   `@@clientName(Azure.ResourceManager.CommonTypes.Resource, "ArmResource", "python");`

## Note

The client rename to `RelayAPIMgmtClient` is an intentional, accepted breaking change.

## Validation

- `tsp format` reports no changes needed.
- `tsp compile` completes successfully with the changes.
