### PR TITLE
CognitiveServices: add capabilitySettings to account and project

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateAccount.json
@@ -20,7 +20,12 @@
           {
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
-        ]
+        ],
+        "capabilitySettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+          "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+        }
       },
       "sku": {
         "name": "S0"
@@ -61,7 +66,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -96,7 +106,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -131,7 +146,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateProject.json
@@ -10,7 +10,11 @@
       "location": "West US",
       "properties": {
         "description": "Description of this project",
-        "displayName": "p1"
+        "displayName": "p1",
+        "capabilitySettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
+        }
       }
     },
     "projectName": "testProject1",
@@ -40,7 +44,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -65,7 +74,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -90,7 +104,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     }

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1669,6 +1669,45 @@ model AccountProperties {
    * Specifies the projects, by project name, that are associated with this resource.
    */
   associatedProjects?: string[];
+
+  /**
+   * Reusable default agent capability settings inherited by child projects.
+   */
+  @added(Versions.v2026_07_15_preview)
+  capabilitySettings?: CapabilitySettings;
+}
+
+/**
+ * Extensible agent capability configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.
+ */
+@added(Versions.v2026_07_15_preview)
+model CapabilitySettings {
+  /**
+   * Azure resource ID of the document store used by agent runtime state.
+   */
+  documentStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.DocumentDB/databaseAccounts";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the vector store used by agent retrieval and indexing.
+   */
+  vectorStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Search/searchServices";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the blob store used by agent file and artifact storage.
+   */
+  blobStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Storage/storageAccounts";
+    }
+  ]>;
 }
 
 /**
@@ -4162,6 +4201,13 @@ model ProjectProperties {
    */
   @visibility(Lifecycle.Read)
   isDefault?: boolean;
+
+  /**
+   * Effective agent capability settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.
+   */
+  @added(Versions.v2026_07_15_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  capabilitySettings?: CapabilitySettings;
 }
 
 /**

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -11743,6 +11743,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "capabilitySettings": {
+          "$ref": "#/definitions/CapabilitySettings",
+          "description": "Reusable default agent capability settings inherited by child projects."
         }
       }
     },
@@ -12792,6 +12796,48 @@
           "description": "An array of objects of type Capability Host.",
           "items": {
             "$ref": "#/definitions/CapabilityHost"
+          }
+        }
+      }
+    },
+    "CapabilitySettings": {
+      "type": "object",
+      "description": "Extensible agent capability configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.",
+      "properties": {
+        "documentStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the document store used by agent runtime state.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DocumentDB/databaseAccounts"
+              }
+            ]
+          }
+        },
+        "vectorStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the vector store used by agent retrieval and indexing.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Search/searchServices"
+              }
+            ]
+          }
+        },
+        "blobStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the blob store used by agent file and artifact storage.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
           }
         }
       }
@@ -17829,6 +17875,14 @@
           "type": "boolean",
           "description": "Indicates whether the project is the default project for the account.",
           "readOnly": true
+        },
+        "capabilitySettings": {
+          "$ref": "#/definitions/CapabilitySettings",
+          "description": "Effective agent capability settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateAccount.json
@@ -20,7 +20,12 @@
           {
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
-        ]
+        ],
+        "capabilitySettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+          "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+        }
       },
       "sku": {
         "name": "S0"
@@ -61,7 +66,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -96,7 +106,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -131,7 +146,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateProject.json
@@ -10,7 +10,11 @@
       "location": "West US",
       "properties": {
         "description": "Description of this project",
-        "displayName": "p1"
+        "displayName": "p1",
+        "capabilitySettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
+        }
       }
     },
     "projectName": "testProject1",
@@ -40,7 +44,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -65,7 +74,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -90,7 +104,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "capabilitySettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     }


### PR DESCRIPTION
Adds `capabilitySettings` property to the CognitiveServices account and project models in the 2026-07-15-preview TypeSpec specification. Targets the API version added in #44334.