### PR TITLE
Attestation (data-plane): .NET SDK client.tsp + http-client-csharp emitter config (2025-06-01 migration)

### DIFF
--- a/specification/attestation/data-plane/Attestation/client.tsp
+++ b/specification/attestation/data-plane/Attestation/client.tsp
@@ -6,6 +6,41 @@ using AttestationService;
 
 @@clientName(AttestationService, "AttestationClient", "!autorest");
 
+// AutoRest -> TypeSpec migration (Option 1): keep the generated operation (REST) clients
+// internal so the hand-written AttestationClient / AttestationAdministrationClient remain
+// the public API surface. Names match the legacy generated REST client names that the
+// existing custom code references.
+//
+// NOTE: @access targets operations (not interfaces) in this TCGC version, so access is
+// applied per-operation. Marking every operation internal makes the generated methods
+// internal and propagates internal access to the models they use.
+@@access(Policy.get, Access.internal);
+@@access(Policy.set, Access.internal);
+@@access(Policy.reset, Access.internal);
+@@clientName(Policy, "PolicyRestClient");
+
+@@access(PolicyCertificates.get, Access.internal);
+@@access(PolicyCertificates.add, Access.internal);
+@@access(PolicyCertificates.remove, Access.internal);
+@@clientName(PolicyCertificates, "PolicyCertificatesRestClient");
+
+@@access(Attestation.attestOpenEnclave, Access.internal);
+@@access(Attestation.attestSgxEnclave, Access.internal);
+@@access(Attestation.attestAzureGuest, Access.internal);
+@@access(Attestation.attestTpm, Access.internal);
+@@access(Attestation.attestSevSnpVm, Access.internal);
+@@access(Attestation.attestTdxVm, Access.internal);
+@@clientName(Attestation, "AttestationRestClient");
+
+@@access(TcbBaselines.get, Access.internal);
+@@clientName(TcbBaselines, "TcbBaselinesRestClient");
+
+@@access(SigningCertificates.get, Access.internal);
+@@clientName(SigningCertificates, "SigningCertificatesRestClient");
+
+@@access(MetadataConfiguration.get, Access.internal);
+@@clientName(MetadataConfiguration, "MetadataConfigurationRestClient");
+
 @@clientName(AttestationResult.`x-ms-sgx-svn`, "svn", "!autorest");
 @@clientName(AttestationResult.svn, "deprecatedSvn", "!autorest");
 
@@ -20,3 +55,15 @@ using AttestationService;
 @@usage(PolicyResult, Usage.output);
 @@usage(AttestationResult, Usage.output);
 @@usage(AttestationCertificateManagementBody, Usage.output);
+
+@@access(PolicyResult, Access.public);
+@@access(AttestationCertificateManagementBody, Access.public);
+@@access(TpmAttestationRequest, Access.public);
+@@access(CertificateModification, Access.public);
+@@usage(TpmAttestationRequest, Usage.input);
+
+// Unix-second timestamps: float32 loses precision for large epoch values (and DateTimeOffset.Max
+// overflows). Map to int64 in C# so the hand-written DateTimeOffset props round-trip exactly.
+@@alternateType(AttestationResult.iat, int64, "csharp");
+@@alternateType(AttestationResult.exp, int64, "csharp");
+@@alternateType(AttestationResult.nbf, int64, "csharp");

--- a/specification/attestation/data-plane/Attestation/client.tsp
+++ b/specification/attestation/data-plane/Attestation/client.tsp
@@ -6,23 +6,15 @@ using AttestationService;
 
 @@clientName(AttestationService, "AttestationClient", "!autorest");
 
-// AutoRest -> TypeSpec migration (Option 1): keep the generated operation (REST) clients
-// internal so the hand-written AttestationClient / AttestationAdministrationClient remain
-// the public API surface. Names match the legacy generated REST client names that the
-// existing custom code references.
-//
-// NOTE: @access targets operations (not interfaces) in this TCGC version, so access is
-// applied per-operation. Marking every operation internal makes the generated methods
-// internal and propagates internal access to the models they use.
 @@access(Policy.get, Access.internal);
 @@access(Policy.set, Access.internal);
 @@access(Policy.reset, Access.internal);
-@@clientName(Policy, "PolicyRestClient");
+@@clientName(Policy, "PolicyRestClient", "!autorest");
 
 @@access(PolicyCertificates.get, Access.internal);
 @@access(PolicyCertificates.add, Access.internal);
 @@access(PolicyCertificates.remove, Access.internal);
-@@clientName(PolicyCertificates, "PolicyCertificatesRestClient");
+@@clientName(PolicyCertificates, "PolicyCertificatesRestClient", "!autorest");
 
 @@access(Attestation.attestOpenEnclave, Access.internal);
 @@access(Attestation.attestSgxEnclave, Access.internal);
