### PR TITLE
[DO NOT MERGE][DRAFT] DPS device data-plane: 2026-11-15-preview ADU device-update APIs

### DIFF
--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/client.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/client.tsp
@@ -4,14 +4,17 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using ProvisioningDeviceClient;
 
-@@clientLocation(RuntimeRegistration.operationStatusLookup,
+@@clientLocation(
+  RuntimeRegistration.operationStatusLookup,
   "RuntimeRegistration"
 );
-@@clientLocation(RuntimeRegistration.deviceRegistrationStatusLookup,
+@@clientLocation(
+  RuntimeRegistration.deviceRegistrationStatusLookup,
   "RuntimeRegistration"
 );
 @@clientLocation(RuntimeRegistration.registerDevice, "RuntimeRegistration");
-@@clientLocation(RuntimeRegistration.registerDeviceAndIssueCertificate,
+@@clientLocation(
+  RuntimeRegistration.registerDeviceAndIssueCertificate,
   "RuntimeRegistration"
 );
 @@clientLocation(DeviceUpdate.getDeviceUpdate, "DeviceUpdate");

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/client.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/client.tsp
@@ -4,16 +4,16 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using ProvisioningDeviceClient;
 
-@@clientLocation(
-  RuntimeRegistration.operationStatusLookup,
+@@clientLocation(RuntimeRegistration.operationStatusLookup,
   "RuntimeRegistration"
 );
-@@clientLocation(
-  RuntimeRegistration.deviceRegistrationStatusLookup,
+@@clientLocation(RuntimeRegistration.deviceRegistrationStatusLookup,
   "RuntimeRegistration"
 );
 @@clientLocation(RuntimeRegistration.registerDevice, "RuntimeRegistration");
-@@clientLocation(
-  RuntimeRegistration.registerDeviceAndIssueCertificate,
+@@clientLocation(RuntimeRegistration.registerDeviceAndIssueCertificate,
   "RuntimeRegistration"
 );
+@@clientLocation(DeviceUpdate.getDeviceUpdate, "DeviceUpdate");
+@@clientLocation(DeviceUpdate.getOnboardingDeviceUpdate, "DeviceUpdate");
+@@clientLocation(DeviceUpdate.reportDeviceUpdateStatus, "DeviceUpdate");

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate.json
@@ -40,9 +40,9 @@
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
           "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
-          "fileUrls": [
-            "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
-          ]
+          "fileUrls": {
+            "file_0": "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+          }
         }
       }
     }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate.json
@@ -1,0 +1,50 @@
+{
+  "title": "DeviceUpdate_GetDeviceUpdate",
+  "operationId": "DeviceUpdate_GetDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
+    "body": {
+      "agentInfo": {
+        "agentSdkVersion": "1.1.0",
+        "agentProfile": 1,
+        "compatibilityProperties": {
+          "manufacturer": "contoso",
+          "model": "vacuum-100"
+        }
+      },
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.0.0"
+      },
+      "agentInfoETag": "\"a0\"",
+      "serviceConfigETag": "\"c0\""
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+      },
+      "body": {
+        "serviceConfiguration": {
+          "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
+        },
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\"",
+        "updateMetadata": {
+          "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+          "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "fileUrls": [
+            "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
@@ -1,5 +1,5 @@
 {
-  "title": "DeviceUpdate_GetDeviceUpdate",
+  "title": "DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen",
   "operationId": "DeviceUpdate_GetDeviceUpdate",
   "parameters": {
     "idScope": "0ne00000000",
@@ -16,6 +16,10 @@
           "model": "vacuum-100"
         }
       },
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
       "installedUpdateId": {
         "provider": "contoso",
         "name": "vacuum",
@@ -27,9 +31,6 @@
   },
   "responses": {
     "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-      },
       "body": {
         "serviceConfiguration": {
           "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
@@ -39,10 +40,10 @@
         "updateMetadata": {
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
-          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
-          "fileUrls": [
-            "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
-          ]
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.c2lnbmF0dXJl",
+          "fileUrls": {
+            "file_0": "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+          }
         }
       }
     }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
@@ -5,8 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
-    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "installedUpdateId": {
         "provider": "Contoso",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
@@ -1,0 +1,25 @@
+{
+  "title": "DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen",
+  "operationId": "DeviceUpdate_GetDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "installedUpdateId": {
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\""
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate.json
@@ -1,0 +1,43 @@
+{
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "agentInfo": {
+        "agentSdkVersion": "1.1.0",
+        "agentProfile": 1,
+        "compatibilityProperties": {
+          "manufacturer": "contoso",
+          "model": "vacuum-100"
+        }
+      },
+      "installedUpdateId": null
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3302"
+      },
+      "body": {
+        "serviceConfiguration": {
+          "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
+        },
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\"",
+        "updateMetadata": {
+          "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+          "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "fileUrls": [
+            "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate.json
@@ -33,9 +33,9 @@
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
           "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
-          "fileUrls": [
-            "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
-          ]
+          "fileUrls": {
+            "file_0": "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
+          }
         }
       }
     }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
@@ -1,12 +1,11 @@
 {
-  "title": "DeviceUpdate_GetDeviceUpdate",
-  "operationId": "DeviceUpdate_GetDeviceUpdate",
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen",
+  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
   "parameters": {
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
     "x-ms-external-device-id": "my-device-01",
-    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",
@@ -16,10 +15,14 @@
           "model": "vacuum-100"
         }
       },
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
       "installedUpdateId": {
-        "provider": "contoso",
-        "name": "vacuum",
-        "version": "1.0.0"
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
       },
       "agentInfoETag": "\"a0\"",
       "serviceConfigETag": "\"c0\""
@@ -27,9 +30,6 @@
   },
   "responses": {
     "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-      },
       "body": {
         "serviceConfiguration": {
           "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
@@ -39,9 +39,9 @@
         "updateMetadata": {
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
-          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.c2lnbmF0dXJl",
           "fileUrls": {
-            "file_0": "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+            "file_0": "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
           }
         }
       }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "installedUpdateId": {
         "provider": "Contoso",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
@@ -1,0 +1,25 @@
+{
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen",
+  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "installedUpdateId": {
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\""
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus.json
@@ -14,7 +14,8 @@
         "version": "1.1.0"
       },
       "lastInstallResult": {
-        "outcome": "Success",
+        "outcome": "SUCCEEDED",
+        "failureOrigin": "NOT_APPLICABLE",
         "resultCode": 700,
         "extendedResultCodes": "00000000",
         "resultDetails": "Update installed successfully."

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus.json
@@ -1,0 +1,32 @@
+{
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.1.0"
+      },
+      "lastInstallResult": {
+        "outcome": "Success",
+        "resultCode": 700,
+        "extendedResultCodes": "00000000",
+        "resultDetails": "Update installed successfully."
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3303"
+      },
+      "body": {}
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
@@ -1,0 +1,48 @@
+{
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen",
+  "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.1.0"
+      },
+      "lastInstallResult": {
+        "outcome": "FAILED",
+        "failureOrigin": "AGENT_EXTENSION",
+        "resultCode": -1,
+        "extendedResultCodes": "0x80004005,0x8000FFFF",
+        "resultDetails": "Extension handler failed during apply.",
+        "stepResults": {
+          "step_0": {
+            "outcome": "SUCCEEDED",
+            "failureOrigin": "NOT_APPLICABLE",
+            "resultCode": 700,
+            "extendedResultCodes": "00000000",
+            "resultDetails": "Download complete."
+          },
+          "step_1": {
+            "outcome": "FAILED",
+            "failureOrigin": "AGENT_EXTENSION",
+            "resultCode": -1,
+            "extendedResultCodes": "0x80004005",
+            "resultDetails": "Apply failed."
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "tpm": {

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "installedUpdateId": {

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
@@ -1,5 +1,5 @@
 {
-  "title": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen",
   "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
   "parameters": {
     "idScope": "0ne00000000",
@@ -9,24 +9,19 @@
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "installedUpdateId": {
-        "provider": "contoso",
-        "name": "vacuum",
-        "version": "1.1.0"
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
       },
       "lastInstallResult": {
-        "outcome": "Success",
+        "outcome": "SUCCEEDED",
+        "failureOrigin": "NOT_APPLICABLE",
         "resultCode": 700,
-        "extendedResultCodes": "00000000",
-        "resultDetails": "Update installed successfully."
+        "extendedResultCodes": "00000000"
       }
     }
   },
   "responses": {
-    "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3303"
-      },
-      "body": {}
-    }
+    "200": {}
   }
 }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "RuntimeRegistration_DeviceRegistrationStatusLookup",
+  "parameters": {
+    "api-version": "2026-11-15-preview",
+    "body": {
+      "payload": {},
+      "registrationId": "qypnuerjeunzogqdezhjgisfr",
+      "tpm": {
+        "endorsementKey": "sbvvzftylrpsetexcmnijtdezppq",
+        "storageRootKey": "juohyrayid"
+      }
+    },
+    "idScope": "a",
+    "registrationId": "urnfaaodcvbbllnmxj"
+  },
+  "title": "RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "assignedHub": "ljexps",
+        "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+        "deviceId": "hjvdlwpugzlk",
+        "errorCode": 13,
+        "errorMessage": "zpctqazbkbiqjkwosis",
+        "etag": "hjtelksspyfzhmet",
+        "issuedCertificateChain": [
+          "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+        ],
+        "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+        "payload": {},
+        "registrationId": "urejrffpkqneou",
+        "status": "unassigned",
+        "substatus": "initialAssignment",
+        "symmetricKey": {
+          "enrollmentGroupId": "w"
+        },
+        "tpm": {
+          "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+        },
+        "x509": {
+          "certificateInfo": {
+            "issuerName": "pvpbipnhcahytrcq",
+            "notAfterUtc": "2025-10-01T17:41:56.534Z",
+            "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+            "serialNumber": "jjvdijgwgpagrjdi",
+            "sha1Thumbprint": "guqltcfgusf",
+            "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+            "subjectName": "jtsfqnbcmmott",
+            "version": 20
+          },
+          "enrollmentGroupId": "qbw",
+          "signingCertificateInfo": {
+            "issuerName": "pvpbipnhcahytrcq",
+            "notAfterUtc": "2025-10-01T17:41:56.534Z",
+            "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+            "serialNumber": "jjvdijgwgpagrjdi",
+            "sha1Thumbprint": "guqltcfgusf",
+            "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+            "subjectName": "jtsfqnbcmmott",
+            "version": 20
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "RuntimeRegistration_DeviceRegistrationStatusLookup",
+  "parameters": {
+    "api-version": "2026-11-15-preview",
+    "body": {},
+    "idScope": "mucolayhjusj",
+    "registrationId": "okxnmx"
+  },
+  "title": "RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "RuntimeRegistration_OperationStatusLookup",
+  "parameters": {
+    "operationId": "fdjhztahuvcjjmutvihsmflepzvsfn",
+    "api-version": "2026-11-15-preview",
+    "idScope": "arjoldcjeedohmpuhenotyesppkgk",
+    "registrationId": "ojruvwccsgwnmscfwodrfjrecxuf"
+  },
+  "title": "RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi",
+        "registrationState": {
+          "assignedHub": "ljexps",
+          "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "deviceId": "hjvdlwpugzlk",
+          "errorCode": 13,
+          "errorMessage": "zpctqazbkbiqjkwosis",
+          "etag": "hjtelksspyfzhmet",
+          "issuedCertificateChain": [
+            "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+          ],
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "payload": {},
+          "registrationId": "urejrffpkqneou",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "symmetricKey": {
+            "enrollmentGroupId": "w"
+          },
+          "tpm": {
+            "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+          },
+          "x509": {
+            "certificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            },
+            "enrollmentGroupId": "qbw",
+            "signingCertificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            }
+          }
+        },
+        "status": "unassigned"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi",
+        "registrationState": {
+          "assignedHub": "ljexps",
+          "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "deviceId": "hjvdlwpugzlk",
+          "errorCode": 13,
+          "errorMessage": "zpctqazbkbiqjkwosis",
+          "etag": "hjtelksspyfzhmet",
+          "issuedCertificateChain": [
+            "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+          ],
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "payload": {},
+          "registrationId": "urejrffpkqneou",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "symmetricKey": {
+            "enrollmentGroupId": "w"
+          },
+          "tpm": {
+            "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+          },
+          "x509": {
+            "certificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            },
+            "enrollmentGroupId": "qbw",
+            "signingCertificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            }
+          }
+        },
+        "status": "unassigned"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RuntimeRegistration_OperationStatusLookup",
+  "parameters": {
+    "operationId": "wacw",
+    "api-version": "2026-11-15-preview",
+    "idScope": "cxcukjqvjopedcgnhtggfdt",
+    "registrationId": "pzgoamgarcmcwvapl"
+  },
+  "title": "RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen.json
@@ -1,0 +1,122 @@
+{
+  "title": "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen",
+  "operationId": "RuntimeRegistration_RegisterDeviceAndIssueCertificate",
+  "parameters": {
+    "registrationId": "ownlzhchadklubcaoqrlvnahxjvpx",
+    "idScope": "aemhxrrelukva",
+    "deviceRegistration": {
+      "registrationId": "qmldcza",
+      "tpm": {
+        "endorsementKey": "ptvkixrjmicy",
+        "storageRootKey": "ezoovqigtxdoievpniumzrfmz"
+      },
+      "csr": "yegu",
+      "payload": {}
+    },
+    "api-version": "2026-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt",
+        "status": "unassigned",
+        "registrationState": {
+          "tpm": {
+            "authenticationKey": "umpmhtunsqbkcttbwytxwzvzvopv"
+          },
+          "x509": {
+            "certificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            },
+            "enrollmentGroupId": "jaztkstjoerljecernsiu",
+            "signingCertificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            }
+          },
+          "symmetricKey": {
+            "enrollmentGroupId": "gigadta"
+          },
+          "registrationId": "utwhgvww",
+          "createdDateTimeUtc": "2025-10-01T17:51:13.304Z",
+          "assignedHub": "csdsyrzttfdyutovgmfieaswnrc",
+          "deviceId": "lehinmpzxvcbdokukewnclocdnsaah",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "errorCode": 7,
+          "errorMessage": "buikxnojfuoowknmj",
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:51:13.305Z",
+          "etag": "hxmi",
+          "payload": {},
+          "issuedCertificateChain": [
+            "aXNzdWVkQ2VydGlmaWNhdGVDaGFpbidzIGl0ZW0x"
+          ]
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt",
+        "status": "unassigned",
+        "registrationState": {
+          "tpm": {
+            "authenticationKey": "umpmhtunsqbkcttbwytxwzvzvopv"
+          },
+          "x509": {
+            "certificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            },
+            "enrollmentGroupId": "jaztkstjoerljecernsiu",
+            "signingCertificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            }
+          },
+          "symmetricKey": {
+            "enrollmentGroupId": "gigadta"
+          },
+          "registrationId": "utwhgvww",
+          "createdDateTimeUtc": "2025-10-01T17:51:13.304Z",
+          "assignedHub": "csdsyrzttfdyutovgmfieaswnrc",
+          "deviceId": "lehinmpzxvcbdokukewnclocdnsaah",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "errorCode": 7,
+          "errorMessage": "buikxnojfuoowknmj",
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:51:13.305Z",
+          "etag": "hxmi",
+          "payload": {},
+          "issuedCertificateChain": [
+            "aXNzdWVkQ2VydGlmaWNhdGVDaGFpbidzIGl0ZW0x"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/examples/2026-11-15-preview/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "title": "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen",
+  "operationId": "RuntimeRegistration_RegisterDeviceAndIssueCertificate",
+  "parameters": {
+    "registrationId": "njckbolwtqfforaqhmfjc",
+    "idScope": "zytdtmjadforourwvpbn",
+    "deviceRegistration": {},
+    "api-version": "2026-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/main.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/main.tsp
@@ -42,4 +42,11 @@ enum Versions {
    * The 2025-07-01-preview API version.
    */
   v2025_07_01_preview: "2025-07-01-preview",
+
+  /**
+   * The 2026-11-15-preview API version. Adds the device-facing ADU (Azure Device
+   * Update) update-fetch and status-report operations for the DPS ADU integration
+   * (first-time / onboarding update). DRAFT / preview.
+   */
+  v2026_11_15_preview: "2026-11-15-preview",
 }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -374,6 +374,7 @@ model UpdateCheckRequest {
   tpm?: TpmAttestation;
 
   /** Currently installed update, or null if none. */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Mirrors the ADU onboarding contract wire shape: installedUpdateId is always present and is null when no update is installed (transparent pass-through)."
   installedUpdateId: InstalledUpdateId | null;
 
   /**
@@ -382,7 +383,8 @@ model UpdateCheckRequest {
    */
   @minLength(1)
   @maxLength(128)
-  agentInfoETag?: string;
+  @encodedName("application/json", "agentInfoETag")
+  agentInfoEtag?: string;
 
   /**
    * ETag from a prior response; lets the service omit unchanged serviceConfiguration.
@@ -390,7 +392,8 @@ model UpdateCheckRequest {
    */
   @minLength(1)
   @maxLength(128)
-  serviceConfigETag?: string;
+  @encodedName("application/json", "serviceConfigETag")
+  serviceConfigEtag?: string;
 }
 
 /**
@@ -447,10 +450,12 @@ model UpdateCheckResponse {
   serviceConfiguration?: ServiceConfiguration;
 
   /** Current ETag of serviceConfiguration. */
-  serviceConfigETag: string;
+  @encodedName("application/json", "serviceConfigETag")
+  serviceConfigEtag: string;
 
   /** Current ETag of the processed agentInfo. */
-  agentInfoETag: string;
+  @encodedName("application/json", "agentInfoETag")
+  agentInfoEtag: string;
 
   /** Present only when an update applies to the device; omitted otherwise. */
   updateMetadata?: UpdateMetadata;
@@ -505,6 +510,7 @@ model ReportStatusRequest {
   tpm?: TpmAttestation;
 
   /** The update now installed, or null. Communicates current device state; not a failure signal. */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Mirrors the ADU onboarding contract wire shape: installedUpdateId is always present and is null when no update is installed (transparent pass-through)."
   installedUpdateId: InstalledUpdateId | null;
 
   /** The terminal result of the installation. */

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -362,8 +362,8 @@ model TpmAttestation {
  */
 @added(Versions.v2026_11_15_preview)
 model UpdateCheckRequest {
-  /** Information describing the ADU agent making the request. */
-  agentInfo: AgentInfo;
+  /** Device agent information. Required unless a still-current agentInfoETag is supplied. */
+  agentInfo?: AgentInfo;
 
   /**
    * Attestation via TPM. Present only for TPM-attested devices, mirroring the
@@ -373,19 +373,23 @@ model UpdateCheckRequest {
    */
   tpm?: TpmAttestation;
 
-  /** The update currently installed on the device, if any. */
-  installedUpdateId?: UpdateId | null;
+  /** Currently installed update, or null if none. */
+  installedUpdateId: InstalledUpdateId | null;
 
   /**
-   * ETag of the last agentInfo the service observed, used by the service to skip
-   * redundant processing. Optional.
+   * ETag from a prior response; lets the service skip re-processing agentInfo.
+   * Optional.
    */
+  @minLength(1)
+  @maxLength(128)
   agentInfoETag?: string;
 
   /**
-   * ETag of the serviceConfiguration the device currently holds, used by the
-   * service to omit unchanged configuration. Optional.
+   * ETag from a prior response; lets the service omit unchanged serviceConfiguration.
+   * Optional.
    */
+  @minLength(1)
+  @maxLength(128)
   serviceConfigETag?: string;
 }
 
@@ -395,28 +399,41 @@ model UpdateCheckRequest {
  */
 @added(Versions.v2026_11_15_preview)
 model AgentInfo {
-  /** Version of the ADU agent SDK on the device. */
+  /** Agent SDK version. Diagnostic only; not used for targeting. */
+  @minLength(1)
+  @maxLength(64)
   agentSdkVersion: string;
 
-  /** ADU agent profile identifier. */
+  /**
+   * Opaque capability identifier; the service maps it to supported manifest versions
+   * and installability constraints. The device must not infer meaning from the value.
+   */
+  @minValue(1)
   agentProfile: int32;
 
-  /** Device compatibility properties (for example manufacturer and model). */
+  /** Device compatibility attributes; combined with agentProfile to compute the device class. */
   compatibilityProperties: Record<string>;
 }
 
 /**
- * Identifies a specific update by provider, name, and version.
+ * Identifier of an update.
  */
 @added(Versions.v2026_11_15_preview)
-model UpdateId {
-  /** Update provider. */
+model InstalledUpdateId {
+  /** Update provider. Alphanumeric plus '.' and '-'. */
+  @minLength(1)
+  @maxLength(64)
+  @pattern("^[a-zA-Z0-9.\\-]+$")
   provider: string;
 
-  /** Update name. */
+  /** Update name. Alphanumeric plus '.' and '-'. */
+  @minLength(1)
+  @maxLength(64)
+  @pattern("^[a-zA-Z0-9.\\-]+$")
   name: string;
 
-  /** Update version. */
+  /** 2 to 4-part numeric version, e.g. 1.2, 1.2.3, 1.2.3.4. */
+  @pattern("^\\d+(\\.\\d+){1,3}$")
   version: string;
 }
 
@@ -426,14 +443,14 @@ model UpdateId {
  */
 @added(Versions.v2026_11_15_preview)
 model UpdateCheckResponse {
-  /** Device service configuration returned on every response. */
-  serviceConfiguration: ServiceConfiguration;
+  /** Device service configuration. Omitted only when a matching serviceConfigETag was supplied. */
+  serviceConfiguration?: ServiceConfiguration;
 
-  /** ETag of the returned serviceConfiguration. */
-  serviceConfigETag?: string;
+  /** Current ETag of serviceConfiguration. */
+  serviceConfigETag: string;
 
-  /** ETag the device should echo on its next request in agentInfoETag. */
-  agentInfoETag?: string;
+  /** Current ETag of the processed agentInfo. */
+  agentInfoETag: string;
 
   /** Present only when an update applies to the device; omitted otherwise. */
   updateMetadata?: UpdateMetadata;
@@ -444,8 +461,8 @@ model UpdateCheckResponse {
  */
 @added(Versions.v2026_11_15_preview)
 model ServiceConfiguration {
-  /** URL from which the device fetches ADU root keys for signature validation. */
-  rootKeyDownloadUrl?: url;
+  /** URL of the current root-key package; the device verifies updateManifestSignature against it. */
+  rootKeyDownloadUrl: url;
 }
 
 /**
@@ -454,16 +471,18 @@ model ServiceConfiguration {
 @added(Versions.v2026_11_15_preview)
 model UpdateMetadata {
   /** Opaque deployment identifier; echoed by the device on reportDeviceUpdateStatus. */
+  @minLength(1)
+  @maxLength(128)
   workflowId: string;
 
-  /** Opaque update manifest string. DPS does not parse this value. */
+  /** Update manifest as a serialized JSON string; verify the signature before parsing. DPS does not parse this value. */
   updateManifest: string;
 
-  /** JWS signature over the update manifest. */
+  /** JWS compact serialization over updateManifest. */
   updateManifestSignature: string;
 
-  /** URLs of the payload files that make up the update. */
-  fileUrls: url[];
+  /** Map of fileId to download URL. */
+  fileUrls: Record<url>;
 }
 
 /**
@@ -471,7 +490,9 @@ model UpdateMetadata {
  */
 @added(Versions.v2026_11_15_preview)
 model ReportStatusRequest {
-  /** Opaque deployment identifier from updateMetadata; the idempotency and routing key. */
+  /** The workflowId from the updateMetadata being reported; the idempotency and routing key. */
+  @minLength(1)
+  @maxLength(128)
   workflowId: string;
 
   /**
@@ -483,11 +504,11 @@ model ReportStatusRequest {
    */
   tpm?: TpmAttestation;
 
-  /** The update the device attempted to install, if any. */
-  installedUpdateId?: UpdateId | null;
+  /** The update now installed, or null. Communicates current device state; not a failure signal. */
+  installedUpdateId: InstalledUpdateId | null;
 
   /** The terminal result of the installation. */
-  lastInstallResult: LastInstallResult;
+  lastInstallResult: InstallResult;
 }
 
 /**
@@ -572,7 +593,7 @@ model StepResult {
  * step fields (spread from `StepResult`) plus an optional per-step breakdown.
  */
 @added(Versions.v2026_11_15_preview)
-model LastInstallResult {
+model InstallResult {
   ...StepResult;
 
   /**

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -348,3 +348,178 @@ model TpmAttestation {
   /** TPM storage root key. */
   storageRootKey?: string;
 }
+
+// =============================================================================
+//  ADU device-facing update integration (first-time / onboarding update)
+//  Added in 2026-11-15-preview. DRAFT — mirrors the ADU device contract
+//  (onboarding-api.tsp / onboarding-api-design.md). DPS is a thin pass-through
+//  to ADR (which forwards to ADU) and does not parse the update manifest.
+// =============================================================================
+
+/**
+ * Request body for a device update check (both the regular/operational and the
+ * onboarding/bootstrap fetch operations share this shape).
+ */
+@added(Versions.v2026_11_15_preview)
+model UpdateCheckRequest {
+  /** Information describing the ADU agent making the request. */
+  agentInfo: AgentInfo;
+
+  /** The update currently installed on the device, if any. */
+  installedUpdateId?: UpdateId | null;
+
+  /**
+   * ETag of the last agentInfo the service observed, used by the service to skip
+   * redundant processing. Optional.
+   */
+  agentInfoETag?: string;
+
+  /**
+   * ETag of the serviceConfiguration the device currently holds, used by the
+   * service to omit unchanged configuration. Optional.
+   */
+  serviceConfigETag?: string;
+}
+
+/**
+ * Information describing the ADU agent and the device it runs on, used to match
+ * the device to an applicable update.
+ */
+@added(Versions.v2026_11_15_preview)
+model AgentInfo {
+  /** Version of the ADU agent SDK on the device. */
+  agentSdkVersion: string;
+
+  /** ADU agent profile identifier. */
+  agentProfile: int32;
+
+  /** Device compatibility properties (for example manufacturer and model). */
+  compatibilityProperties: Record<string>;
+}
+
+/**
+ * Identifies a specific update by provider, name, and version.
+ */
+@added(Versions.v2026_11_15_preview)
+model UpdateId {
+  /** Update provider. */
+  provider: string;
+
+  /** Update name. */
+  name: string;
+
+  /** Update version. */
+  version: string;
+}
+
+/**
+ * Response body for a device update check. When an update applies, updateMetadata
+ * is present; "no update available" is signaled by omitting updateMetadata.
+ */
+@added(Versions.v2026_11_15_preview)
+model UpdateCheckResponse {
+  /** Device service configuration returned on every response. */
+  serviceConfiguration: ServiceConfiguration;
+
+  /** ETag of the returned serviceConfiguration. */
+  serviceConfigETag?: string;
+
+  /** ETag the device should echo on its next request in agentInfoETag. */
+  agentInfoETag?: string;
+
+  /** Present only when an update applies to the device; omitted otherwise. */
+  updateMetadata?: UpdateMetadata;
+}
+
+/**
+ * Device service configuration returned by an update check.
+ */
+@added(Versions.v2026_11_15_preview)
+model ServiceConfiguration {
+  /** URL from which the device fetches ADU root keys for signature validation. */
+  rootKeyDownloadUrl?: url;
+}
+
+/**
+ * Metadata describing an available update. The manifest is opaque to DPS.
+ */
+@added(Versions.v2026_11_15_preview)
+model UpdateMetadata {
+  /** Opaque deployment identifier; echoed by the device on reportDeviceUpdateStatus. */
+  workflowId: string;
+
+  /** Opaque update manifest string. DPS does not parse this value. */
+  updateManifest: string;
+
+  /** JWS signature over the update manifest. */
+  updateManifestSignature: string;
+
+  /** URLs of the payload files that make up the update. */
+  fileUrls: url[];
+}
+
+/**
+ * Request body reporting the terminal result of an update installation.
+ */
+@added(Versions.v2026_11_15_preview)
+model ReportStatusRequest {
+  /** Opaque deployment identifier from updateMetadata; the idempotency and routing key. */
+  workflowId: string;
+
+  /** The update the device attempted to install, if any. */
+  installedUpdateId?: UpdateId | null;
+
+  /** The terminal result of the installation. */
+  lastInstallResult: LastInstallResult;
+}
+
+/**
+ * Terminal outcome of an update installation.
+ */
+@added(Versions.v2026_11_15_preview)
+union InstallOutcome {
+  string,
+
+  /** The installation succeeded. */
+  Success: "Success",
+
+  /** The installation failed. */
+  Failure: "Failure",
+
+  /** The installation is still in progress. */
+  InProgress: "InProgress",
+}
+
+/**
+ * Details of the terminal result of an update installation.
+ */
+@added(Versions.v2026_11_15_preview)
+model LastInstallResult {
+  /** Terminal outcome of the installation. */
+  outcome: InstallOutcome;
+
+  /** Where the failure originated, when the outcome is a failure. */
+  failureOrigin?: string;
+
+  /** Numeric result code; positive values indicate success. */
+  resultCode: int64;
+
+  /** Colon-delimited extended result codes. Optional. */
+  extendedResultCodes?: string;
+
+  /** Human-readable result details. Optional. */
+  resultDetails?: string | null;
+
+  /**
+   * Per-step installation results. Open JSON object defined by the ADU agent.
+   */
+  #suppress "@azure-tools/typespec-azure-core/bad-record-type" "per-step results are an open JSON object per the ADU contract"
+  stepResults?: Record<unknown>;
+}
+
+/**
+ * Result of a reportDeviceUpdateStatus call. Empty in this preview; fields may be
+ * added later.
+ */
+@added(Versions.v2026_11_15_preview)
+model ReportDeviceUpdateStatusResult {}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -352,7 +352,7 @@ model TpmAttestation {
 // =============================================================================
 //  ADU device-facing update integration (first-time / onboarding update)
 //  Added in 2026-11-15-preview. DRAFT — mirrors the ADU device contract
-//  (onboarding-api.tsp / onboarding-api-design.md). DPS is a thin pass-through
+//  (onboarding-api.tsp / device-update-api-design.md). DPS is a thin pass-through
 //  to ADR (which forwards to ADU) and does not parse the update manifest.
 // =============================================================================
 

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -491,47 +491,95 @@ model ReportStatusRequest {
 }
 
 /**
- * Terminal outcome of an update installation.
+ * Terminal outcome of an update attempt or step. Mirrors the ADU `Outcome` enum;
+ * modeled as an extensible union so ADU can add outcomes without a breaking change.
  */
 @added(Versions.v2026_11_15_preview)
-union InstallOutcome {
+union Outcome {
   string,
 
-  /** The installation succeeded. */
-  Success: "Success",
+  /** The attempt succeeded. */
+  Succeeded: "SUCCEEDED",
 
-  /** The installation failed. */
-  Failure: "Failure",
+  /** The attempt failed. */
+  Failed: "FAILED",
 
-  /** The installation is still in progress. */
-  InProgress: "InProgress",
+  /** The attempt was canceled. */
+  Canceled: "CANCELED",
+
+  /** The attempt was skipped. */
+  Skipped: "SKIPPED",
 }
 
 /**
- * Details of the terminal result of an update installation.
+ * Best-effort attestation of which subsystem produced a failure. Advisory only.
+ * Mirrors the ADU `FailureOrigin` enum; extensible union for forward-compat.
+ */
+@added(Versions.v2026_11_15_preview)
+union FailureOrigin {
+  string,
+
+  /** No failure, or origin not applicable. */
+  NotApplicable: "NOT_APPLICABLE",
+
+  /** The ADU cloud service. */
+  AduCloudService: "ADU_CLOUD_SERVICE",
+
+  /** An ADU-managed resource. */
+  AduManagedResource: "ADU_MANAGED_RESOURCE",
+
+  /** The device agent core. */
+  AgentCore: "AGENT_CORE",
+
+  /** An agent extension. */
+  AgentExtension: "AGENT_EXTENSION",
+
+  /** An agent dependency. */
+  AgentDependency: "AGENT_DEPENDENCY",
+
+  /** The device itself. */
+  Device: "DEVICE",
+
+  /** Some other origin. */
+  Other: "OTHER",
+}
+
+/**
+ * Per-step terminal result. Mirrors the ADU `StepResult` model.
+ */
+@added(Versions.v2026_11_15_preview)
+model StepResult {
+  /** Terminal outcome of this step. */
+  outcome: Outcome;
+
+  /** Which subsystem produced a failure. Advisory only. */
+  failureOrigin: FailureOrigin;
+
+  /** A positive value indicates success; a non-positive value indicates failure. Diagnostic only. */
+  resultCode: int64;
+
+  /** Comma-separated unsigned hexadecimal int32 codes for diagnostic correlation. Opaque to the service. */
+  @maxLength(1024)
+  extendedResultCodes: string;
+
+  /** Human-readable diagnostic detail. Not parsed programmatically. */
+  @maxLength(1024)
+  resultDetails?: string;
+}
+
+/**
+ * Terminal install result. Mirrors the ADU `InstallResult` model: the top-level
+ * step fields (spread from `StepResult`) plus an optional per-step breakdown.
  */
 @added(Versions.v2026_11_15_preview)
 model LastInstallResult {
-  /** Terminal outcome of the installation. */
-  outcome: InstallOutcome;
-
-  /** Where the failure originated, when the outcome is a failure. */
-  failureOrigin?: string;
-
-  /** Numeric result code; positive values indicate success. */
-  resultCode: int64;
-
-  /** Colon-delimited extended result codes. Optional. */
-  extendedResultCodes?: string;
-
-  /** Human-readable result details. Optional. */
-  resultDetails?: string | null;
+  ...StepResult;
 
   /**
-   * Per-step installation results. Open JSON object defined by the ADU agent.
+   * Per-step outcomes, keyed `step_0`, `step_1`, …. May be omitted on success;
+   * should be present on failure. Typed per the ADU contract (values are `StepResult`).
    */
-  #suppress "@azure-tools/typespec-azure-core/bad-record-type" "per-step results are an open JSON object per the ADU contract"
-  stepResults?: Record<unknown>;
+  stepResults?: Record<StepResult>;
 }
 
 /**

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -474,6 +474,15 @@ model ReportStatusRequest {
   /** Opaque deployment identifier from updateMetadata; the idempotency and routing key. */
   workflowId: string;
 
+  /**
+   * Attestation via TPM. Present only for TPM-attested devices, mirroring the
+   * Register (DeviceRegistration) request; X.509 and symmetric-key attestation are
+   * carried at the transport layer (TLS client certificate / SAS token) and are not
+   * part of the request body. Auth is enforced per action, so this parity affordance
+   * is present on every device-facing request.
+   */
+  tpm?: TpmAttestation;
+
   /** The update the device attempted to install, if any. */
   installedUpdateId?: UpdateId | null;
 

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/models.tsp
@@ -365,6 +365,14 @@ model UpdateCheckRequest {
   /** Information describing the ADU agent making the request. */
   agentInfo: AgentInfo;
 
+  /**
+   * Attestation via TPM. Present only for TPM-attested devices, mirroring the
+   * Register (DeviceRegistration) request; X.509 and symmetric-key attestation are
+   * carried at the transport layer (TLS client certificate / SAS token) and are not
+   * part of the request body, exactly as in Register.
+   */
+  tpm?: TpmAttestation;
+
   /** The update currently installed on the device, if any. */
   installedUpdateId?: UpdateId | null;
 

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
@@ -44,20 +44,22 @@ interface RuntimeRegistration {
       @path
       idScope: string;
     },
-    {
-      @statusCode _: 200;
-      @body body: RegistrationOperationStatus;
-    } | {
-      @statusCode _: 202;
 
-      @header("retry-after")
-      retryAfter?: int32;
+      | {
+          @statusCode _: 200;
+          @body body: RegistrationOperationStatus;
+        }
+      | {
+          @statusCode _: 202;
 
-      @header("Location")
-      location?: string;
+          @header("retry-after")
+          retryAfter?: int32;
 
-      @body body: RegistrationOperationStatus;
-    },
+          @header("Location")
+          location?: string;
+
+          @body body: RegistrationOperationStatus;
+        },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -93,20 +95,22 @@ interface RuntimeRegistration {
       @path
       idScope: string;
     },
-    {
-      @statusCode _: 200;
-      @body body: RegistrationOperationStatus;
-    } | {
-      @statusCode _: 202;
 
-      @header("retry-after")
-      retryAfter?: int32;
+      | {
+          @statusCode _: 200;
+          @body body: RegistrationOperationStatus;
+        }
+      | {
+          @statusCode _: 202;
 
-      @header("Location")
-      location?: string;
+          @header("retry-after")
+          retryAfter?: int32;
 
-      @body body: RegistrationOperationStatus;
-    },
+          @header("Location")
+          location?: string;
+
+          @body body: RegistrationOperationStatus;
+        },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -172,20 +176,22 @@ interface RuntimeRegistration {
       @bodyRoot
       body: DeviceRegistration;
     },
-    {
-      @statusCode _: 200;
-      @body body: RegistrationOperationStatus;
-    } | {
-      @statusCode _: 202;
 
-      @header("retry-after")
-      retryAfter?: int32;
+      | {
+          @statusCode _: 200;
+          @body body: RegistrationOperationStatus;
+        }
+      | {
+          @statusCode _: 202;
 
-      @header("Location")
-      location?: string;
+          @header("retry-after")
+          retryAfter?: int32;
 
-      @body body: RegistrationOperationStatus;
-    },
+          @header("Location")
+          location?: string;
+
+          @body body: RegistrationOperationStatus;
+        },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -221,20 +227,22 @@ interface RuntimeRegistration {
       @bodyRoot
       deviceRegistration: DeviceRegistration;
     },
-    {
-      @statusCode _: 200;
-      @body body: RegistrationOperationStatus;
-    } | {
-      @statusCode _: 202;
 
-      @header("retry-after")
-      retryAfter?: int32;
+      | {
+          @statusCode _: 200;
+          @body body: RegistrationOperationStatus;
+        }
+      | {
+          @statusCode _: 202;
 
-      @header("Location")
-      location?: string;
+          @header("retry-after")
+          retryAfter?: int32;
 
-      @body body: RegistrationOperationStatus;
-    },
+          @header("Location")
+          location?: string;
+
+          @body body: RegistrationOperationStatus;
+        },
     {},
     ProvisioningServiceErrorDetails
   >;

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
@@ -254,12 +254,25 @@ interface RuntimeRegistration {
  * state: the onboarding/bootstrap fetch before it is provisioned, the
  * regular/operational fetch afterwards. DPS is a thin pass-through to ADR (which
  * forwards to ADU) and does not branch on the update family or parse the manifest.
+ *
+ * Errors from ADU are surfaced verbatim: ADU's machine-readable `error.code`
+ * string (for example `UPDATE_ACCOUNT_NOT_LINKED`, `UNKNOWN_WORKFLOW_ID`,
+ * `UNSUPPORTED_API_VERSION`) is returned in the `x-ms-error-code` response
+ * header, and is also mirrored in the error body `info` dictionary under the key
+ * `aduErrorCode` (plus `aduErrorTarget` when ADU identifies a specific request
+ * element). The device should drive its behavior from that code, not the HTTP
+ * status, since a single status can map to several ADU codes.
  */
 @added(Versions.v2026_11_15_preview)
 interface DeviceUpdate {
   /**
    * Checks for an available device update on the regular / operational path. The
    * device selects this endpoint once it is provisioned.
+   *
+   * On failure, ADU's `error.code` string is returned verbatim in the
+   * `x-ms-error-code` header and mirrored in the error body `info` dictionary
+   * under `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should
+   * branch on that code rather than the HTTP status.
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"
@@ -289,6 +302,11 @@ interface DeviceUpdate {
    * Checks for an available device update on the onboarding / bootstrap path. The
    * device selects this endpoint before it is provisioned; only the external device
    * identifier is available (no ADR device UUID yet).
+   *
+   * On failure, ADU's `error.code` string is returned verbatim in the
+   * `x-ms-error-code` header and mirrored in the error body `info` dictionary
+   * under `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should
+   * branch on that code rather than the HTTP status.
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"
@@ -317,6 +335,11 @@ interface DeviceUpdate {
   /**
    * Reports the terminal result of a device update installation. Idempotent on
    * workflowId; ADU routes the report to the correct update family.
+   *
+   * On failure, ADU's `error.code` string is returned verbatim in the
+   * `x-ms-error-code` header and mirrored in the error body `info` dictionary
+   * under `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should
+   * branch on that code rather than the HTTP status.
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
@@ -44,22 +44,20 @@ interface RuntimeRegistration {
       @path
       idScope: string;
     },
+    {
+      @statusCode _: 200;
+      @body body: RegistrationOperationStatus;
+    } | {
+      @statusCode _: 202;
 
-      | {
-          @statusCode _: 200;
-          @body body: RegistrationOperationStatus;
-        }
-      | {
-          @statusCode _: 202;
+      @header("retry-after")
+      retryAfter?: int32;
 
-          @header("retry-after")
-          retryAfter?: int32;
+      @header("Location")
+      location?: string;
 
-          @header("Location")
-          location?: string;
-
-          @body body: RegistrationOperationStatus;
-        },
+      @body body: RegistrationOperationStatus;
+    },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -95,22 +93,20 @@ interface RuntimeRegistration {
       @path
       idScope: string;
     },
+    {
+      @statusCode _: 200;
+      @body body: RegistrationOperationStatus;
+    } | {
+      @statusCode _: 202;
 
-      | {
-          @statusCode _: 200;
-          @body body: RegistrationOperationStatus;
-        }
-      | {
-          @statusCode _: 202;
+      @header("retry-after")
+      retryAfter?: int32;
 
-          @header("retry-after")
-          retryAfter?: int32;
+      @header("Location")
+      location?: string;
 
-          @header("Location")
-          location?: string;
-
-          @body body: RegistrationOperationStatus;
-        },
+      @body body: RegistrationOperationStatus;
+    },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -176,22 +172,20 @@ interface RuntimeRegistration {
       @bodyRoot
       body: DeviceRegistration;
     },
+    {
+      @statusCode _: 200;
+      @body body: RegistrationOperationStatus;
+    } | {
+      @statusCode _: 202;
 
-      | {
-          @statusCode _: 200;
-          @body body: RegistrationOperationStatus;
-        }
-      | {
-          @statusCode _: 202;
+      @header("retry-after")
+      retryAfter?: int32;
 
-          @header("retry-after")
-          retryAfter?: int32;
+      @header("Location")
+      location?: string;
 
-          @header("Location")
-          location?: string;
-
-          @body body: RegistrationOperationStatus;
-        },
+      @body body: RegistrationOperationStatus;
+    },
     {},
     ProvisioningServiceErrorDetails
   >;
@@ -227,22 +221,134 @@ interface RuntimeRegistration {
       @bodyRoot
       deviceRegistration: DeviceRegistration;
     },
+    {
+      @statusCode _: 200;
+      @body body: RegistrationOperationStatus;
+    } | {
+      @statusCode _: 202;
 
-      | {
-          @statusCode _: 200;
-          @body body: RegistrationOperationStatus;
-        }
-      | {
-          @statusCode _: 202;
+      @header("retry-after")
+      retryAfter?: int32;
 
-          @header("retry-after")
-          retryAfter?: int32;
+      @header("Location")
+      location?: string;
 
-          @header("Location")
-          location?: string;
+      @body body: RegistrationOperationStatus;
+    },
+    {},
+    ProvisioningServiceErrorDetails
+  >;
+}
 
-          @body body: RegistrationOperationStatus;
-        },
+/**
+ * Device-facing ADU (Azure Device Update) integration operations. Added in
+ * 2026-11-15-preview. The device selects the endpoint by its own provisioning
+ * state: the onboarding/bootstrap fetch before it is provisioned, the
+ * regular/operational fetch afterwards. DPS is a thin pass-through to ADR (which
+ * forwards to ADU) and does not branch on the update family or parse the manifest.
+ */
+@added(Versions.v2026_11_15_preview)
+interface DeviceUpdate {
+  /**
+   * Checks for an available device update on the regular / operational path. The
+   * device selects this endpoint once it is provisioned.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"
+  @summary("Checks for an available device update (regular / operational path).")
+  @route("/{idScope}/registrations/{registrationId}/getDeviceUpdate")
+  @post
+  getDeviceUpdate is Azure.Core.Foundations.Operation<
+    {
+      /** The registration ID is alphanumeric, lowercase, and may contain hyphens. */
+      @path
+      registrationId: string;
+
+      /** The scope of the DPS instance. */
+      @path
+      idScope: string;
+
+      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
+      @header("x-ms-external-device-id")
+      xMsExternalDeviceId: string;
+
+      /**
+       * ADR device identifier (UUID), asserted by the gateway. Present on the
+       * regular path only.
+       */
+      @header("x-ms-device-id")
+      xMsDeviceId?: string;
+
+      /** Update check request. */
+      @bodyRoot
+      body: UpdateCheckRequest;
+    },
+    UpdateCheckResponse,
+    {},
+    ProvisioningServiceErrorDetails
+  >;
+
+  /**
+   * Checks for an available device update on the onboarding / bootstrap path. The
+   * device selects this endpoint before it is provisioned; only the external device
+   * identifier is available (no ADR device UUID yet).
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"
+  @summary("Checks for an available device update (onboarding / bootstrap path).")
+  @route("/{idScope}/registrations/{registrationId}/onboarding/getDeviceUpdate")
+  @post
+  getOnboardingDeviceUpdate is Azure.Core.Foundations.Operation<
+    {
+      /** The registration ID is alphanumeric, lowercase, and may contain hyphens. */
+      @path
+      registrationId: string;
+
+      /** The scope of the DPS instance. */
+      @path
+      idScope: string;
+
+      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
+      @header("x-ms-external-device-id")
+      xMsExternalDeviceId: string;
+
+      /** Update check request. */
+      @bodyRoot
+      body: UpdateCheckRequest;
+    },
+    UpdateCheckResponse,
+    {},
+    ProvisioningServiceErrorDetails
+  >;
+
+  /**
+   * Reports the terminal result of a device update installation. Idempotent on
+   * workflowId; ADU routes the report to the correct update family.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name mirrors the ADU device contract for pass-through compatibility"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using Foundations.Operation for consistency with the existing DPS device API"
+  @summary("Reports the terminal result of a device update installation.")
+  @route("/{idScope}/registrations/{registrationId}/reportDeviceUpdateStatus")
+  @post
+  reportDeviceUpdateStatus is Azure.Core.Foundations.Operation<
+    {
+      /** The registration ID is alphanumeric, lowercase, and may contain hyphens. */
+      @path
+      registrationId: string;
+
+      /** The scope of the DPS instance. */
+      @path
+      idScope: string;
+
+      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
+      @header("x-ms-external-device-id")
+      xMsExternalDeviceId: string;
+
+      /** Status report request. */
+      @bodyRoot
+      body: ReportStatusRequest;
+    },
+    ReportDeviceUpdateStatusResult,
     {},
     ProvisioningServiceErrorDetails
   >;

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device/routes.tsp
@@ -268,17 +268,6 @@ interface DeviceUpdate {
       @path
       idScope: string;
 
-      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
-      @header("x-ms-external-device-id")
-      xMsExternalDeviceId: string;
-
-      /**
-       * ADR device identifier (UUID), asserted by the gateway. Present on the
-       * regular path only.
-       */
-      @header("x-ms-device-id")
-      xMsDeviceId?: string;
-
       /** Update check request. */
       @bodyRoot
       body: UpdateCheckRequest;
@@ -308,10 +297,6 @@ interface DeviceUpdate {
       @path
       idScope: string;
 
-      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
-      @header("x-ms-external-device-id")
-      xMsExternalDeviceId: string;
-
       /** Update check request. */
       @bodyRoot
       body: UpdateCheckRequest;
@@ -339,10 +324,6 @@ interface DeviceUpdate {
       /** The scope of the DPS instance. */
       @path
       idScope: string;
-
-      /** External device identifier, asserted by the gateway. Equals the registrationId in DPS. */
-      @header("x-ms-external-device-id")
-      xMsExternalDeviceId: string;
 
       /** Status report request. */
       @bodyRoot

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -1,0 +1,1027 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ProvisioningDeviceClient",
+    "version": "2026-11-15-preview",
+    "description": "API for device runtime operations with the Azure IoT Hub Device Provisioning\nService",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "global.azure-devices-provisioning.net",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "tags": [],
+  "paths": {
+    "/{idScope}/registrations/{registrationId}": {
+      "post": {
+        "operationId": "RuntimeRegistration_DeviceRegistrationStatusLookup",
+        "summary": "Gets the device registration status.",
+        "description": "Gets the device registration status.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "Registration ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Device registration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeviceRegistration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DeviceRegistrationResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{idScope}/registrations/{registrationId}/getDeviceUpdate": {
+      "post": {
+        "operationId": "DeviceUpdate_GetDeviceUpdate",
+        "summary": "Checks for an available device update (regular / operational path).",
+        "description": "Checks for an available device update on the regular / operational path. The\ndevice selects this endpoint once it is provisioned.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "The registration ID is alphanumeric, lowercase, and may contain hyphens.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-external-device-id",
+            "in": "header",
+            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "xMsExternalDeviceId"
+          },
+          {
+            "name": "x-ms-device-id",
+            "in": "header",
+            "description": "ADR device identifier (UUID), asserted by the gateway. Present on the\nregular path only.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "xMsDeviceId"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Update check request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateCheckRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UpdateCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeviceUpdate_GetDeviceUpdate": {
+            "$ref": "./examples/DeviceUpdate_GetDeviceUpdate.json"
+          }
+        }
+      }
+    },
+    "/{idScope}/registrations/{registrationId}/onboarding/getDeviceUpdate": {
+      "post": {
+        "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+        "summary": "Checks for an available device update (onboarding / bootstrap path).",
+        "description": "Checks for an available device update on the onboarding / bootstrap path. The\ndevice selects this endpoint before it is provisioned; only the external device\nidentifier is available (no ADR device UUID yet).",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "The registration ID is alphanumeric, lowercase, and may contain hyphens.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-external-device-id",
+            "in": "header",
+            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "xMsExternalDeviceId"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Update check request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateCheckRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UpdateCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeviceUpdate_GetOnboardingDeviceUpdate": {
+            "$ref": "./examples/DeviceUpdate_GetOnboardingDeviceUpdate.json"
+          }
+        }
+      }
+    },
+    "/{idScope}/registrations/{registrationId}/operations/{operationId}": {
+      "get": {
+        "operationId": "RuntimeRegistration_OperationStatusLookup",
+        "summary": "Gets the registration operation status.",
+        "description": "Gets the registration operation status.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "Registration ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "Operation ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RegistrationOperationStatus"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/RegistrationOperationStatus"
+            },
+            "headers": {
+              "Location": {
+                "type": "string"
+              },
+              "retry-after": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{idScope}/registrations/{registrationId}/register": {
+      "put": {
+        "operationId": "RuntimeRegistration_RegisterDeviceAndIssueCertificate",
+        "summary": "Registers the devices and optionally issue operational certificates for IoT devices.",
+        "description": "Registers the devices and optionally issue operational certificates for IoT devices.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "The registration ID is alphanumeric, lowercase, and may contain hyphens.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deviceRegistration",
+            "in": "body",
+            "description": "Device registration request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeviceRegistration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RegistrationOperationStatus"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/RegistrationOperationStatus"
+            },
+            "headers": {
+              "Location": {
+                "type": "string"
+              },
+              "retry-after": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{idScope}/registrations/{registrationId}/reportDeviceUpdateStatus": {
+      "post": {
+        "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
+        "summary": "Reports the terminal result of a device update installation.",
+        "description": "Reports the terminal result of a device update installation. Idempotent on\nworkflowId; ADU routes the report to the correct update family.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "registrationId",
+            "in": "path",
+            "description": "The registration ID is alphanumeric, lowercase, and may contain hyphens.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "idScope",
+            "in": "path",
+            "description": "The scope of the DPS instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-external-device-id",
+            "in": "header",
+            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "xMsExternalDeviceId"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Status report request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReportStatusRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceErrorDetails"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "The error code for specific error that occurred."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeviceUpdate_ReportDeviceUpdateStatus": {
+            "$ref": "./examples/DeviceUpdate_ReportDeviceUpdateStatus.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AgentInfo": {
+      "type": "object",
+      "description": "Information describing the ADU agent and the device it runs on, used to match\nthe device to an applicable update.",
+      "properties": {
+        "agentSdkVersion": {
+          "type": "string",
+          "description": "Version of the ADU agent SDK on the device."
+        },
+        "agentProfile": {
+          "type": "integer",
+          "format": "int32",
+          "description": "ADU agent profile identifier."
+        },
+        "compatibilityProperties": {
+          "type": "object",
+          "description": "Device compatibility properties (for example manufacturer and model).",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "agentSdkVersion",
+        "agentProfile",
+        "compatibilityProperties"
+      ]
+    },
+    "AssignedDeviceSubstatus": {
+      "type": "string",
+      "description": "Substatus for 'Assigned' devices. Possible values include -\n'initialAssignment': Device has been assigned to an IoT hub for the first time,\n'deviceDataMigrated': Device has been assigned to a different IoT hub and its\ndevice data was migrated from the previously assigned IoT hub. Device data was\nremoved from the previously assigned IoT hub, 'deviceDataReset':  Device has\nbeen assigned to a different IoT hub and its device data was populated from the\ninitial state stored in the enrollment. Device data was removed from the\npreviously assigned IoT hub, 'reprovisionedToInitialAssignment': Device has\nbeen re-provisioned to a previously assigned IoT hub.",
+      "enum": [
+        "initialAssignment",
+        "deviceDataMigrated",
+        "deviceDataReset",
+        "reprovisionedToInitialAssignment"
+      ],
+      "x-ms-enum": {
+        "name": "AssignedDeviceSubstatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "initialAssignment",
+            "value": "initialAssignment",
+            "description": "initialAssignment"
+          },
+          {
+            "name": "deviceDataMigrated",
+            "value": "deviceDataMigrated",
+            "description": "deviceDataMigrated"
+          },
+          {
+            "name": "deviceDataReset",
+            "value": "deviceDataReset",
+            "description": "deviceDataReset"
+          },
+          {
+            "name": "reprovisionedToInitialAssignment",
+            "value": "reprovisionedToInitialAssignment",
+            "description": "reprovisionedToInitialAssignment"
+          }
+        ]
+      }
+    },
+    "DeviceRegistration": {
+      "type": "object",
+      "description": "Device registration.",
+      "properties": {
+        "registrationId": {
+          "type": "string",
+          "description": "The registration ID is a case-insensitive string (up to 128 characters long) of\nalphanumeric characters plus certain special characters : . _ -. No special\ncharacters allowed at start or end."
+        },
+        "tpm": {
+          "$ref": "#/definitions/TpmAttestation",
+          "description": "Attestation via TPM."
+        },
+        "csr": {
+          "type": "string",
+          "description": "A Base64-encoded DER certificate signing request (CSR) in PKCS #10 format,\nexcluding PEM headers and footers. The Common Name (CN) must match the device\nregistrationId. Including this field in the\nRuntimeRegistration_DeviceRegistrationStatusLookup operation will result in\na bad request."
+        },
+        "payload": {
+          "type": "object",
+          "description": "Any object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "DeviceRegistrationResult": {
+      "type": "object",
+      "description": "Device registration result.",
+      "properties": {
+        "tpm": {
+          "$ref": "#/definitions/TpmRegistrationResult",
+          "description": "TPM registration result."
+        },
+        "x509": {
+          "$ref": "#/definitions/X509RegistrationResult",
+          "description": "X509 registration result."
+        },
+        "symmetricKey": {
+          "$ref": "#/definitions/SymmetricKeyRegistrationResult",
+          "description": "Registration result returned when using SymmetricKey attestation."
+        },
+        "registrationId": {
+          "type": "string",
+          "description": "This id is used to uniquely identify a device registration of an enrollment.\nA case-insensitive string (up to 128 characters long) of alphanumeric\ncharacters plus certain special characters : . _ -. No special characters\nallowed at start or end.",
+          "readOnly": true
+        },
+        "createdDateTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Registration create date time (in UTC).",
+          "readOnly": true
+        },
+        "assignedHub": {
+          "type": "string",
+          "description": "Assigned Azure IoT Hub.",
+          "readOnly": true
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/EnrollmentStatus",
+          "description": "Enrollment status.",
+          "readOnly": true
+        },
+        "substatus": {
+          "$ref": "#/definitions/AssignedDeviceSubstatus",
+          "description": "Substatus for 'Assigned' devices. Possible values include -\n'initialAssignment': Device has been assigned to an IoT hub for the first time,\n'deviceDataMigrated': Device has been assigned to a different IoT hub and its\ndevice data was migrated from the previously assigned IoT hub. Device data was\nremoved from the previously assigned IoT hub, 'deviceDataReset':  Device has\nbeen assigned to a different IoT hub and its device data was populated from the\ninitial state stored in the enrollment. Device data was removed from the\npreviously assigned IoT hub, 'reprovisionedToInitialAssignment': Device has\nbeen re-provisioned to a previously assigned IoT hub.",
+          "readOnly": true
+        },
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Error code.",
+          "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Error message.",
+          "readOnly": true
+        },
+        "lastUpdatedDateTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last updated date time (in UTC).",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "The entity tag associated with the resource.",
+          "readOnly": true
+        },
+        "payload": {
+          "type": "object",
+          "description": "Any object",
+          "additionalProperties": {},
+          "readOnly": true
+        },
+        "issuedCertificateChain": {
+          "type": "array",
+          "description": "An array containing the full certificate chain for the issued certificate.\nThe first element is the issued leaf certificate, followed by any intermediate\ncertification authorities (ICAs), and ending with the root certification authority (CA).\nEach certificate in the array is the issuer of the previous certificate.\nThis property is not included in responses for the\nRuntimeRegistration_DeviceRegistrationStatusLookup operation.",
+          "items": {
+            "type": "string",
+            "format": "byte"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "EnrollmentStatus": {
+      "type": "string",
+      "description": "Enrollment status.",
+      "enum": [
+        "unassigned",
+        "assigning",
+        "assigned",
+        "failed",
+        "disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EnrollmentStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "unassigned",
+            "value": "unassigned",
+            "description": "unassigned"
+          },
+          {
+            "name": "assigning",
+            "value": "assigning",
+            "description": "assigning"
+          },
+          {
+            "name": "assigned",
+            "value": "assigned",
+            "description": "assigned"
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "failed"
+          },
+          {
+            "name": "disabled",
+            "value": "disabled",
+            "description": "disabled"
+          }
+        ]
+      }
+    },
+    "InstallOutcome": {
+      "type": "string",
+      "description": "Terminal outcome of an update installation.",
+      "enum": [
+        "Success",
+        "Failure",
+        "InProgress"
+      ],
+      "x-ms-enum": {
+        "name": "InstallOutcome",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Success",
+            "value": "Success",
+            "description": "The installation succeeded."
+          },
+          {
+            "name": "Failure",
+            "value": "Failure",
+            "description": "The installation failed."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The installation is still in progress."
+          }
+        ]
+      }
+    },
+    "LastInstallResult": {
+      "type": "object",
+      "description": "Details of the terminal result of an update installation.",
+      "properties": {
+        "outcome": {
+          "$ref": "#/definitions/InstallOutcome",
+          "description": "Terminal outcome of the installation."
+        },
+        "failureOrigin": {
+          "type": "string",
+          "description": "Where the failure originated, when the outcome is a failure."
+        },
+        "resultCode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Numeric result code; positive values indicate success."
+        },
+        "extendedResultCodes": {
+          "type": "string",
+          "description": "Colon-delimited extended result codes. Optional."
+        },
+        "resultDetails": {
+          "type": "string",
+          "description": "Human-readable result details. Optional.",
+          "x-nullable": true
+        },
+        "stepResults": {
+          "type": "object",
+          "description": "Per-step installation results. Open JSON object defined by the ADU agent.",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "outcome",
+        "resultCode"
+      ]
+    },
+    "ProvisioningServiceErrorDetails": {
+      "type": "object",
+      "description": "Contains the properties of an error returned by the Azure IoT Hub Provisioning\nService.",
+      "properties": {
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Numeric error code."
+        },
+        "trackingId": {
+          "type": "string",
+          "description": "Error tracking ID."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        },
+        "info": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "timestampUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Error timestamp (UTC)."
+        }
+      }
+    },
+    "RegistrationOperationStatus": {
+      "type": "object",
+      "description": "Registration operation status.",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "Operation ID.",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/definitions/EnrollmentStatus",
+          "description": "Device enrollment status."
+        },
+        "registrationState": {
+          "$ref": "#/definitions/DeviceRegistrationResult",
+          "description": "Device registration result."
+        }
+      },
+      "required": [
+        "operationId"
+      ]
+    },
+    "ReportDeviceUpdateStatusResult": {
+      "type": "object",
+      "description": "Result of a reportDeviceUpdateStatus call. Empty in this preview; fields may be\nadded later."
+    },
+    "ReportStatusRequest": {
+      "type": "object",
+      "description": "Request body reporting the terminal result of an update installation.",
+      "properties": {
+        "workflowId": {
+          "type": "string",
+          "description": "Opaque deployment identifier from updateMetadata; the idempotency and routing key."
+        },
+        "installedUpdateId": {
+          "$ref": "#/definitions/UpdateId",
+          "description": "The update the device attempted to install, if any.",
+          "x-nullable": true
+        },
+        "lastInstallResult": {
+          "$ref": "#/definitions/LastInstallResult",
+          "description": "The terminal result of the installation."
+        }
+      },
+      "required": [
+        "workflowId",
+        "lastInstallResult"
+      ]
+    },
+    "ServiceConfiguration": {
+      "type": "object",
+      "description": "Device service configuration returned by an update check.",
+      "properties": {
+        "rootKeyDownloadUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL from which the device fetches ADU root keys for signature validation."
+        }
+      }
+    },
+    "SymmetricKeyRegistrationResult": {
+      "type": "object",
+      "description": "Registration result returned when using SymmetricKey attestation.",
+      "properties": {
+        "enrollmentGroupId": {
+          "type": "string",
+          "description": "Enrollment group ID."
+        }
+      }
+    },
+    "TpmAttestation": {
+      "type": "object",
+      "description": "Attestation via TPM.",
+      "properties": {
+        "endorsementKey": {
+          "type": "string",
+          "description": "TPM endorsement key."
+        },
+        "storageRootKey": {
+          "type": "string",
+          "description": "TPM storage root key."
+        }
+      },
+      "required": [
+        "endorsementKey"
+      ]
+    },
+    "TpmRegistrationResult": {
+      "type": "object",
+      "description": "TPM registration result.",
+      "properties": {
+        "authenticationKey": {
+          "type": "string",
+          "description": "Encrypted authentication key."
+        }
+      }
+    },
+    "UpdateCheckRequest": {
+      "type": "object",
+      "description": "Request body for a device update check (both the regular/operational and the\nonboarding/bootstrap fetch operations share this shape).",
+      "properties": {
+        "agentInfo": {
+          "$ref": "#/definitions/AgentInfo",
+          "description": "Information describing the ADU agent making the request."
+        },
+        "installedUpdateId": {
+          "$ref": "#/definitions/UpdateId",
+          "description": "The update currently installed on the device, if any.",
+          "x-nullable": true
+        },
+        "agentInfoETag": {
+          "type": "string",
+          "description": "ETag of the last agentInfo the service observed, used by the service to skip\nredundant processing. Optional."
+        },
+        "serviceConfigETag": {
+          "type": "string",
+          "description": "ETag of the serviceConfiguration the device currently holds, used by the\nservice to omit unchanged configuration. Optional."
+        }
+      },
+      "required": [
+        "agentInfo"
+      ]
+    },
+    "UpdateCheckResponse": {
+      "type": "object",
+      "description": "Response body for a device update check. When an update applies, updateMetadata\nis present; \"no update available\" is signaled by omitting updateMetadata.",
+      "properties": {
+        "serviceConfiguration": {
+          "$ref": "#/definitions/ServiceConfiguration",
+          "description": "Device service configuration returned on every response."
+        },
+        "serviceConfigETag": {
+          "type": "string",
+          "description": "ETag of the returned serviceConfiguration."
+        },
+        "agentInfoETag": {
+          "type": "string",
+          "description": "ETag the device should echo on its next request in agentInfoETag."
+        },
+        "updateMetadata": {
+          "$ref": "#/definitions/UpdateMetadata",
+          "description": "Present only when an update applies to the device; omitted otherwise."
+        }
+      },
+      "required": [
+        "serviceConfiguration"
+      ]
+    },
+    "UpdateId": {
+      "type": "object",
+      "description": "Identifies a specific update by provider, name, and version.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Update provider."
+        },
+        "name": {
+          "type": "string",
+          "description": "Update name."
+        },
+        "version": {
+          "type": "string",
+          "description": "Update version."
+        }
+      },
+      "required": [
+        "provider",
+        "name",
+        "version"
+      ]
+    },
+    "UpdateMetadata": {
+      "type": "object",
+      "description": "Metadata describing an available update. The manifest is opaque to DPS.",
+      "properties": {
+        "workflowId": {
+          "type": "string",
+          "description": "Opaque deployment identifier; echoed by the device on reportDeviceUpdateStatus."
+        },
+        "updateManifest": {
+          "type": "string",
+          "description": "Opaque update manifest string. DPS does not parse this value."
+        },
+        "updateManifestSignature": {
+          "type": "string",
+          "description": "JWS signature over the update manifest."
+        },
+        "fileUrls": {
+          "type": "array",
+          "description": "URLs of the payload files that make up the update.",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "required": [
+        "workflowId",
+        "updateManifest",
+        "updateManifestSignature",
+        "fileUrls"
+      ]
+    },
+    "X509CertificateInfo": {
+      "type": "object",
+      "description": "X509 certificate info.",
+      "properties": {
+        "subjectName": {
+          "type": "string",
+          "description": "Certificate subject name."
+        },
+        "sha1Thumbprint": {
+          "type": "string",
+          "description": "SHA-1 thumbprint of the certificate."
+        },
+        "sha256Thumbprint": {
+          "type": "string",
+          "description": "SHA-256 thumbprint of the certificate."
+        },
+        "issuerName": {
+          "type": "string",
+          "description": "Certificate issuer name."
+        },
+        "notBeforeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate validity start date (UTC)."
+        },
+        "notAfterUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate expiry date (UTC)."
+        },
+        "serialNumber": {
+          "type": "string",
+          "description": "Certificate serial number."
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Certificate version."
+        }
+      },
+      "required": [
+        "subjectName",
+        "sha1Thumbprint",
+        "sha256Thumbprint",
+        "issuerName",
+        "notBeforeUtc",
+        "notAfterUtc",
+        "serialNumber",
+        "version"
+      ]
+    },
+    "X509RegistrationResult": {
+      "type": "object",
+      "description": "X509 registration result.",
+      "properties": {
+        "certificateInfo": {
+          "$ref": "#/definitions/X509CertificateInfo",
+          "description": "X509 certificate info."
+        },
+        "enrollmentGroupId": {
+          "type": "string",
+          "description": "Enrollment group ID."
+        },
+        "signingCertificateInfo": {
+          "$ref": "#/definitions/X509CertificateInfo",
+          "description": "X509 certificate info."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -641,72 +641,143 @@
         ]
       }
     },
-    "InstallOutcome": {
+    "FailureOrigin": {
       "type": "string",
-      "description": "Terminal outcome of an update installation.",
+      "description": "Best-effort attestation of which subsystem produced a failure. Advisory only.\nMirrors the ADU `FailureOrigin` enum; extensible union for forward-compat.",
       "enum": [
-        "Success",
-        "Failure",
-        "InProgress"
+        "NOT_APPLICABLE",
+        "ADU_CLOUD_SERVICE",
+        "ADU_MANAGED_RESOURCE",
+        "AGENT_CORE",
+        "AGENT_EXTENSION",
+        "AGENT_DEPENDENCY",
+        "DEVICE",
+        "OTHER"
       ],
       "x-ms-enum": {
-        "name": "InstallOutcome",
+        "name": "FailureOrigin",
         "modelAsString": true,
         "values": [
           {
-            "name": "Success",
-            "value": "Success",
-            "description": "The installation succeeded."
+            "name": "NotApplicable",
+            "value": "NOT_APPLICABLE",
+            "description": "No failure, or origin not applicable."
           },
           {
-            "name": "Failure",
-            "value": "Failure",
-            "description": "The installation failed."
+            "name": "AduCloudService",
+            "value": "ADU_CLOUD_SERVICE",
+            "description": "The ADU cloud service."
           },
           {
-            "name": "InProgress",
-            "value": "InProgress",
-            "description": "The installation is still in progress."
+            "name": "AduManagedResource",
+            "value": "ADU_MANAGED_RESOURCE",
+            "description": "An ADU-managed resource."
+          },
+          {
+            "name": "AgentCore",
+            "value": "AGENT_CORE",
+            "description": "The device agent core."
+          },
+          {
+            "name": "AgentExtension",
+            "value": "AGENT_EXTENSION",
+            "description": "An agent extension."
+          },
+          {
+            "name": "AgentDependency",
+            "value": "AGENT_DEPENDENCY",
+            "description": "An agent dependency."
+          },
+          {
+            "name": "Device",
+            "value": "DEVICE",
+            "description": "The device itself."
+          },
+          {
+            "name": "Other",
+            "value": "OTHER",
+            "description": "Some other origin."
           }
         ]
       }
     },
     "LastInstallResult": {
       "type": "object",
-      "description": "Details of the terminal result of an update installation.",
+      "description": "Terminal install result. Mirrors the ADU `InstallResult` model: the top-level\nstep fields (spread from `StepResult`) plus an optional per-step breakdown.",
       "properties": {
         "outcome": {
-          "$ref": "#/definitions/InstallOutcome",
-          "description": "Terminal outcome of the installation."
+          "$ref": "#/definitions/Outcome",
+          "description": "Terminal outcome of this step."
         },
         "failureOrigin": {
-          "type": "string",
-          "description": "Where the failure originated, when the outcome is a failure."
+          "$ref": "#/definitions/FailureOrigin",
+          "description": "Which subsystem produced a failure. Advisory only."
         },
         "resultCode": {
           "type": "integer",
           "format": "int64",
-          "description": "Numeric result code; positive values indicate success."
+          "description": "A positive value indicates success; a non-positive value indicates failure. Diagnostic only."
         },
         "extendedResultCodes": {
           "type": "string",
-          "description": "Colon-delimited extended result codes. Optional."
+          "description": "Comma-separated unsigned hexadecimal int32 codes for diagnostic correlation. Opaque to the service.",
+          "maxLength": 1024
         },
         "resultDetails": {
           "type": "string",
-          "description": "Human-readable result details. Optional.",
-          "x-nullable": true
+          "description": "Human-readable diagnostic detail. Not parsed programmatically.",
+          "maxLength": 1024
         },
         "stepResults": {
           "type": "object",
-          "description": "Per-step installation results. Open JSON object defined by the ADU agent.",
-          "additionalProperties": {}
+          "description": "Per-step outcomes, keyed `step_0`, `step_1`, …. May be omitted on success;\nshould be present on failure. Typed per the ADU contract (values are `StepResult`).",
+          "additionalProperties": {
+            "$ref": "#/definitions/StepResult"
+          }
         }
       },
       "required": [
         "outcome",
-        "resultCode"
+        "failureOrigin",
+        "resultCode",
+        "extendedResultCodes"
       ]
+    },
+    "Outcome": {
+      "type": "string",
+      "description": "Terminal outcome of an update attempt or step. Mirrors the ADU `Outcome` enum;\nmodeled as an extensible union so ADU can add outcomes without a breaking change.",
+      "enum": [
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "SKIPPED"
+      ],
+      "x-ms-enum": {
+        "name": "Outcome",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "SUCCEEDED",
+            "description": "The attempt succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "FAILED",
+            "description": "The attempt failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "CANCELED",
+            "description": "The attempt was canceled."
+          },
+          {
+            "name": "Skipped",
+            "value": "SKIPPED",
+            "description": "The attempt was skipped."
+          }
+        ]
+      }
     },
     "ProvisioningServiceErrorDetails": {
       "type": "object",
@@ -802,6 +873,41 @@
           "description": "URL from which the device fetches ADU root keys for signature validation."
         }
       }
+    },
+    "StepResult": {
+      "type": "object",
+      "description": "Per-step terminal result. Mirrors the ADU `StepResult` model.",
+      "properties": {
+        "outcome": {
+          "$ref": "#/definitions/Outcome",
+          "description": "Terminal outcome of this step."
+        },
+        "failureOrigin": {
+          "$ref": "#/definitions/FailureOrigin",
+          "description": "Which subsystem produced a failure. Advisory only."
+        },
+        "resultCode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "A positive value indicates success; a non-positive value indicates failure. Diagnostic only."
+        },
+        "extendedResultCodes": {
+          "type": "string",
+          "description": "Comma-separated unsigned hexadecimal int32 codes for diagnostic correlation. Opaque to the service.",
+          "maxLength": 1024
+        },
+        "resultDetails": {
+          "type": "string",
+          "description": "Human-readable diagnostic detail. Not parsed programmatically.",
+          "maxLength": 1024
+        }
+      },
+      "required": [
+        "outcome",
+        "failureOrigin",
+        "resultCode",
+        "extendedResultCodes"
+      ]
     },
     "SymmetricKeyRegistrationResult": {
       "type": "object",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -433,16 +433,19 @@
       "properties": {
         "agentSdkVersion": {
           "type": "string",
-          "description": "Version of the ADU agent SDK on the device."
+          "description": "Agent SDK version. Diagnostic only; not used for targeting.",
+          "minLength": 1,
+          "maxLength": 64
         },
         "agentProfile": {
           "type": "integer",
           "format": "int32",
-          "description": "ADU agent profile identifier."
+          "description": "Opaque capability identifier; the service maps it to supported manifest versions\nand installability constraints. The device must not infer meaning from the value.",
+          "minimum": 1
         },
         "compatibilityProperties": {
           "type": "object",
-          "description": "Device compatibility properties (for example manufacturer and model).",
+          "description": "Device compatibility attributes; combined with agentProfile to compute the device class.",
           "additionalProperties": {
             "type": "string"
           }
@@ -701,7 +704,7 @@
         ]
       }
     },
-    "LastInstallResult": {
+    "InstallResult": {
       "type": "object",
       "description": "Terminal install result. Mirrors the ADU `InstallResult` model: the top-level\nstep fields (spread from `StepResult`) plus an optional per-step breakdown.",
       "properties": {
@@ -741,6 +744,36 @@
         "failureOrigin",
         "resultCode",
         "extendedResultCodes"
+      ]
+    },
+    "InstalledUpdateId": {
+      "type": "object",
+      "description": "Identifier of an update.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Update provider. Alphanumeric plus '.' and '-'.",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-zA-Z0-9.\\-]+$"
+        },
+        "name": {
+          "type": "string",
+          "description": "Update name. Alphanumeric plus '.' and '-'.",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-zA-Z0-9.\\-]+$"
+        },
+        "version": {
+          "type": "string",
+          "description": "2 to 4-part numeric version, e.g. 1.2, 1.2.3, 1.2.3.4.",
+          "pattern": "^\\d+(\\.\\d+){1,3}$"
+        }
+      },
+      "required": [
+        "provider",
+        "name",
+        "version"
       ]
     },
     "Outcome": {
@@ -842,24 +875,27 @@
       "properties": {
         "workflowId": {
           "type": "string",
-          "description": "Opaque deployment identifier from updateMetadata; the idempotency and routing key."
+          "description": "The workflowId from the updateMetadata being reported; the idempotency and routing key.",
+          "minLength": 1,
+          "maxLength": 128
         },
         "tpm": {
           "$ref": "#/definitions/TpmAttestation",
           "description": "Attestation via TPM. Present only for TPM-attested devices, mirroring the\nRegister (DeviceRegistration) request; X.509 and symmetric-key attestation are\ncarried at the transport layer (TLS client certificate / SAS token) and are not\npart of the request body. Auth is enforced per action, so this parity affordance\nis present on every device-facing request."
         },
         "installedUpdateId": {
-          "$ref": "#/definitions/UpdateId",
-          "description": "The update the device attempted to install, if any.",
+          "$ref": "#/definitions/InstalledUpdateId",
+          "description": "The update now installed, or null. Communicates current device state; not a failure signal.",
           "x-nullable": true
         },
         "lastInstallResult": {
-          "$ref": "#/definitions/LastInstallResult",
+          "$ref": "#/definitions/InstallResult",
           "description": "The terminal result of the installation."
         }
       },
       "required": [
         "workflowId",
+        "installedUpdateId",
         "lastInstallResult"
       ]
     },
@@ -870,9 +906,12 @@
         "rootKeyDownloadUrl": {
           "type": "string",
           "format": "uri",
-          "description": "URL from which the device fetches ADU root keys for signature validation."
+          "description": "URL of the current root-key package; the device verifies updateManifestSignature against it."
         }
-      }
+      },
+      "required": [
+        "rootKeyDownloadUrl"
+      ]
     },
     "StepResult": {
       "type": "object",
@@ -952,28 +991,32 @@
       "properties": {
         "agentInfo": {
           "$ref": "#/definitions/AgentInfo",
-          "description": "Information describing the ADU agent making the request."
+          "description": "Device agent information. Required unless a still-current agentInfoETag is supplied."
         },
         "tpm": {
           "$ref": "#/definitions/TpmAttestation",
           "description": "Attestation via TPM. Present only for TPM-attested devices, mirroring the\nRegister (DeviceRegistration) request; X.509 and symmetric-key attestation are\ncarried at the transport layer (TLS client certificate / SAS token) and are not\npart of the request body, exactly as in Register."
         },
         "installedUpdateId": {
-          "$ref": "#/definitions/UpdateId",
-          "description": "The update currently installed on the device, if any.",
+          "$ref": "#/definitions/InstalledUpdateId",
+          "description": "Currently installed update, or null if none.",
           "x-nullable": true
         },
         "agentInfoETag": {
           "type": "string",
-          "description": "ETag of the last agentInfo the service observed, used by the service to skip\nredundant processing. Optional."
+          "description": "ETag from a prior response; lets the service skip re-processing agentInfo.\nOptional.",
+          "minLength": 1,
+          "maxLength": 128
         },
         "serviceConfigETag": {
           "type": "string",
-          "description": "ETag of the serviceConfiguration the device currently holds, used by the\nservice to omit unchanged configuration. Optional."
+          "description": "ETag from a prior response; lets the service omit unchanged serviceConfiguration.\nOptional.",
+          "minLength": 1,
+          "maxLength": 128
         }
       },
       "required": [
-        "agentInfo"
+        "installedUpdateId"
       ]
     },
     "UpdateCheckResponse": {
@@ -982,15 +1025,15 @@
       "properties": {
         "serviceConfiguration": {
           "$ref": "#/definitions/ServiceConfiguration",
-          "description": "Device service configuration returned on every response."
+          "description": "Device service configuration. Omitted only when a matching serviceConfigETag was supplied."
         },
         "serviceConfigETag": {
           "type": "string",
-          "description": "ETag of the returned serviceConfiguration."
+          "description": "Current ETag of serviceConfiguration."
         },
         "agentInfoETag": {
           "type": "string",
-          "description": "ETag the device should echo on its next request in agentInfoETag."
+          "description": "Current ETag of the processed agentInfo."
         },
         "updateMetadata": {
           "$ref": "#/definitions/UpdateMetadata",
@@ -998,30 +1041,8 @@
         }
       },
       "required": [
-        "serviceConfiguration"
-      ]
-    },
-    "UpdateId": {
-      "type": "object",
-      "description": "Identifies a specific update by provider, name, and version.",
-      "properties": {
-        "provider": {
-          "type": "string",
-          "description": "Update provider."
-        },
-        "name": {
-          "type": "string",
-          "description": "Update name."
-        },
-        "version": {
-          "type": "string",
-          "description": "Update version."
-        }
-      },
-      "required": [
-        "provider",
-        "name",
-        "version"
+        "serviceConfigETag",
+        "agentInfoETag"
       ]
     },
     "UpdateMetadata": {
@@ -1030,22 +1051,24 @@
       "properties": {
         "workflowId": {
           "type": "string",
-          "description": "Opaque deployment identifier; echoed by the device on reportDeviceUpdateStatus."
+          "description": "Opaque deployment identifier; echoed by the device on reportDeviceUpdateStatus.",
+          "minLength": 1,
+          "maxLength": 128
         },
         "updateManifest": {
           "type": "string",
-          "description": "Opaque update manifest string. DPS does not parse this value."
+          "description": "Update manifest as a serialized JSON string; verify the signature before parsing. DPS does not parse this value."
         },
         "updateManifestSignature": {
           "type": "string",
-          "description": "JWS signature over the update manifest."
+          "description": "JWS compact serialization over updateManifest."
         },
         "fileUrls": {
-          "type": "array",
-          "description": "URLs of the payload files that make up the update.",
-          "items": {
-            "type": "string",
-            "format": "uri"
+          "type": "object",
+          "description": "Map of fileId to download URL.",
+          "additionalProperties": {
+            "format": "uri",
+            "type": "string"
           }
         }
       },

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -109,22 +109,6 @@
             "type": "string"
           },
           {
-            "name": "x-ms-external-device-id",
-            "in": "header",
-            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "xMsExternalDeviceId"
-          },
-          {
-            "name": "x-ms-device-id",
-            "in": "header",
-            "description": "ADR device identifier (UUID), asserted by the gateway. Present on the\nregular path only.",
-            "required": false,
-            "type": "string",
-            "x-ms-client-name": "xMsDeviceId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "Update check request.",
@@ -186,14 +170,6 @@
             "description": "The scope of the DPS instance.",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "x-ms-external-device-id",
-            "in": "header",
-            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "xMsExternalDeviceId"
           },
           {
             "name": "body",
@@ -412,14 +388,6 @@
             "description": "The scope of the DPS instance.",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "x-ms-external-device-id",
-            "in": "header",
-            "description": "External device identifier, asserted by the gateway. Equals the registrationId in DPS.",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "xMsExternalDeviceId"
           },
           {
             "name": "body",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -89,7 +89,7 @@
       "post": {
         "operationId": "DeviceUpdate_GetDeviceUpdate",
         "summary": "Checks for an available device update (regular / operational path).",
-        "description": "Checks for an available device update on the regular / operational path. The\ndevice selects this endpoint once it is provisioned.",
+        "description": "Checks for an available device update on the regular / operational path. The\ndevice selects this endpoint once it is provisioned.\n\nOn failure, ADU's `error.code` string is returned verbatim in the\n`x-ms-error-code` header and mirrored in the error body `info` dictionary\nunder `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should\nbranch on that code rather than the HTTP status.",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -152,7 +152,7 @@
       "post": {
         "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
         "summary": "Checks for an available device update (onboarding / bootstrap path).",
-        "description": "Checks for an available device update on the onboarding / bootstrap path. The\ndevice selects this endpoint before it is provisioned; only the external device\nidentifier is available (no ADR device UUID yet).",
+        "description": "Checks for an available device update on the onboarding / bootstrap path. The\ndevice selects this endpoint before it is provisioned; only the external device\nidentifier is available (no ADR device UUID yet).\n\nOn failure, ADU's `error.code` string is returned verbatim in the\n`x-ms-error-code` header and mirrored in the error body `info` dictionary\nunder `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should\nbranch on that code rather than the HTTP status.",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -370,7 +370,7 @@
       "post": {
         "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
         "summary": "Reports the terminal result of a device update installation.",
-        "description": "Reports the terminal result of a device update installation. Idempotent on\nworkflowId; ADU routes the report to the correct update family.",
+        "description": "Reports the terminal result of a device update installation. Idempotent on\nworkflowId; ADU routes the report to the correct update family.\n\nOn failure, ADU's `error.code` string is returned verbatim in the\n`x-ms-error-code` header and mirrored in the error body `info` dictionary\nunder `aduErrorCode` (plus `aduErrorTarget` when applicable). Devices should\nbranch on that code rather than the HTTP status.",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -74,6 +74,14 @@
               }
             }
           }
+        },
+        "x-ms-examples": {
+          "RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen.json"
+          },
+          "RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen.json"
+          }
         }
       }
     },
@@ -147,8 +155,11 @@
           }
         },
         "x-ms-examples": {
-          "DeviceUpdate_GetDeviceUpdate": {
-            "$ref": "./examples/DeviceUpdate_GetDeviceUpdate.json"
+          "DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json"
+          },
+          "DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json"
           }
         }
       }
@@ -215,8 +226,11 @@
           }
         },
         "x-ms-examples": {
-          "DeviceUpdate_GetOnboardingDeviceUpdate": {
-            "$ref": "./examples/DeviceUpdate_GetOnboardingDeviceUpdate.json"
+          "DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json"
+          },
+          "DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json"
           }
         }
       }
@@ -285,6 +299,14 @@
                 "description": "The error code for specific error that occurred."
               }
             }
+          }
+        },
+        "x-ms-examples": {
+          "RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen.json"
+          },
+          "RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen.json"
           }
         }
       }
@@ -357,6 +379,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen.json"
+          },
+          "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen": {
+            "$ref": "./examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen.json"
+          }
+        },
         "x-ms-long-running-operation": true
       }
     },
@@ -419,8 +449,11 @@
           }
         },
         "x-ms-examples": {
-          "DeviceUpdate_ReportDeviceUpdateStatus": {
-            "$ref": "./examples/DeviceUpdate_ReportDeviceUpdateStatus.json"
+          "DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json"
+          },
+          "DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen": {
+            "$ref": "./examples/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json"
           }
         }
       }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -844,6 +844,10 @@
           "$ref": "#/definitions/AgentInfo",
           "description": "Information describing the ADU agent making the request."
         },
+        "tpm": {
+          "$ref": "#/definitions/TpmAttestation",
+          "description": "Attestation via TPM. Present only for TPM-attested devices, mirroring the\nRegister (DeviceRegistration) request; X.509 and symmetric-key attestation are\ncarried at the transport layer (TLS client certificate / SAS token) and are not\npart of the request body, exactly as in Register."
+        },
         "installedUpdateId": {
           "$ref": "#/definitions/UpdateId",
           "description": "The update currently installed on the device, if any.",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -773,6 +773,10 @@
           "type": "string",
           "description": "Opaque deployment identifier from updateMetadata; the idempotency and routing key."
         },
+        "tpm": {
+          "$ref": "#/definitions/TpmAttestation",
+          "description": "Attestation via TPM. Present only for TPM-attested devices, mirroring the\nRegister (DeviceRegistration) request; X.509 and symmetric-key attestation are\ncarried at the transport layer (TLS client certificate / SAS token) and are not\npart of the request body. Auth is enforced per action, so this parity affordance\nis present on every device-facing request."
+        },
         "installedUpdateId": {
           "$ref": "#/definitions/UpdateId",
           "description": "The update the device attempted to install, if any.",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/device.json
@@ -1007,13 +1007,15 @@
           "type": "string",
           "description": "ETag from a prior response; lets the service skip re-processing agentInfo.\nOptional.",
           "minLength": 1,
-          "maxLength": 128
+          "maxLength": 128,
+          "x-ms-client-name": "agentInfoEtag"
         },
         "serviceConfigETag": {
           "type": "string",
           "description": "ETag from a prior response; lets the service omit unchanged serviceConfiguration.\nOptional.",
           "minLength": 1,
-          "maxLength": 128
+          "maxLength": 128,
+          "x-ms-client-name": "serviceConfigEtag"
         }
       },
       "required": [
@@ -1030,11 +1032,13 @@
         },
         "serviceConfigETag": {
           "type": "string",
-          "description": "Current ETag of serviceConfiguration."
+          "description": "Current ETag of serviceConfiguration.",
+          "x-ms-client-name": "serviceConfigEtag"
         },
         "agentInfoETag": {
           "type": "string",
-          "description": "Current ETag of the processed agentInfo."
+          "description": "Current ETag of the processed agentInfo.",
+          "x-ms-client-name": "agentInfoEtag"
         },
         "updateMetadata": {
           "$ref": "#/definitions/UpdateMetadata",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate.json
@@ -1,0 +1,50 @@
+{
+  "title": "DeviceUpdate_GetDeviceUpdate",
+  "operationId": "DeviceUpdate_GetDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
+    "body": {
+      "agentInfo": {
+        "agentSdkVersion": "1.1.0",
+        "agentProfile": 1,
+        "compatibilityProperties": {
+          "manufacturer": "contoso",
+          "model": "vacuum-100"
+        }
+      },
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.0.0"
+      },
+      "agentInfoETag": "\"a0\"",
+      "serviceConfigETag": "\"c0\""
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+      },
+      "body": {
+        "serviceConfiguration": {
+          "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
+        },
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\"",
+        "updateMetadata": {
+          "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+          "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "fileUrls": [
+            "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
@@ -1,11 +1,12 @@
 {
-  "title": "DeviceUpdate_GetOnboardingDeviceUpdate",
-  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "title": "DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen",
+  "operationId": "DeviceUpdate_GetDeviceUpdate",
   "parameters": {
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
     "x-ms-external-device-id": "my-device-01",
+    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",
@@ -15,14 +16,21 @@
           "model": "vacuum-100"
         }
       },
-      "installedUpdateId": null
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.0.0"
+      },
+      "agentInfoETag": "\"a0\"",
+      "serviceConfigETag": "\"c0\""
     }
   },
   "responses": {
     "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3302"
-      },
       "body": {
         "serviceConfiguration": {
           "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
@@ -32,10 +40,10 @@
         "updateMetadata": {
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
-          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
-          "fileUrls": [
-            "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
-          ]
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.c2lnbmF0dXJl",
+          "fileUrls": {
+            "file_0": "https://contoso.blob.core.windows.net/adu/vacuum-1.1.0.bin"
+          }
         }
       }
     }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MaximumSet_Gen.json
@@ -5,8 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
-    "x-ms-device-id": "8f3b2c1a-9d4e-4f2a-bc1d-2e3f4a5b6c7d",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "installedUpdateId": {
         "provider": "Contoso",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen.json
@@ -1,0 +1,25 @@
+{
+  "title": "DeviceUpdate_GetDeviceUpdate_MinimumSet_Gen",
+  "operationId": "DeviceUpdate_GetDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "installedUpdateId": {
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\""
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate.json
@@ -1,0 +1,43 @@
+{
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "agentInfo": {
+        "agentSdkVersion": "1.1.0",
+        "agentProfile": 1,
+        "compatibilityProperties": {
+          "manufacturer": "contoso",
+          "model": "vacuum-100"
+        }
+      },
+      "installedUpdateId": null
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3302"
+      },
+      "body": {
+        "serviceConfiguration": {
+          "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
+        },
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\"",
+        "updateMetadata": {
+          "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+          "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "fileUrls": [
+            "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "agentInfo": {
         "agentSdkVersion": "1.1.0",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen.json
@@ -1,5 +1,5 @@
 {
-  "title": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate_MaximumSet_Gen",
   "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
   "parameters": {
     "idScope": "0ne00000000",
@@ -15,14 +15,21 @@
           "model": "vacuum-100"
         }
       },
-      "installedUpdateId": null
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
+      "installedUpdateId": {
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
+      },
+      "agentInfoETag": "\"a0\"",
+      "serviceConfigETag": "\"c0\""
     }
   },
   "responses": {
     "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3302"
-      },
       "body": {
         "serviceConfiguration": {
           "rootKeyDownloadUrl": "https://contoso.blob.core.windows.net/adu/rootkeys"
@@ -32,7 +39,7 @@
         "updateMetadata": {
           "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
           "updateManifest": "eyJtYW5pZmVzdCI6ICJvcGFxdWUifQ==",
-          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.signature",
+          "updateManifestSignature": "eyJhbGciOiJSUzI1NiJ9.c2lnbmF0dXJl",
           "fileUrls": {
             "file_0": "https://contoso.blob.core.windows.net/adu/baseline-1.1.0.bin"
           }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "installedUpdateId": {
         "provider": "Contoso",

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen.json
@@ -1,0 +1,25 @@
+{
+  "title": "DeviceUpdate_GetOnboardingDeviceUpdate_MinimumSet_Gen",
+  "operationId": "DeviceUpdate_GetOnboardingDeviceUpdate",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "installedUpdateId": {
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceConfigETag": "\"c1\"",
+        "agentInfoETag": "\"a1\""
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus.json
@@ -1,0 +1,32 @@
+{
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.1.0"
+      },
+      "lastInstallResult": {
+        "outcome": "Success",
+        "resultCode": 700,
+        "extendedResultCodes": "00000000",
+        "resultDetails": "Update installed successfully."
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3303"
+      },
+      "body": {}
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
@@ -1,0 +1,48 @@
+{
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen",
+  "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "parameters": {
+    "idScope": "0ne00000000",
+    "registrationId": "my-device-01",
+    "api-version": "2026-11-15-preview",
+    "x-ms-external-device-id": "my-device-01",
+    "body": {
+      "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
+      "tpm": {
+        "endorsementKey": "eyJlbmRvcnNlbWVudCI6ICJrZXkifQ==",
+        "storageRootKey": "eyJzcmsiOiAia2V5In0="
+      },
+      "installedUpdateId": {
+        "provider": "contoso",
+        "name": "vacuum",
+        "version": "1.1.0"
+      },
+      "lastInstallResult": {
+        "outcome": "FAILED",
+        "failureOrigin": "AGENT_EXTENSION",
+        "resultCode": -1,
+        "extendedResultCodes": "0x80004005,0x8000FFFF",
+        "resultDetails": "Extension handler failed during apply.",
+        "stepResults": {
+          "step_0": {
+            "outcome": "SUCCEEDED",
+            "failureOrigin": "NOT_APPLICABLE",
+            "resultCode": 700,
+            "extendedResultCodes": "00000000",
+            "resultDetails": "Download complete."
+          },
+          "step_1": {
+            "outcome": "FAILED",
+            "failureOrigin": "AGENT_EXTENSION",
+            "resultCode": -1,
+            "extendedResultCodes": "0x80004005",
+            "resultDetails": "Apply failed."
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MaximumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "tpm": {

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
@@ -5,7 +5,6 @@
     "idScope": "0ne00000000",
     "registrationId": "my-device-01",
     "api-version": "2026-11-15-preview",
-    "x-ms-external-device-id": "my-device-01",
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "installedUpdateId": {

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen.json
@@ -1,5 +1,5 @@
 {
-  "title": "DeviceUpdate_ReportDeviceUpdateStatus",
+  "title": "DeviceUpdate_ReportDeviceUpdateStatus_MinimumSet_Gen",
   "operationId": "DeviceUpdate_ReportDeviceUpdateStatus",
   "parameters": {
     "idScope": "0ne00000000",
@@ -9,25 +9,19 @@
     "body": {
       "workflowId": "5a3f2b10-8c7d-4e6f-9a1b-2c3d4e5f6a7b",
       "installedUpdateId": {
-        "provider": "contoso",
-        "name": "vacuum",
-        "version": "1.1.0"
+        "provider": "Contoso",
+        "name": "SensorFirmware",
+        "version": "1.2.3"
       },
       "lastInstallResult": {
         "outcome": "SUCCEEDED",
         "failureOrigin": "NOT_APPLICABLE",
         "resultCode": 700,
-        "extendedResultCodes": "00000000",
-        "resultDetails": "Update installed successfully."
+        "extendedResultCodes": "00000000"
       }
     }
   },
   "responses": {
-    "200": {
-      "headers": {
-        "x-ms-request-id": "3f2504e0-4f89-41d3-9a0c-0305e82c3303"
-      },
-      "body": {}
-    }
+    "200": {}
   }
 }

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "RuntimeRegistration_DeviceRegistrationStatusLookup",
+  "parameters": {
+    "api-version": "2026-11-15-preview",
+    "body": {
+      "payload": {},
+      "registrationId": "qypnuerjeunzogqdezhjgisfr",
+      "tpm": {
+        "endorsementKey": "sbvvzftylrpsetexcmnijtdezppq",
+        "storageRootKey": "juohyrayid"
+      }
+    },
+    "idScope": "a",
+    "registrationId": "urnfaaodcvbbllnmxj"
+  },
+  "title": "RuntimeRegistration_DeviceRegistrationStatusLookup_MaximumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "assignedHub": "ljexps",
+        "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+        "deviceId": "hjvdlwpugzlk",
+        "errorCode": 13,
+        "errorMessage": "zpctqazbkbiqjkwosis",
+        "etag": "hjtelksspyfzhmet",
+        "issuedCertificateChain": [
+          "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+        ],
+        "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+        "payload": {},
+        "registrationId": "urejrffpkqneou",
+        "status": "unassigned",
+        "substatus": "initialAssignment",
+        "symmetricKey": {
+          "enrollmentGroupId": "w"
+        },
+        "tpm": {
+          "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+        },
+        "x509": {
+          "certificateInfo": {
+            "issuerName": "pvpbipnhcahytrcq",
+            "notAfterUtc": "2025-10-01T17:41:56.534Z",
+            "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+            "serialNumber": "jjvdijgwgpagrjdi",
+            "sha1Thumbprint": "guqltcfgusf",
+            "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+            "subjectName": "jtsfqnbcmmott",
+            "version": 20
+          },
+          "enrollmentGroupId": "qbw",
+          "signingCertificateInfo": {
+            "issuerName": "pvpbipnhcahytrcq",
+            "notAfterUtc": "2025-10-01T17:41:56.534Z",
+            "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+            "serialNumber": "jjvdijgwgpagrjdi",
+            "sha1Thumbprint": "guqltcfgusf",
+            "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+            "subjectName": "jtsfqnbcmmott",
+            "version": 20
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "RuntimeRegistration_DeviceRegistrationStatusLookup",
+  "parameters": {
+    "api-version": "2026-11-15-preview",
+    "body": {},
+    "idScope": "mucolayhjusj",
+    "registrationId": "okxnmx"
+  },
+  "title": "RuntimeRegistration_DeviceRegistrationStatusLookup_MinimumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "RuntimeRegistration_OperationStatusLookup",
+  "parameters": {
+    "operationId": "fdjhztahuvcjjmutvihsmflepzvsfn",
+    "api-version": "2026-11-15-preview",
+    "idScope": "arjoldcjeedohmpuhenotyesppkgk",
+    "registrationId": "ojruvwccsgwnmscfwodrfjrecxuf"
+  },
+  "title": "RuntimeRegistration_OperationStatusLookup_MaximumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi",
+        "registrationState": {
+          "assignedHub": "ljexps",
+          "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "deviceId": "hjvdlwpugzlk",
+          "errorCode": 13,
+          "errorMessage": "zpctqazbkbiqjkwosis",
+          "etag": "hjtelksspyfzhmet",
+          "issuedCertificateChain": [
+            "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+          ],
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "payload": {},
+          "registrationId": "urejrffpkqneou",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "symmetricKey": {
+            "enrollmentGroupId": "w"
+          },
+          "tpm": {
+            "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+          },
+          "x509": {
+            "certificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            },
+            "enrollmentGroupId": "qbw",
+            "signingCertificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            }
+          }
+        },
+        "status": "unassigned"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi",
+        "registrationState": {
+          "assignedHub": "ljexps",
+          "createdDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "deviceId": "hjvdlwpugzlk",
+          "errorCode": 13,
+          "errorMessage": "zpctqazbkbiqjkwosis",
+          "etag": "hjtelksspyfzhmet",
+          "issuedCertificateChain": [
+            "MIIBkTCB+wIBADAZMRcwFQYDVQQDDA5leGFtcGxlLWRldmljZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAw"
+          ],
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:41:56.535Z",
+          "payload": {},
+          "registrationId": "urejrffpkqneou",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "symmetricKey": {
+            "enrollmentGroupId": "w"
+          },
+          "tpm": {
+            "authenticationKey": "sofbxakhjrxpiyysjjxkx"
+          },
+          "x509": {
+            "certificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            },
+            "enrollmentGroupId": "qbw",
+            "signingCertificateInfo": {
+              "issuerName": "pvpbipnhcahytrcq",
+              "notAfterUtc": "2025-10-01T17:41:56.534Z",
+              "notBeforeUtc": "2025-10-01T17:41:56.534Z",
+              "serialNumber": "jjvdijgwgpagrjdi",
+              "sha1Thumbprint": "guqltcfgusf",
+              "sha256Thumbprint": "ysryarleygpkejrjlwuxacvcwbxqw",
+              "subjectName": "jtsfqnbcmmott",
+              "version": 20
+            }
+          }
+        },
+        "status": "unassigned"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RuntimeRegistration_OperationStatusLookup",
+  "parameters": {
+    "operationId": "wacw",
+    "api-version": "2026-11-15-preview",
+    "idScope": "cxcukjqvjopedcgnhtggfdt",
+    "registrationId": "pzgoamgarcmcwvapl"
+  },
+  "title": "RuntimeRegistration_OperationStatusLookup_MinimumSet_Gen",
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "xosjboksmobnotwgqejpvxiwi"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen.json
@@ -1,0 +1,122 @@
+{
+  "title": "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MaximumSet_Gen",
+  "operationId": "RuntimeRegistration_RegisterDeviceAndIssueCertificate",
+  "parameters": {
+    "registrationId": "ownlzhchadklubcaoqrlvnahxjvpx",
+    "idScope": "aemhxrrelukva",
+    "deviceRegistration": {
+      "registrationId": "qmldcza",
+      "tpm": {
+        "endorsementKey": "ptvkixrjmicy",
+        "storageRootKey": "ezoovqigtxdoievpniumzrfmz"
+      },
+      "csr": "yegu",
+      "payload": {}
+    },
+    "api-version": "2026-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt",
+        "status": "unassigned",
+        "registrationState": {
+          "tpm": {
+            "authenticationKey": "umpmhtunsqbkcttbwytxwzvzvopv"
+          },
+          "x509": {
+            "certificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            },
+            "enrollmentGroupId": "jaztkstjoerljecernsiu",
+            "signingCertificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            }
+          },
+          "symmetricKey": {
+            "enrollmentGroupId": "gigadta"
+          },
+          "registrationId": "utwhgvww",
+          "createdDateTimeUtc": "2025-10-01T17:51:13.304Z",
+          "assignedHub": "csdsyrzttfdyutovgmfieaswnrc",
+          "deviceId": "lehinmpzxvcbdokukewnclocdnsaah",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "errorCode": 7,
+          "errorMessage": "buikxnojfuoowknmj",
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:51:13.305Z",
+          "etag": "hxmi",
+          "payload": {},
+          "issuedCertificateChain": [
+            "aXNzdWVkQ2VydGlmaWNhdGVDaGFpbidzIGl0ZW0x"
+          ]
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt",
+        "status": "unassigned",
+        "registrationState": {
+          "tpm": {
+            "authenticationKey": "umpmhtunsqbkcttbwytxwzvzvopv"
+          },
+          "x509": {
+            "certificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            },
+            "enrollmentGroupId": "jaztkstjoerljecernsiu",
+            "signingCertificateInfo": {
+              "subjectName": "athzawcpffqefp",
+              "sha1Thumbprint": "lflzqgipxhdyhygtdcm",
+              "sha256Thumbprint": "bmhuhskxlkusklupoqccvwbntqaa",
+              "issuerName": "ewxrnyz",
+              "notBeforeUtc": "2025-10-01T17:51:13.304Z",
+              "notAfterUtc": "2025-10-01T17:51:13.304Z",
+              "serialNumber": "szfshiuynidtbzikkelisiwega",
+              "version": 13
+            }
+          },
+          "symmetricKey": {
+            "enrollmentGroupId": "gigadta"
+          },
+          "registrationId": "utwhgvww",
+          "createdDateTimeUtc": "2025-10-01T17:51:13.304Z",
+          "assignedHub": "csdsyrzttfdyutovgmfieaswnrc",
+          "deviceId": "lehinmpzxvcbdokukewnclocdnsaah",
+          "status": "unassigned",
+          "substatus": "initialAssignment",
+          "errorCode": 7,
+          "errorMessage": "buikxnojfuoowknmj",
+          "lastUpdatedDateTimeUtc": "2025-10-01T17:51:13.305Z",
+          "etag": "hxmi",
+          "payload": {},
+          "issuedCertificateChain": [
+            "aXNzdWVkQ2VydGlmaWNhdGVDaGFpbidzIGl0ZW0x"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen.json
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/preview/2026-11-15-preview/examples/RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen.json
@@ -1,0 +1,22 @@
+{
+  "title": "RuntimeRegistration_RegisterDeviceAndIssueCertificate_MinimumSet_Gen",
+  "operationId": "RuntimeRegistration_RegisterDeviceAndIssueCertificate",
+  "parameters": {
+    "registrationId": "njckbolwtqfforaqhmfjc",
+    "idScope": "zytdtmjadforourwvpbn",
+    "deviceRegistration": {},
+    "api-version": "2026-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt"
+      }
+    },
+    "202": {
+      "body": {
+        "operationId": "iqugvyudcguryywvt"
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/readme.md
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/readme.md
@@ -36,6 +36,16 @@ openapi-type: data-plane
 tag: package-2021-10-01-device
 ```
 
+### Tag: package-preview-2026-11-device
+
+These settings apply only when `--tag=package-preview-2026-11-device` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-11-device'
+input-file:
+  - preview/2026-11-15-preview/device.json
+title: ProvisioningDeviceClient
+```
+
 ### Tag: package-preview-2026-07-service
 
 These settings apply only when `--tag=package-preview-2026-07-service` is specified on the command line.

--- a/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/readme.md
+++ b/specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/readme.md
@@ -36,6 +36,20 @@ openapi-type: data-plane
 tag: package-2021-10-01-device
 ```
 
+### Suppression
+
+```yaml
+directive:
+  - suppress: OperationIdNounVerb
+    from: device.json
+    reason: |
+      The DeviceUpdate operations (getDeviceUpdate, getOnboardingDeviceUpdate,
+      reportDeviceUpdateStatus) deliberately mirror the Azure Device Update (ADU)
+      device onboarding contract operation names so that DPS acts as a transparent
+      pass-through for the device-facing update flow. Renaming them to satisfy the
+      Noun_Verb convention would break naming parity with the partner (ADU) contract.
+```
+
 ### Tag: package-preview-2026-11-device
 
 These settings apply only when `--tag=package-preview-2026-11-device` is specified on the command line.


### PR DESCRIPTION
> **⚠️ DRAFT / DO NOT MERGE.** This PR is staged early **to gather API Stewardship Board (ASB) and CODEOWNERS feedback** on the shape of a new DPS device-facing API set while the underlying contract is still being finalized with the Azure Device Update (ADU) team. It is **not** ready to merge and should not be published.

## What this adds

A new **preview** API version **`2026-11-15-preview`** to the **DPS device data-plane** (`ProvisioningDeviceClient`, `specification/deviceprovisioningservices/data-plane/DeviceProvisioningServices/device`), introducing three device-facing **Azure Device Update (ADU) integration** operations:

| Operation ID | Route | Purpose |
|---|---|---|
| `DeviceUpdate_GetDeviceUpdate` | `POST /{idScope}/registrations/{registrationId}/getDeviceUpdate` | Update check on the **regular / operational** path (device is already provisioned). |
| `DeviceUpdate_GetOnboardingDeviceUpdate` | `POST /{idScope}/registrations/{registrationId}/onboarding/getDeviceUpdate` | Update check on the **onboarding / bootstrap** path (device not yet provisioned; first-time update). |
| `DeviceUpdate_ReportDeviceUpdateStatus` | `POST /{idScope}/registrations/{registrationId}/reportDeviceUpdateStatus` | Report the terminal result of an update install (idempotent on `workflowId`). |

DPS acts as a thin **pass-through** to Azure Device Registry (ADR), which forwards to ADU; DPS does not parse the update manifest and does not branch on the update family.

## Contents

- **TypeSpec source** (authoritative): `device/main.tsp` (new `Versions.v2026_11_15_preview`), `device/models.tsp` (new models), `device/routes.tsp` (new `DeviceUpdate` interface), `device/client.tsp` (client locations).
- **Generated** `preview/2026-11-15-preview/device.json` + examples (via `tsp compile`).
- **Examples** (Min + Max) for all three operations.
- **`readme.md`** tag `package-preview-2026-11-device` (plus a scoped `OperationIdNounVerb` LintDiff suppression — see below).

## Known open items / intentional deviations (feedback wanted)

These are **deliberately** left as-is to surface the discussion — please comment:

1. **Nullable field** — `installedUpdateId` is modeled nullable (`InstalledUpdateId | null`) to match the ADU contract's explicit-null wire shape (the property is always present and is `null` when no update is installed). The `no-nullable` linter rule is suppressed inline with that justification.
2. **Operation naming** — `GetDeviceUpdate` / `GetOnboardingDeviceUpdate` / `ReportDeviceUpdateStatus` are working names (mirroring the ADU device contract; recently renamed Recovery → Onboarding). `OperationIdNounVerb` is suppressed via a `readme.md` directive because the operation IDs intentionally repeat the "DeviceUpdate" noun to stay 1:1 with ADU. Open to steward guidance.
3. **Error model** — reuses the existing DPS `ProvisioningServiceErrorDetails` for a single, uniform device-facing error body. ADU's machine-readable `error.code` string is surfaced **verbatim** in the `x-ms-error-code` response header and mirrored in the error body `info` dictionary under `aduErrorCode` (and `aduErrorTarget` when ADU identifies a request element). Devices branch on that code, not the HTTP status. This is documented on all three operation descriptions.

## Resolved since the initial draft

- **ETag property casing** — the ADU wire names `agentInfoETag` / `serviceConfigETag` are preserved on the JSON wire via `@encodedName`, while the TypeSpec/SDK property names are the guideline-compliant `agentInfoEtag` / `serviceConfigEtag`. No linter suppression needed.
- **Internal-only headers removed** — the `x-ms-external-device-id` and `x-ms-device-id` custom headers were dropped; DPS asserts the device identity internally (they are not part of the device-facing contract).

## Validation done locally & in CI

- `tsp compile` succeeds with **no errors or warnings** (matched to the lockfile-pinned `@typespec/compiler` 1.13.0).
- `tsp format`, `prettier --check`, and `oav validate-example` are all clean on `2026-11-15-preview`.
- Existing versions (`2021-10-01`, `2025-07-01-preview`, `2026-07-01-preview`) are **untouched**.
- CI: TypeSpec Validation, TypeSpec Requirement, Swagger LintDiff, ModelValidation, SemanticValidation, PrettierCheck, and Avocado all **pass**.
- **`Breaking Change (Cross-Version)` is a known, expected failure**: its Error-level diffs come from the pre-existing RuntimeRegistration TypeSpec migration compared against stable `2021-10-01` (`RegisterDevice` → `RegisterDeviceAndIssueCertificate`, `body` → `deviceRegistration`, added `issuedCertificateChain`) — **not** from this ADU change (which is additive + doc-only on the shared surface). It sets the `BreakingChangeReviewRequired` label and needs ARB review, not a code fix.

---

_Authoring assisted by GitHub Copilot._
