### PR TITLE
[TSP Migration][monitor] Apply JS duplicate-model customizations to Python scope

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
@@ -930,32 +930,32 @@ namespace Microsoft.InsightsCombinedClient;
 @@alternateType(
   TenantActionGroups.EmailReceiver,
   ActionGroupsApi.EmailReceiver,
-  "javascript"
+  "javascript,python"
 );
 @@alternateType(
   TenantActionGroups.SmsReceiver,
   ActionGroupsApi.SmsReceiver,
-  "javascript"
+  "javascript,python"
 );
 @@alternateType(
   TenantActionGroups.AzureAppPushReceiver,
   ActionGroupsApi.AzureAppPushReceiver,
-  "javascript"
+  "javascript,python"
 );
 @@alternateType(
   TenantActionGroups.VoiceReceiver,
   ActionGroupsApi.VoiceReceiver,
-  "javascript"
+  "javascript,python"
 );
 @@alternateType(
   TenantActionGroups.Context,
   ActionGroupsApi.Context,
-  "javascript"
+  "javascript,python"
 );
 @@alternateType(
   TenantActionGroups.ActionGroupPatch,
   ActionGroupsApi.ActionGroupPatch,
-  "javascript"
+  "javascript,python"
 );
 
 // These models also collide by name across TenantActionGroups and ActionGroupsApi,
@@ -969,22 +969,22 @@ namespace Microsoft.InsightsCombinedClient;
 @@clientName(
   TenantActionGroups.WebhookReceiver,
   "TenantActionGroupWebhookReceiver",
-  "javascript"
+  "javascript,python"
 );
 @@clientName(
   TenantActionGroups.ActionGroupPatchBody,
   "TenantActionGroupPatchBody",
-  "javascript"
+  "javascript,python"
 );
 @@clientName(
   TenantActionGroups.ActionDetail,
   "TenantActionGroupActionDetail",
-  "javascript"
+  "javascript,python"
 );
 @@clientName(
   TenantActionGroups.TestNotificationDetailsResponse,
   "TenantActionGroupTestNotificationDetailsResponse",
-  "javascript"
+  "javascript,python"
 );
 
 @@clientName(
@@ -1477,15 +1477,16 @@ model MetricSettings {
 @@alternateType(
   ServiceDiagnosticsSettingsApi.MetricSettings,
   MetricSettings,
-  "csharp,java,python"
+  "csharp,java"
 );
 // For JS, redirect straight to DiagnosticsSettings.MetricSettings (identical to the
 // local MetricSettings) so the local Microsoft.InsightsCombinedClient.MetricSettings
 // is not emitted and no longer collides with DiagnosticsSettings.MetricSettings.
+// Python flattens models into a single module like JS, so it takes the same redirect.
 @@alternateType(
   ServiceDiagnosticsSettingsApi.MetricSettings,
   DiagnosticsSettings.MetricSettings,
-  "javascript"
+  "javascript,python"
 );
 
 /**
@@ -1517,15 +1518,16 @@ model LogSettings {
 @@alternateType(
   ServiceDiagnosticsSettingsApi.LogSettings,
   LogSettings,
-  "csharp,java,python"
+  "csharp,java"
 );
 // For JS, redirect straight to DiagnosticsSettings.LogSettings (identical to the local
 // LogSettings) so ServiceDiagnosticsSettingsApi.LogSettings no longer collides with
 // DiagnosticsSettings.LogSettings.
+// Python flattens models into a single module like JS, so it takes the same redirect.
 @@alternateType(
   ServiceDiagnosticsSettingsApi.LogSettings,
   DiagnosticsSettings.LogSettings,
-  "javascript"
+  "javascript,python"
 );
 
 @@clientLocation(


### PR DESCRIPTION
Applies the same duplicate-model client customizations that JavaScript and Go use to the **Python** emitter scope, fixing the Python SDK generation failures on top of #44471.

### Why
Python, like JavaScript, emits all models into a single flat `models` module, so identically-named models from different TypeSpec namespaces collide. C#/Java/Go disambiguate via language namespaces/packages and are unaffected. The JS customizations already added in #44471 solve exactly these 13 collisions, so Python simply reuses them.

### Changes (client.tsp scope only)
**Group A — TenantActionGroups vs ActionGroupsApi (11 models)**
- 6 identical-shape models merged via `@@alternateType(TenantActionGroups.X, ActionGroupsApi.X, ...)`: EmailReceiver, SmsReceiver, AzureAppPushReceiver, VoiceReceiver, Context, ActionGroupPatch
- `ReceiverStatus` (enum) auto-orphaned once receivers are redirected
- 4 differing-shape models renamed via `@@clientName(..., "TenantActionGroup...")`: WebhookReceiver, ActionGroupPatchBody, ActionDetail, TestNotificationDetailsResponse
- Scope changed `"javascript"` -> `"javascript,python"`

**Group B — DiagnosticsSettings vs ServiceDiagnosticsSettingsApi (2 models)**
- MetricSettings / LogSettings: Python now takes the JS redirect to `DiagnosticsSettings.X` (single surviving model) instead of the local model, which still collided with `DiagnosticsSettings.X`
- Local redirect scope `"csharp,java,python"` -> `"csharp,java"`; Diagnostics redirect `"javascript"` -> `"javascript,python"`

No emitter/generator changes — both decorators are already Python-supported in TCGC.

Target branch: `convert/multi-version/monitor` (merge after Python regeneration validation).