### PR TITLE
Update TypeSpec config emitter version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@azure-tools/typespec-client-generator-cli": "0.33.1",
         "@azure-tools/typespec-client-generator-core": "0.69.2",
         "@azure-tools/typespec-liftr-base": "0.13.0",
-        "@azure-tools/typespec-metadata": "0.2.0",
+        "@azure-tools/typespec-metadata": "0.2.1",
         "@azure/avocado": "0.11.0",
         "@azure/oad": "0.12.4",
         "@microsoft.azure/openapi-validator": "2.2.4",
@@ -1253,9 +1253,9 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-metadata": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-metadata/-/typespec-metadata-0.2.0.tgz",
-      "integrity": "sha512-AkjETrRKSBoUlK8JI/BhrIuye7GTuHb3eKOwd5DFPfyvO60FyoFz1st8meYMm2BmbULHJKBhv+Dl4gg/laX1fw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-metadata/-/typespec-metadata-0.2.1.tgz",
+      "integrity": "sha1-wkamri9UtANGQudu/TYnyT4ni2A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1265,7 +1265,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.11.0"
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-migration-validation": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@azure-tools/typespec-client-generator-cli": "0.33.1",
     "@azure-tools/typespec-client-generator-core": "0.69.2",
     "@azure-tools/typespec-liftr-base": "0.13.0",
-    "@azure-tools/typespec-metadata": "0.2.0",
+    "@azure-tools/typespec-metadata": "0.2.1",
     "@azure/avocado": "0.11.0",
     "@azure/oad": "0.12.4",
     "@microsoft.azure/openapi-validator": "2.2.4",


### PR DESCRIPTION
Update TypeSpec emitter version to latest to resolve Go package name issue in the parsed output. New version has the fix to remove Go module version from package name.