### PR TITLE
Fix AgentServer response model contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/readme.md
+++ b/specification/ai-foundry/data-plane/Foundry/readme.md
@@ -1,0 +1,5 @@
+# Foundry data-plane TypeSpec
+
+> see https://aka.ms/autorest
+
+This folder contains the TypeSpec for all data-plane REST APIs of the Foundry service. See `README.md` for contributor guidance.

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
@@ -219,6 +219,12 @@ namespace Azure.AI.Projects {
     }
   );
 
+  // ItemMessage spreads OpenAI.Message, whose content is an array. The Responses
+  // input contract also accepts string shorthand, and this client uses ItemMessage
+  // in the merged input/output item union.
+  @@withoutOmittedProperties(OpenAI.ItemMessage, "content");
+  @@copyProperties(OpenAI.ItemMessage, { content: string | OpenAI.MessageContent[] });
+
   // To avoid conflicts with Azure.Response
   @@clientName(OpenAI.Response, "ResponseObject");
 
@@ -251,6 +257,4 @@ namespace Azure.AI.Projects {
   @@access(UpdateAgentRequest, Access.public);
   @@usage(UpdateAgentRequest, Usage.input);
 
-  @@access(OpenAI.OutputItemCustomToolCallOutput, Access.public);
-  @@usage(OpenAI.OutputItemCustomToolCallOutput, Usage.input | Usage.output);
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/readme.md
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/readme.md
@@ -1,0 +1,5 @@
+# Agent service contracts SDK TypeSpec
+
+> see https://aka.ms/autorest
+
+This folder contains SDK-only TypeSpec projections for Azure AI Agent Service response model contracts. The REST API OpenAPI is emitted from the parent Foundry TypeSpec project.

--- a/specification/ai-foundry/data-plane/Foundry/suppressions.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/suppressions.yaml
@@ -9,6 +9,12 @@
     - "."
     - "**"
 
+- tool: TypeSpecValidation
+  reason: Design underway for folder structure and tool integration for this area
+  paths:
+    - "."
+    - "**"
+
 # Prior suppression currently superseded by the above:
 
 # - tool: TypeSpecValidation


### PR DESCRIPTION
## Summary
- Keep OpenAI-compatible message input shorthand for AgentServer response items by overriding `OpenAI.ItemMessage.content` to accept `string | MessageContent[]`.
- Remove stale `OpenAI.OutputItemCustomToolCallOutput` access/usage decorators; current OpenAI TypeSpec exposes custom tool output through `ItemCustomToolCallOutput` and `CustomToolCallOutputResource`.

## Validation
- `npx tsp compile sdk-service-agents-contracts/client.tsp --emit @typespec/openapi3`
- `npx tsp compile sdk-service-agents-contracts/client.tsp --emit @typespec/http-client-csharp`
- .NET `Azure.AI.AgentServer.Responses` project build: 0 warnings, 0 errors
- .NET `Azure.AI.AgentServer.Responses.Tests` net8.0: 1982 passed
- Python SDK focused validation passed locally after regenerating from this contract shape: `951 passed, 1 warning`