### PR TITLE
[Test] Reorder CognitiveServices enum members to observe JS changelog

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -17,16 +17,16 @@ namespace Microsoft.CognitiveServices;
  */
 union SkuTier {
   string,
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Free pricing tier"
-  Free: "Free",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Basic pricing tier"
-  Basic: "Basic",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Standard pricing tier"
-  Standard: "Standard",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Premium pricing tier"
-  Premium: "Premium",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Enterprise pricing tier"
   Enterprise: "Enterprise",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Premium pricing tier"
+  Premium: "Premium",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Standard pricing tier"
+  Standard: "Standard",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Basic pricing tier"
+  Basic: "Basic",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "Free pricing tier"
+  Free: "Free",
 }
 
 /**
@@ -1370,10 +1370,10 @@ union AgentDeploymentProvisioningState {
  */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "'ResourceIdentityType' uses extensible union instead of fixed enum for forward compatibility"
 enum ResourceIdentityType {
-  None,
   SystemAssigned,
-  UserAssigned,
+  None,
   `SystemAssigned, UserAssigned`,
+  UserAssigned,
 }
 
 /**


### PR DESCRIPTION
**Do not merge — experimental.**

Reorders the members of two enums in CognitiveServices.Management/models.tsp to observe whether enum member reordering surfaces as a breaking change in the generated JS SDK changelog (via the ADO SDK generation pipeline):

- **`SkuTier`** — an extensible enum (`union` with `string`): members reversed.
- **`ResourceIdentityType`** — a fixed `enum`: members reordered.

No behavioral/API-surface change is intended; this is purely to inspect the changelog/breaking-change tooling output.