### PR TITLE
fix: isolation header for Foundry data-plane

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1379,10 +1379,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1410,8 +1410,8 @@
                 }
               },
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -1547,10 +1547,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1571,8 +1571,8 @@
             "description": "The request has succeeded.",
             "headers": {
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -1635,10 +1635,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1659,8 +1659,8 @@
             "description": "The request has succeeded.",
             "headers": {
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -12387,10 +12387,10 @@
         "description": "Creates a new conversation resource.",
         "parameters": [
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -12528,10 +12528,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -12616,10 +12616,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -12704,10 +12704,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -12782,10 +12782,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -12875,10 +12875,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -13028,10 +13028,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -13144,10 +13144,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -13231,10 +13231,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -17183,10 +17183,10 @@
         "description": "Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.",
         "parameters": [
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -18042,10 +18042,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -18234,10 +18234,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -18324,10 +18324,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -18411,10 +18411,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -18540,10 +18540,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -923,10 +923,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -946,8 +946,8 @@ paths:
               schema:
                 type: string
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -1036,10 +1036,10 @@ paths:
           description: The unique identifier of the invocation.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -1054,8 +1054,8 @@ paths:
           description: The request has succeeded.
           headers:
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the session ID associated with the invocation.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -1095,10 +1095,10 @@ paths:
           description: The unique identifier of the invocation to cancel.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -1113,8 +1113,8 @@ paths:
           description: The request has succeeded.
           headers:
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the session ID associated with the invocation.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -13156,10 +13156,10 @@ paths:
       summary: Create a conversation
       description: Creates a new conversation resource.
       parameters:
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -13380,10 +13380,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -13438,10 +13438,10 @@ paths:
           description: The id of the conversation to update.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -13619,10 +13619,10 @@ paths:
           description: The id of the conversation to retrieve.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -13757,10 +13757,10 @@ paths:
           description: The id of the conversation to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -13906,10 +13906,10 @@ paths:
             items:
               type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -14224,10 +14224,10 @@ paths:
           schema:
             $ref: '#/components/schemas/OpenAI.ItemType'
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -14410,10 +14410,10 @@ paths:
           description: The id of the conversation item to retrieve.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -14576,10 +14576,10 @@ paths:
           description: The id of the conversation item to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -23799,10 +23799,10 @@ paths:
       summary: Create a model response
       description: Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.
       parameters:
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -25821,10 +25821,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -26112,10 +26112,10 @@ paths:
             type: integer
             format: int32
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -26307,10 +26307,10 @@ paths:
           description: The ID of the response to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -26434,10 +26434,10 @@ paths:
           description: The ID of the response to cancel.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -26653,10 +26653,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -1045,8 +1045,8 @@
             "description": "The request has succeeded.",
             "headers": {
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -1506,10 +1506,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1537,8 +1537,8 @@
                 }
               },
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -1674,10 +1674,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1698,8 +1698,8 @@
             "description": "The request has succeeded.",
             "headers": {
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -1762,10 +1762,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -1786,8 +1786,8 @@
             "description": "The request has succeeded.",
             "headers": {
               "x-agent-session-id": {
-                "required": true,
-                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
                 "schema": {
                   "type": "string"
                 }
@@ -15305,10 +15305,10 @@
         "description": "Creates a new conversation resource.",
         "parameters": [
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15446,10 +15446,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15534,10 +15534,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15622,10 +15622,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15700,10 +15700,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15793,10 +15793,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -15946,10 +15946,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -16062,10 +16062,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -16149,10 +16149,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -20101,10 +20101,10 @@
         "description": "Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.",
         "parameters": [
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -20984,10 +20984,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -21176,10 +21176,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -21266,10 +21266,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -21353,10 +21353,10 @@
             }
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }
@@ -21482,10 +21482,10 @@
             "explode": false
           },
           {
-            "name": "x-ms-user-identity",
+            "name": "x-agent-session-id",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
             "schema": {
               "type": "string"
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -695,8 +695,8 @@ paths:
           description: The request has succeeded.
           headers:
             x-agent-session-id:
-              required: true
-              description: Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -1012,10 +1012,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -1035,8 +1035,8 @@ paths:
               schema:
                 type: string
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -1125,10 +1125,10 @@ paths:
           description: The unique identifier of the invocation.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -1143,8 +1143,8 @@ paths:
           description: The request has succeeded.
           headers:
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the session ID associated with the invocation.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -1184,10 +1184,10 @@ paths:
           description: The unique identifier of the invocation to cancel.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
         - name: api-version
@@ -1202,8 +1202,8 @@ paths:
           description: The request has succeeded.
           headers:
             x-agent-session-id:
-              required: true
-              description: Session ID for this invocation. Returns the session ID associated with the invocation.
+              required: false
+              description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
               schema:
                 type: string
           content:
@@ -15085,10 +15085,10 @@ paths:
       summary: Create a conversation
       description: Creates a new conversation resource.
       parameters:
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -15309,10 +15309,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -15367,10 +15367,10 @@ paths:
           description: The id of the conversation to update.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -15548,10 +15548,10 @@ paths:
           description: The id of the conversation to retrieve.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -15686,10 +15686,10 @@ paths:
           description: The id of the conversation to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -15835,10 +15835,10 @@ paths:
             items:
               type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -16153,10 +16153,10 @@ paths:
           schema:
             $ref: '#/components/schemas/OpenAI.ItemType'
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -16339,10 +16339,10 @@ paths:
           description: The id of the conversation item to retrieve.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -16505,10 +16505,10 @@ paths:
           description: The id of the conversation item to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -25728,10 +25728,10 @@ paths:
       summary: Create a model response
       description: Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.
       parameters:
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -27775,10 +27775,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -28066,10 +28066,10 @@ paths:
             type: integer
             format: int32
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -28261,10 +28261,10 @@ paths:
           description: The ID of the response to delete.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -28388,10 +28388,10 @@ paths:
           description: The ID of the response to cancel.
           schema:
             type: string
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:
@@ -28607,10 +28607,10 @@ paths:
           schema:
             type: string
           explode: false
-        - name: x-ms-user-identity
+        - name: x-agent-session-id
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          description: Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.
           schema:
             type: string
       responses:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -50,14 +50,13 @@ interface AgentInvocations {
       /** The request body. */
       @body request: unknown;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     {
       /** Unique identifier for this invocation. */
       @header("x-agent-invocation-id") invocationId: string;
 
-      /** Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request. */
-      @header("x-agent-session-id") agentSessionId: string;
+      ...AgentSessionIdResponseHeader;
 
       /** The content type of the response body. */
       @header contentType: string;
@@ -82,11 +81,10 @@ interface AgentInvocations {
       /** The unique identifier of the invocation. */
       @path invocation_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     {
-      /** Session ID for this invocation. Returns the session ID associated with the invocation. */
-      @header("x-agent-session-id") agentSessionId: string;
+      ...AgentSessionIdResponseHeader;
 
       /** The content type of the response body. */
       @header contentType: string;
@@ -117,11 +115,10 @@ interface AgentInvocations {
       /** Optional request body. */
       @body request?: unknown;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     {
-      /** Session ID for this invocation. Returns the session ID associated with the invocation. */
-      @header("x-agent-session-id") agentSessionId: string;
+      ...AgentSessionIdResponseHeader;
 
       /** The content type of the response body. */
       @header contentType: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -46,8 +46,7 @@ interface AgentWebsocket {
       ];
     } & AgentWebsocketPreviewHeader,
     {
-      /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */
-      @header("x-agent-session-id") sessionId: string;
+      ...AgentSessionIdResponseHeader;
 
       /** The response body (101 Switching Protocols). */
       @body response: unknown;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -28,18 +28,6 @@ alias AcceptJsonHeader = {
   @header accept: "application/json";
 };
 
-/**
- * Optional request header carrying an opaque per-user identity for delegation.
- * When present and the caller has the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission,
- * the service scopes endpoint-scoped data (responses, conversations, sessions) to the
- * supplied user identity instead of the caller's own identity.
- * If the caller has delegation RBAC but does not pass this header, the caller's own identity is used.
- */
-alias UserDelegationHeader = {
-  /** Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission. */
-  @header("x-ms-user-identity") user_identity?: string;
-};
-
 // NOTE: Platform-internal headers (x-agent-foundry-call-id, x-foundry-foundation-token)
 // are NOT part of the public API spec. They are injected by the platform and resolved
 // server-side. If needed for contracts, they should be added in the contracts entry point.

--- a/specification/ai-foundry/data-plane/Foundry/src/common/openai-templates.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/openai-templates.tsp
@@ -6,6 +6,7 @@ using TypeSpec.Http;
 
 namespace Azure.AI.Projects;
 
+/** Optional response header containing the session ID for hosted agent requests. */
 alias AgentSessionIdResponseHeader = {
   @doc("Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.")
   @header("x-agent-session-id")
@@ -31,7 +32,7 @@ op OpenAIAgentOperation<
   ErrorResponse = ApiErrorResponse
 > is OpenAIOperation<
   {
-    ...UserIsolationKeyHeader;
+    ...AgentSessionIdResponseHeader;
     ...Params;
   },
   Response,
@@ -46,7 +47,7 @@ op OpenAIAgentSessionOperation<
   Params extends Reflection.Model,
   Response extends Reflection.Model,
   ErrorResponse = ApiErrorResponse
->(...UserIsolationKeyHeader, ...Params):
+>(...AgentSessionIdResponseHeader, ...Params):
   | (Response & AgentSessionIdResponseHeader)
   | AzureRangeErrorResponse<ErrorResponse>;
 
@@ -58,7 +59,7 @@ op OpenAIAgentStreamingOperation<
   Params extends Reflection.Model,
   Event,
   ErrorResponse = ApiErrorResponse
->(...UserIsolationKeyHeader, ...Params):
+>(...AgentSessionIdResponseHeader, ...Params):
   | SseResponseOf<Event>
   | AzureRangeErrorResponse<ErrorResponse>;
 
@@ -71,7 +72,7 @@ op OpenAIAgentPagedOperation<
   ErrorResponse = ApiErrorResponse
 > is OpenAIOperation<
   {
-    ...UserIsolationKeyHeader;
+    ...AgentSessionIdResponseHeader;
     ...Params;
   },
   Response,
@@ -86,6 +87,6 @@ op OpenAIAgentFilteredPagedOperation<
   Params extends Reflection.Model,
   Item extends Reflection.Model,
   ErrorResponse = ApiErrorResponse
->(...UserIsolationKeyHeader, ...CommonPageQueryParameters, ...Params):
+>(...AgentSessionIdResponseHeader, ...CommonPageQueryParameters, ...Params):
   | AgentsPagedResult<Item>
   | AzureRangeErrorResponse<ErrorResponse>;

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/conversations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/conversations/routes.tsp
@@ -1,6 +1,7 @@
 import "./models.tsp";
 import "../../common/models.tsp";
 import "../responses/models.tsp";
+import "../../common/openai-templates.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
@@ -19,7 +20,7 @@ interface Conversations {
   @post
   @operationId("createConversation")
   createConversation is OpenAIOperation<
-    OpenAI.CreateConversationBody & UserDelegationHeader,
+    OpenAI.CreateConversationBody & AgentSessionIdResponseHeader,
     OpenAI.ConversationResource
   >;
 
@@ -36,7 +37,7 @@ interface Conversations {
       @path conversation_id: string;
 
       ...OpenAI.UpdateConversationBody;
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -53,7 +54,7 @@ interface Conversations {
       /** The id of the conversation to retrieve. */
       @path conversation_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -70,7 +71,7 @@ interface Conversations {
       /** The id of the conversation to delete. */
       @path conversation_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.DeletedConversationResource
   >;
@@ -90,7 +91,7 @@ interface Conversations {
       ...CommonPageQueryParameters;
       ...AgentNameQueryParam;
       ...AgentIdQueryParam;
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentsPagedResult<OpenAI.ConversationResource>
   >;
@@ -118,7 +119,7 @@ interface Conversations {
       @maxItems(20)
       items: OpenAI.Item[];
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.ConversationItemList
   >;
@@ -138,7 +139,7 @@ interface Conversations {
       /** The id of the conversation item to retrieve. */
       @path item_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.OutputItem
   >;
@@ -158,7 +159,7 @@ interface Conversations {
       /** The id of the conversation item to delete. */
       @path item_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -178,7 +179,7 @@ interface Conversations {
 
       ...CommonPageQueryParameters;
       ...ItemTypeQueryParameter;
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentsPagedResult<OpenAI.OutputItem>
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/responses/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/responses/routes.tsp
@@ -1,16 +1,11 @@
 import "./models.tsp";
 import "../../common/models.tsp";
+import "../../common/openai-templates.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 
 namespace Azure.AI.Projects;
-
-/** Optional response header containing the session ID for hosted agent requests. */
-alias AgentSessionIdResponseHeader = {
-  /** Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request. */
-  @header("x-agent-session-id") agentSessionId?: string;
-};
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "OpenAI-based operations are not conventionally versioned"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
@@ -25,7 +20,7 @@ interface Responses {
   @operationId("createResponse")
   @post
   createResponse is OpenAIOperation<
-    OpenAI.CreateResponse & UserDelegationHeader,
+    OpenAI.CreateResponse & AgentSessionIdResponseHeader,
 
       | (AgentSessionIdResponseHeader & OpenAI.Response)
       | (AgentSessionIdResponseHeader &
@@ -62,7 +57,7 @@ interface Responses {
       /** The sequence number of the event after which to start streaming. */
       @query starting_after?: int32;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
 
       | (AgentSessionIdResponseHeader & {
@@ -89,7 +84,7 @@ interface Responses {
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentSessionIdResponseHeader & {
       /** The request body. */
@@ -113,7 +108,7 @@ interface Responses {
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
 
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentSessionIdResponseHeader & {
       /** The request body. */
@@ -137,7 +132,7 @@ interface Responses {
       response_id: string;
 
       ...CommonPageQueryParameters;
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentSessionIdResponseHeader & {
       /** The request body. */
@@ -158,7 +153,7 @@ interface Responses {
       ...AgentNameQueryParam;
       ...AgentIdQueryParam;
       ...ConversationIdQueryParam;
-      ...UserDelegationHeader;
+      ...AgentSessionIdResponseHeader;
     },
     AgentsPagedResult<OpenAI.Response>
   >;


### PR DESCRIPTION
fixes merge collisions by replacing x-ms-user-identity by x-agent-session-id headers

Open questions:
- POST /agents/{agent_name}/endpoint/protocols/invocations has x-agent-invocation-id and is the only one with that, expected?