### PR TITLE
[elastic] Add python client name customization (ElasticMgmtClient)

### DIFF
--- a/specification/elastic/Elastic.Management/client.tsp
+++ b/specification/elastic/Elastic.Management/client.tsp
@@ -5,6 +5,8 @@ using Azure.Core;
 using Azure.ClientGenerator.Core;
 using Microsoft.Elastic;
 
+@@clientName(Microsoft.Elastic, "ElasticMgmtClient", "python");
+
 // Client customizations for Java SDK to maintain backward compatibility
 
 // Fix case change in ExternalUserInfo.userName -> username


### PR DESCRIPTION
## Summary

Adds a Python client-name customization for the `Microsoft.Elastic` TypeSpec.

## What changed

Added to `specification/elastic/Elastic.Management/client.tsp`:

`@@clientName(Microsoft.Elastic, "ElasticMgmtClient", "python");`

## Note

The client name `ElasticMgmtClient` is an intentional, accepted breaking change.

## Validation

- `tsp format` reports no changes needed.
- `tsp compile` completes successfully with the change.
