### PR TITLE
[Do not submit] Update the techspec file with the selective fields

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -4353,6 +4353,16 @@ model ServerBlobAuditingPolicyProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/no-format" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   storageAccountSubscriptionId?: Azure.Core.uuid;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Format: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+  */
+  @added(Versions.v2025_08_01_preview)
+  requiredFields?: string;
+
 }
 
 /**
@@ -4489,6 +4499,15 @@ model DatabaseBlobAuditingPolicyProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/no-format" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   storageAccountSubscriptionId?: Azure.Core.uuid;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Format: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+  */
+  @added(Versions.v2025_08_01_preview)
+  requiredFields?: string;
 }
 
 /**
@@ -4630,6 +4649,15 @@ model ExtendedDatabaseBlobAuditingPolicyProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/no-format" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   storageAccountSubscriptionId?: Azure.Core.uuid;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Format: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+  */
+  @added(Versions.v2025_08_01_preview)
+  requiredFields?: string;
 }
 
 /**
@@ -4786,6 +4814,15 @@ model ExtendedServerBlobAuditingPolicyProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/no-format" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   storageAccountSubscriptionId?: Azure.Core.uuid;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Format: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+  */
+  @added(Versions.v2025_08_01_preview)
+  requiredFields?: string;
 }
 
 /**

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
@@ -42956,6 +42956,10 @@
         "storageAccountSubscriptionId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "Specifies the blob storage subscription Id."
+        },
+        "requiredFields": {
+          "type": "string",
+          "description": "Specifies the required fields to include in audit events (optional).\nFormat: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation."
         }
       },
       "required": [
@@ -46193,6 +46197,10 @@
         "storageAccountSubscriptionId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "Specifies the blob storage subscription Id."
+        },
+        "requiredFields": {
+          "type": "string",
+          "description": "Specifies the required fields to include in audit events (optional).\nFormat: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation."
         }
       },
       "required": [
@@ -46298,6 +46306,10 @@
         "storageAccountSubscriptionId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "Specifies the blob storage subscription Id."
+        },
+        "requiredFields": {
+          "type": "string",
+          "description": "Specifies the required fields to include in audit events (optional).\nFormat: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation."
         }
       },
       "required": [
@@ -56937,6 +56949,10 @@
         "storageAccountSubscriptionId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "Specifies the blob storage subscription Id."
+        },
+        "requiredFields": {
+          "type": "string",
+          "description": "Specifies the required fields to include in audit events (optional).\nFormat: Comma-separated field names enclosed in single quotes (e.g., 'event_time,action_id,statement').\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation."
         }
       },
       "required": [


### PR DESCRIPTION
This change adds a new parameter to the existing APIs -
    DatabaseBlobAuditingPolicy
    ExtendedDatabaseBlobAuditingPolicy
    ServerBlobAuditingPolicy
    ExtendedBlobAuditingPolicy

     New parameter requiredFields is added to these APIs to support
     the selective fields auditing in Azure SQL.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
