### PR TITLE
Add Python client name customization for azure-mgmt-dns

### DIFF
--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -5,6 +5,7 @@ using Microsoft.Network;
 
 @@clientName(Microsoft.Network, "DnsManagementClient", "javascript");
 @@clientName(Microsoft.Network, "DnsManagementClient", "java");
+@@clientName(Microsoft.Network, "DnsManagementClient", "python");
 
 @@clientName(Microsoft.Network.RecordSetProperties.TTL, "ttl", "java");
 


### PR DESCRIPTION
Add `@@clientName(Microsoft.Network, "DnsManagementClient", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-dns` SDK (`DnsManagementClient`).