### PR TITLE
feat(agents-optimization): add max_stalls to OptimizationOptions

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -191,6 +191,10 @@ model OptimizationOptions {
 
   @doc("Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.")
   evaluation_level?: EvaluationLevel;
+
+  @doc("Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.")
+  @minValue(1)
+  max_stalls?: int32;
 }
 
 @extension("x-ms-foundry-meta", AgentsOptimizationPreview)


### PR DESCRIPTION
Adds max_stalls to OptimizationOptions TypeSpec. Exposes the GEPA early-stopping parameter. Related Vienna PR: https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2189426 (merged).