### PR TITLE
Graduate Client EC Ref to GA

### DIFF
--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -1007,7 +1007,6 @@ model AudioEchoCancellation {
    * - `client`: EC uses the client-supplied reference channel (ch1 of stereo input). Internal TTS loopback is skipped.
    */
   @added(Versions.v2026_06_01_preview)
-  @removed(Versions.v2026_07_15)
   reference_source?: EchoCancellationReferenceSource = EchoCancellationReferenceSource.server;
 
   /**
@@ -1017,7 +1016,6 @@ model AudioEchoCancellation {
    * When set to 2, `reference_source` must be `client` and `input_audio_format` must be `pcm16`.
    */
   @added(Versions.v2026_06_01_preview)
-  @removed(Versions.v2026_07_15)
   @minValue(1)
   @maxValue(2)
   channels?: int32 = 1;
@@ -1026,7 +1024,6 @@ model AudioEchoCancellation {
 /** The source of the echo cancellation reference signal. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case.
 @added(Versions.v2026_06_01_preview)
-@removed(Versions.v2026_07_15)
 union EchoCancellationReferenceSource {
   string,
 

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -237,6 +237,39 @@
           "x-ms-enum": {
             "modelAsString": false
           }
+        },
+        "reference_source": {
+          "type": "string",
+          "description": "The source of the echo cancellation reference signal.\n- `server`: EC uses the internal TTS loopback as the reference signal (default, existing behavior).\n- `client`: EC uses the client-supplied reference channel (ch1 of stereo input). Internal TTS loopback is skipped.",
+          "default": "server",
+          "enum": [
+            "server",
+            "client"
+          ],
+          "x-ms-enum": {
+            "name": "EchoCancellationReferenceSource",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "server",
+                "value": "server",
+                "description": "EC uses the internal TTS loopback as the reference signal."
+              },
+              {
+                "name": "client",
+                "value": "client",
+                "description": "EC uses the client-supplied reference channel from the stereo input stream."
+              }
+            ]
+          }
+        },
+        "channels": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of input audio channels.\n- `1`: Mono input (default).\n- `2`: Interleaved stereo input where channel 0 is the microphone signal and channel 1 is the echo reference signal.\nWhen set to 2, `reference_source` must be `client` and `input_audio_format` must be `pcm16`.",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 2
         }
       },
       "required": [
@@ -1734,6 +1767,30 @@
       "required": [
         "type"
       ]
+    },
+    "EchoCancellationReferenceSource": {
+      "type": "string",
+      "description": "The source of the echo cancellation reference signal.",
+      "enum": [
+        "server",
+        "client"
+      ],
+      "x-ms-enum": {
+        "name": "EchoCancellationReferenceSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "server",
+            "value": "server",
+            "description": "EC uses the internal TTS loopback as the reference signal."
+          },
+          {
+            "name": "client",
+            "value": "client",
+            "description": "EC uses the client-supplied reference channel from the stereo input stream."
+          }
+        ]
+      }
     },
     "EouDetection": {
       "type": "object",


### PR DESCRIPTION
## Summary

Graduates the client-side echo-cancellation reference feature into the GA `2026-07-15` stable VoiceLive data-plane API.

This is a **stacked change on top of #44425** (base branch: `yulin/voice-live-2026-07-15`). #44425 introduces the stable `2026-07-15` version but intentionally holds echo-cancellation reference config back in preview via `@removed(Versions.v2026_07_15)`. This PR carries that one feature forward into GA.

The feature shipped in `2026-06-01-preview` and is now ready for GA.

## Changes

**`custom.tsp`** — removed the `@removed(Versions.v2026_07_15)` decorator from the three echo-cancellation elements (leaving their original `@added(Versions.v2026_06_01_preview)` intact, so they carry forward from preview into stable):
- `union EchoCancellationReferenceSource` (`server` | `client`)
- `AudioEchoCancellation.reference_source` (default `server`)
- `AudioEchoCancellation.channels` (int32, 1–2, default 1)

**`stable/2026-07-15/VoiceLive.json`** — regenerated via `tsp compile` (compiles clean, no warnings). Adds `reference_source`, `channels`, and the `EchoCancellationReferenceSource` enum to the stable swagger (+57 lines). No other definitions changed.

## Verification

- `tsp compile specification/ai/data-plane/VoiceLive` completed successfully with no warnings.
- Confirmed the held-back features remain **absent** from the stable JSON: 0 occurrences of `smart_end_of_turn`, `rtc.call`, `output_audio_buffer.started/stopped`.
- Confirmed echo-cancellation elements are **present** in the stable JSON.
- Only two files changed: `custom.tsp` and `stable/2026-07-15/VoiceLive.json`.