### PR TITLE
Add Python client name customization for azure-mgmt-selfhelp

### DIFF
--- a/specification/help/resource-manager/Microsoft.Help/Help/client.tsp
+++ b/specification/help/resource-manager/Microsoft.Help/Help/client.tsp
@@ -4,6 +4,7 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.Help;
 
+@@clientName(Microsoft.Help, "SelfHelpMgmtClient", "python");
 @@clientName(Solutions, "SelfhelpSolutions", "csharp");
 @@clientName(ValidationScope.IpAddressFormat, "IPAddressFormat", "csharp");
 


### PR DESCRIPTION
Add `@@clientName(Microsoft.Help, "SelfHelpMgmtClient", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-selfhelp` SDK (`SelfHelpMgmtClient`).