@@ -30,16 +22,20 @@ using AttestationService;
 @@access(Attestation.attestTpm, Access.internal);
 @@access(Attestation.attestSevSnpVm, Access.internal);
 @@access(Attestation.attestTdxVm, Access.internal);
-@@clientName(Attestation, "AttestationRestClient");
+@@clientName(Attestation, "AttestationRestClient", "!autorest");
 
 @@access(TcbBaselines.get, Access.internal);
-@@clientName(TcbBaselines, "TcbBaselinesRestClient");
+@@clientName(TcbBaselines, "TcbBaselinesRestClient", "!autorest");
 
 @@access(SigningCertificates.get, Access.internal);
-@@clientName(SigningCertificates, "SigningCertificatesRestClient");
+@@clientName(SigningCertificates, "SigningCertificatesRestClient", "!autorest");
 
 @@access(MetadataConfiguration.get, Access.internal);
-@@clientName(MetadataConfiguration, "MetadataConfigurationRestClient");
+@@clientName(
+  MetadataConfiguration,
+  "MetadataConfigurationRestClient",
+  "!autorest"
+);
 
 @@clientName(AttestationResult.`x-ms-sgx-svn`, "svn", "!autorest");
 @@clientName(AttestationResult.svn, "deprecatedSvn", "!autorest");
@@ -62,8 +58,6 @@ using AttestationService;
 @@access(CertificateModification, Access.public);
 @@usage(TpmAttestationRequest, Usage.input);
 
-// Unix-second timestamps: float32 loses precision for large epoch values (and DateTimeOffset.Max
-// overflows). Map to int64 in C# so the hand-written DateTimeOffset props round-trip exactly.
 @@alternateType(AttestationResult.iat, int64, "csharp");
 @@alternateType(AttestationResult.exp, int64, "csharp");
 @@alternateType(AttestationResult.nbf, int64, "csharp");

--- a/specification/attestation/data-plane/Attestation/client.tsp
+++ b/specification/attestation/data-plane/Attestation/client.tsp
@@ -4,59 +4,59 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using AttestationService;
 
-@@clientName(AttestationService, "AttestationClient", "!autorest");
+@@clientName(AttestationService, "AttestationClient", "csharp");
 
-@@access(Policy.get, Access.internal);
-@@access(Policy.set, Access.internal);
-@@access(Policy.reset, Access.internal);
-@@clientName(Policy, "PolicyRestClient", "!autorest");
+@@access(Policy.get, Access.internal, "csharp");
+@@access(Policy.set, Access.internal, "csharp");
+@@access(Policy.reset, Access.internal, "csharp");
+@@clientName(Policy, "PolicyRestClient", "csharp");
 
-@@access(PolicyCertificates.get, Access.internal);
-@@access(PolicyCertificates.add, Access.internal);
-@@access(PolicyCertificates.remove, Access.internal);
-@@clientName(PolicyCertificates, "PolicyCertificatesRestClient", "!autorest");
+@@access(PolicyCertificates.get, Access.internal, "csharp");
+@@access(PolicyCertificates.add, Access.internal, "csharp");
+@@access(PolicyCertificates.remove, Access.internal, "csharp");
+@@clientName(PolicyCertificates, "PolicyCertificatesRestClient", "csharp");
 
-@@access(Attestation.attestOpenEnclave, Access.internal);
-@@access(Attestation.attestSgxEnclave, Access.internal);
-@@access(Attestation.attestAzureGuest, Access.internal);
-@@access(Attestation.attestTpm, Access.internal);
-@@access(Attestation.attestSevSnpVm, Access.internal);
-@@access(Attestation.attestTdxVm, Access.internal);
-@@clientName(Attestation, "AttestationRestClient", "!autorest");
+@@access(Attestation.attestOpenEnclave, Access.internal, "csharp");
+@@access(Attestation.attestSgxEnclave, Access.internal, "csharp");
+@@access(Attestation.attestAzureGuest, Access.internal, "csharp");
+@@access(Attestation.attestTpm, Access.internal, "csharp");
+@@access(Attestation.attestSevSnpVm, Access.internal, "csharp");
+@@access(Attestation.attestTdxVm, Access.internal, "csharp");
+@@clientName(Attestation, "AttestationRestClient", "csharp");
 
-@@access(TcbBaselines.get, Access.internal);
-@@clientName(TcbBaselines, "TcbBaselinesRestClient", "!autorest");
+@@access(TcbBaselines.get, Access.internal, "csharp");
+@@clientName(TcbBaselines, "TcbBaselinesRestClient", "csharp");
 
