### PR TITLE
Add OperationalInsights C# provisioning emitter

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -245,6 +245,7 @@ using Microsoft.OperationalInsights;
   "csharp"
 );
 @@clientName(AssociatedWorkspace.associateDate, "AssociatedOn", "csharp");
+@@alternateType(AssociatedWorkspace.workspaceId, uuid, "csharp");
 @@alternateType(ClusterProperties.clusterId, uuid, "csharp");
 @@clientName(
   ClusterEntityStatus,
@@ -260,6 +261,11 @@ using Microsoft.OperationalInsights;
 @@clientName(
   ClusterReplicationProperties,
   "OperationalInsightsClusterReplicationProperties",
+  "csharp"
+);
+@@alternateType(
+  ClusterReplicationProperties.location,
+  Azure.Core.azureLocation,
   "csharp"
 );
 @@clientName(
@@ -281,6 +287,7 @@ using Microsoft.OperationalInsights;
   "OperationalInsightsKeyVaultProperties",
   "csharp"
 );
+@@alternateType(KeyVaultProperties.keyVaultUri, url, "csharp");
 @@clientName(
   LinkedServiceEntityStatus,
   "OperationalInsightsLinkedServiceEntityStatus",
@@ -290,6 +297,11 @@ using Microsoft.OperationalInsights;
 @@clientName(
   PrivateLinkScopedResource,
   "OperationalInsightsPrivateLinkScopedResourceInfo",
+  "csharp"
+);
+@@alternateType(
+  PrivateLinkScopedResource.resourceId,
+  armResourceIdentifier,
   "csharp"
 );
 @@clientName(
@@ -322,6 +334,8 @@ using Microsoft.OperationalInsights;
 @@clientName(TablePlanEnum, "OperationalInsightsTablePlan", "csharp");
 @@clientName(SearchResults, "OperationalInsightsTableSearchResults", "csharp");
 @@clientName(RestoredLogs, "OperationalInsightsTableRestoredLogs", "csharp");
+@@alternateType(SearchResults.azureAsyncOperationId, uuid, "csharp");
+@@alternateType(RestoredLogs.azureAsyncOperationId, uuid, "csharp");
 @@clientName(
   ResultStatistics,
   "OperationalInsightsTableResultStatistics",
@@ -360,9 +374,19 @@ using Microsoft.OperationalInsights;
   "OperationalInsightsWorkspaceFeatures",
   "csharp"
 );
+@@alternateType(
+  WorkspaceFeatures.clusterResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
 @@clientName(
   WorkspaceReplicationProperties,
   "OperationalInsightsWorkspaceReplicationProperties",
+  "csharp"
+);
+@@alternateType(
+  WorkspaceReplicationProperties.location,
+  Azure.Core.azureLocation,
   "csharp"
 );
 @@clientName(

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -15,6 +15,10 @@ options:
     namespace: "Azure.ResourceManager.OperationalInsights"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.OperationalInsights"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-07-01"
   "@azure-tools/typespec-python":
     service-dir: "sdk/loganalytics"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-loganalytics"


### PR DESCRIPTION
Adds the C# provisioning emitter configuration for `Microsoft.OperationalInsights` using stable API version `2025-07-01`.

Corresponding SDK migration: Azure/azure-sdk-for-net#57387