### PR TITLE
Improve Redis Enterprise migration model names

### DIFF
--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -29,6 +29,11 @@ using Microsoft.Cache;
   "IsSkipDataMigration",
   "csharp"
 );
+@@clientName(
+  AzureCacheForRedisMigrationProperties.forceMigrate,
+  "IsForceMigrate",
+  "csharp"
+);
 @@clientName(AofFrequency, "PersistenceSettingAofFrequency", "csharp");
 @@clientName(Cluster, "RedisEnterpriseCluster", "csharp");
 @@clientName(ClusteringPolicy, "RedisEnterpriseClusteringPolicy", "csharp");
@@ -113,6 +118,31 @@ using Microsoft.Cache;
 @@clientName(
   MigrationValidationResponse,
   "RedisEnterpriseMigrationValidationResponseResult",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationRequest.skipDataMigration,
+  "IsSkipDataMigration",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationRequest.forceMigrate,
+  "IsForceMigrate",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationDisparity,
+  "RedisEnterpriseMigrationValidationDisparity",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationError,
+  "RedisEnterpriseMigrationValidationError",
+  "csharp"
+);
+@@clientName(
+  MigrationValidationWarning,
+  "RedisEnterpriseMigrationValidationWarning",
   "csharp"
 );
 @@clientName(OperationStatus, "RedisEnterpriseOperationStatus", "csharp");


### PR DESCRIPTION
Addresses follow-up Azure SDK for .NET API review feedback from Azure/azure-sdk-for-net#60681 for Redis Enterprise migration validation APIs.

Changes:
- Adds C# client names for migration boolean properties:
  - `forceMigrate` -> `IsForceMigrate`
  - `skipDataMigration` -> `IsSkipDataMigration`
- Adds `RedisEnterprise` context to migration validation model names:
  - `MigrationValidationDisparity` -> `RedisEnterpriseMigrationValidationDisparity`
  - `MigrationValidationError` -> `RedisEnterpriseMigrationValidationError`
  - `MigrationValidationWarning` -> `RedisEnterpriseMigrationValidationWarning`

SDK PR: Azure/azure-sdk-for-net#60709
Follow-up to Azure/azure-sdk-for-net#60681