-@@access(SigningCertificates.get, Access.internal);
-@@clientName(SigningCertificates, "SigningCertificatesRestClient", "!autorest");
+@@access(SigningCertificates.get, Access.internal, "csharp");
+@@clientName(SigningCertificates, "SigningCertificatesRestClient", "csharp");
 
-@@access(MetadataConfiguration.get, Access.internal);
+@@access(MetadataConfiguration.get, Access.internal, "csharp");
 @@clientName(
   MetadataConfiguration,
   "MetadataConfigurationRestClient",
-  "!autorest"
+  "csharp"
 );
 
-@@clientName(AttestationResult.`x-ms-sgx-svn`, "svn", "!autorest");
-@@clientName(AttestationResult.svn, "deprecatedSvn", "!autorest");
+@@clientName(AttestationResult.`x-ms-sgx-svn`, "svn", "csharp");
+@@clientName(AttestationResult.svn, "deprecatedSvn", "csharp");
 
-@@usage(CertificateModification, Usage.output);
-@@usage(PolicyModification, Usage.output);
-@@usage(AttestOpenEnclaveRequest, Usage.output);
-@@usage(AttestSgxEnclaveRequest, Usage.output);
-@@usage(JsonWebKeySet, Usage.output);
-@@usage(PolicyCertificatesResult, Usage.output);
-@@usage(PolicyCertificatesModificationResult, Usage.output);
-@@usage(StoredAttestationPolicy, Usage.output);
-@@usage(PolicyResult, Usage.output);
-@@usage(AttestationResult, Usage.output);
-@@usage(AttestationCertificateManagementBody, Usage.output);
+@@usage(CertificateModification, Usage.output, "csharp");
+@@usage(PolicyModification, Usage.output, "csharp");
+@@usage(AttestOpenEnclaveRequest, Usage.output, "csharp");
+@@usage(AttestSgxEnclaveRequest, Usage.output, "csharp");
+@@usage(JsonWebKeySet, Usage.output, "csharp");
+@@usage(PolicyCertificatesResult, Usage.output, "csharp");
+@@usage(PolicyCertificatesModificationResult, Usage.output, "csharp");
+@@usage(StoredAttestationPolicy, Usage.output, "csharp");
+@@usage(PolicyResult, Usage.output, "csharp");
+@@usage(AttestationResult, Usage.output, "csharp");
+@@usage(AttestationCertificateManagementBody, Usage.output, "csharp");
 
-@@access(PolicyResult, Access.public);
-@@access(AttestationCertificateManagementBody, Access.public);
-@@access(TpmAttestationRequest, Access.public);
-@@access(CertificateModification, Access.public);
-@@usage(TpmAttestationRequest, Usage.input);
+@@access(PolicyResult, Access.public, "csharp");
+@@access(AttestationCertificateManagementBody, Access.public, "csharp");
+@@access(TpmAttestationRequest, Access.public, "csharp");
+@@access(CertificateModification, Access.public, "csharp");
+@@usage(TpmAttestationRequest, Usage.input, "csharp");
 
 @@alternateType(AttestationResult.iat, int64, "csharp");
 @@alternateType(AttestationResult.exp, int64, "csharp");

--- a/specification/attestation/data-plane/Attestation/tspconfig.yaml
+++ b/specification/attestation/data-plane/Attestation/tspconfig.yaml
@@ -22,6 +22,10 @@ options:
     flavor: "azure"
     generate-test: false
     generate-sample: false
+  "@azure-typespec/http-client-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    namespace: "Azure.Security.Attestation"
+    model-namespace: false
   "@azure-tools/typespec-csharp":
     namespace: "Azure.Security.Attestation"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

- SDK-configuration-only change for the Azure.Security.Attestation .NET data-plane SDK migration to the TypeSpec `@azure-typespec/http-client-csharp` emitter (service API version 2025-06-01). No changes to the API specification (main.tsp / models.tsp / routes.tsp) — the REST/wire contract is unchanged.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Changes
- tspconfig.yaml: add the `@azure-typespec/http-client-csharp` emitter block (emitter-output-dir, namespace: Azure.Security.Attestation, model-namespace: false).
- client.tsp: .NET client customizations (all SDK-shaping, no wire impact):
  - Keep generated operation (REST) clients internal + restore legacy `*RestClient` names so the hand-written AttestationClient / AttestationAdministrationClient stay the public surface.
  - @@access / @@usage to emit the JWT-token-body models the new emitter otherwise skips.
  - @@alternateType(AttestationResult.iat|exp|nbf, int64, "csharp") — Unix-second
    timestamps (float32 loses precision / overflows) mapped to int64 in C# only.

## Related
- .NET SDK PR: <link to the azure-sdk-for-net PR> (to be opened)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
