### PR TITLE
Add exact C# names for management enum members

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -632,6 +632,16 @@ using Azure.ResourceManager;
   "csharp"
 );
 @@clientName(ResourceType, "CdnResourceType", "csharp");
+@@clientName(
+  ResourceType.`Microsoft.Cdn/Profiles/Endpoints`,
+  Azure.ClientGenerator.Core.exact("Endpoints"),
+  "csharp"
+);
+@@clientName(
+  ResourceType.`Microsoft.Cdn/Profiles/AfdEndpoints`,
+  Azure.ClientGenerator.Core.exact("FrontDoorEndpoints"),
+  "csharp"
+);
 @@clientName(SslProtocol, "DeliveryRuleSslProtocol", "csharp");
 @@clientName(
   SslProtocol.TLSv1,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/client.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/client.tsp
@@ -103,6 +103,26 @@ namespace Customizations;
 @@clientName(ServerVersion.Five0, "FIVE_ZERO", "java");
 @@clientName(ServerVersion.Six0, "SIX_ZERO", "java");
 @@clientName(ServerVersion.Seven0, "SEVEN_ZERO", "java");
+@@clientName(
+  ServerVersion.Three2,
+  Azure.ClientGenerator.Core.exact("V3_2"),
+  "csharp"
+);
+@@clientName(
+  ServerVersion.Three6,
+  Azure.ClientGenerator.Core.exact("V3_6"),
+  "csharp"
+);
+@@clientName(
+  ServerVersion.Four0,
+  Azure.ClientGenerator.Core.exact("V4_0"),
+  "csharp"
+);
+@@clientName(
+  ServerVersion.Four2,
+  Azure.ClientGenerator.Core.exact("V4_2"),
+  "csharp"
+);
 
 /**
  *  The subscription resource ID for an access rule.

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/tspconfig.yaml
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/tspconfig.yaml
@@ -59,7 +59,7 @@ options:
     enable-wire-path-attribute: true
     namespace: "Azure.ResourceManager.CosmosDB"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2026-03-15"
+    api-version: "2026-04-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/client.tsp
+++ b/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/client.tsp
@@ -2088,25 +2088,53 @@ op DataBoxEdgeDevicesGetExtendedInformationCustomized(
 @@clientName(SkuName.TCA_Large, "TcaLarge", "csharp");
 @@clientName(SkuName.EdgePR_Base_UPS, "EdgePRBaseUps", "csharp");
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_64_1VPU_W, "EP2_64_1VpuW", "csharp");
+@@clientName(
+  SkuName.EP2_64_1VPU_W,
+  Azure.ClientGenerator.Core.exact("EP2_64_1VpuW"),
+  "csharp"
+);
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_128_1T4_Mx1_W, "EP2_128_1T4Mx1W", "csharp");
+@@clientName(
+  SkuName.EP2_128_1T4_Mx1_W,
+  Azure.ClientGenerator.Core.exact("EP2_128_1T4Mx1W"),
+  "csharp"
+);
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_256_2T4_W, "EP2_256_2T4W", "csharp");
+@@clientName(
+  SkuName.EP2_256_2T4_W,
+  Azure.ClientGenerator.Core.exact("EP2_256_2T4W"),
+  "csharp"
+);
 @@clientName(SkuName.RCA_Small, "RcaSmall", "csharp");
 @@clientName(SkuName.RCA_Large, "RcaLarge", "csharp");
 @@clientName(SkuName.RDC, "Rdc", "csharp");
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_64_Mx1_W, "EP2_64_Mx1W", "csharp");
+@@clientName(
+  SkuName.EP2_64_Mx1_W,
+  Azure.ClientGenerator.Core.exact("EP2_64_Mx1W"),
+  "csharp"
+);
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_128_GPU1_Mx1_W, "EP2_128Gpu1Mx1W", "csharp");
+@@clientName(
+  SkuName.EP2_128_GPU1_Mx1_W,
+  Azure.ClientGenerator.Core.exact("EP2_128Gpu1Mx1W"),
+  "csharp"
+);
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(SkuName.EP2_256_GPU2_Mx1, "EP2_256Gpu2Mx1", "csharp");
+@@clientName(
+  SkuName.EP2_256_GPU2_Mx1,
+  Azure.ClientGenerator.Core.exact("EP2_256Gpu2Mx1"),
+  "csharp"
+);
 @@clientName(SkuName.EdgeMR_TCP, "EdgeMRTcp", "csharp");
 
 @@clientName(EncryptionAlgorithm.AES256, "Aes256", "csharp");
 #suppress "@azure-tools/typespec-client-generator-core/invalid-name" "Underscores required in C# client name to match existing SDK enum member for backward compatibility."
-@@clientName(EncryptionAlgorithm.RSAES_PKCS1_v_1_5, "RsaesPkcs1V1_5", "csharp");
+@@clientName(
+  EncryptionAlgorithm.RSAES_PKCS1_v_1_5,
+  Azure.ClientGenerator.Core.exact("RsaesPkcs1V1_5"),
+  "csharp"
+);
 
 @@usage(Alert, Usage.input | Usage.output, "csharp");
 @@usage(DiagnosticRemoteSupportSettings, Usage.input | Usage.output, "csharp");

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -210,10 +210,26 @@ using Microsoft.EventHub;
 );
 
 @@clientName(TlsVersion, "EventHubsTlsVersion", "csharp");
-@@clientName(TlsVersion.`1.0`, "Tls1_0", "csharp");
-@@clientName(TlsVersion.`1.1`, "Tls1_1", "csharp");
-@@clientName(TlsVersion.`1.2`, "Tls1_2", "csharp");
-@@clientName(TlsVersion.`1.3`, "Tls1_3", "csharp");
+@@clientName(
+  TlsVersion.`1.0`,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  TlsVersion.`1.1`,
+  Azure.ClientGenerator.Core.exact("Tls1_1"),
+  "csharp"
+);
+@@clientName(
+  TlsVersion.`1.2`,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
+@@clientName(
+  TlsVersion.`1.3`,
+  Azure.ClientGenerator.Core.exact("Tls1_3"),
+  "csharp"
+);
 @@clientName(PublicNetworkAccess, "EventHubsPublicNetworkAccess", "csharp");
 @@clientName(
   ProvisioningIssueProperties,

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
@@ -57,6 +57,7 @@ options:
     namespace: "{package-name}"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2025-05-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/client.tsp
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/client.tsp
@@ -13,8 +13,18 @@ using Microsoft.DBforMySQL;
 );
 @@clientName(Microsoft.DBforMySQL, "MySQLManagementClient", "python");
 
-@@clientName(ServerVersion.`5.7`, "Five7", "javascript,go,csharp");
-@@clientName(ServerVersion.`8.0.21`, "Eight021", "javascript,go,csharp");
+@@clientName(ServerVersion.`5.7`, "Five7", "javascript,go");
+@@clientName(ServerVersion.`8.0.21`, "Eight021", "javascript,go");
+@@clientName(
+  ServerVersion.`5.7`,
+  Azure.ClientGenerator.Core.exact("Ver5_7"),
+  "csharp"
+);
+@@clientName(
+  ServerVersion.`8.0.21`,
+  Azure.ClientGenerator.Core.exact("Ver8_0_21"),
+  "csharp"
+);
 @@clientName(ServerVersion.`5.7`, "FIVE7", "python");
 @@clientName(ServerVersion.`8.0.21`, "EIGHT0_21", "python");
 @@clientName(ServerVersion.`8.4`, "EIGHT4", "python");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -683,6 +683,31 @@ using Azure.ClientGenerator.Core;
 @@usage(AdminCredentialsForPatch, Usage.input, "csharp");
 
 // Preserve backward-compatible version enum member names
+@@clientName(
+  PostgresMajorVersion.`11`,
+  Azure.ClientGenerator.Core.exact("Ver11"),
+  "csharp"
+);
+@@clientName(
+  PostgresMajorVersion.`12`,
+  Azure.ClientGenerator.Core.exact("Ver12"),
+  "csharp"
+);
+@@clientName(
+  PostgresMajorVersion.`13`,
+  Azure.ClientGenerator.Core.exact("Ver13"),
+  "csharp"
+);
+@@clientName(
+  PostgresMajorVersion.`14`,
+  Azure.ClientGenerator.Core.exact("Ver14"),
+  "csharp"
+);
+@@clientName(
+  PostgresMajorVersion.`15`,
+  Azure.ClientGenerator.Core.exact("Ver15"),
+  "csharp"
+);
 @@clientName(PostgresMajorVersion.`16`, "Sixteen", "csharp");
 @@clientName(PostgresMajorVersion.`17`, "Seventeen", "csharp");
 @@clientName(PostgresMajorVersion.`18`, "Eighteen", "csharp");

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -105,6 +105,16 @@ using Microsoft.Cache;
   "RedisEnterpriseMigrationProvisioningState",
   "csharp"
 );
+@@clientName(
+  MigrationValidationRequest,
+  "RedisEnterpriseMigrationValidationRequestContent",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationResponse,
+  "RedisEnterpriseMigrationValidationResponseResult",
+  "csharp"
+);
 @@clientName(OperationStatus, "RedisEnterpriseOperationStatus", "csharp");
 @@clientName(OperationStatus.error, "ErrorResponse", "csharp");
 @@clientName(OperationStatus.startTime, "StartOn", "csharp");
@@ -146,6 +156,21 @@ using Microsoft.Cache;
 @@clientName(SkuDetails, "RedisEnterpriseSkuDetails", "csharp");
 @@clientName(SkuDetailsList, "RedisEnterpriseSkuDetailsList", "csharp");
 @@clientName(TlsVersion, "RedisEnterpriseTlsVersion", "csharp");
+@@clientName(
+  TlsVersion.One0,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  TlsVersion.One1,
+  Azure.ClientGenerator.Core.exact("Tls1_1"),
+  "csharp"
+);
+@@clientName(
+  TlsVersion.One2,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
 @@clientName(
   OperationsStatusOperationGroup.get,
   "GetRedisEnterpriseOperationsStatus",

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
@@ -49,6 +49,7 @@ options:
     namespace: "Azure.ResourceManager.RedisEnterprise"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2025-08-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Moves selected C# enum member compatibility names into TypeSpec using exact client names so the .NET SDK no longer needs SDK-side CodeGenMember enum member customization files.

Also pins C# emitter API versions for the affected services where current TypeSpec defaults had advanced beyond the existing SDK API version, keeping the SDK regeneration diff focused on enum member names.

SDK PR: Azure/azure-sdk-for-net#60681