### PR TITLE
Use exact FrontDoor TLS enum member names

### DIFF
--- a/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/client.tsp
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/client.tsp
@@ -256,6 +256,16 @@ interface ProfilesOverrides {
 @@clientName(ResourceType, "FrontDoorResourceType", "csharp");
 @@clientName(MinimumTLSVersion, "FrontDoorRequiredMinimumTlsVersion", "csharp");
 @@clientName(
+  MinimumTLSVersion.`1.0`,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  MinimumTLSVersion.`1.2`,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
+@@clientName(
   ManagedRuleSetException,
   "FrontDoorManagedRuleSetException",
   "csharp"


### PR DESCRIPTION
Updates FrontDoor C# client-name customizations to use `Azure.ClientGenerator.Core.exact(...)` for `MinimumTLSVersion` members so generated .NET enum-like members preserve the existing SDK names with underscores:

- `Tls1_0`
- `Tls1_2`

Related issue: Azure/azure-sdk-for-net#60125
Corresponding SDK PR: Azure/azure-sdk-for-net#60575