### PR TITLE
Add Python client name customization for azure-mgmt-confidentialledger

### DIFF
--- a/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
+++ b/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
@@ -4,7 +4,7 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.ConfidentialLedger;
 
-@@clientName(Microsoft.ConfidentialLedger, "ConfidentialLedger", "python");
+@@clientName(Microsoft.ConfidentialLedger, "ConfidentialLedgerMgmtClient", "python");
 
 // Mitigate breaking change: "AadBasedSecurityPrincipal" was renamed to "AADBasedSecurityPrincipal"
 @@clientName(

--- a/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
+++ b/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
@@ -4,7 +4,11 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.ConfidentialLedger;
 
-@@clientName(Microsoft.ConfidentialLedger, "ConfidentialLedgerMgmtClient", "python");
+@@clientName(
+  Microsoft.ConfidentialLedger,
+  "ConfidentialLedgerMgmtClient",
+  "python"
+);
 
 // Mitigate breaking change: "AadBasedSecurityPrincipal" was renamed to "AADBasedSecurityPrincipal"
 @@clientName(

--- a/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
+++ b/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/client.tsp
@@ -4,6 +4,8 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.ConfidentialLedger;
 
+@@clientName(Microsoft.ConfidentialLedger, "ConfidentialLedger", "python");
+
 // Mitigate breaking change: "AadBasedSecurityPrincipal" was renamed to "AADBasedSecurityPrincipal"
 @@clientName(
   Microsoft.ConfidentialLedger.AADBasedSecurityPrincipal,


### PR DESCRIPTION
Add `@@clientName(Microsoft.ConfidentialLedger, "ConfidentialLedger", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-confidentialledger` SDK (`ConfidentialLedger`).