### PR TITLE
Add Python TypeDict generation for AgentServer contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agentserver-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agentserver-contracts/client.tsp
@@ -160,9 +160,6 @@ namespace Azure.AI.Projects {
   @@usage(OpenAI.OutputItemCodeInterpreterToolCall, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemCompactionBody, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemComputerToolCall, Usage.input | Usage.output);
-  @@usage(OpenAI.OutputItemComputerToolCallOutputResource, Usage.input | Usage.output);
-  @@usage(OpenAI.OutputItemCustomToolCall, Usage.input | Usage.output);
-  @@usage(OpenAI.OutputItemCustomToolCallOutput, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemFileSearchToolCall, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemFunctionShellCall, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemFunctionShellCallOutput, Usage.input | Usage.output);
@@ -179,7 +176,6 @@ namespace Azure.AI.Projects {
   @@access(OpenAI.OutputItemOutputMessage, Access.internal);
   @@usage(OpenAI.OutputItemReasoningItem, Usage.input | Usage.output);
   @@usage(OpenAI.OutputItemWebSearchToolCall, Usage.input | Usage.output);
-  @@usage(OpenAI.FunctionToolCallOutputResource, Usage.input | Usage.output);
 
   // --- OutputContent subtypes (3 concrete types) ---
   @@usage(OpenAI.OutputContentOutputTextContent, Usage.input | Usage.output);

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agentserver-contracts/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agentserver-contracts/tspconfig.yaml
@@ -2,6 +2,14 @@ emit:
   - "@typespec/http-client-csharp"
   - "@typespec/openapi3"
 options:
+  "@azure-tools/typespec-python":
+    package-mode: "azure-dataplane"
+    emitter-output-dir: "{output-dir}"
+    package-name: "azure-ai-agentserver-responses"
+    namespace: "azure.ai.agentserver.responses.models"
+    api-version: "virtual-public-preview"
+    flavor: azure
+    models-mode: typeddict
   "@typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}"
     package-name: Azure.AI.AgentServer.Responses


### PR DESCRIPTION
## Summary
- enable Python TypeDict generation options for the AgentServer contract view
- remove brittle OpenAI output-resource/custom-tool usage decorators that are not required for generated model coverage

## Validation
- TypeSpec Python TypeDict generation succeeds without SDK-side client.tsp patching
- OpenAPI generation succeeds
- C# emitter compile succeeds in the current TypeSpec dependency stack
- AgentServer focused tests pass in azure-sdk-for-python: 951 passed, 1 warning
