### PR TITLE
[cosmos-db] Exclude Java from MongoIndex.key flattening

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/client.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/client.tsp
@@ -2498,7 +2498,7 @@ op sqlResourcesGetSqlRoleDefinitionCustomized(
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@Legacy.flattenProperty(MongoIndex.key, "!autorest,!javascript");
+@@Legacy.flattenProperty(MongoIndex.key, "!autorest,!javascript,!java");
 
 // Restorable* "GetResult" models declare id/name/type inline rather than
 // extending CommonTypes.Resource, so the generator cannot infer them as ARM


### PR DESCRIPTION
Java (typespec-java) was included in the `flattenProperty` scope for `MongoIndex.key` (scope `!autorest,!javascript`). This flattened the public `key()`/`withKey(MongoIndexKeys)` API into `keys()`/`withKeys(List<String>)` and moved `MongoIndexKeys` to the implementation package (see Azure/azure-sdk-for-java#49695).

This adds `!java` to the scope so the Java SDK keeps its existing public API.

The corresponding Java SDK regeneration is in a separate azure-sdk-for-java PR.