### PR TITLE
Add GA toolbox search tool type

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -26915,31 +26915,8 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentIdentityStatus"
-              }
-            ],
-            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
-      },
-      "AgentIdentityStatus": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "active",
-              "disabled"
-            ]
-          }
-        ],
-        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -75039,12 +75016,6 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
-          },
-          "max_stalls": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -78404,27 +78375,6 @@
         },
         "description": "A project connection resource."
       },
-      "ToolSearchToolboxTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "toolbox_search"
-            ],
-            "description": "The type of the tool. Always `toolbox_search`."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ToolboxTool"
-          }
-        ],
-        "description": "A toolbox search tool stored in a toolbox."
-      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -78612,8 +78562,7 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
-            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -78632,7 +78581,6 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
-          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -26915,8 +26915,31 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentIdentityStatus"
+              }
+            ],
+            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
+      },
+      "AgentIdentityStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "active",
+              "disabled"
+            ]
+          }
+        ],
+        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -75016,6 +75039,12 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
+          },
+          "max_stalls": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -78375,6 +78404,27 @@
         },
         "description": "A project connection resource."
       },
+      "ToolSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -78562,7 +78612,8 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
+            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -78581,6 +78632,7 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
+          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -78404,6 +78404,27 @@
         },
         "description": "A project connection resource."
       },
+      "ToolSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -78493,27 +78514,6 @@
             "preview_tool"
           ]
         }
-      },
-      "ToolboxSearchToolboxTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "toolbox_search"
-            ],
-            "description": "The type of the tool. Always `toolbox_search`."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ToolboxTool"
-          }
-        ],
-        "description": "A toolbox search tool stored in a toolbox."
       },
       "ToolboxSkill": {
         "type": "object",
@@ -78613,7 +78613,7 @@
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
-            "toolbox_search": "#/components/schemas/ToolboxSearchToolboxTool"
+            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -26915,8 +26915,31 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentIdentityStatus"
+              }
+            ],
+            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
+      },
+      "AgentIdentityStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "active",
+              "disabled"
+            ]
+          }
+        ],
+        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -75016,6 +75039,12 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
+          },
+          "max_stalls": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -78465,6 +78494,27 @@
           ]
         }
       },
+      "ToolboxSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolboxSkill": {
         "type": "object",
         "required": [
@@ -78562,7 +78612,8 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
+            "toolbox_search": "#/components/schemas/ToolboxSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -78581,6 +78632,7 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
+          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -38318,18 +38318,6 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
-        status:
-          allOf:
-            - $ref: '#/components/schemas/AgentIdentityStatus'
-          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
-    AgentIdentityStatus:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - active
-            - disabled
-      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -72319,11 +72307,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
-        max_stalls:
-          type: integer
-          format: int32
-          minimum: 1
-          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -74541,19 +74524,6 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
-    ToolSearchToolboxTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - toolbox_search
-          description: The type of the tool. Always `toolbox_search`.
-      allOf:
-        - $ref: '#/components/schemas/ToolboxTool'
-      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -74684,7 +74654,6 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
-          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -74700,7 +74669,6 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
-        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -74541,6 +74541,19 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
+    ToolSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -74599,19 +74612,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
-    ToolboxSearchToolboxTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - toolbox_search
-          description: The type of the tool. Always `toolbox_search`.
-      allOf:
-        - $ref: '#/components/schemas/ToolboxTool'
-      description: A toolbox search tool stored in a toolbox.
     ToolboxSkill:
       type: object
       required:
@@ -74684,7 +74684,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
-          toolbox_search: '#/components/schemas/ToolboxSearchToolboxTool'
+          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -38318,6 +38318,18 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentIdentityStatus'
+          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
+    AgentIdentityStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - active
+            - disabled
+      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -72307,6 +72319,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
+        max_stalls:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -74582,6 +74599,19 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
+    ToolboxSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolboxSkill:
       type: object
       required:
@@ -74654,6 +74684,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
+          toolbox_search: '#/components/schemas/ToolboxSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -74669,6 +74700,7 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
+        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -38318,6 +38318,18 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentIdentityStatus'
+          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
+    AgentIdentityStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - active
+            - disabled
+      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -72307,6 +72319,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
+        max_stalls:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -74524,6 +74541,19 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
+    ToolSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -74654,6 +74684,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
+          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -74669,6 +74700,7 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
+        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83170,6 +83170,27 @@
         },
         "description": "A project connection resource."
       },
+      "ToolSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -83259,27 +83280,6 @@
             "preview_tool"
           ]
         }
