### PR TITLE
Add Python client name customization for azure-mgmt-guestconfig

### DIFF
--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/client.tsp
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/client.tsp
@@ -7,6 +7,12 @@ using Microsoft.GuestConfiguration;
 using TypeSpec.Http;
 using TypeSpec.Rest;
 
+@@clientName(
+  Microsoft.GuestConfiguration,
+  "GuestConfigurationClient",
+  "python"
+);
+
 // ============================================================================
 // Type alternate types - fix property types for backward compatibility
 // ============================================================================


### PR DESCRIPTION
Add `@@clientName(Microsoft.GuestConfiguration, "GuestConfigurationClient", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-guestconfig` SDK (`GuestConfigurationClient`).