### PR TITLE
feat(agents-optimization): add max_stalls to OptimizationOptions

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -194,6 +194,10 @@ model OptimizationOptions {
 
   @doc("Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.")
   evaluation_level?: EvaluationLevel;
+
+  @doc("Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.")
+  @minValue(1)
+  max_stalls?: int32;
 }
 
 @doc("Caller-supplied inputs for an optimization job.")


### PR DESCRIPTION
## Summary

Adds max_stalls to OptimizationOptions in the agents-optimization TypeSpec.

## What is max_stalls?

A stall occurs when the optimizer proposes a new prompt, evaluates it on a small reflective minibatch, and the subset score does not improve vs the current best - so no full validation-set evaluation is triggered. After max_stalls consecutive failures the optimizer stops early rather than exhausting the full candidate budget. This lets callers trade off exploration depth against wall-clock time. When omitted the service uses its internal default (5). Must be >= 1 when set.

## Change

src/agents-optimization/models.tsp: add max_stalls?: int32 with @minValue(1) and doc-comment to OptimizationOptions

## Related

This TypeSpec addition aligns with a service-side change that exposed max_stalls as a tunable parameter in the optimization REST API.