### PR TITLE
Relay: add stable API version 2026-01-01 (minimumTlsVersion)

### DIFF
--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_CreateOrUpdateAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "HybridConnections_DeleteAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_GetAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListAuthorizationRules",
+  "title": "RelayHybridConnectionAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListKeys",
+  "title": "RelayHybridConnectionAuthorizationRuleListKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "HybridConnections_RegenerateKeys",
+  "title": "RelayHybridConnectionAuthorizationRuleRegenerateKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionCreate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "requiresClientAuthorization": true
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Hybrid-01",
+        "type": "Microsoft.Relay/Namespaces/HybridConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+        "properties": {
+          "createdAt": "2017-01-23T20:34:49.4131724Z",
+          "requiresClientAuthorization": true,
+          "updatedAt": "2017-01-23T20:34:49.4131724Z"
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_CreateOrUpdate",
+  "title": "RelayHybridConnectionCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Hybrid-01",
+        "type": "Microsoft.Relay/Namespaces/HybridConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+        "properties": {
+          "createdAt": "2017-01-23T20:34:49.4131724Z",
+          "listenerCount": 1,
+          "requiresClientAuthorization": true,
+          "updatedAt": "2017-01-23T20:34:49.4131724Z",
+          "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored."
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_Get",
+  "title": "RelayHybridConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridConnectionListAll.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-Relay-Hybrid-01",
+            "type": "Microsoft.Relay/Namespaces/HybridConnections",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:49.4131724Z",
+              "listenerCount": 1,
+              "requiresClientAuthorization": true,
+              "updatedAt": "2017-01-23T20:34:49.4131724Z",
+              "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored."
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListByNamespace",
+  "title": "RelayHybridConnectionListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridconnectionDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/HybridConnection/RelayHybridconnectionDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "HybridConnections_Delete",
+  "title": "RelayHybridconnectionDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "RelayNameSpaceAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "RelayNameSpaceAuthorizationRuleListKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "RelayNameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceCheckNameAvailability.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "parameters": {
+      "name": "example-RelayNamespace1321"
+    },
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "RelayCheckNameAvailability"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceCreate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "parameters": {
+      "location": "South Central US",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2"
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayNamespace-5849",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+        "location": "South Central US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "example-RelayNamespace-5849",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+        "location": "South Central US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "RelayNamespaceCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "SouthCentralUS",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "RelayNameSpaceDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceGet.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayRelayNamespace-01",
+    "resourceGroupName": "RG-eg",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "createdAt": "2017-01-23T20:38:12.46Z",
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-01",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://example-RelayRelayNamespace-01.servicebus.windows.net:443/",
+          "updatedAt": "2017-01-23T20:38:34.533Z",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "RelayNameSpaceGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceListByResourceGroup.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceListByResourceGroup.json
@@ -1,0 +1,258 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayNamespace-3054",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3054",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3054",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3054.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "oaisdjfoiasdjfoiajsdfoijasd",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/oaisdjfoiasdjfoiajsdfoijasd",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:oaisdjfoiasdjfoiajsdfoijasd",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://oaisdjfoiasdjfoiajsdfoijasd.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "abc123",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/abc123",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:abc123",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://abc123.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-5849",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "example-RelayNamespace-4984",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-4984",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-4984",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-4984.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-5606",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5606",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5606",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-5606.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-7703",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-7703",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-7703",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-7703.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "zzzzzzzzzzzzzzzzzzzzzz-00001",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/zzzzzzzzzzzzzzzzzzzzzz-00001",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:zzzzzzzzzzzzzzzzzzzzzz-00001",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://zzzzzzzzzzzzzzzzzzzzzz-00001.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-3919",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3919",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3919",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3919.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://aiosdjfaoidjasdoijasdfoijasdfofijsdf.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-3413",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3413",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3413",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3413.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-8695",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-8695",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-8695",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-8695.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-4801",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-4801",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-4801",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-4801.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-2812",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-2812",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-2812",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-2812.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "RelayNameSpaceListByResourceGroup"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceListBySubscription.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceListBySubscription.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayRelayNamespace-01",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+            "location": "West US",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:49.4131724Z",
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-01",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayRelayNamespace-01.servicebus.windows.net:443/",
+              "updatedAt": "2017-01-23T20:34:59.4131724Z",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "example-RelayRelayNamespace-02",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-02",
+            "location": "West US",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:39.4131724Z",
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-02",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayRelayNamespace-02.servicebus.windows.net:443/",
+              "updatedAt": "2017-01-23T20:34:49.4131724Z",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "RelayNameSpaceListBySubscription"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceUpdate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/NameSpaces/RelayNameSpaceUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayRelayNamespace-01",
+    "parameters": {
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4",
+        "tag5": "value5",
+        "tag6": "value6"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.3"
+      }
+    },
+    "resourceGroupName": "RG-eg",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relayrelaynamespace-01",
+          "provisioningState": "Succeeded",
+          "minimumTlsVersion": "1.3"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4",
+          "tag5": "value5",
+          "tag6": "value6"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relayrelaynamespace-01",
+          "provisioningState": "Succeeded",
+          "minimumTlsVersion": "1.3"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4",
+          "tag5": "value5",
+          "tag6": "value6"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "RelayNameSpaceUpdate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsCreate.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "You may pass",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "You may pass",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "You may pass",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsGet.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/{RGName}/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approve please",
+            "status": "Pending"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsList.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateEndpointConnectionsList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnection name}",
+            "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+            "location": "South Central US",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "approve please",
+                "status": "Pending"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "PrivateEndpointConnectionsList"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateLinkResourcesGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateLinkResourcesGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateLinkResourceName": "{PrivateLinkResource name}",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "namespace",
+        "type": "Microsoft.Relay/namespaces/privateLinkResources",
+        "id": "subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateLinkResources/namespace",
+        "properties": {
+          "groupId": "namespace",
+          "requiredMembers": [
+            "namespace"
+          ],
+          "requiredZoneNames": [
+            "privatelink.servicebus.windows.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateLinkResourcesList.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/PrivateEndpointConnections/PrivateLinkResourcesList.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.Relay/namespaces/privateLinkResources",
+            "id": "subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.servicebus.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_List",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_CreateOrUpdateAuthorizationRule",
+  "title": "RelayAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WCFRelays_DeleteAuthorizationRule",
+  "title": "RelayAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_GetAuthorizationRule",
+  "title": "RelayAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-Wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListAuthorizationRules",
+  "title": "RelayAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListKeys",
+  "title": "RelayAuthorizationRuleListKey.json"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "WCFRelays_RegenerateKeys",
+  "title": "RelayAuthorizationRuleRegenerateKey.json"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-9953",
+    "parameters": {
+      "properties": {
+        "relayType": "NetTcp",
+        "requiresClientAuthorization": true,
+        "requiresTransportSecurity": true
+      }
+    },
+    "relayName": "example-Relay-Wcf-1194",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Wcf-1194",
+        "type": "Microsoft.Relay/WcfRelays",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9953/WcfRelays/example-Relay-Wcf-1194",
+        "properties": {
+          "createdAt": "2017-03-16T00:26:17.5014661Z",
+          "isDynamic": false,
+          "relayType": "NetTcp",
+          "requiresClientAuthorization": true,
+          "requiresTransportSecurity": true,
+          "updatedAt": "2017-03-16T00:26:17.5014661Z"
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_CreateOrUpdate",
+  "title": "RelayCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WCFRelays_Delete",
+  "title": "RelayDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-9953",
+    "relayName": "example-Relay-Wcf-1194",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Wcf-1194",
+        "type": "Microsoft.Relay/WcfRelays",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9953/WcfRelays/example-Relay-Wcf-1194",
+        "properties": {
+          "createdAt": "2017-03-16T00:26:17.5014661Z",
+          "isDynamic": false,
+          "listenerCount": 0,
+          "relayType": "NetTcp",
+          "requiresClientAuthorization": true,
+          "requiresTransportSecurity": true,
+          "updatedAt": "2017-03-16T00:26:17.5014661Z"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "WCFRelays_Get",
+  "title": "RelayGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/Relay/RelayListAll.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-Relay-Wcf-01",
+            "type": "Microsoft.Relay/Namespaces/WcfRelays",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01",
+            "properties": {
+              "createdAt": "2017-01-24T00:46:27.0049983Z",
+              "isDynamic": false,
+              "relayType": "NetTcp",
+              "requiresClientAuthorization": true,
+              "requiresTransportSecurity": true,
+              "updatedAt": "2017-01-24T00:46:27.0049983Z",
+              "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListByNamespace",
+  "title": "RelayListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/RelayOperations_List.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/RelayOperations_List.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Relay/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/register/action",
+            "display": {
+              "operation": "Registers the Relay Resource Provider",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/write",
+            "display": {
+              "operation": "Create or Update Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/read",
+            "display": {
+              "operation": "Get Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/Delete",
+            "display": {
+              "operation": "Delete Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "RelayOperationsList"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/VirtualNetworkRules/RelayNetworkRuleSetCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/VirtualNetworkRules/RelayNetworkRuleSetCreate.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "trustedServiceAccessEnabled": false
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Relay/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroupid/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "trustedServiceAccessEnabled": false
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/VirtualNetworkRules/RelayNetworkRuleSetGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/examples/2026-01-01/VirtualNetworkRules/RelayNetworkRuleSetGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Relay/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroupid/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "trustedServiceAccessEnabled": false
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/main.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/main.tsp
@@ -46,6 +46,11 @@ enum Versions {
    * The 2024-01-01 API version.
    */
   v2024_01_01: "2024-01-01",
+
+  /**
+   * The 2026-01-01 API version.
+   */
+  v2026_01_01: "2026-01-01",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/models.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/models.tsp
@@ -1,8 +1,10 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-resource-manager";
 
 using TypeSpec.Rest;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 
 namespace Microsoft.Relay;
@@ -328,6 +330,23 @@ model Sku {
 }
 
 /**
+ * The minimum TLS version for the cluster to support, e.g. 1.2
+ */
+union TlsVersion {
+  string,
+
+  /**
+   * TLS version 1.2
+   */
+  `1.2`: "1.2",
+
+  /**
+   * TLS version 1.3
+   */
+  `1.3`: "1.3",
+}
+
+/**
  * Properties of the namespace.
  */
 model RelayNamespaceProperties {
@@ -379,6 +398,12 @@ model RelayNamespaceProperties {
    * This determines if traffic is allowed over public network. By default it is enabled.
    */
   publicNetworkAccess?: PublicNetworkAccess = "Enabled";
+
+  /**
+   * The minimum TLS version for the cluster to support, e.g. 1.2
+   */
+  @added(Versions.v2026_01_01)
+  minimumTlsVersion?: TlsVersion = "1.2";
 }
 
 /**

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/readme.md
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/readme.md
@@ -25,7 +25,7 @@ These are the global settings for the Relay API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2024-01
+tag: package-2026-01
 ```
 
 ### Tag: package-2021-11-01
@@ -81,6 +81,15 @@ These settings apply only when `--tag=package-2024-01` is specified on the comma
 ``` yaml $(tag) == 'package-2024-01'
 input-file:
 - stable/2024-01-01/relay.json
+```
+
+### Tag: package-2026-01
+
+These settings apply only when `--tag=package-2026-01` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-01'
+input-file:
+- stable/2026-01-01/relay.json
 ```
 
 ---

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_CreateOrUpdateAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "HybridConnections_DeleteAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_GetAuthorizationRule",
+  "title": "RelayHybridConnectionAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/Hybridconnections/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListAuthorizationRules",
+  "title": "RelayHybridConnectionAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListKeys",
+  "title": "RelayHybridConnectionAuthorizationRuleListKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "HybridConnections_RegenerateKeys",
+  "title": "RelayHybridConnectionAuthorizationRuleRegenerateKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionCreate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "requiresClientAuthorization": true
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Hybrid-01",
+        "type": "Microsoft.Relay/Namespaces/HybridConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+        "properties": {
+          "createdAt": "2017-01-23T20:34:49.4131724Z",
+          "requiresClientAuthorization": true,
+          "updatedAt": "2017-01-23T20:34:49.4131724Z"
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_CreateOrUpdate",
+  "title": "RelayHybridConnectionCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Hybrid-01",
+        "type": "Microsoft.Relay/Namespaces/HybridConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+        "properties": {
+          "createdAt": "2017-01-23T20:34:49.4131724Z",
+          "listenerCount": 1,
+          "requiresClientAuthorization": true,
+          "updatedAt": "2017-01-23T20:34:49.4131724Z",
+          "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored."
+        }
+      }
+    }
+  },
+  "operationId": "HybridConnections_Get",
+  "title": "RelayHybridConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridConnectionListAll.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-Relay-Hybrid-01",
+            "type": "Microsoft.Relay/Namespaces/HybridConnections",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/HybridConnections/example-Relay-Hybrid-01",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:49.4131724Z",
+              "listenerCount": 1,
+              "requiresClientAuthorization": true,
+              "updatedAt": "2017-01-23T20:34:49.4131724Z",
+              "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored."
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridConnections_ListByNamespace",
+  "title": "RelayHybridConnectionListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridconnectionDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/HybridConnection/RelayHybridconnectionDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "hybridConnectionName": "example-Relay-Hybrid-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "HybridConnections_Delete",
+  "title": "RelayHybridconnectionDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "RelayNameSpaceAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "RelayNameSpaceAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "RelayNameSpaceAuthorizationRuleListKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "RelayNameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceCheckNameAvailability.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "parameters": {
+      "name": "example-RelayNamespace1321"
+    },
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "RelayCheckNameAvailability"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceCreate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "parameters": {
+      "location": "South Central US",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2"
+      }
+    },
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayNamespace-5849",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+        "location": "South Central US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "example-RelayNamespace-5849",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+        "location": "South Central US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "RelayNamespaceCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "SouthCentralUS",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "RelayNameSpaceDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceGet.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayRelayNamespace-01",
+    "resourceGroupName": "RG-eg",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "createdAt": "2017-01-23T20:38:12.46Z",
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-01",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://example-RelayRelayNamespace-01.servicebus.windows.net:443/",
+          "updatedAt": "2017-01-23T20:38:34.533Z",
+          "minimumTlsVersion": "1.2"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "RelayNameSpaceGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceListByResourceGroup.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceListByResourceGroup.json
@@ -1,0 +1,258 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayNamespace-3054",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3054",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3054",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3054.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "oaisdjfoiasdjfoiajsdfoijasd",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/oaisdjfoiasdjfoiajsdfoijasd",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:oaisdjfoiasdjfoiajsdfoijasd",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://oaisdjfoiasdjfoiajsdfoijasd.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "abc123",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/abc123",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:abc123",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://abc123.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-5849",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5849",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5849",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-5849.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "example-RelayNamespace-4984",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-4984",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-4984",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-4984.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-5606",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-5606",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-5606",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-5606.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-7703",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-7703",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-7703",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-7703.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "zzzzzzzzzzzzzzzzzzzzzz-00001",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/zzzzzzzzzzzzzzzzzzzzzz-00001",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:zzzzzzzzzzzzzzzzzzzzzz-00001",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://zzzzzzzzzzzzzzzzzzzzzz-00001.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-3919",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3919",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3919",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3919.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:aiosdjfaoidjasdoijasdfoijasdfofijsdf",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://aiosdjfaoidjasdoijasdfoijasdfofijsdf.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-3413",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-3413",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-3413",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-3413.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-8695",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-8695",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-8695",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-8695.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-4801",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-4801",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-4801",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-4801.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "example-RelayNamespace-2812",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-2812",
+            "location": "South Central US",
+            "properties": {
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relaynamespace-2812",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayNamespace-2812.servicebus.windows-int.net:443/",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "RelayNameSpaceListByResourceGroup"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceListBySubscription.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceListBySubscription.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayRelayNamespace-01",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+            "location": "West US",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:49.4131724Z",
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-01",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayRelayNamespace-01.servicebus.windows.net:443/",
+              "updatedAt": "2017-01-23T20:34:59.4131724Z",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "example-RelayRelayNamespace-02",
+            "type": "Microsoft.Relay/Namespaces",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-02",
+            "location": "West US",
+            "properties": {
+              "createdAt": "2017-01-23T20:34:39.4131724Z",
+              "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-RelayRelayNamespace-02",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://example-RelayRelayNamespace-02.servicebus.windows.net:443/",
+              "updatedAt": "2017-01-23T20:34:49.4131724Z",
+              "minimumTlsVersion": "1.2"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "RelayNameSpaceListBySubscription"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceUpdate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/NameSpaces/RelayNameSpaceUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayRelayNamespace-01",
+    "parameters": {
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4",
+        "tag5": "value5",
+        "tag6": "value6"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.3"
+      }
+    },
+    "resourceGroupName": "RG-eg",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relayrelaynamespace-01",
+          "provisioningState": "Succeeded",
+          "minimumTlsVersion": "1.3"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4",
+          "tag5": "value5",
+          "tag6": "value6"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "example-RelayRelayNamespace-01",
+        "type": "Microsoft.Relay/Namespaces",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG-eg/providers/Microsoft.Relay/namespaces/example-RelayRelayNamespace-01",
+        "location": "West US",
+        "properties": {
+          "metricId": "ffffffff-ffff-ffff-ffff-ffffffffffff:example-Relayrelaynamespace-01",
+          "provisioningState": "Succeeded",
+          "minimumTlsVersion": "1.3"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4",
+          "tag5": "value5",
+          "tag6": "value6"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "RelayNameSpaceUpdate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsCreate.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "You may pass",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "You may pass",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "You may pass",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsGet.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateEndpointConnectionName": "{privateEndpointConnection name}",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnection name}",
+        "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/{RGName}/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+        "location": "South Central US",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approve please",
+            "status": "Pending"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsList.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateEndpointConnectionsList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnection name}",
+            "type": "Microsoft.Relay/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateEndpointConnections/{privateEndpointConnection name}",
+            "location": "South Central US",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Network/privateEndpoints/ali-relay-pve-1"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "approve please",
+                "status": "Pending"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "PrivateEndpointConnectionsList"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateLinkResourcesGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateLinkResourcesGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "privateLinkResourceName": "{PrivateLinkResource name}",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "namespace",
+        "type": "Microsoft.Relay/namespaces/privateLinkResources",
+        "id": "subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateLinkResources/namespace",
+        "properties": {
+          "groupId": "namespace",
+          "requiredMembers": [
+            "namespace"
+          ],
+          "requiredZoneNames": [
+            "privatelink.servicebus.windows.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateLinkResourcesList.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/PrivateEndpointConnections/PrivateLinkResourcesList.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-5849",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.Relay/namespaces/privateLinkResources",
+            "id": "subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/alitest/providers/Microsoft.Relay/namespaces/relay-private-endpoint-test/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.servicebus.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_List",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_CreateOrUpdateAuthorizationRule",
+  "title": "RelayAuthorizationRuleCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WCFRelays_DeleteAuthorizationRule",
+  "title": "RelayAuthorizationRuleDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-RelayAuthRules-01",
+        "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+        "properties": {
+          "rights": [
+            "Listen"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_GetAuthorizationRule",
+  "title": "RelayAuthorizationRuleGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-Wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-RelayAuthRules-01",
+            "type": "Microsoft.Relay/Namespaces/WcfRelay/AuthorizationRules",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01/AuthorizationRules/example-RelayAuthRules-01",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListAuthorizationRules",
+  "title": "RelayAuthorizationRuleListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleListKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListKeys",
+  "title": "RelayAuthorizationRuleListKey.json"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleRegenerateKey.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "authorizationRuleName": "example-RelayAuthRules-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "example-RelayAuthRules-01",
+        "primaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://example-Relaynamespace-01.servicebus.windows.net/;SharedAccessKeyName=example-RelayAuthRules-01;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "WCFRelays_RegenerateKeys",
+  "title": "RelayAuthorizationRuleRegenerateKey.json"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-9953",
+    "parameters": {
+      "properties": {
+        "relayType": "NetTcp",
+        "requiresClientAuthorization": true,
+        "requiresTransportSecurity": true
+      }
+    },
+    "relayName": "example-Relay-Wcf-1194",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Wcf-1194",
+        "type": "Microsoft.Relay/WcfRelays",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroup/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9953/WcfRelays/example-Relay-Wcf-1194",
+        "properties": {
+          "createdAt": "2017-03-16T00:26:17.5014661Z",
+          "isDynamic": false,
+          "relayType": "NetTcp",
+          "requiresClientAuthorization": true,
+          "requiresTransportSecurity": true,
+          "updatedAt": "2017-03-16T00:26:17.5014661Z"
+        }
+      }
+    }
+  },
+  "operationId": "WCFRelays_CreateOrUpdate",
+  "title": "RelayCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayDelete.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "relayName": "example-Relay-wcf-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WCFRelays_Delete",
+  "title": "RelayDelete"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-9953",
+    "relayName": "example-Relay-Wcf-1194",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "example-Relay-Wcf-1194",
+        "type": "Microsoft.Relay/WcfRelays",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9953/WcfRelays/example-Relay-Wcf-1194",
+        "properties": {
+          "createdAt": "2017-03-16T00:26:17.5014661Z",
+          "isDynamic": false,
+          "listenerCount": 0,
+          "relayType": "NetTcp",
+          "requiresClientAuthorization": true,
+          "requiresTransportSecurity": true,
+          "updatedAt": "2017-03-16T00:26:17.5014661Z"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "WCFRelays_Get",
+  "title": "RelayGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayListAll.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/Relay/RelayListAll.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-01",
+    "resourceGroupName": "resourcegroup",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "example-Relay-Wcf-01",
+            "type": "Microsoft.Relay/Namespaces/WcfRelays",
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/RG1-eg/providers/Microsoft.Relay/namespaces/example-RelayNamespace-01/WcfRelays/example-Relay-Wcf-01",
+            "properties": {
+              "createdAt": "2017-01-24T00:46:27.0049983Z",
+              "isDynamic": false,
+              "relayType": "NetTcp",
+              "requiresClientAuthorization": true,
+              "requiresTransportSecurity": true,
+              "updatedAt": "2017-01-24T00:46:27.0049983Z",
+              "userMetadata": "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WCFRelays_ListByNamespace",
+  "title": "RelayListAll"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/RelayOperations_List.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/RelayOperations_List.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Relay/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/register/action",
+            "display": {
+              "operation": "Registers the Relay Resource Provider",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/write",
+            "display": {
+              "operation": "Create or Update Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/read",
+            "display": {
+              "operation": "Get Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/Relays/Delete",
+            "display": {
+              "operation": "Delete Relay",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Relay"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.Relay/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure Relay",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "RelayOperationsList"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/VirtualNetworkRules/RelayNetworkRuleSetCreate.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/VirtualNetworkRules/RelayNetworkRuleSetCreate.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "trustedServiceAccessEnabled": false
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Relay/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroupid/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "trustedServiceAccessEnabled": false
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/VirtualNetworkRules/RelayNetworkRuleSetGet.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/examples/VirtualNetworkRules/RelayNetworkRuleSetGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "namespaceName": "example-RelayNamespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Relay/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourcegroupid/providers/Microsoft.Relay/namespaces/example-RelayNamespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "trustedServiceAccessEnabled": false
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/relay.json
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/stable/2026-01-01/relay.json
@@ -1,0 +1,3511 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Relay API",
+    "version": "2026-01-01",
+    "description": "Use these API to manage Azure Relay resources through Azure Resource Manager.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "AuthorizationRules"
+    },
+    {
+      "name": "HybridConnections"
+    },
+    {
+      "name": "WCFRelays"
+    },
+    {
+      "name": "RelayNamespaces"
+    },
+    {
+      "name": "NetworkRuleSets"
+    },
+    {
+      "name": "HybridConnectionOperationGroup"
+    },
+    {
+      "name": "WcfRelaysOps"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "PrivateLinkResources"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Relay/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayOperationsList": {
+            "$ref": "./examples/RelayOperations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Relay/checkNameAvailability": {
+      "post": {
+        "operationId": "Namespaces_CheckNameAvailability",
+        "description": "Check the specified namespace name availability.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailability"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayCheckNameAvailability": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Relay/namespaces": {
+      "get": {
+        "operationId": "Namespaces_List",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Lists all the available namespaces within the subscription regardless of the resourceGroups.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceListBySubscription": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces": {
+      "get": {
+        "operationId": "Namespaces_ListByResourceGroup",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Lists all the available namespaces within the ResourceGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceListByResourceGroup": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}": {
+      "get": {
+        "operationId": "Namespaces_Get",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Returns the description for the specified namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceGet": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdate",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Create Azure Relay namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RelayNamespace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'RelayNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNamespaceCreate": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceCreate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/RelayNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Namespaces_Update",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Creates or updates a namespace. Once created, this namespace's resource manifest is immutable. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for updating a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RelayUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'RelayNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RelayNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceUpdate": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_Delete",
+        "tags": [
+          "RelayNamespaces"
+        ],
+        "description": "Deletes an existing namespace. This operation also removes all associated resources under the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceDelete": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/authorizationRules": {
+      "get": {
+        "operationId": "Namespaces_ListAuthorizationRules",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Authorization rules for a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleListAll": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "Namespaces_GetAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Authorization rule for a namespace by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleGet": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Creates or updates an authorization rule for a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The authorization rule parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleCreate": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_DeleteAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Deletes a namespace authorization rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleDelete": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "Namespaces_ListKeys",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Primary and secondary connection strings to the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleListKey": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "Namespaces_RegenerateKeys",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Regenerates the primary or secondary connection strings to the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayNameSpaceAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/NameSpaces/RelayNameSpaceAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections": {
+      "get": {
+        "operationId": "HybridConnections_ListByNamespace",
+        "tags": [
+          "HybridConnectionOperationGroup"
+        ],
+        "description": "Lists the hybrid connection within the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HybridConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionListAll": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections/{hybridConnectionName}": {
+      "get": {
+        "operationId": "HybridConnections_Get",
+        "tags": [
+          "HybridConnectionOperationGroup"
+        ],
+        "description": "Returns the description for the specified hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HybridConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionGet": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "HybridConnections_CreateOrUpdate",
+        "tags": [
+          "HybridConnectionOperationGroup"
+        ],
+        "description": "Creates or updates a service hybrid connection. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a hybrid connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HybridConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'HybridConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HybridConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionCreate": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "HybridConnections_Delete",
+        "tags": [
+          "HybridConnectionOperationGroup"
+        ],
+        "description": "Deletes a hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridconnectionDelete": {
+            "$ref": "./examples/HybridConnection/RelayHybridconnectionDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections/{hybridConnectionName}/authorizationRules": {
+      "get": {
+        "operationId": "HybridConnections_ListAuthorizationRules",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Authorization rules for a hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleListAll": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections/{hybridConnectionName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "HybridConnections_GetAuthorizationRule",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Hybrid connection authorization rule for a hybrid connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleGet": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "HybridConnections_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Creates or updates an authorization rule for a hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The authorization rule parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleCreate": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "HybridConnections_DeleteAuthorizationRule",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Deletes a hybrid connection authorization rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleDelete": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections/{hybridConnectionName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "HybridConnections_ListKeys",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Primary and secondary connection strings to the hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleListKey": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/hybridConnections/{hybridConnectionName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "HybridConnections_RegenerateKeys",
+        "tags": [
+          "HybridConnections"
+        ],
+        "description": "Regenerates the primary or secondary connection strings to the hybrid connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "hybridConnectionName",
+            "in": "path",
+            "description": "The hybrid connection name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayHybridConnectionAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/HybridConnection/RelayHybridConnectionAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/networkRuleSets/default": {
+      "get": {
+        "operationId": "Namespaces_GetNetworkRuleSet",
+        "tags": [
+          "NetworkRuleSets"
+        ],
+        "description": "Gets NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetGet": {
+            "$ref": "./examples/VirtualNetworkRules/RelayNetworkRuleSetGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+        "tags": [
+          "NetworkRuleSets"
+        ],
+        "description": "Create or update NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The Namespace IpFilterRule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkRuleSet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetCreate": {
+            "$ref": "./examples/VirtualNetworkRules/RelayNetworkRuleSetCreate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the available PrivateEndpointConnections within a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnectionsList": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateEndpointConnectionsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets a description for the specified Private Endpoint Connection name.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionGet": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateEndpointConnectionsGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Creates or updates PrivateEndpointConnections of service namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update Status of PrivateEndPoint Connection to namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionCreate": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateEndpointConnectionsCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes an existing namespace. This operation also removes all associated resources under the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionDelete": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateEndpointConnectionsDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_List",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "description": "Lists the private link resources for a container registry.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateLinkResourcesGet": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateLinkResourcesList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/privateLinkResources/{privateLinkResourceName}": {
+      "get": {
+        "operationId": "PrivateLinkResources_Get",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "description": "Gets a private link resource by a specified group name for a container registry.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateLinkResourceName",
+            "in": "path",
+            "description": "The name of the private link resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionGet": {
+            "$ref": "./examples/PrivateEndpointConnections/PrivateLinkResourcesGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays": {
+      "get": {
+        "operationId": "WCFRelays_ListByNamespace",
+        "tags": [
+          "WcfRelaysOps"
+        ],
+        "description": "Lists the WCF relays within the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WcfRelaysListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayListAll": {
+            "$ref": "./examples/Relay/RelayListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays/{relayName}": {
+      "get": {
+        "operationId": "WCFRelays_Get",
+        "tags": [
+          "WcfRelaysOps"
+        ],
+        "description": "Returns the description for the specified WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WcfRelay"
+            }
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayGet": {
+            "$ref": "./examples/Relay/RelayGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "WCFRelays_CreateOrUpdate",
+        "tags": [
+          "WcfRelaysOps"
+        ],
+        "description": "Creates or updates a WCF relay. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a WCF relay.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WcfRelay"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'WcfRelay' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WcfRelay"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayCreate": {
+            "$ref": "./examples/Relay/RelayCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "WCFRelays_Delete",
+        "tags": [
+          "WcfRelaysOps"
+        ],
+        "description": "Deletes a WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayDelete": {
+            "$ref": "./examples/Relay/RelayDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays/{relayName}/authorizationRules": {
+      "get": {
+        "operationId": "WCFRelays_ListAuthorizationRules",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Authorization rules for a WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleListAll": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays/{relayName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "WCFRelays_GetAuthorizationRule",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Get authorizationRule for a WCF relay by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleGet": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "WCFRelays_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Creates or updates an authorization rule for a WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The authorization rule parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleCreate": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "WCFRelays_DeleteAuthorizationRule",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Deletes a WCF relay authorization rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleDelete": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays/{relayName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "WCFRelays_ListKeys",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Primary and secondary connection strings to the WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleListKey.json": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/wcfRelays/{relayName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "WCFRelays_RegenerateKeys",
+        "tags": [
+          "WCFRelays"
+        ],
+        "description": "Regenerates the primary or secondary connection strings to the WCF relay.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "relayName",
+            "in": "path",
+            "description": "The relay name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RelayAuthorizationRuleRegenerateKey.json": {
+            "$ref": "./examples/Relay/RelayAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessKeys": {
+      "type": "object",
+      "description": "Namespace/Relay Connection String",
+      "properties": {
+        "primaryConnectionString": {
+          "type": "string",
+          "description": "Primary connection string of the created namespace authorization rule."
+        },
+        "secondaryConnectionString": {
+          "type": "string",
+          "description": "Secondary connection string of the created namespace authorization rule."
+        },
+        "primaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit primary key for signing and validating the SAS token."
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit secondary key for signing and validating the SAS token."
+        },
+        "keyName": {
+          "type": "string",
+          "description": "A string that describes the authorization rule."
+        }
+      }
+    },
+    "AccessRights": {
+      "type": "string",
+      "enum": [
+        "Manage",
+        "Send",
+        "Listen"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRights",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Manage",
+            "value": "Manage"
+          },
+          {
+            "name": "Send",
+            "value": "Send"
+          },
+          {
+            "name": "Listen",
+            "value": "Listen"
+          }
+        ]
+      }
+    },
+    "AuthorizationRule": {
+      "type": "object",
+      "description": "Single item in a List or Get AuthorizationRule operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthorizationRuleProperties",
+          "description": "Properties supplied to create or update AuthorizationRule",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AuthorizationRuleListResult": {
+      "type": "object",
+      "description": "The response of a AuthorizationRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AuthorizationRule items on this page",
+          "items": {
+            "$ref": "#/definitions/AuthorizationRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthorizationRuleProperties": {
+      "type": "object",
+      "description": "Properties supplied to create or update AuthorizationRule",
+      "properties": {
+        "rights": {
+          "type": "array",
+          "description": "The rights associated with the rule.",
+          "items": {
+            "$ref": "#/definitions/AccessRights"
+          }
+        }
+      },
+      "required": [
+        "rights"
+      ]
+    },
+    "CheckNameAvailability": {
+      "type": "object",
+      "description": "Description of the check name availability request properties.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The namespace name to check for availability. The namespace name can contain only letters, numbers, and hyphens. The namespace must start with a letter, and it must end with a letter or number."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "CheckNameAvailabilityResult": {
+      "type": "object",
+      "description": "Description of the check name availability request properties.",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "The detailed info regarding the reason associated with the namespace.",
+          "readOnly": true
+        },
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "Value indicating namespace is available. Returns true if the namespace is available; otherwise, false."
+        },
+        "reason": {
+          "$ref": "#/definitions/UnavailableReason",
+          "description": "The reason for unavailability of a namespace."
+        }
+      }
+    },
+    "ConnectionState": {
+      "type": "object",
+      "description": "ConnectionState information.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkConnectionStatus",
+          "description": "Status of the connection."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the connection state."
+        }
+      }
+    },
+    "DefaultAction": {
+      "type": "string",
+      "description": "Default Action for Network Rule Set",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "DefaultAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "EndPointProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Private Endpoint Connection.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "EndPointProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "HybridConnection": {
+      "type": "object",
+      "description": "Description of hybrid connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HybridConnectionProperties",
+          "description": "Properties of the HybridConnection.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "HybridConnectionListResult": {
+      "type": "object",
+      "description": "The response of a HybridConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HybridConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/HybridConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "HybridConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the HybridConnection.",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the hybrid connection was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was updated.",
+          "readOnly": true
+        },
+        "listenerCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of listeners for this hybrid connection. Note that min : 1 and max:25 are supported.",
+          "maximum": 25,
+          "readOnly": true
+        },
+        "requiresClientAuthorization": {
+          "type": "boolean",
+          "description": "Returns true if client authorization is needed for this hybrid connection; otherwise, false."
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "The usermetadata is a placeholder to store user-defined string data for the hybrid connection endpoint. For example, it can be used to store descriptive data, such as a list of teams and their contact information. Also, user-defined configuration settings can be stored."
+        }
+      }
+    },
+    "KeyType": {
+      "type": "string",
+      "description": "The access key to regenerate.",
+      "enum": [
+        "PrimaryKey",
+        "SecondaryKey"
+      ],
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PrimaryKey",
+            "value": "PrimaryKey"
+          },
+          {
+            "name": "SecondaryKey",
+            "value": "SecondaryKey"
+          }
+        ]
+      }
+    },
+    "NWRuleSetIpRules": {
+      "type": "object",
+      "description": "The response from the List namespace operation.",
+      "properties": {
+        "ipMask": {
+          "type": "string",
+          "description": "IP Mask"
+        },
+        "action": {
+          "$ref": "#/definitions/NetworkRuleIPAction",
+          "description": "The IP Filter Action"
+        }
+      }
+    },
+    "NetworkRuleIPAction": {
+      "type": "string",
+      "description": "The IP Filter Action",
+      "enum": [
+        "Allow"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkRuleIPAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          }
+        ]
+      }
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "Description of topic resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkRuleSetProperties",
+          "description": "NetworkRuleSet properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkRuleSetProperties": {
+      "type": "object",
+      "description": "NetworkRuleSet properties",
+      "properties": {
+        "trustedServiceAccessEnabled": {
+          "type": "boolean",
+          "description": "Value that indicates whether Trusted Service Access is Enabled or not."
+        },
+        "defaultAction": {
+          "$ref": "#/definitions/DefaultAction",
+          "description": "Default Action for Network Rule Set"
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled"
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "List of IpRules",
+          "items": {
+            "$ref": "#/definitions/NWRuleSetIpRules"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "PrivateEndpoint information.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier for Private Endpoint."
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the PrivateEndpointConnection.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection resource.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The Private Endpoint resource for this Connection."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/ConnectionState",
+          "description": "Details about the state of the connection."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/EndPointProvisioningState",
+          "description": "Provisioning state of the Private Endpoint Connection."
+        }
+      }
+    },
+    "PrivateLinkConnectionStatus": {
+      "type": "string",
+      "description": "Status of the connection.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateLinkConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A resource that supports private link capabilities.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "A resource that supports private link capabilities.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of PrivateLinkResource",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id."
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource Private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourcesListResult": {
+      "type": "object",
+      "description": "Result of the List private link resources operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A collection of private link resources",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "A link for the next page of private link resources."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "This determines if traffic is allowed over public network. By default it is enabled.",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "SecuredByPerimeter"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "SecuredByPerimeter",
+            "value": "SecuredByPerimeter"
+          }
+        ]
+      }
+    },
+    "RegenerateAccessKeyParameters": {
+      "type": "object",
+      "description": "Parameters supplied to the regenerate authorization rule operation, specifies which key needs to be reset.",
+      "properties": {
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "The access key to regenerate."
+        },
+        "key": {
+          "type": "string",
+          "description": "Optional. If the key value is provided, this is set to key type, or autogenerated key value set for key type."
+        }
+      },
+      "required": [
+        "keyType"
+      ]
+    },
+    "RelayNamespace": {
+      "type": "object",
+      "description": "Description of a namespace resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RelayNamespaceProperties",
+          "description": "Description of Relay namespace",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "SKU of the namespace."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "RelayNamespaceListResult": {
+      "type": "object",
+      "description": "The response of a RelayNamespace list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RelayNamespace items on this page",
+          "items": {
+            "$ref": "#/definitions/RelayNamespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RelayNamespaceProperties": {
+      "type": "object",
+      "description": "Properties of the namespace.",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the Namespace.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the Namespace.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was updated.",
+          "readOnly": true
+        },
+        "serviceBusEndpoint": {
+          "type": "string",
+          "description": "Endpoint you can use to perform Service Bus operations.",
+          "readOnly": true
+        },
+        "metricId": {
+          "type": "string",
+          "description": "Identifier for Azure Insights metrics.",
+          "readOnly": true
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "minimumTlsVersion": {
+          "type": "string",
+          "description": "The minimum TLS version for the cluster to support, e.g. 1.2",
+          "default": "1.2",
+          "enum": [
+            "1.2",
+            "1.3"
+          ],
+          "x-ms-enum": {
+            "name": "TlsVersion",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "1.2",
+                "value": "1.2",
+                "description": "TLS version 1.2"
+              },
+              {
+                "name": "1.3",
+                "value": "1.3",
+                "description": "TLS version 1.3"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "RelayUpdateParameters": {
+      "type": "object",
+      "description": "Description of a namespace resource.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "SKU of the namespace."
+        },
+        "properties": {
+          "$ref": "#/definitions/RelayNamespaceProperties",
+          "description": "Description of Relay namespace.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceNamespacePatch"
+        }
+      ]
+    },
+    "Relaytype": {
+      "type": "string",
+      "description": "WCF relay type.",
+      "enum": [
+        "NetTcp",
+        "Http"
+      ],
+      "x-ms-enum": {
+        "name": "Relaytype",
+        "modelAsString": false
+      }
+    },
+    "ResourceNamespacePatch": {
+      "type": "object",
+      "description": "Definition of resource.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "Sku": {
+      "type": "object",
+      "description": "SKU of the namespace.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "Name of this SKU."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The tier of this SKU."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "Name of this SKU.",
+      "enum": [
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          }
+        ]
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The tier of this SKU.",
+      "enum": [
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          }
+        ]
+      }
+    },
+    "UnavailableReason": {
+      "type": "string",
+      "description": "Specifies the reason for the unavailability of the service.",
+      "enum": [
+        "None",
+        "InvalidName",
+        "SubscriptionIsDisabled",
+        "NameInUse",
+        "NameInLockdown",
+        "TooManyNamespaceInCurrentSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "UnavailableReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "InvalidName",
+            "value": "InvalidName"
+          },
+          {
+            "name": "SubscriptionIsDisabled",
+            "value": "SubscriptionIsDisabled"
+          },
+          {
+            "name": "NameInUse",
+            "value": "NameInUse"
+          },
+          {
+            "name": "NameInLockdown",
+            "value": "NameInLockdown"
+          },
+          {
+            "name": "TooManyNamespaceInCurrentSubscription",
+            "value": "TooManyNamespaceInCurrentSubscription"
+          }
+        ]
+      }
+    },
+    "WcfRelay": {
+      "type": "object",
+      "description": "Description of the WCF relay resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WcfRelayProperties",
+          "description": "Properties of the WCF relay.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WcfRelayProperties": {
+      "type": "object",
+      "description": "Properties of the WCF relay.",
+      "properties": {
+        "isDynamic": {
+          "type": "boolean",
+          "description": "Returns true if the relay is dynamic; otherwise, false.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the WCF relay was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was updated.",
+          "readOnly": true
+        },
+        "listenerCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of listeners for this relay. Note that min :1 and max:25 are supported.",
+          "maximum": 25,
+          "readOnly": true
+        },
+        "relayType": {
+          "$ref": "#/definitions/Relaytype",
+          "description": "WCF relay type."
+        },
+        "requiresClientAuthorization": {
+          "type": "boolean",
+          "description": "Returns true if client authorization is needed for this relay; otherwise, false."
+        },
+        "requiresTransportSecurity": {
+          "type": "boolean",
+          "description": "Returns true if transport security is needed for this relay; otherwise, false."
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "The usermetadata is a placeholder to store user-defined string data for the WCF Relay endpoint. For example, it can be used to store descriptive data, such as list of teams and their contact information. Also, user-defined configuration settings can be stored."
+        }
+      }
+    },
+    "WcfRelaysListResult": {
+      "type": "object",
+      "description": "The response of the list WCF relay operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WcfRelay items on this page",
+          "items": {
+            "$ref": "#/definitions/WcfRelay"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary

Adds a new **stable** API version `2026-01-01` for **Microsoft.Relay**, based on the existing `2024-01-01` version.

The only functional addition is a new `minimumTlsVersion` property on the Relay namespace, mirroring resource-provider PR `15816344`.

## Changes

- **New API version `2026-01-01`** added to the `Versions` enum in `main.tsp`.
- **New property** `minimumTlsVersion` on `RelayNamespaceProperties`:
  - Type: `TlsVersion` enum (`x-ms-enum` `modelAsString: true`) with allowed values **`1.2`** and **`1.3`**.
  - Default: **`1.2`**.
  - Gated with `@added(Versions.v2026_01_01)` so it appears **only** in `2026-01-01`.
- Generated `stable/2026-01-01/relay.json` + examples (via `tsp compile`).
- Added `examples/2026-01-01/` (copied from `2024-01-01`); namespace Create/Get/Update/List examples demonstrate `minimumTlsVersion`.
- Added `package-2026-01` tag to `readme.md` and set it as the default tag.

## No breaking changes

`stable/2024-01-01/relay.json` is **byte-for-byte unchanged**. The new property is purely additive and only present in `2026-01-01`.

## Validation

- `tsp compile . --warn-as-error` — passes (0 warnings/errors).
- `tsp format` — clean.
- `npx tsv <project>` (TypeSpecValidation suite) — passes (exit 0), including generated-swagger/TypeSpec consistency check.
- Prettier (swagger plugin) on JSON — clean.

## Related

- Resource-provider PR: `msazure/One/ServiceBus-Messaging` PR **15816344**
- Work Item: **38052778**

> Opened as **draft** for API review.
