### PR TITLE
ImageBuilder: C# client.tsp customizations for .NET SDK generation

### DIFF
--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -23,4 +23,32 @@ using Microsoft.VirtualMachineImages;
 
 // C#: model names must not end with 'Collection' (AZC0030).
 @@clientName(RunOutputCollection, "RunOutputListResult", "csharp");
-@@clientName(TriggerCollection, "TriggerListResult", "csharp");
+@@clientName(TriggerCollection, "ImageTemplateTriggerListResult", "csharp");
+
+// C#: give the generic 'Trigger' resource trio RP/domain context (RESNAME001).
+@@clientName(Trigger, "ImageTemplateTrigger", "csharp");
+
+// C#: boolean properties must start with a verb prefix (AZC0030 BOOL naming).
+@@clientName(ImageTemplatePowerShellCustomizer.runElevated, "IsRunElevated", "csharp");
+@@clientName(ImageTemplatePowerShellCustomizer.runAsSystem, "IsRunAsSystem", "csharp");
+@@clientName(ImageTemplatePowerShellValidator.runElevated, "IsRunElevated", "csharp");
+@@clientName(ImageTemplatePowerShellValidator.runAsSystem, "IsRunAsSystem", "csharp");
+@@clientName(ImageTemplatePropertiesValidate.continueDistributeOnFailure,
+  "ShouldContinueDistributeOnFailure",
+  "csharp"
+);
+@@clientName(ImageTemplatePropertiesValidate.sourceValidationOnly, "IsSourceValidationOnly", "csharp");
+@@clientName(ImageTemplateSharedImageDistributor.excludeFromLatest, "IsExcludedFromLatest", "csharp");
+
+// C#: DateTimeOffset properties should end with 'On'.
+@@clientName(TriggerStatus.time, "RecordedOn", "csharp");
+
+// C#: string location should surface as AzureLocation.
+@@alternateType(ImageTemplateManagedImageDistributor.location, Azure.Core.azureLocation, "csharp");
+
+// C#: drop the leaked 'Properties' envelope naming from public model names.
+@@clientName(ImageTemplatePropertiesErrorHandling, "ImageTemplateErrorHandling", "csharp");
+@@clientName(ImageTemplatePropertiesOptimize, "ImageTemplateOptimizeConfig", "csharp");
+@@clientName(ImageTemplatePropertiesOptimizeWorkload, "ImageTemplateWorkloadOptimization", "csharp");
+@@clientName(ImageTemplatePropertiesValidate, "ImageTemplateValidationConfig", "csharp");
+@@clientName(ImageTemplateUpdateParametersProperties, "ImageTemplatePatchProperties", "csharp");

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -28,6 +28,9 @@ using Microsoft.VirtualMachineImages;
 // C#: give the generic 'Trigger' resource trio RP/domain context (RESNAME001).
 @@clientName(Trigger, "ImageTemplateTrigger", "csharp");
 
+// C#: give the generic 'RunOutput' resource trio RP/domain context (RESNAME001).
+@@clientName(RunOutput, "ImageTemplateRunOutput", "csharp");
+
 // C#: boolean properties must start with a verb prefix (AZC0030 BOOL naming).
 @@clientName(
   ImageTemplatePowerShellCustomizer.runElevated,
@@ -75,6 +78,38 @@ using Microsoft.VirtualMachineImages;
   "csharp"
 );
 
