### PR TITLE
Enable provisioning for ServiceFabricManagedClusters

### DIFF
--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/tspconfig.yaml
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/tspconfig.yaml
@@ -15,6 +15,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ServiceFabricManagedClusters"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.ServiceFabricManagedClusters"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2026-02-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-servicefabricmanagedclusters"
     namespace: "azure.mgmt.servicefabricmanagedclusters"


### PR DESCRIPTION
# Description

Enable the C# provisioning emitter for Service Fabric Managed Clusters.

# Changes

- Adds `@azure-typespec/http-client-csharp-provisioning` to the ServiceFabricManagedClusters TypeSpec config.
- Uses namespace `Azure.Provisioning.ServiceFabricManagedClusters`.
- Pins the provisioning emitter to API version `2026-02-01`.

# Validation

Generated the corresponding .NET provisioning package locally from this spec branch.