### PR TITLE
Add ESAN generic backup/restore parameters to DataProtection 2026-06-01

### DIFF
--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/PutBackupInstanceWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/PutBackupInstanceWithGenericParameters.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "subscriptionId": "97cda027-4279-4cde-b4ff-19afa0021d87",
+    "resourceGroupName": "ESAN-ECYBVTRG",
+    "vaultName": "ESANVault",
+    "api-version": "2026-06-01",
+    "backupInstanceName": "esan-volgroup-bi",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "friendlyName": "esan-volgroup-bi",
+        "dataSourceInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+          "resourceUri": "SampleresourceUri123",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceName": "esan-volgroup-bi",
+          "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceLocation": "eastus2euap",
+          "objectType": "Datasource"
+        },
+        "dataSourceSetInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceType": "Microsoft.ElasticSan/elasticSans",
+          "resourceLocation": "eastus2euap",
+          "objectType": "DatasourceSet"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+          "policyParameters": {
+            "dataStoreParametersList": [
+              {
+                "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                "objectType": "AzureOperationalStoreParameters",
+                "dataStoreType": "OperationalStore"
+              }
+            ],
+            "backupDatasourceParametersList": [
+              {
+                "objectType": "GenericBackupDatasourceParameters",
+                "resourceSelectors": [
+                  "vol1",
+                  "vol2",
+                  "vol3"
+                ]
+              }
+            ]
+          }
+        },
+        "objectType": "BackupInstance"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/esan-volgroup-bi",
+        "name": "esan-volgroup-bi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "esan-volgroup-bi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+            "resourceUri": "SampleresourceUri123",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceName": "esan-volgroup-bi",
+            "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceType": "Microsoft.ElasticSan/elasticSans",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "GenericBackupDatasourceParameters",
+                  "resourceSelectors": [
+                    "vol1",
+                    "vol2",
+                    "vol3"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2026-06-01",
+        "Location": "https://management.windowsazure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2026-06-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/esan-volgroup-bi",
+        "name": "esan-volgroup-bi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "esan-volgroup-bi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+            "resourceUri": "SampleresourceUri123",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceName": "esan-volgroup-bi",
+            "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceType": "Microsoft.ElasticSan/elasticSans",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "GenericBackupDatasourceParameters",
+                  "resourceSelectors": [
+                    "vol1",
+                    "vol2",
+                    "vol3"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  },
+  "operationId": "BackupInstances_CreateOrUpdate",
+  "title": "Create BackupInstance with GenericBackupDatasourceParameters"
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -39,10 +39,10 @@
                 "source-vol2",
                 "source-vol3"
               ],
-              "resourceNameOverrides": {
-                "source-vol1": "target-vol1",
-                "source-vol2": "target-vol2"
-              }
+              "resourceNameOverrides": [
+                { "sourceName": "source-vol1", "targetName": "target-vol1" },
+                { "sourceName": "source-vol2", "targetName": "target-vol2" }
+              ]
             }
           }
         ]

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -39,10 +39,10 @@
                 "source-vol2",
                 "source-vol3"
               ],
