### PR TITLE
Emit auto-release label during SDK PR creation

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -372,7 +372,21 @@ stages:
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
               -OpenAsDraft $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
               -UpdateExistingPullRequest $true
-        
+
+        - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
+          - task: PowerShell@2
+            displayName: Add auto-release label
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            inputs:
+              pwsh: true
+              workingDirectory: $(SdkRepoDirectory)
+              filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
+              arguments: >
+                -RepoOwner "azure"
+                -RepoName "$(SdkRepoName)"
+                -IssueNumber "$(Submitted.PullRequest.Number)"
+                -Labels "auto-release"
+                -AuthToken "$(GH_TOKEN)"
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - pwsh: |


### PR DESCRIPTION
## Description

Adds the SDK generation pipeline step that emits the auto-release label for SDK pull requests intended for self-service release. This ensures the label is applied during PR creation, or immediately after creation, so post-merge auto-release can use it as the explicit opt-in signal.

## Related issue

Fixes Azure/azure-sdk-tools#16237