### PR TITLE
[TEST] DeviceUpdate Java need to use two-client, to maintain backward compatible as prior GA lib

### DIFF
--- a/specification/deviceupdate/data-plane/duiothub/client.tsp
+++ b/specification/deviceupdate/data-plane/duiothub/client.tsp
@@ -13,314 +13,314 @@ namespace Customization;
   "logCollectionId"
 );
 
-// The C# namespace is `Azure.IoT.DeviceUpdate`; a sub-client literally named
-// `DeviceUpdate` collides with the namespace's last segment, so the C# emitter
-// disambiguates by renaming the namespace to `Azure.IoT._DeviceUpdate`. Use
-// `DeviceUpdates` for C# only to avoid the collision; all other languages keep
-// the original `DeviceUpdate` name (no collision there, and it preserves the
-// already-shipped public client/operation-group name).
-@@clientLocation(
-  DeviceUpdateOperationGroup.listUpdates,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listUpdates,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.importUpdate,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.importUpdate,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.getUpdate,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.getUpdate,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.deleteUpdate,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.deleteUpdate,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listProviders,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listProviders,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listNames,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listNames,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listVersions,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listVersions,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listFiles,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listFiles,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdates", "csharp");
-@@clientLocation(
-  DeviceUpdateOperationGroup.getFile,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listOperationStatuses,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.listOperationStatuses,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.getOperationStatus,
-  "DeviceUpdates",
-  "csharp"
-);
-@@clientLocation(
-  DeviceUpdateOperationGroup.getOperationStatus,
-  "DeviceUpdate",
-  "!csharp,!java"
-);
+// // The C# namespace is `Azure.IoT.DeviceUpdate`; a sub-client literally named
+// // `DeviceUpdate` collides with the namespace's last segment, so the C# emitter
+// // disambiguates by renaming the namespace to `Azure.IoT._DeviceUpdate`. Use
+// // `DeviceUpdates` for C# only to avoid the collision; all other languages keep
+// // the original `DeviceUpdate` name (no collision there, and it preserves the
+// // already-shipped public client/operation-group name).
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listUpdates,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listUpdates,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.importUpdate,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.importUpdate,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.getUpdate,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.getUpdate,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.deleteUpdate,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.deleteUpdate,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listProviders,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listProviders,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listNames,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listNames,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listVersions,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listVersions,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listFiles,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listFiles,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdates", "csharp");
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.getFile,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listOperationStatuses,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.listOperationStatuses,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.getOperationStatus,
+//   "DeviceUpdates",
+//   "csharp"
+// );
+// @@clientLocation(
+//   DeviceUpdateOperationGroup.getOperationStatus,
+//   "DeviceUpdate",
+//   "!csharp,!java"
+// );
 
-@@clientLocation(
-  DeviceManagementOperationGroup.listDeviceClasses,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeviceClass,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.updateDeviceClass,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.deleteDeviceClass,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listInstallableUpdatesForDeviceClass,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listDevices,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.importDevices,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDevice,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeviceModule,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getUpdateCompliance,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listGroups,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.deleteGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getUpdateComplianceForGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listBestUpdatesForGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listDeploymentsForGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.createOrUpdateDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeploymentManagementOperationGroup.deleteDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeploymentStatus,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listDeviceClassSubgroupsForGroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.deleteDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeviceClassSubgroupUpdateCompliance,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getBestUpdatesForDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listDeploymentsForDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeploymentForDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeploymentManagementOperationGroup.deleteDeploymentForDeviceClassSubgroup,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.stopDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.retryDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getDeviceClassSubgroupDeploymentStatus,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listDeviceStatesForDeviceClassSubgroupDeployment,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getOperationStatus,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listOperationStatuses,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.startLogCollection,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getLogCollection,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listLogCollections,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.getLogCollectionDetailedStatus,
-  "DeviceManagement",
-  "!java"
-);
-@@clientLocation(
-  DeviceManagementOperationGroup.listHealthOfDevices,
-  "DeviceManagement",
-  "!java"
-);
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDeviceClasses,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeviceClass,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.updateDeviceClass,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.deleteDeviceClass,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listInstallableUpdatesForDeviceClass,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDevices,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.importDevices,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDevice,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeviceModule,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getUpdateCompliance,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listGroups,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.deleteGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getUpdateComplianceForGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listBestUpdatesForGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDeploymentsForGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.createOrUpdateDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeploymentManagementOperationGroup.deleteDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeploymentStatus,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDeviceClassSubgroupsForGroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.deleteDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeviceClassSubgroupUpdateCompliance,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getBestUpdatesForDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDeploymentsForDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeploymentForDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeploymentManagementOperationGroup.deleteDeploymentForDeviceClassSubgroup,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.stopDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.retryDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getDeviceClassSubgroupDeploymentStatus,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listDeviceStatesForDeviceClassSubgroupDeployment,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getOperationStatus,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listOperationStatuses,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.startLogCollection,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getLogCollection,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listLogCollections,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.getLogCollectionDetailedStatus,
+//   "DeviceManagement",
+//   "!java"
+// );
+// @@clientLocation(
+//   DeviceManagementOperationGroup.listHealthOfDevices,
+//   "DeviceManagement",
+//   "!java"
+// );
 
 // Hoist `instanceId` from per-operation parameter to client-constructor
 // parameter, matching the original swagger's

--- a/specification/deviceupdate/data-plane/duiothub/client.tsp
+++ b/specification/deviceupdate/data-plane/duiothub/client.tsp
@@ -367,6 +367,12 @@ interface ClientDeviceUpdateClient {
   getOperationStatus is DeviceUpdateOperationGroup.getOperationStatus;
 }
 
+@clientInitialization(
+  {
+    parameters: DeviceUpdateClientOptions,
+  },
+  "java"
+)
 @client(
   {
     name: "DeviceManagementClient",

--- a/specification/deviceupdate/data-plane/duiothub/client.tsp
+++ b/specification/deviceupdate/data-plane/duiothub/client.tsp
@@ -4,6 +4,8 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using DeviceUpdateClient;
 
+namespace Customization;
+
 @@clientName(LogCollection.operationId, "logCollectionId");
 
 @@clientName(
@@ -25,7 +27,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listUpdates,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.importUpdate,
@@ -35,7 +37,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.importUpdate,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.getUpdate,
@@ -45,7 +47,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.getUpdate,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.deleteUpdate,
@@ -55,7 +57,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.deleteUpdate,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.listProviders,
@@ -65,7 +67,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listProviders,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.listNames,
@@ -75,7 +77,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listNames,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.listVersions,
@@ -85,7 +87,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listVersions,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.listFiles,
@@ -95,10 +97,14 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listFiles,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdates", "csharp");
-@@clientLocation(DeviceUpdateOperationGroup.getFile, "DeviceUpdate", "!csharp");
+@@clientLocation(
+  DeviceUpdateOperationGroup.getFile,
+  "DeviceUpdate",
+  "!csharp,!java"
+);
 @@clientLocation(
   DeviceUpdateOperationGroup.listOperationStatuses,
   "DeviceUpdates",
@@ -107,7 +113,7 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.listOperationStatuses,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 @@clientLocation(
   DeviceUpdateOperationGroup.getOperationStatus,
@@ -117,155 +123,203 @@ using DeviceUpdateClient;
 @@clientLocation(
   DeviceUpdateOperationGroup.getOperationStatus,
   "DeviceUpdate",
-  "!csharp"
+  "!csharp,!java"
 );
 
 @@clientLocation(
   DeviceManagementOperationGroup.listDeviceClasses,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeviceClass,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.updateDeviceClass,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.deleteDeviceClass,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listInstallableUpdatesForDeviceClass,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listDevices,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.importDevices,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
-@@clientLocation(DeviceManagementOperationGroup.getDevice, "DeviceManagement");
+@@clientLocation(
+  DeviceManagementOperationGroup.getDevice,
+  "DeviceManagement",
+  "!java"
+);
 @@clientLocation(
   DeviceManagementOperationGroup.getDeviceModule,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getUpdateCompliance,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
-@@clientLocation(DeviceManagementOperationGroup.listGroups, "DeviceManagement");
-@@clientLocation(DeviceManagementOperationGroup.getGroup, "DeviceManagement");
+@@clientLocation(
+  DeviceManagementOperationGroup.listGroups,
+  "DeviceManagement",
+  "!java"
+);
+@@clientLocation(
+  DeviceManagementOperationGroup.getGroup,
+  "DeviceManagement",
+  "!java"
+);
 @@clientLocation(
   DeviceManagementOperationGroup.deleteGroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getUpdateComplianceForGroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listBestUpdatesForGroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listDeploymentsForGroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.createOrUpdateDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeploymentManagementOperationGroup.deleteDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeploymentStatus,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listDeviceClassSubgroupsForGroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.deleteDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeviceClassSubgroupUpdateCompliance,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getBestUpdatesForDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listDeploymentsForDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeploymentForDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeploymentManagementOperationGroup.deleteDeploymentForDeviceClassSubgroup,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.stopDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.retryDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getDeviceClassSubgroupDeploymentStatus,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listDeviceStatesForDeviceClassSubgroupDeployment,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getOperationStatus,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listOperationStatuses,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.startLogCollection,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getLogCollection,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listLogCollections,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.getLogCollectionDetailedStatus,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 @@clientLocation(
   DeviceManagementOperationGroup.listHealthOfDevices,
-  "DeviceManagement"
+  "DeviceManagement",
+  "!java"
 );
 
 // Hoist `instanceId` from per-operation parameter to client-constructor
@@ -281,5 +335,83 @@ model DeviceUpdateClientOptions {
   DeviceUpdateClient,
   {
     parameters: DeviceUpdateClientOptions,
-  }
+  },
+  "!java"
 );
+
+// Java lib GAed with 2 clients
+@clientInitialization(
+  {
+    parameters: DeviceUpdateClientOptions,
+  },
+  "java"
+)
+@client(
+  {
+    name: "DeviceUpdateClient",
+    service: DeviceUpdateClient,
+  },
+  "java"
+)
+interface ClientDeviceUpdateClient {
+  listUpdates is DeviceUpdateOperationGroup.listUpdates;
+  importUpdate is DeviceUpdateOperationGroup.importUpdate;
+  getUpdate is DeviceUpdateOperationGroup.getUpdate;
+  deleteUpdate is DeviceUpdateOperationGroup.deleteUpdate;
+  listProviders is DeviceUpdateOperationGroup.listProviders;
+  listNames is DeviceUpdateOperationGroup.listNames;
+  listVersions is DeviceUpdateOperationGroup.listVersions;
+  listFiles is DeviceUpdateOperationGroup.listFiles;
+  getFile is DeviceUpdateOperationGroup.getFile;
+  listOperationStatuses is DeviceUpdateOperationGroup.listOperationStatuses;
+  getOperationStatus is DeviceUpdateOperationGroup.getOperationStatus;
+}
+
+@client(
+  {
+    name: "DeviceManagementClient",
+    service: DeviceUpdateClient,
+  },
+  "java"
+)
+interface DeviceManagementClient {
+  listDeviceClasses is DeviceManagementOperationGroup.listDeviceClasses;
+  getDeviceClass is DeviceManagementOperationGroup.getDeviceClass;
+  updateDeviceClass is DeviceManagementOperationGroup.updateDeviceClass;
+  deleteDeviceClass is DeviceManagementOperationGroup.deleteDeviceClass;
+  listInstallableUpdatesForDeviceClass is DeviceManagementOperationGroup.listInstallableUpdatesForDeviceClass;
+  listDevices is DeviceManagementOperationGroup.listDevices;
+  importDevices is DeviceManagementOperationGroup.importDevices;
+  getDevice is DeviceManagementOperationGroup.getDevice;
+  getDeviceModule is DeviceManagementOperationGroup.getDeviceModule;
+  getUpdateCompliance is DeviceManagementOperationGroup.getUpdateCompliance;
+  listGroups is DeviceManagementOperationGroup.listGroups;
+  getGroup is DeviceManagementOperationGroup.getGroup;
+  deleteGroup is DeviceManagementOperationGroup.deleteGroup;
+  getUpdateComplianceForGroup is DeviceManagementOperationGroup.getUpdateComplianceForGroup;
+  listBestUpdatesForGroup is DeviceManagementOperationGroup.listBestUpdatesForGroup;
+  listDeploymentsForGroup is DeviceManagementOperationGroup.listDeploymentsForGroup;
+  getDeployment is DeviceManagementOperationGroup.getDeployment;
+  createOrUpdateDeployment is DeviceManagementOperationGroup.createOrUpdateDeployment;
+  deleteDeployment is DeploymentManagementOperationGroup.deleteDeployment;
+  getDeploymentStatus is DeviceManagementOperationGroup.getDeploymentStatus;
+  listDeviceClassSubgroupsForGroup is DeviceManagementOperationGroup.listDeviceClassSubgroupsForGroup;
+  getDeviceClassSubgroup is DeviceManagementOperationGroup.getDeviceClassSubgroup;
+  deleteDeviceClassSubgroup is DeviceManagementOperationGroup.deleteDeviceClassSubgroup;
+  getDeviceClassSubgroupUpdateCompliance is DeviceManagementOperationGroup.getDeviceClassSubgroupUpdateCompliance;
+  getBestUpdatesForDeviceClassSubgroup is DeviceManagementOperationGroup.getBestUpdatesForDeviceClassSubgroup;
+  listDeploymentsForDeviceClassSubgroup is DeviceManagementOperationGroup.listDeploymentsForDeviceClassSubgroup;
+  getDeploymentForDeviceClassSubgroup is DeviceManagementOperationGroup.getDeploymentForDeviceClassSubgroup;
+  deleteDeploymentForDeviceClassSubgroup is DeploymentManagementOperationGroup.deleteDeploymentForDeviceClassSubgroup;
+  stopDeployment is DeviceManagementOperationGroup.stopDeployment;
+  retryDeployment is DeviceManagementOperationGroup.retryDeployment;
+  getDeviceClassSubgroupDeploymentStatus is DeviceManagementOperationGroup.getDeviceClassSubgroupDeploymentStatus;
+  listDeviceStatesForDeviceClassSubgroupDeployment is DeviceManagementOperationGroup.listDeviceStatesForDeviceClassSubgroupDeployment;
+  getOperationStatus is DeviceManagementOperationGroup.getOperationStatus;
+  listOperationStatuses is DeviceManagementOperationGroup.listOperationStatuses;
+  startLogCollection is DeviceManagementOperationGroup.startLogCollection;
+  getLogCollection is DeviceManagementOperationGroup.getLogCollection;
+  listLogCollections is DeviceManagementOperationGroup.listLogCollections;
+  getLogCollectionDetailedStatus is DeviceManagementOperationGroup.getLogCollectionDetailedStatus;
+  listHealthOfDevices is DeviceManagementOperationGroup.listHealthOfDevices;
+}

--- a/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
+++ b/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
@@ -34,6 +34,7 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/azure-iot-deviceupdate"
     namespace: com.azure.iot.deviceupdate
     flavor: azure
+    generate-samples: false
     generate-tests: false
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/iot-device-update"

--- a/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
+++ b/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
@@ -34,6 +34,7 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/azure-iot-deviceupdate"
     namespace: com.azure.iot.deviceupdate
     flavor: azure
+    generate-tests: false
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/iot-device-update"
     package-details:

--- a/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
+++ b/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
@@ -36,6 +36,7 @@ options:
     flavor: azure
     generate-samples: false
     generate-tests: false
+    customization-class: customization/src/main/java/DeviceUpdateCustomization.java
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/iot-device-update"
     package-details:


### PR DESCRIPTION
Draft PR for testing Java client split.

Includes:
- Java `@client` split into `DeviceUpdateClient` and `DeviceManagementClient`
- Java-scoped `@clientInitialization`
- Existing `@clientLocation` adjustments scoped away from Java