### PR TITLE
Remove SDK release type param that's no longer supported by azsdk cli

### DIFF
--- a/eng/tools/release-plan/src/release-plan.ts
+++ b/eng/tools/release-plan/src/release-plan.ts
@@ -170,8 +170,6 @@ function runCreateReleasePlan(
     context.tspProjectPath,
     "--api-release-type",
     context.apiReleaseType,
-    "--sdk-type",
-    context.sdkReleaseType,
     "--release-month",
     context.targetMonth,
     "--pull-request",

--- a/eng/tools/release-plan/test/release-plan.test.ts
+++ b/eng/tools/release-plan/test/release-plan.test.ts
@@ -93,7 +93,7 @@ describe("ensureReleasePlan", () => {
           code: 0,
           out: "null",
         },
-      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --sdk-type preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
+      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
         {
           code: 0,
           out: JSON.stringify({ id: 999, release_plan_link: "https://example.test/999" }),
@@ -118,7 +118,7 @@ describe("ensureReleasePlan", () => {
           code: 0,
           out: "null",
         },
-      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --sdk-type preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release true --output json":
+      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release true --output json":
         {
           code: 0,
           out: JSON.stringify({ id: 1000, release_plan_link: "https://example.test/1000" }),
@@ -165,7 +165,7 @@ describe("ensureReleasePlan", () => {
           code: 0,
           out: "null",
         },
-      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --sdk-type preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
+      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
         {
           code: 0,
           out: "{ broken json",
@@ -187,7 +187,7 @@ describe("ensureReleasePlan", () => {
           code: 0,
           out: "null",
         },
-      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --sdk-type preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
+      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --release-month July 2026 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
         {
           code: 1,
           out: "",
@@ -211,7 +211,7 @@ describe("ensureReleasePlan", () => {
           code: 0,
           out: "null",
         },
-      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --sdk-type preview --release-month December 2025 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
+      "release-plan create --typespec-path specification/foo/Contoso.Service --api-release-type Public Preview --release-month December 2025 --pull-request https://github.com/Azure/azure-rest-api-specs/pull/123 --force false --test-release false --output json":
         {
           code: 0,
           out: JSON.stringify({ id: 500 }),


### PR DESCRIPTION
Remove SDK release type param from create release plan CLI command in auto release plan pipeline.