### PR TITLE
Remove unnecessary HDInsight C# scope suppressions

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/client.tsp
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/client.tsp
@@ -516,7 +516,11 @@ using Azure.ClientGenerator.Core;
   "GetVirtualMachineAsyncOperationStatus",
   "csharp"
 );
-@@clientName(VirtualMachines.restartHosts::parameters.body, "content", "csharp");
+@@clientName(
+  VirtualMachines.restartHosts::parameters.body,
+  "content",
+  "csharp"
+);
 
 // Mark listUsages as pageable to match old SDK's Pageable<HDInsightUsage> return type
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility"

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/client.tsp
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/client.tsp
@@ -352,6 +352,12 @@ using Azure.ClientGenerator.Core;
 );
 #suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@clientName(Configurations.get, "GetConfiguration", "csharp");
+@@clientName(Configurations.update, "UpdateConfiguration", "csharp");
+@@clientName(
+  Configurations.update::parameters.resource,
+  "clusterConfiguration",
+  "csharp"
+);
 @@clientName(
   ScriptExecutionHistory.listByCluster,
   "GetScriptExecutionHistories",
@@ -405,48 +411,7 @@ using Azure.ClientGenerator.Core;
 );
 @@clientName(JsonWebKeyEncryptionAlgorithm.RSA1_5, "Rsa15", "csharp");
 
-/*
- * @@scope suppressions for C# SDK generation.
- *
- * The HDInsight ARM resource hierarchy has exactly 4 resource types
- * (see https://learn.microsoft.com/en-us/azure/templates/microsoft.hdinsight):
- *   - Microsoft.HDInsight/clusters
- *   - Microsoft.HDInsight/clusters/applications
- *   - Microsoft.HDInsight/clusters/privateEndpointConnections
- *   - Microsoft.HDInsight/clusters/privateLinkResources
- *
- * Operations below are NOT standalone ARM resources — they are action endpoints
- * or sub-operations on the Cluster resource. Without suppression, the MPG generator
- * would create phantom resource types (e.g., clusters/azureasyncoperations,
- * clusters/extensions) due to extra path segments being interpreted as child resources.
- *
- * These operations are implemented as custom code in the SDK (Customize/ folder)
- * with manual HTTP request building to preserve backward API compatibility.
- */
-
-// Configurations: action endpoints on Cluster for getting/updating Hadoop config maps
-@@scope(Configurations.update, "!csharp");
-@@scope(Configurations.get, "!csharp");
-
-// VirtualMachines: action endpoints on Cluster for host restart and its async status
-@@scope(VirtualMachines.restartHosts, "!csharp");
-@@scope(VirtualMachines.getAsyncOperationStatus, "!csharp");
-
-// Async operation status polling endpoints — not real resources, just GET on
-// /azureasyncoperations/{operationId} paths under clusters, applications, extensions
-@@scope(Applications.getAzureAsyncOperationStatus, "!csharp");
-@@scope(Clusters.getAzureAsyncOperationStatus, "!csharp");
-@@scope(Extensions.getAzureAsyncOperationStatus, "!csharp");
-
-// Extensions: CRUD-like endpoints on Cluster but NOT a real ARM resource type
-@@scope(Extensions.get, "!csharp");
-@@scope(Extensions.delete, "!csharp");
-
-// ScriptActions: action endpoints on Cluster for script execution history
-@@scope(ScriptActions.getExecutionAsyncOperationStatus, "!csharp");
-@@scope(ScriptActions.getExecutionDetail, "!csharp");
-
-// Locations: regional async operation status — not a child resource
+// Location async operation status is an LRO polling endpoint and should not be exposed as an SDK API.
 @@scope(LocationsOperationGroup.getAzureAsyncOperationStatus, "!csharp");
 
 @@clientName(
@@ -480,6 +445,8 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 @@clientName(Extensions.create, "CreateExtension", "csharp");
+@@clientName(Extensions.get, "GetExtension", "csharp");
+@@clientName(Extensions.delete, "DeleteExtension", "csharp");
 @@clientName(
   Extensions.disableAzureMonitorAgent,
   "DisableAzureMonitorAgentExtension",
@@ -549,6 +516,7 @@ using Azure.ClientGenerator.Core;
   "GetVirtualMachineAsyncOperationStatus",
   "csharp"
 );
+@@clientName(VirtualMachines.restartHosts::parameters.body, "content", "csharp");
 
 // Mark listUsages as pageable to match old SDK's Pageable<HDInsightUsage> return type
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility"


### PR DESCRIPTION
## Summary

Removes unnecessary HDInsight C# scope suppressions that forced several action/sub-operation endpoints out of SDK generation.

The HDInsight management generator can now keep these endpoints on the existing cluster/application resources without producing phantom resource types, so the SDK no longer needs raw-HTTP custom code for them.

## Changes

- Removes broad C# `@@scope(..., "!csharp")` suppressions for HDInsight action/sub-operation endpoints.
- Keeps `LocationsOperationGroup.getAzureAsyncOperationStatus` scoped out because it is an LRO polling endpoint and should not be exposed as an SDK API.
- Adds C# client-name customizations needed to preserve the existing .NET SDK public API names and parameter names after regeneration.

## SDK impact

The paired .NET SDK PR regenerates `Azure.ResourceManager.HDInsight` and preserves the existing public API surface while moving formerly custom raw-HTTP implementations into generated code.

## Links

- SDK PR: Azure/azure-sdk-for-net#60686