### PR TITLE
Add task generation data generation options

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -30901,6 +30901,7 @@
           "mapping": {
             "simple_qna": "#/components/schemas/SimpleQnADataGenerationJobOptions",
             "traces": "#/components/schemas/TracesDataGenerationJobOptions",
+            "task_generation": "#/components/schemas/TaskGenerationDataGenerationJobOptions",
             "tool_use": "#/components/schemas/ToolUseFineTuningDataGenerationJobOptions"
           }
         },
@@ -31108,7 +31109,8 @@
             "enum": [
               "simple_qna",
               "traces",
-              "tool_use"
+              "tool_use",
+              "task_generation"
             ]
           }
         ],
@@ -77993,6 +77995,32 @@
           }
         },
         "description": "Base class for targets with discriminator support."
+      },
+      "TaskGenerationDataGenerationJobOptions": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "task_generation"
+            ],
+            "description": "The data generation job type, which is TaskGeneration for this model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DataGenerationJobOptions"
+          }
+        ],
+        "description": "The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "DataGenerationJobs=V1Preview"
+          ]
+        }
       },
       "TaxonomyCategory": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -78015,7 +78015,7 @@
             "$ref": "#/components/schemas/DataGenerationJobOptions"
           }
         ],
-        "description": "The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "description": "The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "DataGenerationJobs=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40973,6 +40973,7 @@ components:
         mapping:
           simple_qna: '#/components/schemas/SimpleQnADataGenerationJobOptions'
           traces: '#/components/schemas/TracesDataGenerationJobOptions'
+          task_generation: '#/components/schemas/TaskGenerationDataGenerationJobOptions'
           tool_use: '#/components/schemas/ToolUseFineTuningDataGenerationJobOptions'
       description: Options for managing data generation jobs.
       x-ms-foundry-meta:
@@ -41103,6 +41104,7 @@ components:
             - simple_qna
             - traces
             - tool_use
+            - task_generation
       description: The supported data generation job types.
       x-ms-foundry-meta:
         conditional_previews:
@@ -74273,6 +74275,22 @@ components:
           azure_ai_model: '#/components/schemas/AzureAIModelTargetUpdate'
           azure_ai_agent: '#/components/schemas/AzureAIAgentTargetUpdate'
       description: Base class for targets with discriminator support.
+    TaskGenerationDataGenerationJobOptions:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - task_generation
+          description: The data generation job type, which is TaskGeneration for this model.
+      allOf:
+        - $ref: '#/components/schemas/DataGenerationJobOptions'
+      description: The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - DataGenerationJobs=V1Preview
     TaxonomyCategory:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -74287,7 +74287,7 @@ components:
           description: The data generation job type, which is TaskGeneration for this model.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
-      description: The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      description: The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -82781,7 +82781,7 @@
             "$ref": "#/components/schemas/DataGenerationJobOptions"
           }
         ],
-        "description": "The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "description": "The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "DataGenerationJobs=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -34382,6 +34382,7 @@
           "mapping": {
             "simple_qna": "#/components/schemas/SimpleQnADataGenerationJobOptions",
             "traces": "#/components/schemas/TracesDataGenerationJobOptions",
+            "task_generation": "#/components/schemas/TaskGenerationDataGenerationJobOptions",
             "tool_use": "#/components/schemas/ToolUseFineTuningDataGenerationJobOptions"
           }
         },
@@ -34589,7 +34590,8 @@
             "enum": [
               "simple_qna",
               "traces",
-              "tool_use"
+              "tool_use",
+              "task_generation"
             ]
           }
         ],
@@ -82759,6 +82761,32 @@
           }
         },
         "description": "Base class for targets with discriminator support."
+      },
+      "TaskGenerationDataGenerationJobOptions": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "task_generation"
+            ],
+            "description": "The data generation job type, which is TaskGeneration for this model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DataGenerationJobOptions"
+          }
+        ],
+        "description": "The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "DataGenerationJobs=V1Preview"
+          ]
+        }
       },
       "TaxonomyCategory": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -77491,7 +77491,7 @@ components:
           description: The data generation job type, which is TaskGeneration for this model.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
-      description: The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      description: The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -43302,6 +43302,7 @@ components:
         mapping:
           simple_qna: '#/components/schemas/SimpleQnADataGenerationJobOptions'
           traces: '#/components/schemas/TracesDataGenerationJobOptions'
+          task_generation: '#/components/schemas/TaskGenerationDataGenerationJobOptions'
           tool_use: '#/components/schemas/ToolUseFineTuningDataGenerationJobOptions'
       description: Options for managing data generation jobs.
       x-ms-foundry-meta:
@@ -43432,6 +43433,7 @@ components:
             - simple_qna
             - traces
             - tool_use
+            - task_generation
       description: The supported data generation job types.
       x-ms-foundry-meta:
         conditional_previews:
@@ -77477,6 +77479,22 @@ components:
           azure_ai_model: '#/components/schemas/AzureAIModelTargetUpdate'
           azure_ai_agent: '#/components/schemas/AzureAIAgentTargetUpdate'
       description: Base class for targets with discriminator support.
+    TaskGenerationDataGenerationJobOptions:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - task_generation
+          description: The data generation job type, which is TaskGeneration for this model.
+      allOf:
+        - $ref: '#/components/schemas/DataGenerationJobOptions'
+      description: The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - DataGenerationJobs=V1Preview
     TaxonomyCategory:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -22,6 +22,9 @@ union DataGenerationJobType {
 
   @doc("Tool calling conversation between user and agent.")
   tool_use: "tool_use",
+
+  @doc("Task generation for evaluation scenarios.")
+  task_generation: "task_generation",
 }
 
 @doc("LLM model options for data generation jobs.")
@@ -216,6 +219,13 @@ model SimpleQnADataGenerationJobOptions extends DataGenerationJobOptions {
 model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
   @doc("The data generation job type, which is Traces for this model.")
   type: "traces";
+}
+
+@doc("The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
+@extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
+model TaskGenerationDataGenerationJobOptions extends DataGenerationJobOptions {
+  @doc("The data generation job type, which is TaskGeneration for this model.")
+  type: "task_generation";
 }
 
 @doc("The options for a data generation job with ToolUse type. Used only for fine-tuning scenarios.")

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -221,7 +221,7 @@ model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
   type: "traces";
 }
 
-@doc("The options for a task generation data generation job. Use with the evaluation scenario and prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
+@doc("The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model TaskGenerationDataGenerationJobOptions extends DataGenerationJobOptions {
   @doc("The data generation job type, which is TaskGeneration for this model.")


### PR DESCRIPTION
Adds TaskGeneration support to the Foundry DataGeneration V2 options contract.

Changes:
- Add task_generation to DataGenerationJobType.
- Add TaskGenerationDataGenerationJobOptions.
- Update OpenAPI discriminator mappings for v1 and virtual-public-preview.
- Keep train_split on the shared base options for downstream compatibility.

Validation:
- TypeSpec validation succeeded in the prior session.
- Local compile succeeded in the prior session, with unrelated agent-identity snapshot churn removed from the final diff.