### PR TITLE
VoiceLive: C# client naming fixes for 2026-07-15

### DIFF
--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -3,6 +3,21 @@ import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
 
+@@clientName(VoiceLive.OpenAIVoice.type, "Kind", "csharp");
+@@clientName(VoiceLive.AzureVoice.type, "Kind", "csharp");
+@@clientName(VoiceLive.AzureRealtimeNativeVoice.type, "Kind", "csharp");
+@@clientName(
+  VoiceLive.RequestSession.parallel_tool_calls,
+  "AllowParallelToolCalls",
+  "csharp"
+);
+@@clientName(
+  VoiceLive.ResponseSession.parallel_tool_calls,
+  "AllowParallelToolCalls",
+  "csharp"
+);
+@@clientName(VoiceLive.ResponseSession.expires_at, "ExpiresOn", "csharp");
+
 @@access(VoiceLive.ClientEventSessionUpdate, Access.public, "python");
 @@access(VoiceLive.ClientEventInputAudioBufferAppend, Access.public, "python");
 @@access(VoiceLive.ClientEventInputAudioBufferCommit, Access.public, "python");

--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -3,9 +3,6 @@ import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
 
-@@clientName(VoiceLive.OpenAIVoice.type, "Kind", "csharp");
-@@clientName(VoiceLive.AzureVoice.type, "Kind", "csharp");
-@@clientName(VoiceLive.AzureRealtimeNativeVoice.type, "Kind", "csharp");
 @@clientName(
   VoiceLive.RequestSession.parallel_tool_calls,
   "AllowParallelToolCalls",

--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -3,6 +3,7 @@ import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
 
+@@clientName(VoiceLive.AzureRealtimeNativeVoice.type, "Kind", "csharp");
 @@clientName(
   VoiceLive.RequestSession.parallel_tool_calls,
   "AllowParallelToolCalls",


### PR DESCRIPTION
Address .NET SDK review comments (wire contract unchanged, csharp scope only): voice 	ype->Kind, parallel_tool_calls->AllowParallelToolCalls, xpires_at->ExpiresOn.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
