### PR TITLE
Add Python client name customization for azure-mgmt-cosmosdbforpostgresql

### DIFF
--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/PostgresqlHsc/client.tsp
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/PostgresqlHsc/client.tsp
@@ -4,6 +4,11 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.DBforPostgreSQL;
 
+@@clientName(
+  Microsoft.DBforPostgreSQL,
+  "CosmosdbForPostgresqlMgmtClient",
+  "python"
+);
 @@clientName(ClusterProperties.pointInTimeUTC, "PointInTimeUtc", "java");
 
 @@alternateType(


### PR DESCRIPTION
Add `@@clientName(Microsoft.DBforPostgreSQL, "CosmosdbForPostgresqlMgmtClient", "python")` so the generated Python client name stays consistent with the existing `azure-mgmt-cosmosdbforpostgresql` SDK (`CosmosdbForPostgresqlMgmtClient`).