### PR TITLE
[confluent] Use exact() for python enum client names of ConnectorClass

### DIFF
--- a/specification/confluent/Confluent.Management/client.tsp
+++ b/specification/confluent/Confluent.Management/client.tsp
@@ -18,6 +18,7 @@ using Microsoft.Confluent;
   exact("AZURECOSMOSV2SINK"),
   "python"
 );
+
 #suppress "experimental-feature" "exact"
 @@clientName(
   ConnectorClass.AZURECOSMOSV2SOURCE,

--- a/specification/confluent/Confluent.Management/client.tsp
+++ b/specification/confluent/Confluent.Management/client.tsp
@@ -12,10 +12,16 @@ using Microsoft.Confluent;
   "javascript,python"
 );
 
-@@clientName(ConnectorClass.AZURECOSMOSV2SINK, "AZURECOSMOSV2SINK", "python");
+#suppress "experimental-feature" "exact"
+@@clientName(
+  ConnectorClass.AZURECOSMOSV2SINK,
+  exact("AZURECOSMOSV2SINK"),
+  "python"
+);
+#suppress "experimental-feature" "exact"
 @@clientName(
   ConnectorClass.AZURECOSMOSV2SOURCE,
-  "AZURECOSMOSV2SOURCE",
+  exact("AZURECOSMOSV2SOURCE"),
   "python"
 );
 


### PR DESCRIPTION
Replace the plain `@clientName` overrides for `ConnectorClass.AZURECOSMOSV2SINK` and `ConnectorClass.AZURECOSMOSV2SOURCE` (added in #44713) with the TCGC `exact()` function for Python.

Plain `@clientName(..., "python")` still runs the value through the Python emitter's naming normalization, so the intended enum keys were not guaranteed to be preserved verbatim. Wrapping the name in `exact()` tells the Python emitter to keep the enum keys exactly as `AZURECOSMOSV2SINK` / `AZURECOSMOSV2SOURCE`, matching the previously generated keys.

- Verified the spec compiles successfully (`tsp compile --no-emit`).
- Formatted with `tsp format`.
