### PR TITLE
fix: handle renamed tspconfig files in namespace detection

### DIFF
--- a/.github/workflows/src/namespace-approval/detect-namespaces.js
+++ b/.github/workflows/src/namespace-approval/detect-namespaces.js
@@ -2,7 +2,7 @@ import { execFile } from "child_process";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import { join } from "path";
-import { getChangedFiles, tspconfig } from "../../../shared/src/changed-files.js";
+import { getChangedFilesStatuses, tspconfig } from "../../../shared/src/changed-files.js";
 import { loadFormatRules, validateNamespaceFormat } from "./validate-format.js";
 
 /**
@@ -214,19 +214,34 @@ export default async function detectNamespaces({ context, core }) {
     context.payload
   );
 
-  const changedFiles = (
-    await getChangedFiles({
-      cwd: process.env.GITHUB_WORKSPACE ?? process.cwd(),
-      paths: ["specification"],
-    })
-  ).filter((file) => tspconfig(file));
+  const cwd = process.env.GITHUB_WORKSPACE ?? process.cwd();
+  const statuses = await getChangedFilesStatuses({ cwd, paths: ["specification"] });
 
-  if (changedFiles.length === 0) {
+  // Build a list of changed tspconfig files with their base path for comparison.
+  // - Additions: new files, no base path (all namespaces are new)
+  // - Modifications: same path on base
+  // - Renames: use the old (from) path for base comparison
+  // - Deletions: skip (file removed, nothing to review)
+  /** @type {{ file: string, basePath: string | null }[]} */
+  const changedTspconfigs = [];
+  for (const file of statuses.additions.filter(tspconfig)) {
+    changedTspconfigs.push({ file, basePath: null });
+  }
+  for (const file of statuses.modifications.filter(tspconfig)) {
+    changedTspconfigs.push({ file, basePath: file });
+  }
+  for (const rename of statuses.renames) {
+    if (tspconfig(rename.to)) {
+      changedTspconfigs.push({ file: rename.to, basePath: rename.from });
+    }
+  }
+
+  if (changedTspconfigs.length === 0) {
     core.info("No tspconfig.yaml changes detected, skipping");
     return;
   }
 
-  core.info(`Found tspconfig.yaml changes: ${changedFiles.join(", ")}`);
+  core.info(`Found tspconfig.yaml changes: ${changedTspconfigs.map((c) => c.file).join(", ")}`);
 
   /** @type {Record<string, string>} */
   const namespacesFound = {};
