### PR TITLE
[Education] Exclude csharp flatten for LabProperties budget to avoid custom code

### DIFF
--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -45,3 +45,14 @@ using Microsoft.Education;
 
 @@clientName(GrantType, "EducationGrantType", "csharp");
 @@clientName(GrantStatus, "EducationGrantStatus", "csharp");
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "workaround: avoid "
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  LabProperties.totalBudget,
+  "!csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Property flatten for SDK backward compatibility."
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  LabProperties.totalAllocatedBudget,
+  "!csharp"
+);

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -46,7 +46,11 @@ using Microsoft.Education;
 @@clientName(GrantType, "EducationGrantType", "csharp");
 @@clientName(GrantStatus, "EducationGrantStatus", "csharp");
 
-// TODO: exclude csharp flatten for now, see issue https://github.com/Azure/azure-sdk-for-net/issues/60644
+@@clientName(LabDetails, "EducationLab", "csharp");
+@@clientName(StudentDetails, "EducationStudent", "csharp");
+
+// TODO: these two properties are flattened in original spec, and it causes duplicate members in c# sdk code
+// let service team fix spec, see https://github.com/Azure/azure-sdk-for-net/issues/60644#issuecomment-4979513139
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "workaround avoid generating duplicate members"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(
   LabProperties.totalBudget,

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -48,6 +48,7 @@ using Microsoft.Education;
 
 @@clientName(LabDetails, "EducationLab", "csharp");
 @@clientName(StudentDetails, "EducationStudent", "csharp");
+@@clientName(JoinRequestDetails, "EducationJoinRequest", "csharp");
 
 // TODO: these two properties are flattened in original spec, and it causes duplicate members in c# sdk code
 // let service team fix spec, see https://github.com/Azure/azure-sdk-for-net/issues/60644#issuecomment-4979513139

--- a/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/client.tsp
@@ -46,12 +46,13 @@ using Microsoft.Education;
 @@clientName(GrantType, "EducationGrantType", "csharp");
 @@clientName(GrantStatus, "EducationGrantStatus", "csharp");
 
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "workaround: avoid "
+// TODO: exclude csharp flatten for now, see issue https://github.com/Azure/azure-sdk-for-net/issues/60644
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "workaround avoid generating duplicate members"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(
   LabProperties.totalBudget,
   "!csharp"
 );
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Property flatten for SDK backward compatibility."
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "workaround avoid generating duplicate members"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(
   LabProperties.totalAllocatedBudget,
   "!csharp"


### PR DESCRIPTION
## Summary
Adds `csharp`-scoped legacy `flattenProperty` exclusions for the Education `LabProperties` model so that `totalBudget` and `totalAllocatedBudget` are **not** flattened in the C# SDK.

## Motivation
The default flattening turned `EducationAmount totalBudget` / `totalAllocatedBudget` into `*Currency` (string) + `*Value` (float?) pairs on `LabDetailsData`. Keeping them flattened required an SDK-side `[CodeGenSuppress]` custom-code workaround. Excluding the `csharp` scope from flattening removes the need for that custom code and exposes the properties as `EducationAmount`.

## Changes
- `client.tsp`: add `@@Azure.ClientGenerator.Core.Legacy.flattenProperty(LabProperties.totalBudget, "!csharp")` and same for `totalAllocatedBudget`.