### PR TITLE
TypeSpec: align DeletedServer with Swagger for 2025-08-01-preview

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/DeletedServer.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/DeletedServer.tsp
@@ -27,7 +27,7 @@ model DeletedServer
   /**
    * Resource location.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "location represents the geographic location of the original server, not an ARM envelope location"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "location is intentionally placed at the ARM resource envelope level to match the actual API wire format, where it represents the geographic location of the original server"
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "DeletedServer has no create operation; x-ms-mutability must be read-only to satisfy LocationMustHaveXmsMutability without implying a create path"
   @added(Versions.v2025_08_01_preview)
   @visibility(Lifecycle.Read)

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/DeletedServer.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/DeletedServer.tsp
@@ -8,6 +8,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 
 namespace Microsoft.Sql;
 /**
@@ -22,6 +23,16 @@ model DeletedServer
     SegmentName = "deletedServers",
     NamePattern = ""
   >;
+
+  /**
+   * Resource location.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "location represents the geographic location of the original server, not an ARM envelope location"
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "DeletedServer has no create operation; x-ms-mutability must be read-only to satisfy LocationMustHaveXmsMutability without implying a create path"
+  @added(Versions.v2025_08_01_preview)
+  @visibility(Lifecycle.Read)
+  @extension("x-ms-mutability", #["read"])
+  location?: string;
 }
 
 alias DeletedServersOps = Azure.ResourceManager.Legacy.LegacyOperations<
@@ -34,7 +45,7 @@ alias DeletedServersOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @path
     @segment("locations")
     @key
-    locationName: string;
+    locationName: Azure.Core.azureLocation;
   },
   {
     /** The name of the deleted server. */

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerGet.json
@@ -11,11 +11,14 @@
         "name": "sqlcrudtest-d-1414",
         "type": "Microsoft.Sql/deletedServers",
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+        "location": "japaneast",
         "properties": {
           "deletionTime": "2017-06-15T11:20:00.345Z",
           "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
           "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-          "version": "12.0"
+          "version": "12.0",
+          "originalResourceGroup": "Default",
+          "scheduledPurgeTime": "2017-06-22T11:20:00.345Z"
         }
       }
     }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerList.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerList.json
