### PR TITLE
Add SAP Monitor C# management emitter

### DIFF
--- a/specification/workloads/Workloads.SAPMonitor.Management/tspconfig.yaml
+++ b/specification/workloads/Workloads.SAPMonitor.Management/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     azure-resource-provider-folder: "resource-manager"
     emit-common-types-schema: "never"
     output-file: "{azure-resource-provider-folder}/{service-name}/monitors/{version-status}/{version}/monitors.json"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Workloads"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-ts":
     experimental-extensible-enums: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-sapmonitors"


### PR DESCRIPTION
## Summary

Add the C# management emitter configuration for the SAP Monitor TypeSpec project.

The existing Azure SDK for .NET package already contains the SAP Monitor resources under `Azure.ResourceManager.Workloads`, so this emitter targets that established namespace and package directory.

## Validation

- `pnpm exec prettier --check specification/workloads/Workloads.SAPMonitor.Management/tspconfig.yaml`
- `pnpm exec tsp compile specification/workloads/Workloads.SAPMonitor.Management/main.tsp --no-emit`
