### PR TITLE
Add Redis provisioning name constraints

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
@@ -199,6 +199,30 @@ model RedisCommonPropertiesRedisConfigurationRecordString {
 );
 @@scope(Operations.list, "!csharp");
 @@clientName(RedisResource, "Redis", "csharp");
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning"
+@@clientOption(
+  RedisResource,
+  "resource-name-constraint",
+  #{
+    minLength: 1,
+    maxLength: 63,
+    pattern: "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$",
+  },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning"
+@@clientOption(
+  RedisFirewallRule,
+  "resource-name-constraint",
+  #{
+    minLength: 1,
+    maxLength: 256,
+    pattern: "^[a-zA-Z0-9]+$",
+  },
+  "csharp"
+);
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
 @@clientOption(
   RedisResource,

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
@@ -216,11 +216,7 @@ model RedisCommonPropertiesRedisConfigurationRecordString {
 @@clientOption(
   RedisFirewallRule,
   "resource-name-constraint",
-  #{
-    minLength: 1,
-    maxLength: 256,
-    pattern: "^[a-zA-Z0-9]+$",
-  },
+  #{ minLength: 1, maxLength: 256, pattern: "^[a-zA-Z0-9]+$" },
   "csharp"
 );
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"


### PR DESCRIPTION
Adds C# `resource-name-constraint` client options for Redis provisioning migration compatibility.

The legacy reflection provisioning generator used:
- `RedisResource`: min 1, max 63, letters/digits/hyphen
- `RedisFirewallRule`: min 1, max 256, letters/digits

The TypeSpec currently has no min/max decorators for these names, so the TypeSpec provisioning generator falls back to the default max length. These client options preserve the shipped Azure.Provisioning.Redis naming behavior without changing Swagger shape.

Related SDK PR: Azure/azure-sdk-for-net#60978