-      },
-      "ToolboxSearchToolboxTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "toolbox_search"
-            ],
-            "description": "The type of the tool. Always `toolbox_search`."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ToolboxTool"
-          }
-        ],
-        "description": "A toolbox search tool stored in a toolbox."
       },
       "ToolboxSkill": {
         "type": "object",
@@ -83379,7 +83379,7 @@
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
-            "toolbox_search": "#/components/schemas/ToolboxSearchToolboxTool"
+            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -30184,8 +30184,31 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentIdentityStatus"
+              }
+            ],
+            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
+      },
+      "AgentIdentityStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "active",
+              "disabled"
+            ]
+          }
+        ],
+        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -79658,6 +79681,12 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
+          },
+          "max_stalls": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -83141,6 +83170,27 @@
         },
         "description": "A project connection resource."
       },
+      "ToolSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -83328,7 +83378,8 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
+            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -83347,6 +83398,7 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
+          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -30184,8 +30184,31 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentIdentityStatus"
+              }
+            ],
+            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
+      },
+      "AgentIdentityStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "active",
+              "disabled"
+            ]
+          }
+        ],
+        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -79658,6 +79681,12 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
+          },
+          "max_stalls": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -83231,6 +83260,27 @@
           ]
         }
       },
+      "ToolboxSearchToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolbox_search"
+            ],
+            "description": "The type of the tool. Always `toolbox_search`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A toolbox search tool stored in a toolbox."
+      },
       "ToolboxSkill": {
         "type": "object",
         "required": [
@@ -83328,7 +83378,8 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
+            "toolbox_search": "#/components/schemas/ToolboxSearchToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -83347,6 +83398,7 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
+          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -30184,31 +30184,8 @@
           "client_id": {
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentIdentityStatus"
-              }
-            ],
-            "description": "The status of the agent identity. Present for both the agent instance identity and the agent blueprint."
           }
         }
-      },
-      "AgentIdentityStatus": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "active",
-              "disabled"
-            ]
-          }
-        ],
-        "description": "The status of an agent identity, applicable to both the agent instance identity and the agent blueprint."
       },
       "AgentKind": {
         "anyOf": [
@@ -79681,12 +79658,6 @@
               }
             ],
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
-          },
-          "max_stalls": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "description": "Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set."
           }
         },
         "description": "Tuning knobs and run-mode for an optimization job.",
@@ -83170,27 +83141,6 @@
         },
         "description": "A project connection resource."
       },
-      "ToolSearchToolboxTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "toolbox_search"
-            ],
-            "description": "The type of the tool. Always `toolbox_search`."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ToolboxTool"
-          }
-        ],
-        "description": "A toolbox search tool stored in a toolbox."
-      },
       "ToolUseFineTuningDataGenerationJobOptions": {
         "type": "object",
         "required": [
@@ -83378,8 +83328,7 @@
             "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
-            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool",
-            "toolbox_search": "#/components/schemas/ToolSearchToolboxTool"
+            "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
           }
         },
         "description": "An abstract representation of a tool stored in a toolbox."
@@ -83398,7 +83347,6 @@
           "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
-          "toolbox_search",
           "toolbox_search_preview"
         ],
         "description": "Supported tool types for tools stored in a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -40500,6 +40500,18 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentIdentityStatus'
+          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
+    AgentIdentityStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - active
+            - disabled
+      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -75426,6 +75438,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
+        max_stalls:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -77728,6 +77745,19 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
+    ToolSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -77858,6 +77888,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
+          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -77873,6 +77904,7 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
+        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -40500,6 +40500,18 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentIdentityStatus'
+          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
+    AgentIdentityStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - active
+            - disabled
+      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -75426,6 +75438,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
+        max_stalls:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -77786,6 +77803,19 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
+    ToolboxSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolboxSkill:
       type: object
       required:
@@ -77858,6 +77888,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
+          toolbox_search: '#/components/schemas/ToolboxSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -77873,6 +77904,7 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
+        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -77745,6 +77745,19 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
+    ToolSearchToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - toolbox_search
+          description: The type of the tool. Always `toolbox_search`.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -77803,19 +77816,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
-    ToolboxSearchToolboxTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - toolbox_search
-          description: The type of the tool. Always `toolbox_search`.
-      allOf:
-        - $ref: '#/components/schemas/ToolboxTool'
-      description: A toolbox search tool stored in a toolbox.
     ToolboxSkill:
       type: object
       required:
