### PR TITLE
[ConfidentialLedger] Add client.tsp to rename models for .NET SDK (AZC0012/AZC0030)

### DIFF
--- a/specification/confidentialledger/data-plane/ConfidentialLedger/client.tsp
+++ b/specification/confidentialledger/data-plane/ConfidentialLedger/client.tsp
@@ -1,0 +1,27 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+// The following model/enum types are generated with single, generic names that
+// trigger the .NET analyzers AZC0012 (single-word type name -> collision risk)
+// and AZC0030 (discouraged type-name suffix such as "Collection"/"Response").
+// Rename them for the C# SDK only so it follows the Azure SDK for .NET naming
+// guidelines. The scope is limited to "csharp" so the REST/wire contract and the
+// already-generated JavaScript, Python and Java SDKs are left unchanged.
+
+// AZC0012: single, generic type names.
+@@clientName(ConfidentialLedger.Bundle, "LedgerBundle", "csharp");
+@@clientName(ConfidentialLedger.Constitution, "LedgerConstitution", "csharp");
+@@clientName(ConfidentialLedger.Metadata, "LedgerEndpointMetadata", "csharp");
+@@clientName(ConfidentialLedger.Mode, "LedgerEndpointMode", "csharp");
+@@clientName(ConfidentialLedger.Role, "LedgerRole", "csharp");
+
+// AZC0012 + AZC0030: single, generic name that also ends with "Collection".
+@@clientName(ConfidentialLedger.Collection, "LedgerCollectionInfo", "csharp");
+
+// AZC0030: type name ends with the discouraged "Response" suffix.
+@@clientName(ConfidentialLedger.UserDefinedFunctionExecutionResponse,
+  "UserDefinedFunctionExecution",
+  "csharp"
+);


### PR DESCRIPTION
## Summary

Adds a `client.tsp` to the ConfidentialLedger data-plane spec that renames generated model/enum types **for the .NET SDK only** (scope `csharp`), so `Azure.Security.ConfidentialLedger` follows the [Azure SDK for .NET naming guidelines](https://azure.github.io/azure-sdk/dotnet_introduction.html) instead of suppressing analyzers **AZC0012** and **AZC0030**.

This addresses the outstanding review feedback on [Azure/azure-sdk-for-net#59947](https://github.com/Azure/azure-sdk-for-net/pull/59947) (jsquire), where the analyzer suppressions were not approved.

## Renames (C# surface only — REST/wire contract unchanged)

| Wire/REST name | .NET SDK name | Rule |
| --- | --- | --- |
| `Bundle` | `LedgerBundle` | AZC0012 |
| `Constitution` | `LedgerConstitution` | AZC0012 |
| `Metadata` | `LedgerEndpointMetadata` | AZC0012 |
| `Mode` | `LedgerEndpointMode` | AZC0012 |
| `Role` | `LedgerRole` | AZC0012 |
| `Collection` | `LedgerCollectionInfo` | AZC0012 + AZC0030 |
| `UserDefinedFunctionExecutionResponse` | `UserDefinedFunctionExecution` | AZC0030 |

Because the renames are scoped to `csharp`, the already-generated JavaScript, Python and Java SDKs are unaffected.

## Notes
- After merge, regenerate the .NET SDK and remove the AZC0012/AZC0030 entries from `eng/analyzerallowlist/Azure.Security.ConfidentialLedger.txt`.
- Related to release plan 2123 (GA, Azure Confidential Ledger).