@@ -12,22 +12,28 @@
             "name": "sqlcrudtest-d-1414",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-15T20:20:00.345Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-22T20:20:00.345Z"
             }
           },
           {
             "name": "sqlcrudtest-d-2424",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-2424",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-13T10:10:00.678Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-2424.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-2424",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-20T10:10:00.678Z"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerListBySubscription.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerListBySubscription.json
@@ -11,22 +11,28 @@
             "name": "sqlcrudtest-d-1414",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-15T20:20:00.345Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-22T20:20:00.345Z"
             }
           },
           {
             "name": "sqlcrudtest-d-2424",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-2424",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-13T10:10:00.678Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-2424.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-2424",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-20T10:10:00.678Z"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerRecover.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/DeletedServerRecover.json
@@ -12,11 +12,14 @@
         "name": "sqlcrudtest-d-1414",
         "type": "Microsoft.Sql/deletedServers",
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+        "location": "japaneast",
         "properties": {
           "deletionTime": "2017-06-15T11:20:00.345Z",
           "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
           "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-          "version": "12.0"
+          "version": "12.0",
+          "originalResourceGroup": "Default",
+          "scheduledPurgeTime": "2017-06-22T11:20:00.345Z"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -7394,7 +7394,7 @@ model DataWarehouseUserActivitiesProperties {
 /**
  * The properties of a deleted server.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "DeletedServer is a read-only proxy resource that represents a deleted server record. It has no provisioning lifecycle and does not support provisioning state."
 model DeletedServerProperties {
   /**
    * The version of the deleted server.
@@ -7406,7 +7406,6 @@ model DeletedServerProperties {
    * The deletion time of the deleted server.
    */
   @visibility(Lifecycle.Read)
-  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   deletionTime?: utcDateTime;
 
   /**
@@ -7433,7 +7432,6 @@ model DeletedServerProperties {
    */
   @added(Versions.v2025_08_01_preview)
   @visibility(Lifecycle.Read)
-  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   scheduledPurgeTime?: utcDateTime;
 }
 

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -7416,10 +7416,25 @@ model DeletedServerProperties {
   originalId?: string;
 
   /**
+   * The resource group of the original server before deletion.
+   */
+  @added(Versions.v2025_08_01_preview)
+  @visibility(Lifecycle.Read)
+  originalResourceGroup?: string;
+
+  /**
    * The fully qualified domain name of the server.
    */
   @visibility(Lifecycle.Read)
   fullyQualifiedDomainName?: string;
+
+  /**
+   * The date and time when the deleted server will be permanently deleted (purged).
+   */
+  @added(Versions.v2025_08_01_preview)
+  @visibility(Lifecycle.Read)
+  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  scheduledPurgeTime?: utcDateTime;
 }
 
 /**

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerGet.json
@@ -11,11 +11,14 @@
         "name": "sqlcrudtest-d-1414",
         "type": "Microsoft.Sql/deletedServers",
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+        "location": "japaneast",
         "properties": {
           "deletionTime": "2017-06-15T11:20:00.345Z",
           "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
           "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-          "version": "12.0"
+          "version": "12.0",
+          "originalResourceGroup": "Default",
+          "scheduledPurgeTime": "2017-06-22T11:20:00.345Z"
         }
       }
     }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerList.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerList.json
@@ -12,22 +12,28 @@
             "name": "sqlcrudtest-d-1414",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-15T20:20:00.345Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-22T20:20:00.345Z"
             }
           },
           {
             "name": "sqlcrudtest-d-2424",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-2424",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-13T10:10:00.678Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-2424.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-2424",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-20T10:10:00.678Z"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerListBySubscription.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerListBySubscription.json
@@ -11,22 +11,28 @@
             "name": "sqlcrudtest-d-1414",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-15T20:20:00.345Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-22T20:20:00.345Z"
             }
           },
           {
             "name": "sqlcrudtest-d-2424",
             "type": "Microsoft.Sql/deletedServers",
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-2424",
+            "location": "japaneast",
             "properties": {
               "deletionTime": "2017-06-13T10:10:00.678Z",
               "fullyQualifiedDomainName": "sqlcrudtest-d-2424.database.windows.net",
               "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-2424",
-              "version": "12.0"
+              "version": "12.0",
+              "originalResourceGroup": "Default",
+              "scheduledPurgeTime": "2017-06-20T10:10:00.678Z"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerRecover.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/DeletedServerRecover.json
@@ -12,11 +12,14 @@
         "name": "sqlcrudtest-d-1414",
         "type": "Microsoft.Sql/deletedServers",
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Sql/locations/japaneast/deletedServers/sqlcrudtest-d-1414",
+        "location": "japaneast",
         "properties": {
           "deletionTime": "2017-06-15T11:20:00.345Z",
           "fullyQualifiedDomainName": "sqlcrudtest-d-1414.database.windows.net",
           "originalId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/sqlcrudtest-d-1414",
-          "version": "12.0"
+          "version": "12.0",
+          "originalResourceGroup": "Default",
+          "scheduledPurgeTime": "2017-06-22T11:20:00.345Z"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
@@ -44832,6 +44832,14 @@
           "$ref": "#/definitions/DeletedServerProperties",
           "description": "Resource properties.",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location.",
+          "readOnly": true,
+          "x-ms-mutability": [
+            "read"
+          ]
         }
       },
       "allOf": [
@@ -44881,9 +44889,20 @@
           "description": "The original ID of the server before deletion.",
           "readOnly": true
         },
+        "originalResourceGroup": {
+          "type": "string",
+          "description": "The resource group of the original server before deletion.",
+          "readOnly": true
+        },
         "fullyQualifiedDomainName": {
           "type": "string",
           "description": "The fully qualified domain name of the server.",
+          "readOnly": true
+        },
+        "scheduledPurgeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the deleted server will be permanently deleted (purged).",
           "readOnly": true
         }
       }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/readme.md
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/readme.md
@@ -10955,5 +10955,25 @@ suppressions:
   - code: LatestVersionOfCommonTypesMustBeUsed
     from: WorkloadGroups.json
     where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/workloadGroups/{workloadGroupName}"].delete.responses.default.schema["$ref"]
+  - code: PathForTrackedResourceTypes
+    from: openapi.json
+    where: $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/deletedServers/{deletedServerName}"]
+    reason: DeletedServer is an ARM proxy resource (subscription-scoped), not a tracked resource. The location property on DeletedServer is informational only and does not make it a tracked resource.
+  - code: AllTrackedResourcesMustHaveDelete
+    from: openapi.json
+    where: $.definitions.DeletedServer
+    reason: DeletedServer is an ARM proxy resource, not a tracked resource. It does not require a delete operation.
+  - code: TrackedResourcePatchOperation
+    from: openapi.json
+    where: $.definitions.DeletedServer
+    reason: DeletedServer is an ARM proxy resource, not a tracked resource. It does not require a patch operation.
+  - code: TrackedResourcesMustHavePut
+    from: openapi.json
+    where: $.definitions.DeletedServer
+    reason: DeletedServer is an ARM proxy resource, not a tracked resource. It does not require a put operation.
+  - code: LocationMustHaveXmsMutability
+    from: openapi.json
+    where: $.definitions.DeletedServer.properties.location
+    reason: The location property on DeletedServer is read-only informational data representing the original server location. It is not user-settable and does not support create mutability.
 
 ```


### PR DESCRIPTION
## Description

Align `DeletedServer` TypeSpec definitions with the checked-in Swagger spec for the `2025-08-01-preview` API version.

## Changes

**`DeletedServer.tsp`**
- Added `location` field (read-only) to the `DeletedServer` model
- Added `list` operation (`ArmListBySubscription<DeletedServer>`) to the `DeletedServers` interface

**`models.tsp`**
- Added `originalResourceGroup` property (read-only) to `DeletedServerProperties`
- Added `scheduledPurgeTime` property (read-only) to `DeletedServerProperties`

## Related

- Companion internal PR: https://msdata.visualstudio.com/Database%20Systems/_git/DsMainDev/pullrequest/2186093
- Work Item: #5259463 — Rest API: Expose 2025-08-01-preview version of Deleted Server API endpoint with newly added properties in all clouds