### PR TITLE
Add Python client name customization for azure-mgmt-sqlvirtualmachine

### DIFF
--- a/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/client.tsp
+++ b/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/client.tsp
@@ -296,5 +296,10 @@ using Microsoft.SqlVirtualMachine;
   "SqlVirtualMachineManagementClient",
   "javascript"
 );
+@@clientName(
+  Microsoft.SqlVirtualMachine,
+  "SqlVirtualMachineManagementClient",
+  "python"
+);
 @@clientName(ReadableSecondary.No, "$DO_NOT_NORMALIZE$NO", "javascript");
 @@clientName(ReadableSecondary.All, "$DO_NOT_NORMALIZE$ALL", "javascript");


### PR DESCRIPTION
Add `@@clientName(Microsoft.SqlVirtualMachine, "SqlVirtualMachineManagementClient", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-sqlvirtualmachine` SDK (`SqlVirtualMachineManagementClient`).