### PR TITLE
Add optional status field to AgentIdentity model

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -672,6 +672,9 @@ model AgentIdentity {
 
   @doc("The client ID of the agent instance. Also referred to as the instance ID")
   client_id: string;
+
+  @doc("The status of the agent identity")
+  status?: string;
 }
 
 union AgentBlueprintReferenceType {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -673,11 +673,11 @@ model AgentIdentity {
   @doc("The client ID of the agent instance. Also referred to as the instance ID")
   client_id: string;
 
-  @doc("The status of the agent identity")
+  @doc("The status of the agent identity. Present for both the agent instance identity and the agent blueprint.")
   status?: AgentIdentityStatus;
 }
 
-@doc("The status of an agent identity.")
+@doc("The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.")
 union AgentIdentityStatus {
   string,
 

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -674,7 +674,18 @@ model AgentIdentity {
   client_id: string;
 
   @doc("The status of the agent identity")
-  status?: string;
+  status?: AgentIdentityStatus;
+}
+
+@doc("The status of an agent identity.")
+union AgentIdentityStatus {
+  string,
+
+  @doc("The agent identity is active and can be used to access resources.")
+  active: "active",
+
+  @doc("The agent identity is disabled and cannot be used to access resources.")
+  disabled: "disabled",
 }
 
 union AgentBlueprintReferenceType {


### PR DESCRIPTION
## Summary

Adds an optional string `status` property to the Foundry `AgentIdentity` model (`specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp`) to denote the status of the agent identity.

## Details

- Field: `status?: string` (optional, non-breaking)
- `AgentIdentity` is a read-only response model returned by agent Get operations (referenced as `instance_identity` / `blueprint`).

## Validation

- `tsp compile .` introduces no new errors. The 2 pre-existing errors in `tag-definitions.tsp` are unrelated to this change and present on the base branch as well.