+// C#: ARM resource-id string properties should surface as ResourceIdentifier.
+@@alternateType(
+  ImageTemplateManagedImageDistributor.imageId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ImageTemplateManagedImageSource.imageId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ImageTemplateSharedImageDistributor.galleryImageId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ImageTemplateSharedImageVersionSource.imageVersionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  VirtualNetworkConfig.subnetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  VirtualNetworkConfig.containerInstanceSubnetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+
 // C#: drop the leaked 'Properties' envelope naming from public model names.
 @@clientName(
   ImageTemplatePropertiesErrorHandling,
@@ -107,3 +142,30 @@ using Microsoft.VirtualMachineImages;
   Record<Azure.ResourceManager.CommonTypes.UserAssignedIdentity>,
   "csharp"
 );
+
+// C#: give generic enums/types RP/domain context so they are understandable in
+// IntelliSense without a fully qualified name (RESNAME001 / contextual naming).
+@@clientName(ProvisioningState, "ImageBuilderProvisioningState", "csharp");
+@@clientName(ResourceIdentityType, "ImageBuilderIdentityType", "csharp");
+@@clientName(DataDisk, "ImageBuilderDataDisk", "csharp");
+@@clientName(RunState, "ImageTemplateRunState", "csharp");
+@@clientName(RunSubState, "ImageTemplateRunSubState", "csharp");
+@@clientName(TargetRegion, "ImageTemplateTargetRegion", "csharp");
+@@clientName(TriggerStatus, "ImageTemplateTriggerStatus", "csharp");
+@@clientName(VirtualNetworkConfig, "ImageBuilderVirtualNetworkConfig", "csharp");
+@@clientName(AutoRunState, "ImageTemplateAutoRunState", "csharp");
+@@clientName(OnBuildError, "ImageBuilderOnBuildError", "csharp");
+@@clientName(ProvisioningError, "ImageBuilderProvisioningError", "csharp");
+@@clientName(ProvisioningErrorCode, "ImageBuilderProvisioningErrorCode", "csharp");
+@@clientName(ReplicationMode, "ImageTemplateReplicationMode", "csharp");
+@@clientName(VMBootOptimizationState, "ImageTemplateVMBootOptimizationState", "csharp");
+@@clientName(
+  WorkloadOptimizationState,
+  "ImageTemplateWorkloadOptimizationState",
+  "csharp"
+);
+
+// C#: flatten the PATCH body 'properties' envelope so callers set Distribute/Source/etc.
+// directly on ImageTemplatePatch, consistent with the flattened ImageTemplateData (API design).
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Flattening the PATCH properties bag for C# API consistency with the resource data model."
+@@Legacy.flattenProperty(ImageTemplateUpdateParameters.properties, "csharp");

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -152,13 +152,25 @@ using Microsoft.VirtualMachineImages;
 @@clientName(RunSubState, "ImageTemplateRunSubState", "csharp");
 @@clientName(TargetRegion, "ImageTemplateTargetRegion", "csharp");
 @@clientName(TriggerStatus, "ImageTemplateTriggerStatus", "csharp");
-@@clientName(VirtualNetworkConfig, "ImageBuilderVirtualNetworkConfig", "csharp");
+@@clientName(
+  VirtualNetworkConfig,
+  "ImageBuilderVirtualNetworkConfig",
+  "csharp"
+);
 @@clientName(AutoRunState, "ImageTemplateAutoRunState", "csharp");
 @@clientName(OnBuildError, "ImageBuilderOnBuildError", "csharp");
 @@clientName(ProvisioningError, "ImageBuilderProvisioningError", "csharp");
-@@clientName(ProvisioningErrorCode, "ImageBuilderProvisioningErrorCode", "csharp");
+@@clientName(
+  ProvisioningErrorCode,
+  "ImageBuilderProvisioningErrorCode",
+  "csharp"
+);
 @@clientName(ReplicationMode, "ImageTemplateReplicationMode", "csharp");
-@@clientName(VMBootOptimizationState, "ImageTemplateVMBootOptimizationState", "csharp");
+@@clientName(
+  VMBootOptimizationState,
+  "ImageTemplateVMBootOptimizationState",
+  "csharp"
+);
 @@clientName(
   WorkloadOptimizationState,
   "ImageTemplateWorkloadOptimizationState",

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -12,3 +12,14 @@ using Microsoft.VirtualMachineImages;
   "ImageBuilderClient",
   "javascript,python,java"
 );
+
+// C#: common-types Resource.id is a plain string; map to ResourceIdentifier so generated
+// *Data ctors satisfy the ResourceData base (fixes CS1503).
+@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+
+// C#: model names must not end with 'Collection' (AZC0030).
+@@clientName(RunOutputCollection, "RunOutputListResult", "csharp");
+@@clientName(TriggerCollection, "TriggerListResult", "csharp");

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -29,26 +29,81 @@ using Microsoft.VirtualMachineImages;
 @@clientName(Trigger, "ImageTemplateTrigger", "csharp");
 
 // C#: boolean properties must start with a verb prefix (AZC0030 BOOL naming).
-@@clientName(ImageTemplatePowerShellCustomizer.runElevated, "IsRunElevated", "csharp");
-@@clientName(ImageTemplatePowerShellCustomizer.runAsSystem, "IsRunAsSystem", "csharp");
-@@clientName(ImageTemplatePowerShellValidator.runElevated, "IsRunElevated", "csharp");
-@@clientName(ImageTemplatePowerShellValidator.runAsSystem, "IsRunAsSystem", "csharp");
-@@clientName(ImageTemplatePropertiesValidate.continueDistributeOnFailure,
+@@clientName(
+  ImageTemplatePowerShellCustomizer.runElevated,
+  "IsRunElevated",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePowerShellCustomizer.runAsSystem,
+  "IsRunAsSystem",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePowerShellValidator.runElevated,
+  "IsRunElevated",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePowerShellValidator.runAsSystem,
+  "IsRunAsSystem",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePropertiesValidate.continueDistributeOnFailure,
   "ShouldContinueDistributeOnFailure",
   "csharp"
 );
-@@clientName(ImageTemplatePropertiesValidate.sourceValidationOnly, "IsSourceValidationOnly", "csharp");
-@@clientName(ImageTemplateSharedImageDistributor.excludeFromLatest, "IsExcludedFromLatest", "csharp");
+@@clientName(
+  ImageTemplatePropertiesValidate.sourceValidationOnly,
+  "IsSourceValidationOnly",
+  "csharp"
+);
+@@clientName(
+  ImageTemplateSharedImageDistributor.excludeFromLatest,
+  "IsExcludedFromLatest",
+  "csharp"
+);
 
 // C#: DateTimeOffset properties should end with 'On'.
 @@clientName(TriggerStatus.time, "RecordedOn", "csharp");
 
 // C#: string location should surface as AzureLocation.
-@@alternateType(ImageTemplateManagedImageDistributor.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(
+  ImageTemplateManagedImageDistributor.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
 
 // C#: drop the leaked 'Properties' envelope naming from public model names.
-@@clientName(ImageTemplatePropertiesErrorHandling, "ImageTemplateErrorHandling", "csharp");
-@@clientName(ImageTemplatePropertiesOptimize, "ImageTemplateOptimizeConfig", "csharp");
-@@clientName(ImageTemplatePropertiesOptimizeWorkload, "ImageTemplateWorkloadOptimization", "csharp");
-@@clientName(ImageTemplatePropertiesValidate, "ImageTemplateValidationConfig", "csharp");
-@@clientName(ImageTemplateUpdateParametersProperties, "ImageTemplatePatchProperties", "csharp");
+@@clientName(
+  ImageTemplatePropertiesErrorHandling,
+  "ImageTemplateErrorHandling",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePropertiesOptimize,
+  "ImageTemplateOptimizeConfig",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePropertiesOptimizeWorkload,
+  "ImageTemplateWorkloadOptimization",
+  "csharp"
+);
+@@clientName(
+  ImageTemplatePropertiesValidate,
+  "ImageTemplateValidationConfig",
+  "csharp"
+);
+@@clientName(
+  ImageTemplateUpdateParametersProperties,
+  "ImageTemplatePatchProperties",
+  "csharp"
+);
+
+@@alternateType(
+  ImageTemplateIdentity.userAssignedIdentities,
+  Record<Azure.ResourceManager.CommonTypes.UserAssignedIdentity>,
+  "csharp"
+);

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/client.tsp
@@ -15,7 +15,8 @@ using Microsoft.VirtualMachineImages;
 
 // C#: common-types Resource.id is a plain string; map to ResourceIdentifier so generated
 // *Data ctors satisfy the ResourceData base (fixes CS1503).
-@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id,
+@@alternateType(
+  Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );


### PR DESCRIPTION
## Summary
Adds C#-scoped client customizations for the **Azure Image Builder** (`Microsoft.VirtualMachineImages`) TypeSpec project so the .NET management SDK generates and builds cleanly.

## Changes (`client.tsp`)
- `@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id, Azure.Core.armResourceIdentifier, "csharp")` — maps the common-types `string` resource `id` to `ResourceIdentifier` so generated `*Data` constructors satisfy the `ResourceData` base (fixes CS1503).
- `@@clientName(RunOutputCollection, "RunOutputListResult", "csharp")` — avoids AZC0030 (model name must not end with `Collection`).
- `@@clientName(TriggerCollection, "TriggerListResult", "csharp")` — same as above.

All decorators are `csharp`-scoped and do not affect other languages.

## Related
Paired with the azure-sdk-for-net onboarding PR for `Azure.ResourceManager.ImageBuilder`.