### PR TITLE
Add CSharp mgmt emitters

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertRuleRecommendations/tspconfig.yaml
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertRuleRecommendations/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.AlertRuleRecommendations"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/alertsmanagement"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-alertrulerecommendations"

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/tspconfig.yaml
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.PreviewAlertRule"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/alertsmanagement"
     package-dir: "azure-mgmt-previewalertrule"

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PrometheusRuleGroups/tspconfig.yaml
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PrometheusRuleGroups/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.PrometheusRuleGroups"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/alertsmanagement"
     package-dir: "azure-mgmt-prometheusrulegroups"

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/TenantActivityLogAlerts/tspconfig.yaml
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/TenantActivityLogAlerts/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.TenantActivityLogAlerts"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/alertsmanagement"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-tenantactivitylogalerts"

--- a/specification/edge/Microsoft.Edge.Management/tspconfig.yaml
+++ b/specification/edge/Microsoft.Edge.Management/tspconfig.yaml
@@ -17,6 +17,9 @@ options:
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/edge/{version-status}/{version}/operations.json"
     arm-types-dir: "{project-root}/../../common-types/resource-management"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.CommonEdgeSiteManagerOperations"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-commonedgesitemanageroperations"
     namespace: "com.azure.resourcemanager.commonedgesitemanageroperations"

--- a/specification/marketplacecatalog/resource-manager/Microsoft.Marketplace/Reviews/tspconfig.yaml
+++ b/specification/marketplacecatalog/resource-manager/Microsoft.Marketplace/Reviews/tspconfig.yaml
@@ -9,9 +9,6 @@ options:
     emitter-output-dir: "{project-root}"
     output-file: "{version-status}/{version}/reviews.json"
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
-  "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.Marketplace"
-    emitter-output-dir: "{output-dir}/sdk/marketplace/{namespace}"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-marketplace"
     namespace: "com.azure.resourcemanager.marketplace"

--- a/specification/marketplacecatalog/resource-manager/Microsoft.Marketplace/Reviews/tspconfig.yaml
+++ b/specification/marketplacecatalog/resource-manager/Microsoft.Marketplace/Reviews/tspconfig.yaml
@@ -9,6 +9,9 @@ options:
     emitter-output-dir: "{project-root}"
     output-file: "{version-status}/{version}/reviews.json"
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Marketplace"
+    emitter-output-dir: "{output-dir}/sdk/marketplace/{namespace}"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-marketplace"
     namespace: "com.azure.resourcemanager.marketplace"

--- a/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/tspconfig.yaml
+++ b/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/tspconfig.yaml
@@ -12,6 +12,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.MigrationDiscovery"
+    emitter-output-dir: "{output-dir}/sdk/migrationdiscovery/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-offazure"
     namespace: "azure.mgmt.offazure"

--- a/specification/programmableconnectivity/ProgrammableConnectivity.Management/tspconfig.yaml
+++ b/specification/programmableconnectivity/ProgrammableConnectivity.Management/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
     emit-common-types-schema: never
 
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.ProgrammableConnectivity"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-programmableconnectivity"
     namespace: "azure.mgmt.programmableconnectivity"

--- a/specification/verifiedid/Microsoft.VerifiedId.Management/tspconfig.yaml
+++ b/specification/verifiedid/Microsoft.VerifiedId.Management/tspconfig.yaml
@@ -13,6 +13,9 @@ options:
     emitter-output-dir: "{project-root}/.."
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/verifiedid.json"
     use-read-only-status-schema: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.VerifiedId"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-ts":
     experimental-extensible-enums: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-verifiedid"


### PR DESCRIPTION
## Summary

Split from #44486: add `@azure-typespec/http-client-csharp-mgmt` to management-plane TypeSpec projects whose Python SDK validation is blocked by Python package-name reservation or recently validated reservation status, and whose .NET namespace/source was confirmed.

## Python SDK validation finding

Latest Python SDK validation build: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6534259

Python generation itself succeeded for the projects in this split. The remaining hard failures are post-generation package-name reservation checks: these generated Python package names are not registered on PyPI yet.

The log guidance is:

1. Request namespace review at https://aka.ms/azsdk/ns-review
2. After namespace approval, trigger the Python package-name reservation pipeline: https://aka.ms/python-reserve-pkg

Remaining packages reported as **not registered** by the latest Python validation log:

| TypeSpec project | Python package |
| --- | --- |
| `specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertRuleRecommendations` | `azure-mgmt-alertrulerecommendations` |
| `specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/TenantActivityLogAlerts` | `azure-mgmt-tenantactivitylogalerts` |
| `specification/edge/Microsoft.Edge.Management` | `azure-mgmt-commonedgesitemanageroperations` |
| `specification/programmableconnectivity/ProgrammableConnectivity.Management` | `azure-mgmt-programmableconnectivity` |

Packages from the original split that now pass the PyPI registration check in build 6534259:

| TypeSpec project | Python package | Latest status |
| --- | --- | --- |
| `specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule` | `azure-mgmt-previewalertrule` | Already registered on PyPI |
| `specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PrometheusRuleGroups` | `azure-mgmt-prometheusrulegroups` | Already registered on PyPI |
| `specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure` | `azure-mgmt-offazure` | Already registered on PyPI |
| `specification/verifiedid/Microsoft.VerifiedId.Management` | `azure-mgmt-verifiedid` | Generated successfully; no package reservation error reported in the latest log |

`Marketplace Reviews` was removed from this split because the existing `Azure.ResourceManager.Marketplace` package does not appear to cover Reviews, and no Reviews-specific .NET namespace approval/source was found.

## Validation

- `pnpm exec prettier --check` on changed `tspconfig.yaml` files
- `pnpm exec tsp compile <project>/main.tsp --no-emit` for all changed TypeSpec projects before the split
