### PR TITLE
EventHub: Generate latest API version for C#

### DIFF
--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
@@ -57,7 +57,6 @@ options:
     namespace: "{package-name}"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-05-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Purpose
Remove the stale Event Hubs C# emitter override for `2025-05-01-preview` so default SDK generation selects the latest stable `2026-01-01` API version.

## Context
The generated-code verification for [Azure SDK for .NET PR #60294](https://github.com/Azure/azure-sdk-for-net/pull/60294) regenerates without command-line emitter overrides. The current `tspconfig.yaml` forces the preview API, causing CI to remove the `2026-01-01` surface even though the SDK's spec pin includes that stable version.

## Validation
- `git diff --check` passes.
- Full `npx tsv` validation is currently blocked locally because `packagefeedproxy.microsoft.io` does not yet contain `@typespec/compiler` 1.14.0.