### PR TITLE
[Python] Mitigate operation group casing breaking changes for azure-mgmt-elastic

### DIFF
--- a/specification/elastic/Elastic.Management/back-compatible.tsp
+++ b/specification/elastic/Elastic.Management/back-compatible.tsp
@@ -94,13 +94,23 @@ using Microsoft.Elastic;
 @@clientLocation(
   ElasticMonitorResources.listAssociatedTrafficFiltersList,
   "listAssociatedTrafficFilters",
-  "!csharp"
+  "!csharp,!python"
+);
+@@clientLocation(
+  ElasticMonitorResources.listAssociatedTrafficFiltersList,
+  "ListAssociatedTrafficFilters",
+  "python"
 );
 @@clientName(ElasticMonitorResources.listAssociatedTrafficFiltersList, "list");
 @@clientLocation(
   ElasticMonitorResources.createAndAssociateIPFilterCreate,
   "createAndAssociateIPFilter",
-  "!csharp,!java"
+  "!csharp,!java,!python"
+);
+@@clientLocation(
+  ElasticMonitorResources.createAndAssociateIPFilterCreate,
+  "CreateAndAssociateIPFilter",
+  "python"
 );
 @@clientName(
   ElasticMonitorResources.createAndAssociateIPFilterCreate,
@@ -109,7 +119,12 @@ using Microsoft.Elastic;
 @@clientLocation(
   ElasticMonitorResources.createAndAssociatePLFilterCreate,
   "createAndAssociatePLFilter",
-  "!csharp"
+  "!csharp,!python"
+);
+@@clientLocation(
+  ElasticMonitorResources.createAndAssociatePLFilterCreate,
+  "CreateAndAssociatePLFilter",
+  "python"
 );
 @@clientName(
   ElasticMonitorResources.createAndAssociatePLFilterCreate,


### PR DESCRIPTION
for https://github.com/Azure/azure-sdk-for-python/pull/47865

Mitigate Python SDK breaking changes caused by operation group name casing during the Swagger-to-TypeSpec migration of `azure-mgmt-elastic`.

Three operation groups were relocated via `@@clientLocation` using camelCase string literals in `back-compatible.tsp`, while all sibling groups use PascalCase. This lowered the first letter of the generated Python operation-group class names, breaking existing consumers:

- `CreateAndAssociateIPFilterOperations` -> `createAndAssociateIPFilterOperations`
- `CreateAndAssociatePLFilterOperations` -> `createAndAssociatePLFilterOperations`
- `ListAssociatedTrafficFiltersOperations` -> `listAssociatedTrafficFiltersOperations`

Mitigation: add Python-scoped `@@clientLocation` entries that relocate these operations into PascalCase groups, and exclude Python from the existing shared (camelCase) `@@clientLocation` entries. Other languages (JS/Go) keep their current behavior unchanged.