@@ -235,7 +250,7 @@ export default async function detectNamespaces({ context, core }) {
   let isMgmt = false;
   let isDataPlane = false;
 
-  for (const file of changedFiles) {
+  for (const { file } of changedTspconfigs) {
     const result = await extractNamespaces(file, namespacesFound, artifactNames, core);
     if (result.isMgmt) {
       isMgmt = true;
@@ -247,10 +262,14 @@ export default async function detectNamespaces({ context, core }) {
 
   // Compare against base branch to filter out languages with unchanged namespaces.
   // Only report languages whose namespace actually differs from the base version.
-  for (const file of changedFiles) {
-    const baseContent = await readBaseVersion(file);
+  for (const { basePath } of changedTspconfigs) {
+    if (!basePath) {
+      // File is new (addition) — all namespaces are genuinely new
+      continue;
+    }
+    const baseContent = await readBaseVersion(basePath);
     if (!baseContent) {
-      // File is new (not on base branch) — all namespaces are genuinely new
+      // Shouldn't happen for modifications, but possible for renames if git history is shallow
       continue;
     }
     try {
@@ -273,7 +292,7 @@ export default async function detectNamespaces({ context, core }) {
       }
     } catch (e) {
       core.warning(
-        `Failed to parse base version of ${file}: ${/** @type {Error} */ (e).message}, treating as new`,
+        `Failed to parse base version of ${basePath}: ${/** @type {Error} */ (e).message}, treating as new`,
       );
     }
   }

--- a/.github/workflows/test/namespace-approval/detect-namespaces.test.js
+++ b/.github/workflows/test/namespace-approval/detect-namespaces.test.js
@@ -34,9 +34,15 @@ vi.mock("child_process", () => ({
   ),
 }));
 
-// Mock getChangedFiles — path must match the import in detect-namespaces.js
+// Mock getChangedFilesStatuses — path must match the import in detect-namespaces.js
 vi.mock("../../../shared/src/changed-files.js", () => ({
-  getChangedFiles: vi.fn().mockResolvedValue([]),
+  getChangedFilesStatuses: vi.fn().mockResolvedValue({
+    additions: [],
+    modifications: [],
+    deletions: [],
+    renames: [],
+    total: 0,
+  }),
   tspconfig: (/** @type {string} */ file) =>
     file.startsWith("specification/") && file.endsWith("/tspconfig.yaml"),
 }));
@@ -50,12 +56,12 @@ vi.mock("../../src/namespace-approval/validate-format.js", () => ({
 // Import after mocks
 const { default: detectNamespaces } =
   await import("../../src/namespace-approval/detect-namespaces.js");
-const { getChangedFiles } = await import("../../../shared/src/changed-files.js");
+const { getChangedFilesStatuses } = await import("../../../shared/src/changed-files.js");
 
 /** @type {import("vitest").Mock} */
 const readFileMock = /** @type {any} */ (readFile);
 /** @type {import("vitest").Mock} */
-const getChangedFilesMock = /** @type {any} */ (getChangedFiles);
+const getChangedFilesStatusesMock = /** @type {any} */ (getChangedFilesStatuses);
 /** @type {import("vitest").Mock} */
 const execFileMock = /** @type {any} */ (execFile);
 
@@ -69,6 +75,21 @@ function args() {
   return /** @type {import("@actions/github-script").AsyncFunctionArguments} */ (
     /** @type {unknown} */ ({ context, core })
   );
+}
+
+/**
+ * Helper to mock getChangedFilesStatuses with modifications (most common case).
+ * @param {string[]} modifications - Files that were modified
+ * @param {{ additions?: string[], renames?: {from: string, to: string}[] }} [extra]
+ */
+function mockFileStatuses(modifications, extra = {}) {
+  getChangedFilesStatusesMock.mockResolvedValue({
+    additions: extra.additions ?? [],
+    modifications,
+    deletions: [],
+    renames: extra.renames ?? [],
+    total: modifications.length + (extra.additions?.length ?? 0) + (extra.renames?.length ?? 0),
+  });
 }
 
 function mgmtTspconfig() {
@@ -164,7 +185,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 42 }, action: "opened" };
     const file = "specification/compute/Compute.Management/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     readFileMock.mockResolvedValue(mgmtTspconfig());
 
     await detectNamespaces(args());
@@ -177,7 +198,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 43 }, action: "opened" };
     const file = "specification/eventgrid/EventGrid/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     readFileMock.mockResolvedValue(dataplaneTspconfig());
 
     await detectNamespaces(args());
@@ -190,7 +211,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 44 }, action: "opened" };
     const file = "specification/storage/Storage/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     readFileMock.mockResolvedValue(rustTspconfig());
 
     await detectNamespaces(args());
@@ -202,7 +223,7 @@ describe("detect-namespaces", () => {
     core = createMockCore();
     context = createMockContext();
     context.payload = { pull_request: { number: 45 }, action: "opened" };
-    getChangedFilesMock.mockResolvedValue(["specification/compute/readme.md"]);
+    mockFileStatuses(["specification/compute/readme.md"]);
 
     await detectNamespaces(args());
 
@@ -215,7 +236,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 46 }, action: "opened" };
     const file = "specification/compute/Compute.Management/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     readFileMock.mockResolvedValue(yaml.dump({ linter: {} }));
     mockGitShowNotFound();
 
@@ -229,7 +250,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 47 }, action: "synchronize" };
     const file = "specification/compute/Compute.Management/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     // PR version: same namespaces as base, but with added generate-samples option
     const prContent = yaml.dump({
       options: {
@@ -271,7 +292,7 @@ describe("detect-namespaces", () => {
     context = createMockContext();
     context.payload = { pull_request: { number: 48 }, action: "synchronize" };
     const file = "specification/compute/Compute.Management/tspconfig.yaml";
-    getChangedFilesMock.mockResolvedValue([file]);
+    mockFileStatuses([file]);
     // PR version: typescript namespace changed
     const prContent = yaml.dump({
       options: {
@@ -312,5 +333,120 @@ describe("detect-namespaces", () => {
       expect.stringContaining("Namespace unchanged for dotnet"),
     );
     expect(core.info).toHaveBeenCalledWith(expect.stringContaining("Namespace unchanged for java"));
+  });
+
+  it("should skip unchanged namespaces when file is renamed (folder migration)", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 49 }, action: "opened" };
+    const oldPath = "specification/edgezones/resource-manager/tspconfig.yaml";
+    const newPath =
+      "specification/edgezones/resource-manager/Microsoft.EdgeZones/EdgeZones/tspconfig.yaml";
+    // Report as a rename
+    mockFileStatuses([], { renames: [{ from: oldPath, to: newPath }] });
+    // PR version: namespaces unchanged, only output paths differ
+    const content = yaml.dump({
+      options: {
+        "@azure-tools/typespec-python": {
+          "emitter-output-dir": "{output-dir}/{service-dir}/azure-mgmt-edgezones",
+          namespace: "azure.mgmt.edgezones",
+        },
+        "@azure-tools/typespec-java": {
+          namespace: "com.azure.resourcemanager.edgezones",
+        },
+        "@azure-tools/typespec-csharp": {
+          namespace: "Azure.ResourceManager.EdgeZones",
+        },
+      },
+    });
+    readFileMock.mockResolvedValue(content);
+    // Base version at old path: same namespaces
+    mockGitShowReturns(content);
+
+    await detectNamespaces(args());
+
+    // All namespaces unchanged → should not output results
+    expect(core.setOutput).not.toHaveBeenCalled();
+    expect(core.info).toHaveBeenCalledWith(
+      "No namespace changes detected after comparing with base branch",
+    );
+  });
+
+  it("should use old path for git show when file is renamed", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 50 }, action: "opened" };
+    const oldPath = "specification/edgezones/resource-manager/tspconfig.yaml";
+    const newPath =
+      "specification/edgezones/resource-manager/Microsoft.EdgeZones/EdgeZones/tspconfig.yaml";
+    mockFileStatuses([], { renames: [{ from: oldPath, to: newPath }] });
+    // PR version: typescript namespace changed during rename
+    const prContent = yaml.dump({
+      options: {
+        "@azure-tools/typespec-csharp": {
+          namespace: "Azure.ResourceManager.EdgeZones",
+        },
+        "@azure-tools/typespec-ts": {
+          namespace: "@azure/arm-edgezones-v2",
+        },
+      },
+    });
+    readFileMock.mockResolvedValue(prContent);
+    // Base version: original typescript namespace
+    const baseContent = yaml.dump({
+      options: {
+        "@azure-tools/typespec-csharp": {
+          namespace: "Azure.ResourceManager.EdgeZones",
+        },
+        "@azure-tools/typespec-ts": {
+          namespace: "@azure/arm-edgezones",
+        },
+      },
+    });
+    execFileMock.mockImplementation(
+      (
+        /** @type {string} */ _cmd,
+        /** @type {string[]} */ args,
+        /** @type {(err: Error | null, stdout: string, stderr: string) => void} */ cb,
+      ) => {
+        // Verify git show is called with the OLD path, not the new path
+        expect(args[1]).toContain(oldPath);
+        expect(args[1]).not.toContain("Microsoft.EdgeZones");
+        cb(null, baseContent, "");
+      },
+    );
+
+    await detectNamespaces(args());
+
+    // Only typescript changed → should output results
+    expect(core.setOutput).toHaveBeenCalledWith("results", "true");
+    // dotnet unchanged
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("Namespace unchanged for dotnet"),
+    );
+  });
+
+  it("should treat additions as new files (no base comparison)", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 51 }, action: "opened" };
+    const file = "specification/newservice/NewService/tspconfig.yaml";
+    mockFileStatuses([], { additions: [file] });
+    readFileMock.mockResolvedValue(
+      yaml.dump({
+        options: {
+          "@azure-tools/typespec-java": {
+            namespace: "com.azure.newservice",
+          },
+        },
+      }),
+    );
+    // git show should NOT be called for additions
+    mockGitShowNotFound();
+
+    await detectNamespaces(args());
+
+    // New file → all namespaces reported
+    expect(core.setOutput).toHaveBeenCalledWith("results", "true");
   });
 });


### PR DESCRIPTION
## Problem

Folder migration PRs (like #44612) rename tspconfig.yaml to a new path. The namespace detection uses the new path to compare against the base branch, but git show fails because the file didn't exist at that path on base. This causes all namespaces to be treated as new - a false positive.

## Fix

Switch from getChangedFiles (name-only) to getChangedFilesStatuses (name-status) to distinguish additions, modifications, and renames. For renamed files, use the old path for the base-branch comparison.

- Additions: skip comparison, all namespaces are new
- Modifications: compare same path (existing behavior)
- Renames: compare against old path via git show
- Deletions: ignored

No action required unless a PR shows up with your language's pending label. The workflow handles detection and notifications automatically.

## Tests

- Renamed file with unchanged namespaces: should NOT trigger
- Renamed file with one namespace changed: should only report the changed language
- Addition treated as new file

All 63 namespace-approval tests pass.