### PR TITLE
Set Python SDK client name to ManagedApplicationsMgmtClient for Solutions.Management

### DIFF
--- a/specification/solutions/Solutions.Management/client.tsp
+++ b/specification/solutions/Solutions.Management/client.tsp
@@ -9,11 +9,7 @@ using Microsoft.Solutions;
   "listOperations",
   "javascript"
 );
-@@clientName(
-  Microsoft.Solutions,
-  "ApplicationClient",
-  "javascript,go,java"
-);
+@@clientName(Microsoft.Solutions, "ApplicationClient", "javascript,go,java");
 @@clientName(Microsoft.Solutions, "ManagedApplicationsMgmtClient", "python");
 
 @@clientName(Operations.list, "list_operations", "python");

--- a/specification/solutions/Solutions.Management/client.tsp
+++ b/specification/solutions/Solutions.Management/client.tsp
@@ -12,8 +12,9 @@ using Microsoft.Solutions;
 @@clientName(
   Microsoft.Solutions,
   "ApplicationClient",
-  "javascript,python,go,java"
+  "javascript,go,java"
 );
+@@clientName(Microsoft.Solutions, "ManagedApplicationsMgmtClient", "python");
 
 @@clientName(Operations.list, "list_operations", "python");
 @@clientLocation(Operations.list, Microsoft.Solutions, "python,javascript");


### PR DESCRIPTION
fix client name breaking for https://github.com/Azure/azure-sdk-for-python/pull/47898