### PR TITLE
[Translation] Fix DocumentTranslation getSupportedFormats 'type' parameter and response enum casing

### DIFF
--- a/specification/translation/data-plane/DocumentTranslation/examples/2024-05-01/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/examples/2024-05-01/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/examples/2024-11-01-preview/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/examples/2024-11-01-preview/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/examples/2025-12-01-preview/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/examples/2025-12-01-preview/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/models.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/models.tsp
@@ -46,10 +46,10 @@ model DocumentTranslateResult {
 @doc("Format types")
 union FileFormatType {
   @doc("Document type file format")
-  Document: "document",
+  Document: "Document",
 
   @doc("Glossary type file format")
-  Glossary: "glossary",
+  Glossary: "Glossary",
 
   string,
 }

--- a/specification/translation/data-plane/DocumentTranslation/models.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/models.tsp
@@ -14,7 +14,7 @@ model DocumentTranslateContent {
   document: HttpPart<bytes>;
 
   @doc("Glossary-translation memory will be used during translation in the form. ")
-  glossary?: HttpPart<bytes[]>;
+  glossary?: HttpPart<bytes>[];
 }
 
 @doc("Document Translate Result / Response.")

--- a/specification/translation/data-plane/DocumentTranslation/preview/2024-11-01-preview/examples/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/preview/2024-11-01-preview/examples/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/preview/2024-11-01-preview/openapi.json
+++ b/specification/translation/data-plane/DocumentTranslation/preview/2024-11-01-preview/openapi.json
@@ -396,11 +396,11 @@
             "name": "type",
             "in": "query",
             "description": "the type of format like document or glossary ",
-            "required": false,
+            "required": true,
             "type": "string",
             "enum": [
-              "document",
-              "glossary"
+              "Document",
+              "Glossary"
             ],
             "x-ms-enum": {
               "name": "FileFormatType",
@@ -408,12 +408,12 @@
               "values": [
                 {
                   "name": "Document",
-                  "value": "document",
+                  "value": "Document",
                   "description": "Document type file format"
                 },
                 {
                   "name": "Glossary",
-                  "value": "glossary",
+                  "value": "Glossary",
                   "description": "Glossary type file format"
                 }
               ]
@@ -842,8 +842,8 @@
       "type": "string",
       "description": "Format types",
       "enum": [
-        "document",
-        "glossary"
+        "Document",
+        "Glossary"
       ],
       "x-ms-enum": {
         "name": "FileFormatType",
@@ -851,12 +851,12 @@
         "values": [
           {
             "name": "Document",
-            "value": "document",
+            "value": "Document",
             "description": "Document type file format"
           },
           {
             "name": "Glossary",
-            "value": "glossary",
+            "value": "Glossary",
             "description": "Glossary type file format"
           }
         ]

--- a/specification/translation/data-plane/DocumentTranslation/preview/2025-12-01-preview/examples/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/preview/2025-12-01-preview/examples/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/preview/2025-12-01-preview/openapi.json
+++ b/specification/translation/data-plane/DocumentTranslation/preview/2025-12-01-preview/openapi.json
@@ -396,11 +396,11 @@
             "name": "type",
             "in": "query",
             "description": "the type of format like document or glossary ",
-            "required": false,
+            "required": true,
             "type": "string",
             "enum": [
-              "document",
-              "glossary"
+              "Document",
+              "Glossary"
             ],
             "x-ms-enum": {
               "name": "FileFormatType",
@@ -408,12 +408,12 @@
               "values": [
                 {
                   "name": "Document",
-                  "value": "document",
+                  "value": "Document",
                   "description": "Document type file format"
                 },
                 {
                   "name": "Glossary",
-                  "value": "glossary",
+                  "value": "Glossary",
                   "description": "Glossary type file format"
                 }
               ]
@@ -852,8 +852,8 @@
       "type": "string",
       "description": "Format types",
       "enum": [
-        "document",
-        "glossary"
+        "Document",
+        "Glossary"
       ],
       "x-ms-enum": {
         "name": "FileFormatType",
@@ -861,12 +861,12 @@
         "values": [
           {
             "name": "Document",
-            "value": "document",
+            "value": "Document",
             "description": "Document type file format"
           },
           {
             "name": "Glossary",
-            "value": "glossary",
+            "value": "Glossary",
             "description": "Glossary type file format"
           }
         ]

--- a/specification/translation/data-plane/DocumentTranslation/routes.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/routes.tsp
@@ -275,7 +275,7 @@ interface DocumentTranslationOperations {
     {
       @doc("the type of format like document or glossary ")
       @query("type")
-      type?: FileFormatType;
+      type: FileFormatType;
     },
     SupportedFileFormats
   >;

--- a/specification/translation/data-plane/DocumentTranslation/stable/2024-05-01/examples/format.json
+++ b/specification/translation/data-plane/DocumentTranslation/stable/2024-05-01/examples/format.json
@@ -7,7 +7,7 @@
     "resourceGroupName": "TestResourceGroup",
     "endpoint": "{endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "type": "document"
+    "type": "Document"
   },
   "responses": {
     "200": {
@@ -24,7 +24,8 @@
             ],
             "contentTypes": [
               "text/plain"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "PortableDocumentFormat",
@@ -33,7 +34,8 @@
             ],
             "contentTypes": [
               "application/pdf"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlWord",
@@ -42,7 +44,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlPresentation",
@@ -51,7 +54,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "OpenXmlSpreadsheet",
@@ -60,7 +64,8 @@
             ],
             "contentTypes": [
               "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ]
+            ],
+            "type": "Document"
           },
           {
             "format": "HtmlFile",
@@ -70,7 +75,8 @@
             ],
             "contentTypes": [
               "text/html"
-            ]
+            ],
+            "type": "Document"
           }
         ]
       }

--- a/specification/translation/data-plane/DocumentTranslation/stable/2024-05-01/openapi.json
+++ b/specification/translation/data-plane/DocumentTranslation/stable/2024-05-01/openapi.json
@@ -396,11 +396,11 @@
             "name": "type",
             "in": "query",
             "description": "the type of format like document or glossary ",
-            "required": false,
+            "required": true,
             "type": "string",
             "enum": [
-              "document",
-              "glossary"
+              "Document",
+              "Glossary"
             ],
             "x-ms-enum": {
               "name": "FileFormatType",
@@ -408,12 +408,12 @@
               "values": [
                 {
                   "name": "Document",
-                  "value": "document",
+                  "value": "Document",
                   "description": "Document type file format"
                 },
                 {
                   "name": "Glossary",
-                  "value": "glossary",
+                  "value": "Glossary",
                   "description": "Glossary type file format"
                 }
               ]
@@ -803,8 +803,8 @@
       "type": "string",
       "description": "Format types",
       "enum": [
-        "document",
-        "glossary"
+        "Document",
+        "Glossary"
       ],
       "x-ms-enum": {
         "name": "FileFormatType",
@@ -812,12 +812,12 @@
         "values": [
           {
             "name": "Document",
-            "value": "document",
+            "value": "Document",
             "description": "Document type file format"
           },
           {
             "name": "Glossary",
-            "value": "glossary",
+            "value": "Glossary",
             "description": "Glossary type file format"
           }
         ]

--- a/specification/translation/data-plane/DocumentTranslation/tspconfig.yaml
+++ b/specification/translation/data-plane/DocumentTranslation/tspconfig.yaml
@@ -43,11 +43,10 @@ options:
     flavor: azure
     api-version: "2024-05-01"
   "@azure-tools/typespec-ts":
-    emitter-output-dir: "{output-dir}/{service-dir}/ai-translation-document-rest"
+    emitter-output-dir: "{output-dir}/{service-dir}/ai-translation-document"
     generate-metadata: true
-    is-modular-library: false
     package-details:
-      name: "@azure-rest/ai-translation-document"
+      name: "@azure/ai-translation-document"
       description: "Microsoft Translation Document"
     flavor: azure
     generate-sample-project: false


### PR DESCRIPTION
## Summary

Corrects long-standing inaccuracies in the Document Translation API, across all existing versions (`2024-05-01`, `2024-11-01-preview`, `2025-12-01-preview`). **The actual service wire contract is unchanged** — these edits make the spec match real service behavior.

### 1. `getSupportedFormats` `type` query parameter is required
The service returns **404** when `type` is omitted, and only accepts the request when `type` is present (an empty `type=` is accepted). The parameter was modeled as optional. Changed to required.

### 2. `FileFormatType` response enum casing
The service returns **PascalCase** values (`"Document"` / `"Glossary"`) in the `FileFormat.type` response, but the enum declared lowercase (`"document"` / `"glossary"`), so SDK consumers comparing the response value against the enum constant silently failed. Corrected the enum values to PascalCase.

- The `type` query parameter is **case-insensitive** and the enum is **extensible** (`modelAsString`), so the request remains fully backward-compatible (empty and any-casing values still accepted).

### 3. `document:translate` glossary multipart type
The `glossary` form field on `DocumentTranslateContent` was declared as `HttpPart<bytes[]>` (array **inside** the part). This models the glossary as a **single** multipart part whose body is a base64-encoded JSON array (`format: byte`, `contentType: application/json`) rather than what the service actually accepts: **multiple binary glossary file parts**. Changed to `HttpPart<bytes>[]` (array **outside** the part) so each glossary file is a separate raw binary part (`format: binary`).

- This bug has existed since the multipart models were migrated to `HttpPart<>`. It was masked because the **Swagger 2.0 (autorest) `openapi.json` output is byte-for-byte identical** for both forms — the divergence only appears in the TypeSpec HTTP metadata that the language SDK emitters consume (verified via the OpenAPI 3 emitter: `format: byte` + `application/json` encoding → `format: binary`). So there is **no `openapi.json` diff** for this change, but generated SDKs now correctly model multi-file binary glossary upload.

## Changes
- `models.tsp` — `FileFormatType` values → PascalCase; `glossary` → `HttpPart<bytes>[]`.
- `routes.tsp` — `getSupportedFormats` `type` param → required.
- Regenerated `openapi.json` for all three versions; updated `format.json` examples' request `type` value. (The glossary fix produces no `openapi.json` diff.)

## Reviewer note
The breaking-change tooling will flag `required: false → true` and the enum-value casing change on the published versions. These are **spec corrections, not contract changes** — the service has always behaved this way — so a suppression / breaking-change-board acknowledgement is expected. The glossary fix does not change `openapi.json`, but it does change generated SDK surface (single base64 part → multiple binary parts); SDK/namespace reviewers should be aware.