-              "resourceNameOverrides": [
-                { "sourceName": "source-vol1", "targetName": "target-vol1" },
-                { "sourceName": "source-vol2", "targetName": "target-vol2" }
-              ]
+              "resourceNameOverrides": {
+                "source-vol1": "target-vol1",
+                "source-vol2": "target-vol2"
+              }
             }
           }
         ]

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/examples/2026-06-01/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault1",
+    "api-version": "2026-06-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "recoveryPointId": "hardcodedRP",
+      "sourceDataStoreType": "OperationalStore",
+      "restoreTargetInfo": {
+        "restoreLocation": "southeastasia",
+        "recoveryOption": "FailIfExists",
+        "objectType": "ItemLevelRestoreTargetInfo",
+        "datasourceInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/target-esan-volgroup",
+          "resourceUri": "SampleresourceUri123",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceName": "target-esan-volgroup",
+          "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceLocation": "eastus2euap",
+          "objectType": "Datasource"
+        },
+        "datasourceSetInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceType": "Microsoft.ElasticSan/elasticSans",
+          "resourceLocation": "eastus2euap",
+          "objectType": "DatasourceSet"
+        },
+        "restoreCriteria": [
+          {
+            "objectType": "GenericRestoreDatasourceCriteria",
+            "resourceSelectors": {
+              "objectType": "resourceListSelectionCriteria",
+              "resourceIdentifiers": [
+                "source-vol1",
+                "source-vol2",
+                "source-vol3"
+              ],
+              "resourceNameOverrides": {
+                "source-vol1": "target-vol1",
+                "source-vol2": "target-vol2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  },
+  "operationId": "BackupInstances_TriggerRestore",
+  "title": "Trigger Restore with GenericRestoreDatasourceCriteria"
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
@@ -3291,6 +3291,22 @@ model PostgreSqlFlexibleServerBackupDatasourceParameters
 }
 
 /**
+ * Generic parameters to be used during configuration of backup
+ */
+@added(Versions.v2026_06_01)
+model GenericBackupDatasourceParameters extends BackupDatasourceParameters {
+  /**
+   * List of resource selectors to be backed up during configuration of backup
+   */
+  resourceSelectors: string[];
+
+  /**
+   * Type of the specific object - used for deserializing
+   */
+  objectType: "GenericBackupDatasourceParameters";
+}
+
+/**
  * Azure retention rule
  */
 model AzureRetentionRule extends BasePolicyRule {
@@ -3631,6 +3647,44 @@ model RangeBasedItemLevelRestoreCriteria extends ItemLevelRestoreCriteria {
    * Type of the specific object - used for deserializing
    */
   objectType: "RangeBasedItemLevelRestoreCriteria";
+}
+
+/**
+ * Generic criteria to be used during restore
+ */
+@added(Versions.v2026_06_01)
+model GenericRestoreDatasourceCriteria extends ItemLevelRestoreCriteria {
+  /**
+   * List of resource identifiers that need to be restored
+   */
+  resourceSelectors: ResourceListSelectionCriteria;
+
+  /**
+   * Type of the specific object - used for deserializing
+   */
+  objectType: "GenericRestoreDatasourceCriteria";
+}
+
+/**
+ * Specifies the list of resources to be restored
+ */
+@added(Versions.v2026_06_01)
+model ResourceListSelectionCriteria {
+  /**
+   * Type of the specific object - used for deserializing
+   */
+  objectType: string;
+
+  /**
+   * List of resource identifiers to restore from
+   */
+  resourceIdentifiers: string[];
+
+  /**
+   * This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Backward-compatible source-to-target name override map for generic restore"
+  resourceNameOverrides?: Record<string>;
 }
 
 /**

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
@@ -3666,6 +3666,22 @@ model GenericRestoreDatasourceCriteria extends ItemLevelRestoreCriteria {
 }
 
 /**
+ * Represents a source-to-target resource name override mapping
+ */
+@added(Versions.v2026_06_01)
+model ResourceNameOverride {
+  /**
+   * Source resource name
+   */
+  sourceName: string;
+
+  /**
+   * Target resource name to restore into
+   */
+  targetName: string;
+}
+
+/**
  * Specifies the list of resources to be restored
  */
 @added(Versions.v2026_06_01)
@@ -3681,10 +3697,10 @@ model ResourceListSelectionCriteria {
   resourceIdentifiers: string[];
 
   /**
-   * This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format
+   * List of source-to-target resource name overrides. Any source resource name not included will be restored with a default naming format
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Backward-compatible source-to-target name override map for generic restore"
-  resourceNameOverrides?: Record<string>;
+  @identifiers(#["sourceName"])
+  resourceNameOverrides?: ResourceNameOverride[];
 }
 
 /**

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
@@ -3666,22 +3666,6 @@ model GenericRestoreDatasourceCriteria extends ItemLevelRestoreCriteria {
 }
 
 /**
- * Represents a source-to-target resource name override mapping
- */
-@added(Versions.v2026_06_01)
-model ResourceNameOverride {
-  /**
-   * Source resource name
-   */
-  sourceName: string;
-
-  /**
-   * Target resource name to restore into
-   */
-  targetName: string;
-}
-
-/**
  * Specifies the list of resources to be restored
  */
 @added(Versions.v2026_06_01)
@@ -3697,10 +3681,10 @@ model ResourceListSelectionCriteria {
   resourceIdentifiers: string[];
 
   /**
-   * List of source-to-target resource name overrides. Any source resource name not included will be restored with a default naming format
+   * This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format
    */
-  @identifiers(#["sourceName"])
-  resourceNameOverrides?: ResourceNameOverride[];
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Backward-compatible source-to-target name override map for generic restore"
+  resourceNameOverrides?: Record<string>;
 }
 
 /**

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
@@ -1044,6 +1044,9 @@
           },
           "Create BackupInstance to perform critical operation With MUA": {
             "$ref": "./examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json"
+          },
+          "Create BackupInstance with GenericBackupDatasourceParameters": {
+            "$ref": "./examples/BackupInstanceOperations/PutBackupInstanceWithGenericParameters.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1640,6 +1643,9 @@
           },
           "Trigger Restore With Rehydration": {
             "$ref": "./examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json"
+          },
+          "Trigger Restore with GenericRestoreDatasourceCriteria": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7027,6 +7033,47 @@
         }
       }
     },
+    "GenericBackupDatasourceParameters": {
+      "type": "object",
+      "description": "Generic parameters to be used during configuration of backup",
+      "properties": {
+        "resourceSelectors": {
+          "type": "array",
+          "description": "List of resource selectors to be backed up during configuration of backup",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "resourceSelectors"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupDatasourceParameters"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericBackupDatasourceParameters"
+    },
+    "GenericRestoreDatasourceCriteria": {
+      "type": "object",
+      "description": "Generic criteria to be used during restore",
+      "properties": {
+        "resourceSelectors": {
+          "$ref": "#/definitions/ResourceListSelectionCriteria",
+          "description": "List of resource identifiers that need to be restored"
+        }
+      },
+      "required": [
+        "resourceSelectors"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericRestoreDatasourceCriteria"
+    },
     "GranularityLevel": {
       "type": "string",
       "enum": [
@@ -8325,6 +8372,34 @@
         {
           "$ref": "#/definitions/DppTrackedResourceList"
         }
+      ]
+    },
+    "ResourceListSelectionCriteria": {
+      "type": "object",
+      "description": "Specifies the list of resources to be restored",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "Type of the specific object - used for deserializing"
+        },
+        "resourceIdentifiers": {
+          "type": "array",
+          "description": "List of resource identifiers to restore from",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resourceNameOverrides": {
+          "type": "object",
+          "description": "This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "objectType",
+        "resourceIdentifiers"
       ]
     },
     "ResourceMoveDetails": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
@@ -8390,14 +8390,11 @@
           }
         },
         "resourceNameOverrides": {
-          "type": "array",
-          "description": "List of source-to-target resource name overrides. Any source resource name not included will be restored with a default naming format",
-          "items": {
-            "$ref": "#/definitions/ResourceNameOverride"
-          },
-          "x-ms-identifiers": [
-            "sourceName"
-          ]
+          "type": "object",
+          "description": "This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": [
@@ -8492,24 +8489,6 @@
           }
         ]
       }
-    },
-    "ResourceNameOverride": {
-      "type": "object",
-      "description": "Represents a source-to-target resource name override mapping",
-      "properties": {
-        "sourceName": {
-          "type": "string",
-          "description": "Source resource name"
-        },
-        "targetName": {
-          "type": "string",
-          "description": "Target resource name to restore into"
-        }
-      },
-      "required": [
-        "sourceName",
-        "targetName"
-      ]
     },
     "ResourcePropertiesObjectType": {
       "type": "string",

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/dataprotection.json
@@ -8390,11 +8390,14 @@
           }
         },
         "resourceNameOverrides": {
-          "type": "object",
-          "description": "This is a map of source resource names to target resources names to restore into. Any source name not included in the map will be restored with a default naming format",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "type": "array",
+          "description": "List of source-to-target resource name overrides. Any source resource name not included will be restored with a default naming format",
+          "items": {
+            "$ref": "#/definitions/ResourceNameOverride"
+          },
+          "x-ms-identifiers": [
+            "sourceName"
+          ]
         }
       },
       "required": [
@@ -8489,6 +8492,24 @@
           }
         ]
       }
+    },
+    "ResourceNameOverride": {
+      "type": "object",
+      "description": "Represents a source-to-target resource name override mapping",
+      "properties": {
+        "sourceName": {
+          "type": "string",
+          "description": "Source resource name"
+        },
+        "targetName": {
+          "type": "string",
+          "description": "Target resource name to restore into"
+        }
+      },
+      "required": [
+        "sourceName",
+        "targetName"
+      ]
     },
     "ResourcePropertiesObjectType": {
       "type": "string",

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/PutBackupInstanceWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/PutBackupInstanceWithGenericParameters.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "subscriptionId": "97cda027-4279-4cde-b4ff-19afa0021d87",
+    "resourceGroupName": "ESAN-ECYBVTRG",
+    "vaultName": "ESANVault",
+    "api-version": "2026-06-01",
+    "backupInstanceName": "esan-volgroup-bi",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "friendlyName": "esan-volgroup-bi",
+        "dataSourceInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+          "resourceUri": "SampleresourceUri123",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceName": "esan-volgroup-bi",
+          "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceLocation": "eastus2euap",
+          "objectType": "Datasource"
+        },
+        "dataSourceSetInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceType": "Microsoft.ElasticSan/elasticSans",
+          "resourceLocation": "eastus2euap",
+          "objectType": "DatasourceSet"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+          "policyParameters": {
+            "dataStoreParametersList": [
+              {
+                "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                "objectType": "AzureOperationalStoreParameters",
+                "dataStoreType": "OperationalStore"
+              }
+            ],
+            "backupDatasourceParametersList": [
+              {
+                "objectType": "GenericBackupDatasourceParameters",
+                "resourceSelectors": [
+                  "vol1",
+                  "vol2",
+                  "vol3"
+                ]
+              }
+            ]
+          }
+        },
+        "objectType": "BackupInstance"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/esan-volgroup-bi",
+        "name": "esan-volgroup-bi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "esan-volgroup-bi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+            "resourceUri": "SampleresourceUri123",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceName": "esan-volgroup-bi",
+            "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceType": "Microsoft.ElasticSan/elasticSans",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "GenericBackupDatasourceParameters",
+                  "resourceSelectors": [
+                    "vol1",
+                    "vol2",
+                    "vol3"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2026-06-01",
+        "Location": "https://management.windowsazure.com/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2026-06-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupInstances/esan-volgroup-bi",
+        "name": "esan-volgroup-bi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "esan-volgroup-bi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/esan-volgroup",
+            "resourceUri": "SampleresourceUri123",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceName": "esan-volgroup-bi",
+            "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+            "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+            "resourceType": "Microsoft.ElasticSan/elasticSans",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.DataProtection/backupVaults/ESANVault/backupPolicies/BVTPolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "GenericBackupDatasourceParameters",
+                  "resourceSelectors": [
+                    "vol1",
+                    "vol2",
+                    "vol3"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  },
+  "operationId": "BackupInstances_CreateOrUpdate",
+  "title": "Create BackupInstance with GenericBackupDatasourceParameters"
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -39,10 +39,10 @@
                 "source-vol2",
                 "source-vol3"
               ],
-              "resourceNameOverrides": {
-                "source-vol1": "target-vol1",
-                "source-vol2": "target-vol2"
-              }
+              "resourceNameOverrides": [
+                { "sourceName": "source-vol1", "targetName": "target-vol1" },
+                { "sourceName": "source-vol2", "targetName": "target-vol2" }
+              ]
             }
           }
         ]

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -39,10 +39,10 @@
                 "source-vol2",
                 "source-vol3"
               ],
-              "resourceNameOverrides": [
-                { "sourceName": "source-vol1", "targetName": "target-vol1" },
-                { "sourceName": "source-vol2", "targetName": "target-vol2" }
-              ]
+              "resourceNameOverrides": {
+                "source-vol1": "target-vol1",
+                "source-vol2": "target-vol2"
+              }
             }
           }
         ]

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/stable/2026-06-01/examples/BackupInstanceOperations/TriggerRestoreWithGenericParameters.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault1",
+    "api-version": "2026-06-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "recoveryPointId": "hardcodedRP",
+      "sourceDataStoreType": "OperationalStore",
+      "restoreTargetInfo": {
+        "restoreLocation": "southeastasia",
+        "recoveryOption": "FailIfExists",
+        "objectType": "ItemLevelRestoreTargetInfo",
+        "datasourceInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc/volumeGroups/target-esan-volgroup",
+          "resourceUri": "SampleresourceUri123",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceName": "target-esan-volgroup",
+          "resourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceLocation": "eastus2euap",
+          "objectType": "Datasource"
+        },
+        "datasourceSetInfo": {
+          "resourceID": "/subscriptions/97cda027-4279-4cde-b4ff-19afa0021d87/resourceGroups/ESAN-ECYBVTRG/providers/Microsoft.ElasticSan/elasticSans/ecy-bvt-adhoc",
+          "datasourceType": "Microsoft.ElasticSan/elasticSans/volumeGroups",
+          "resourceType": "Microsoft.ElasticSan/elasticSans",
+          "resourceLocation": "eastus2euap",
+          "objectType": "DatasourceSet"
+        },
+        "restoreCriteria": [
+          {
+            "objectType": "GenericRestoreDatasourceCriteria",
+            "resourceSelectors": {
+              "objectType": "resourceListSelectionCriteria",
+              "resourceIdentifiers": [
+                "source-vol1",
+                "source-vol2",
+                "source-vol3"
+              ],
+              "resourceNameOverrides": {
+                "source-vol1": "target-vol1",
+                "source-vol2": "target-vol2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2026-06-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  },
+  "operationId": "BackupInstances_TriggerRestore",
+  "title": "Trigger Restore with GenericRestoreDatasourceCriteria"
+}


### PR DESCRIPTION
## Why
Ports the ESAN (Elastic SAN) generic backup/restore parameters from the 2024-02-01-preview OpenAPI spec into TypeSpec. These models were dropped during the OpenAPI-to-TypeSpec migration and are needed for the 2026-06-01 stable API version.

## What
Adds 3 models gated to `2026-06-01` in `models.tsp`:
- `GenericBackupDatasourceParameters` (`resourceSelectors: string[]`)
- `GenericRestoreDatasourceCriteria` (`resourceSelectors: ResourceListSelectionCriteria`)
- `ResourceListSelectionCriteria` (`resourceIdentifiers` + `resourceNameOverrides` source-to-target map)

Adds example JSONs for configure-backup and trigger-restore, and regenerates `stable/2026-06-01/dataprotection.json`.

## How
Authored in TypeSpec with `@added(Versions.v2026_06_01)`; compiled with `tsp compile` (0 warnings, 0 errors). Generated swagger definitions match the original 2024-02-01-preview shapes exactly.