### PR TITLE
Add scopeType and scopeId to Usages and ModelCapacities in 2026-07-01

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesClassicScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,13 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 2,
+            "limit": 20000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "Classic"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesDataZoneScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages DataZone Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,14 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 4,
+            "limit": 40000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "DataZone",
+            "scopeId": "US"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/GetUsagesGlobalScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Global Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,14 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 5,
+            "limit": 50000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "Global",
+            "scopeId": "Global"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesClassicScope.json
@@ -8,7 +8,7 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -19,16 +19,15 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
               "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "scopeType": "Classic"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesDataZoneScope.json
@@ -8,27 +8,27 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities DataZone Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "DataZoneStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListLocationBasedModelCapacitiesGlobalScope.json
@@ -8,27 +8,27 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities Global Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "GlobalStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacities.json
@@ -25,7 +25,9 @@
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard"
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesClassicScope.json
@@ -1,14 +1,13 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -19,16 +18,15 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
               "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "scopeType": "Classic"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesDataZoneScope.json
@@ -1,34 +1,33 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities DataZone Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "DataZoneStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListModelCapacitiesGlobalScope.json
@@ -1,34 +1,33 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities Global Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "GlobalStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
             }
           }
         ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesClassicScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,10 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 2,
+            "limit": 100,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "Classic"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesDataZoneScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages DataZone Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,11 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 4,
+            "limit": 300,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "DataZone",
+            "scopeId": "US"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-01/ListUsagesGlobalScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Global Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,11 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 5,
+            "limit": 500,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "Global",
+            "scopeId": "Global"
           }
         ]
       }

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -201,7 +201,6 @@ union QuotaUsageStatus {
 @added(Versions.v2026_03_15_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_15_preview)
-@removed(Versions.v2026_07_01)
 union QuotaScopeType {
   string,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Regional quota scope"
@@ -2336,7 +2335,6 @@ model Usage {
   @added(Versions.v2026_03_15_preview)
   @removed(Versions.v2026_05_01)
   @added(Versions.v2026_05_15_preview)
-  @removed(Versions.v2026_07_01)
   scopeType?: QuotaScopeType | null;
 
   /**
@@ -2348,7 +2346,6 @@ model Usage {
   @added(Versions.v2026_03_15_preview)
   @removed(Versions.v2026_05_01)
   @added(Versions.v2026_05_15_preview)
-  @removed(Versions.v2026_07_01)
   scopeId?: string | null;
 }
 
@@ -2873,7 +2870,6 @@ model ModelSkuCapacityProperties {
   @added(Versions.v2026_03_15_preview)
   @removed(Versions.v2026_05_01)
   @added(Versions.v2026_05_15_preview)
-  @removed(Versions.v2026_07_01)
   scopeId?: string | null;
 
   /**
@@ -2885,7 +2881,6 @@ model ModelSkuCapacityProperties {
   @added(Versions.v2026_03_15_preview)
   @removed(Versions.v2026_05_01)
   @added(Versions.v2026_05_15_preview)
-  @removed(Versions.v2026_07_01)
   scopeType?: QuotaScopeType | null;
 }
 

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/cognitiveservices.json
@@ -529,6 +529,15 @@
         "x-ms-examples": {
           "ListLocationBasedModelCapacities": {
             "$ref": "./examples/ListLocationBasedModelCapacities.json"
+          },
+          "ListLocationBasedModelCapacities Classic Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesClassicScope.json"
+          },
+          "ListLocationBasedModelCapacities DataZone Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesDataZoneScope.json"
+          },
+          "ListLocationBasedModelCapacities Global Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesGlobalScope.json"
           }
         },
         "x-ms-pageable": {
@@ -829,6 +838,15 @@
         "x-ms-examples": {
           "Get Usages": {
             "$ref": "./examples/ListUsages.json"
+          },
+          "Get Usages Classic Scope": {
+            "$ref": "./examples/ListUsagesClassicScope.json"
+          },
+          "Get Usages DataZone Scope": {
+            "$ref": "./examples/ListUsagesDataZoneScope.json"
+          },
+          "Get Usages Global Scope": {
+            "$ref": "./examples/ListUsagesGlobalScope.json"
           }
         },
         "x-ms-pageable": {
@@ -892,6 +910,15 @@
         "x-ms-examples": {
           "ListModelCapacities": {
             "$ref": "./examples/ListModelCapacities.json"
+          },
+          "ListModelCapacities Classic Scope": {
+            "$ref": "./examples/ListModelCapacitiesClassicScope.json"
+          },
+          "ListModelCapacities DataZone Scope": {
+            "$ref": "./examples/ListModelCapacitiesDataZoneScope.json"
+          },
+          "ListModelCapacities Global Scope": {
+            "$ref": "./examples/ListModelCapacitiesGlobalScope.json"
           }
         },
         "x-ms-pageable": {
@@ -8860,6 +8887,15 @@
         "x-ms-examples": {
           "Get Usages": {
             "$ref": "./examples/GetUsages.json"
+          },
+          "Get Usages Classic Scope": {
+            "$ref": "./examples/GetUsagesClassicScope.json"
+          },
+          "Get Usages DataZone Scope": {
+            "$ref": "./examples/GetUsagesDataZoneScope.json"
+          },
+          "Get Usages Global Scope": {
+            "$ref": "./examples/GetUsagesGlobalScope.json"
           }
         }
       }
@@ -14107,6 +14143,16 @@
           "type": "number",
           "format": "float",
           "description": "The available capacity for deployment with a fine-tune version of this model and sku."
+        },
+        "scopeId": {
+          "type": "string",
+          "description": "The scope identifier for model SKU capacity.",
+          "x-nullable": true
+        },
+        "scopeType": {
+          "$ref": "#/definitions/QuotaScopeType",
+          "description": "The scope type for model SKU capacity.",
+          "x-nullable": true
         }
       }
     },
@@ -15094,6 +15140,38 @@
             "key"
           ]
         }
+      }
+    },
+    "QuotaScopeType": {
+      "type": "string",
+      "description": "The quota scope that determines the level at which the quota is applied.",
+      "enum": [
+        "Regional",
+        "Global",
+        "DataZone",
+        "Classic"
+      ],
+      "x-ms-enum": {
+        "name": "QuotaScopeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional"
+          },
+          {
+            "name": "Global",
+            "value": "Global"
+          },
+          {
+            "name": "DataZone",
+            "value": "DataZone"
+          },
+          {
+            "name": "Classic",
+            "value": "Classic"
+          }
+        ]
       }
     },
     "QuotaTier": {
@@ -17003,6 +17081,16 @@
         "status": {
           "$ref": "#/definitions/QuotaUsageStatus",
           "description": "Cognitive Services account quota usage status."
+        },
+        "scopeType": {
+          "$ref": "#/definitions/QuotaScopeType",
+          "description": "The scope type of the quota usage.",
+          "x-nullable": true
+        },
+        "scopeId": {
+          "type": "string",
+          "description": "The scope identifier of the quota usage.",
+          "x-nullable": true
         }
       }
     },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsages.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsages.json
@@ -21,7 +21,9 @@
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
-            "unit": "Count"
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "eastus"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesClassicScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,13 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 2,
+            "limit": 20000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "Classic"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesDataZoneScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages DataZone Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,14 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 4,
+            "limit": 40000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "DataZone",
+            "scopeId": "US"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/GetUsagesGlobalScope.json
@@ -6,7 +6,7 @@
     "resourceGroupName": "myResourceGroup",
     "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Global Scope",
   "responses": {
     "200": {
       "body": {
@@ -16,14 +16,14 @@
               "localizedValue": "Face.Transactions",
               "value": "Face.Transactions"
             },
-            "currentValue": 3,
-            "limit": 30000,
+            "currentValue": 5,
+            "limit": 50000,
             "nextResetTime": "2018-03-28T09:33:51Z",
             "quotaPeriod": "30.00:00:00",
             "status": "Included",
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "eastus"
+            "scopeType": "Global",
+            "scopeId": "Global"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacities.json
@@ -26,7 +26,9 @@
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard"
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesClassicScope.json
@@ -8,7 +8,7 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -19,16 +19,15 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
               "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "scopeType": "Classic"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesDataZoneScope.json
@@ -8,27 +8,27 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities DataZone Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "DataZoneStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListLocationBasedModelCapacitiesGlobalScope.json
@@ -8,27 +8,27 @@
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListLocationBasedModelCapacities Global Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "GlobalStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacities.json
@@ -25,7 +25,9 @@
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard"
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesClassicScope.json
@@ -1,14 +1,13 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -19,16 +18,15 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
               "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "scopeType": "Classic"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesDataZoneScope.json
@@ -1,34 +1,33 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities DataZone Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "DataZoneStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListModelCapacitiesGlobalScope.json
@@ -1,34 +1,33 @@
 {
-  "operationId": "LocationBasedModelCapacities_List",
+  "operationId": "ModelCapacities_List",
   "parameters": {
     "api-version": "2026-07-01",
-    "location": "WestUS",
     "modelFormat": "OpenAI",
     "modelName": "ada",
     "modelVersion": "1",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "ListLocationBasedModelCapacities",
+  "title": "ListModelCapacities Global Scope",
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "name": "Standard",
+            "name": "GlobalStandard",
             "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
             "location": "WestUS",
             "properties": {
-              "availableCapacity": 300,
-              "availableFinetuneCapacity": 20,
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
               "model": {
                 "name": "ada",
                 "format": "OpenAI",
                 "version": "1"
               },
-              "skuName": "Standard",
-              "scopeId": "WestUS",
-              "scopeType": "Regional"
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
             }
           }
         ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsages.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsages.json
@@ -17,7 +17,9 @@
             },
             "currentValue": 3,
             "limit": 200,
-            "unit": "Count"
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "westus"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesClassicScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Classic Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,10 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 2,
+            "limit": 100,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "Classic"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesDataZoneScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages DataZone Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,11 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 4,
+            "limit": 300,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "DataZone",
+            "scopeId": "US"
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/examples/ListUsagesGlobalScope.json
@@ -5,7 +5,7 @@
     "location": "WestUS",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
-  "title": "Get Usages",
+  "title": "Get Usages Global Scope",
   "responses": {
     "200": {
       "body": {
@@ -15,11 +15,11 @@
               "localizedValue": "Cognitive Services total account limit",
               "value": "AccountCount"
             },
-            "currentValue": 3,
-            "limit": 200,
+            "currentValue": 5,
+            "limit": 500,
             "unit": "Count",
-            "scopeType": "Regional",
-            "scopeId": "westus"
+            "scopeType": "Global",
+            "scopeId": "Global"
           }
         ]
       }


### PR DESCRIPTION
Removed @removed(Versions.v2026_07_01) from QuotaScopeType, Usage.scopeType/scopeId, and ModelSkuCapacityProperties.scopeType/scopeId so these properties are exposed in the stable 2026-07-01 API version, matching the 2026-01-15-preview shape.

Also copies the 12 scope-variant example files (Classic/DataZone/Global for GetUsages, ListUsages, ListModelCapacities, ListLocationBasedModelCapacities) from 2026-01-15-preview to 2026-07-01 with the api-version bumped, and updates the 4 base example bodies to include scopeType/scopeId. Regenerated cognitiveservices.json now references all example variants via x-ms-examples.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
