### PR TITLE
Add Python client name customization for azure-mgmt-botservice

### DIFF
--- a/specification/botservice/resource-manager/Microsoft.BotService/BotService/client.tsp
+++ b/specification/botservice/resource-manager/Microsoft.BotService/BotService/client.tsp
@@ -9,6 +9,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 
 namespace Microsoft.BotService {
+  @@clientName(Microsoft.BotService, "AzureBotService", "python");
   @@scope(Operations.list, "!csharp");
   @@clientName(AlexaChannelProperties.urlFragment, "UriFragment", "csharp");
   @@alternateType(AlexaChannelProperties.serviceEndpointUri, url, "csharp");

--- a/specification/botservice/resource-manager/Microsoft.BotService/BotService/client.tsp
+++ b/specification/botservice/resource-manager/Microsoft.BotService/BotService/client.tsp
@@ -9,7 +9,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 
 namespace Microsoft.BotService {
-  @@clientName(Microsoft.BotService, "AzureBotService", "python");
+  @@clientName(Microsoft.BotService, "AzureBotServiceMgmtClient", "python");
   @@scope(Operations.list, "!csharp");
   @@clientName(AlexaChannelProperties.urlFragment, "UriFragment", "csharp");
   @@alternateType(AlexaChannelProperties.serviceEndpointUri, url, "csharp");


### PR DESCRIPTION
Add `@@clientName(Microsoft.BotService, "AzureBotService", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-botservice` SDK (`AzureBotService`).