### PR TITLE
Photon TypeSpec uri fix

### DIFF
--- a/specification/storage/data-plane/BlobStorage/Common/routes.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/routes.tsp
@@ -640,7 +640,8 @@ interface Container {
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   @added(Versions.v2026_12_06)
   @get
-  @route("?restype=container&comp=list&flat&arrow")
+  @sharedRoute
+  @route("?restype=container&comp=list")
   listBlobFlatSegmentApacheArrow(
     /** The Accept header indicating the response should be returned as an Apache Arrow stream, falling back to XML otherwise. */
     #suppress "@typespec/http/content-type-ignored" "Raw response, deserialized by client"
@@ -703,7 +704,8 @@ interface Container {
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   @added(Versions.v2026_12_06)
   @get
-  @route("?restype=container&comp=list&hierarchy&arrow")
+  @sharedRoute
+  @route("?restype=container&comp=list")
   listBlobHierarchySegmentApacheArrow(
     /** The Accept header indicating the response should be returned as an Apache Arrow stream, falling back to XML otherwise. */
     #suppress "@typespec/http/content-type-ignored" "Raw response, deserialized by client"

--- a/specification/storage/data-plane/BlobStorage/stable/2026-12-06/generated_blob.json
+++ b/specification/storage/data-plane/BlobStorage/stable/2026-12-06/generated_blob.json
@@ -12297,207 +12297,7 @@
         }
       }
     },
-    "?restype=container&comp=list&_overload=listBlobHierarchySegment": {
-      "get": {
-        "operationId": "Container_ListBlobHierarchySegment",
-        "description": "Returns a list of the blobs in the specified container. A delimiter can be used to traverse a virtual hierarchy of blobs as though it were a file system.",
-        "parameters": [
-          {
-            "name": "x-ms-version",
-            "in": "header",
-            "description": "Specifies the version of the operation to use for this request.",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "version"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
-            "name": "delimiter",
-            "in": "query",
-            "description": "If specified, the operation returns a BlobPrefix element that acts as a placeholder for all blobs whose names begin with the same substring up to the appearance of the delimiter character. The delimiter may be a single character or a string.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "description": "Filters the results to return only resources whose name begins with the specified prefix.",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "marker",
-            "in": "query",
-            "description": "An opaque string value that identifies the portion of the result set to return with this operation.",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "maxresults",
-            "in": "query",
-            "description": "Specifies the maximum number of resources to return. If the request does not specify maxresults, or specifies a value greater than 5000, the server will return up to 5000 items.",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1
-          },
-          {
-            "name": "include",
-            "in": "query",
-            "description": "Specify to include additional, optional information.",
-            "required": false,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "copy",
-                "deleted",
-                "metadata",
-                "snapshots",
-                "uncommittedblobs",
-                "versions",
-                "tags",
-                "immutabilitypolicy",
-                "legalhold",
-                "deletedwithversions"
-              ],
-              "x-ms-enum": {
-                "name": "ListBlobsIncludeItem",
-                "modelAsString": false,
-                "values": [
-                  {
-                    "name": "Copy",
-                    "value": "copy",
-                    "description": "Include copies."
-                  },
-                  {
-                    "name": "Deleted",
-                    "value": "deleted",
-                    "description": "Include deleted blobs."
-                  },
-                  {
-                    "name": "Metadata",
-                    "value": "metadata",
-                    "description": "Include metadata."
-                  },
-                  {
-                    "name": "Snapshots",
-                    "value": "snapshots",
-                    "description": "Include snapshots."
-                  },
-                  {
-                    "name": "UncommittedBlobs",
-                    "value": "uncommittedblobs",
-                    "description": "Include uncommitted blobs."
-                  },
-                  {
-                    "name": "Versions",
-                    "value": "versions",
-                    "description": "Include versions."
-                  },
-                  {
-                    "name": "Tags",
-                    "value": "tags",
-                    "description": "Include tags."
-                  },
-                  {
-                    "name": "ImmutabilityPolicy",
-                    "value": "immutabilitypolicy",
-                    "description": "Include immutability policies."
-                  },
-                  {
-                    "name": "LegalHold",
-                    "value": "legalhold",
-                    "description": "Include legal hold."
-                  },
-                  {
-                    "name": "DeletedWithVersions",
-                    "value": "deletedwithversions",
-                    "description": "Include deleted with versions."
-                  }
-                ]
-              }
-            },
-            "collectionFormat": "csv"
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\\\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\\\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
-            "name": "startFrom",
-            "in": "query",
-            "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; for recursive list, multiple entity levels are supported. (Inclusive)",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/ListBlobsHierarchicalResponse"
-            },
-            "headers": {
-              "Date": {
-                "type": "string",
-                "format": "date-time-rfc7231",
-                "description": "Date-time value generated by the service that indicates the time at which the response was initiated."
-              },
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              },
-              "x-ms-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, server-generated string identifier for the request."
-              },
-              "x-ms-version": {
-                "type": "string",
-                "description": "Specifies the version of the operation to use for this request."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "headers": {
-              "x-ms-copy-source-error-code": {
-                "type": "string",
-                "description": "The error code for the copy source."
-              },
-              "x-ms-copy-source-status-code": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The status code for the copy source."
-              },
-              "x-ms-error-code": {
-                "type": "string",
-                "description": "The error code."
-              }
-            }
-          }
-        }
-      }
-    },
-    "?restype=container&comp=list&flat&arrow": {
+    "?restype=container&comp=list&_overload=listBlobFlatSegmentApacheArrow": {
       "get": {
         "operationId": "Container_ListBlobFlatSegmentApacheArrow",
         "description": "Returns a list of the blobs in Apache Arrow format as raw data, to be deserialized by the client.",
@@ -12714,7 +12514,207 @@
         }
       }
     },