@@ -77888,7 +77888,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
-          toolbox_search: '#/components/schemas/ToolboxSearchToolboxTool'
+          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -40500,18 +40500,6 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
-        status:
-          allOf:
-            - $ref: '#/components/schemas/AgentIdentityStatus'
-          description: The status of the agent identity. Present for both the agent instance identity and the agent blueprint.
-    AgentIdentityStatus:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - active
-            - disabled
-      description: The status of an agent identity, applicable to both the agent instance identity and the agent blueprint.
     AgentKind:
       anyOf:
         - type: string
@@ -75438,11 +75426,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
-        max_stalls:
-          type: integer
-          format: int32
-          minimum: 1
-          description: Maximum number of consecutive reflective minibatch rejections before stopping early. A 'stall' occurs when the optimizer proposes a prompt change, evaluates it on a small subset, and the score does not improve — so no full validation-set evaluation is triggered. The counter resets whenever a minibatch passes and its full-validation score beats the current best. Only a sustained plateau of `max_stalls` consecutive minibatch failures triggers the stop. When omitted, the optimizer uses its internal default. Must be >= 1 when set.
       description: Tuning knobs and run-mode for an optimization job.
       x-ms-foundry-meta:
         conditional_previews:
@@ -77745,19 +77728,6 @@ components:
           type: string
           description: A project connection in a ToolProjectConnectionList attached to this tool.
       description: A project connection resource.
-    ToolSearchToolboxTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - toolbox_search
-          description: The type of the tool. Always `toolbox_search`.
-      allOf:
-        - $ref: '#/components/schemas/ToolboxTool'
-      description: A toolbox search tool stored in a toolbox.
     ToolUseFineTuningDataGenerationJobOptions:
       type: object
       required:
@@ -77888,7 +77858,6 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
-          toolbox_search: '#/components/schemas/ToolSearchToolboxTool'
       description: An abstract representation of a tool stored in a toolbox.
     ToolboxToolType:
       type: string
@@ -77904,7 +77873,6 @@ components:
         - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
-        - toolbox_search
         - toolbox_search_preview
       description: Supported tool types for tools stored in a toolbox.
     ToolboxVersionObject:

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -234,7 +234,7 @@ model ToolboxSearchPreviewToolboxTool extends ToolboxTool {
 /**
  * A toolbox search tool stored in a toolbox.
  */
-model ToolboxSearchToolboxTool extends ToolboxTool {
+model ToolSearchToolboxTool extends ToolboxTool {
   /**
    * The type of the tool. Always `toolbox_search`.
    */

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -79,6 +79,7 @@ alias ToolboxBrowserAutomationPreviewToolType = "browser_automation_preview";
 alias ToolboxReminderPreviewToolType = "reminder_preview";
 alias ToolboxWorkIQPreviewToolType = "work_iq_preview";
 alias ToolboxFabricIQPreviewToolType = "fabric_iq_preview";
+alias ToolboxSearchToolType = "toolbox_search";
 alias ToolboxSearchPreviewToolType = "toolbox_search_preview";
 
 /**
@@ -96,6 +97,7 @@ union ToolboxToolType {
   reminder_preview: ToolboxReminderPreviewToolType,
   work_iq_preview: ToolboxWorkIQPreviewToolType,
   fabric_iq_preview: ToolboxFabricIQPreviewToolType,
+  toolbox_search: ToolboxSearchToolType,
   toolbox_search_preview: ToolboxSearchPreviewToolType,
 }
 
@@ -227,6 +229,16 @@ model ToolboxSearchPreviewToolboxTool extends ToolboxTool {
    * The type of the tool. Always `toolbox_search_preview`.
    */
   type: ToolboxSearchPreviewToolType;
+}
+
+/**
+ * A toolbox search tool stored in a toolbox.
+ */
+model ToolboxSearchToolboxTool extends ToolboxTool {
+  /**
+   * The type of the tool. Always `toolbox_search`.
+   */
+  type: ToolboxSearchToolType;
 }
 @doc("Policy configuration for a toolbox, including content safety and other governance settings.")
 model ToolboxPolicies {


### PR DESCRIPTION
## Problem
Toolbox search is moving toward GA, but the Foundry toolbox schema only exposes the preview tool type value toolbox_search_preview.

## Why it happened
The toolbox tool type union and generated OpenAPI only defined the preview toolbox search discriminator value.

## Fix
Add the GA toolbox search discriminator value toolbox_search as ToolboxSearchToolType, add the corresponding ToolboxSearchToolboxTool model, and regenerate the Foundry OpenAPI outputs for v1 and virtual-public-preview.

## Validation
- npx tsp compile . from specification/ai-foundry/data-plane/Foundry