### PR TITLE
[storagesync] Add python client name customization (StorageSyncMgmtClient)

### DIFF
--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/client.tsp
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/client.tsp
@@ -5,6 +5,8 @@ using Azure.Core;
 using Azure.ClientGenerator.Core;
 using Microsoft.StorageSync;
 
+@@clientName(Microsoft.StorageSync, "StorageSyncMgmtClient", "python");
+
 @@scope(locationOperationStatusGet, "!csharp");
 @@scope(OperationStatusOperationGroup.get, "!csharp");
 @@scope(Operations.list, "!csharp");


### PR DESCRIPTION
## Summary

Adds a Python client-name customization for the StorageSync (`Microsoft.StorageSync`) TypeSpec.

## What changed

Added to `specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/client.tsp`:

`@@clientName(Microsoft.StorageSync, "StorageSyncMgmtClient", "python");`

## Note

The client name `StorageSyncMgmtClient` is an intentional, accepted breaking change.

## Validation

- `tsp format` reports no changes needed.
- `tsp compile` completes successfully with the change.