-    "?restype=container&comp=list&hierarchy&arrow": {
+    "?restype=container&comp=list&_overload=listBlobHierarchySegment": {
+      "get": {
+        "operationId": "Container_ListBlobHierarchySegment",
+        "description": "Returns a list of the blobs in the specified container. A delimiter can be used to traverse a virtual hierarchy of blobs as though it were a file system.",
+        "parameters": [
+          {
+            "name": "x-ms-version",
+            "in": "header",
+            "description": "Specifies the version of the operation to use for this request.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "delimiter",
+            "in": "query",
+            "description": "If specified, the operation returns a BlobPrefix element that acts as a placeholder for all blobs whose names begin with the same substring up to the appearance of the delimiter character. The delimiter may be a single character or a string.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "description": "Filters the results to return only resources whose name begins with the specified prefix.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "marker",
+            "in": "query",
+            "description": "An opaque string value that identifies the portion of the result set to return with this operation.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "maxresults",
+            "in": "query",
+            "description": "Specifies the maximum number of resources to return. If the request does not specify maxresults, or specifies a value greater than 5000, the server will return up to 5000 items.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Specify to include additional, optional information.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "copy",
+                "deleted",
+                "metadata",
+                "snapshots",
+                "uncommittedblobs",
+                "versions",
+                "tags",
+                "immutabilitypolicy",
+                "legalhold",
+                "deletedwithversions"
+              ],
+              "x-ms-enum": {
+                "name": "ListBlobsIncludeItem",
+                "modelAsString": false,
+                "values": [
+                  {
+                    "name": "Copy",
+                    "value": "copy",
+                    "description": "Include copies."
+                  },
+                  {
+                    "name": "Deleted",
+                    "value": "deleted",
+                    "description": "Include deleted blobs."
+                  },
+                  {
+                    "name": "Metadata",
+                    "value": "metadata",
+                    "description": "Include metadata."
+                  },
+                  {
+                    "name": "Snapshots",
+                    "value": "snapshots",
+                    "description": "Include snapshots."
+                  },
+                  {
+                    "name": "UncommittedBlobs",
+                    "value": "uncommittedblobs",
+                    "description": "Include uncommitted blobs."
+                  },
+                  {
+                    "name": "Versions",
+                    "value": "versions",
+                    "description": "Include versions."
+                  },
+                  {
+                    "name": "Tags",
+                    "value": "tags",
+                    "description": "Include tags."
+                  },
+                  {
+                    "name": "ImmutabilityPolicy",
+                    "value": "immutabilitypolicy",
+                    "description": "Include immutability policies."
+                  },
+                  {
+                    "name": "LegalHold",
+                    "value": "legalhold",
+                    "description": "Include legal hold."
+                  },
+                  {
+                    "name": "DeletedWithVersions",
+                    "value": "deletedwithversions",
+                    "description": "Include deleted with versions."
+                  }
+                ]
+              }
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\\\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\\\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          {
+            "name": "startFrom",
+            "in": "query",
+            "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; for recursive list, multiple entity levels are supported. (Inclusive)",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ListBlobsHierarchicalResponse"
+            },
+            "headers": {
+              "Date": {
+                "type": "string",
+                "format": "date-time-rfc7231",
+                "description": "Date-time value generated by the service that indicates the time at which the response was initiated."
+              },
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              },
+              "x-ms-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, server-generated string identifier for the request."
+              },
+              "x-ms-version": {
+                "type": "string",
+                "description": "Specifies the version of the operation to use for this request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "headers": {
+              "x-ms-copy-source-error-code": {
+                "type": "string",
+                "description": "The error code for the copy source."
+              },
+              "x-ms-copy-source-status-code": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The status code for the copy source."
+              },
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code."
+              }
+            }
+          }
+        }
+      }
+    },
+    "?restype=container&comp=list&_overload=listBlobHierarchySegmentApacheArrow": {
       "get": {
         "operationId": "Container_ListBlobHierarchySegmentApacheArrow",
         "description": "Returns a list of the blobs in Apache Arrow format as raw data, to be deserialized by the client. A delimiter can be used to traverse a virtual hierarchy of blobs as though it were a file system.",


### PR DESCRIPTION
Continuation of this PR https://github.com/Azure/azure-rest-api-specs/pull/44283
The apache arrow URIs should be the exact same as the original ListBlob URIs