### PR TITLE
Compute 2026-04-01: add capacityReservationType to VMSS VM instance view

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-04-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-04-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "vmScaleSetName": "myVirtualMachineScaleSet",
+    "instanceId": "0",
+    "api-version": "2026-04-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "platformUpdateDomain": 0,
+        "platformFaultDomain": 0,
+        "rdpThumbPrint": null,
+        "vmAgent": {
+          "vmAgentVersion": "2.7.41491.1010",
+          "statuses": [
+            {
+              "code": "ProvisioningState/succeeded",
+              "level": "Info",
+              "displayStatus": "Ready",
+              "message": "GuestAgent is running and processing the extensions.",
+              "time": "2026-04-01T05:00:32+00:00"
+            }
+          ],
+          "extensionHandlers": null
+        },
+        "disks": [
+          {
+            "name": "myOSDisk",
+            "encryptionSettings": null,
+            "statuses": [
+              {
+                "code": "ProvisioningState/succeeded",
+                "level": "Info",
+                "displayStatus": "Provisioning succeeded",
+                "message": null,
+                "time": "2026-04-01T04:58:58.0882815+00:00"
+              }
+            ]
+          }
+        ],
+        "extensions": null,
+        "bootDiagnostics": null,
+        "capacityReservationType": "Open",
+        "statuses": [
+          {
+            "code": "ProvisioningState/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": null,
+            "time": "2026-04-01T04:59:58.1852966+00:00"
+          },
+          {
+            "code": "PowerState/running",
+            "level": "Info",
+            "displayStatus": "VM running",
+            "message": null,
+            "time": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetVMs_GetInstanceView",
+  "title": "Get instance view of a virtual machine from a VM scale set that is eligible for and consuming an open capacity reservation."
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -5310,6 +5310,13 @@ model VirtualMachineScaleSetVMInstanceView {
   @added(Versions.v2026_03_01)
   @visibility(Lifecycle.Read)
   interconnectInstanceView?: InterconnectInstanceView;
+
+  /**
+   * Specifies which type of capacity reservation the virtual machine scale set VM instance will consume capacity from if eligible or whether it is explicitly opted out from being associated and consuming capacity from any reserved capacity available in the subscription. Minimum api-version: 2026-04-01.
+   */
+  @added(Versions.v2026_04_01)
+  @visibility(Lifecycle.Read)
+  capacityReservationType?: CapacityReservationType;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/ComputeRP.json
@@ -9798,6 +9798,9 @@
         "x-ms-examples": {
           "Get instance view of a virtual machine from a VM scale set placed on a dedicated host group through automatic placement.": {
             "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewAutoPlacedOnDedicatedHostGroup.json"
+          },
+          "Get instance view of a virtual machine from a VM scale set that is eligible for and consuming an open capacity reservation.": {
+            "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType.json"
           }
         }
       }
@@ -24410,6 +24413,11 @@
         "interconnectInstanceView": {
           "$ref": "#/definitions/InterconnectInstanceView",
           "description": "The Interconnect runtime view of the Scale Set VM instance. Minimum api-version: 2026-03-01.",
+          "readOnly": true
+        },
+        "capacityReservationType": {
+          "$ref": "#/definitions/CapacityReservationType",
+          "description": "Specifies which type of capacity reservation the virtual machine scale set VM instance will consume capacity from if eligible or whether it is explicitly opted out from being associated and consuming capacity from any reserved capacity available in the subscription. Minimum api-version: 2026-04-01.",
           "readOnly": true
         }
       }

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-04-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "vmScaleSetName": "myVirtualMachineScaleSet",
+    "instanceId": "0",
+    "api-version": "2026-04-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "platformUpdateDomain": 0,
+        "platformFaultDomain": 0,
+        "rdpThumbPrint": null,
+        "vmAgent": {
+          "vmAgentVersion": "2.7.41491.1010",
+          "statuses": [
+            {
+              "code": "ProvisioningState/succeeded",
+              "level": "Info",
+              "displayStatus": "Ready",
+              "message": "GuestAgent is running and processing the extensions.",
+              "time": "2026-04-01T05:00:32+00:00"
+            }
+          ],
+          "extensionHandlers": null
+        },
+        "disks": [
+          {
+            "name": "myOSDisk",
+            "encryptionSettings": null,
+            "statuses": [
+              {
+                "code": "ProvisioningState/succeeded",
+                "level": "Info",
+                "displayStatus": "Provisioning succeeded",
+                "message": null,
+                "time": "2026-04-01T04:58:58.0882815+00:00"
+              }
+            ]
+          }
+        ],
+        "extensions": null,
+        "bootDiagnostics": null,
+        "capacityReservationType": "Open",
+        "statuses": [
+          {
+            "code": "ProvisioningState/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": null,
+            "time": "2026-04-01T04:59:58.1852966+00:00"
+          },
+          {
+            "code": "PowerState/running",
+            "level": "Info",
+            "displayStatus": "VM running",
+            "message": null,
+            "time": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetVMs_GetInstanceView",
+  "title": "Get instance view of a virtual machine from a VM scale set that is eligible for and consuming an open capacity reservation."
+}


### PR DESCRIPTION
## Summary
Adds the read-only `capacityReservationType` property to the **VMSS VM instance view** for the Compute `2026-04-01` API version (authored in TypeSpec; `ComputeRP.json` regenerated via `tsp compile`).

### Change
- **`capacityReservationType`** (read-only) on `VirtualMachineScaleSetVMInstanceView` — surfaced in the `VirtualMachineScaleSetVMs_GetInstanceView` response. Indicates which type of capacity reservation the scale set VM instance will consume capacity from if eligible, or whether it is explicitly opted out. References the shared `CapacityReservationType` union (introduced in #44376).
- Gated with `@added(Versions.v2026_04_01)` and `@visibility(Lifecycle.Read)`.
- Adds a dedicated example (`VirtualMachineScaleSetVM_Get_InstanceViewWithCapacityReservationType`) showing a scale set VM instance consuming an open capacity reservation.

### Notes
- Rebased onto `compute-2026-04-01` after #44376 merged. The previously included `disableCapacityReservationAssignment` property and the `CapacityReservationType` union definition were **removed** because #44376 now provides them; this PR keeps only the VMSS-instance-view property and references the shared union.
- Source files edited by hand: `models.tsp` and the new source example. `ComputeRP.json` and the generated example copy are produced solely by `tsp compile` (idempotent, not hand-edited).
- The shared `CapacityReservationType` union currently omits the `DeferredSpot` value that exists in the RP codebase enum. We only want to add features that are available to the public. If/when deferred spot becomes used, we will need to add it.