### PR TITLE
PurgeLakeData API (2026-03-01)

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/Workspace.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/Workspace.tsp
@@ -2,12 +2,14 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 
 using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 
 namespace Microsoft.OperationalInsights;
 /**
@@ -384,6 +386,28 @@ interface Workspaces {
   >;
 
   /**
+   * Purges data lake data in a Log Analytics workspace for a table over a specified time range.
+   *
+   * This operation deletes data lake data (Auxiliary tables, or Analytics tables mirrored to the data lake) for the specified table within the given time range. The operation is long-running; poll the URL returned in the Azure-AsyncOperation response header to track its status.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/no-response-body" "The service returns the operationId in the 202 response body so callers can correlate the asynchronous purge operation."
+  #suppress "@azure-tools/typespec-azure-resource-manager/lro-location-header" "The service tracks the operation via the Azure-AsyncOperation header only; it does not return a Location header."
+  @added(Versions.v2026_03_01)
+  @tag("Workspaces")
+  @autoRoute
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  purgeLakeData is ArmResourceActionAsyncBase<
+    Workspace,
+    WorkspacePurgeLakeDataBody,
+    ArmAcceptedLroResponse<LroHeaders = ArmAsyncOperationHeader<FinalResult = void> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot
+      _: WorkspacePurgeResponse;
+    },
+    BaseParameters = Azure.ResourceManager.Foundations.DefaultBaseParameters<Workspace>
+  >;
+
+  /**
    * Deactivates failover for the specified workspace.
    *
    * The failback operation is asynchronous and can take up to 30 minutes to complete. The status of the operation can be checked using the operationId returned in the response.
@@ -414,4 +438,8 @@ interface Workspaces {
 @@doc(
   Workspaces.purge::parameters.body,
   "Describes the body of a request to purge data in a single table of an Log Analytics Workspace"
+);
+@@doc(
+  Workspaces.purgeLakeData::parameters.body,
+  "Describes the body of a request to purge data lake data in a single table of an Log Analytics Workspace"
 );

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/back-compatible.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/back-compatible.tsp
@@ -131,6 +131,7 @@ using Microsoft.OperationalInsights;
 @@clientName(Workspaces.usagesList, "List");
 @@clientLocation(Workspaces.purge, "WorkspacePurge");
 @@clientLocation(Workspaces.getPurgeStatus, "WorkspacePurge");
+@@clientLocation(Workspaces.purgeLakeData, "WorkspacePurge");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(Workspace.properties);
 

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/examples/2026-03-01/WorkspacesPurgeLakeData.json
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/examples/2026-03-01/WorkspacesPurgeLakeData.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "OIAutoRest5123",
+    "workspaceName": "aztest5048",
+    "body": {
+      "table": "AuxiliaryLogs_CL",
+      "timeRange": {
+        "startTime": "2026-03-01T00:00:00Z",
+        "endTime": "2026-03-02T00:00:00Z"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "body": {
+        "operationId": "purgelakedata-7d7cf277-9113-4ab3-8359-d0364b74d01d"
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/OIAutoRest5123/providers/Microsoft.OperationalInsights/workspaces/aztest5048/operations/purgelakedata-7d7cf277-9113-4ab3-8359-d0364b74d01d?api-version=2026-03-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "WorkspacePurge_PurgeLakeData",
+  "title": "WorkspacesPurgeLakeData"
+}

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/models.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/models.tsp
@@ -2664,6 +2664,38 @@ model WorkspacePurgeStatusResponse {
 }
 
 /**
+ * Describes the body of a request to purge data lake data in a Log Analytics workspace.
+ */
+@added(Versions.v2026_03_01)
+model WorkspacePurgeLakeDataBody {
+  /**
+   * The name of the table from which to purge data lake data. Must be an Auxiliary table, or an Analytics table that is mirrored to the data lake.
+   */
+  table: string;
+
+  /**
+   * The time range over which data lake data is purged.
+   */
+  timeRange: WorkspacePurgeLakeDataTimeRange;
+}
+
+/**
+ * The time range over which a data lake purge request operates.
+ */
+@added(Versions.v2026_03_01)
+model WorkspacePurgeLakeDataTimeRange {
+  /**
+   * The inclusive start of the time range, in UTC. Must fall on an hour boundary (minutes and seconds must be zero).
+   */
+  startTime: utcDateTime;
+
+  /**
+   * The exclusive end of the time range, in UTC. Must fall on an hour boundary and be earlier than the start of the current hour.
+   */
+  endTime: utcDateTime;
+}
+
+/**
  * The list workspaces operation response.
  */
 model WorkspaceListResult {

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/stable/2026-03-01/examples/WorkspacesPurgeLakeData.json
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/stable/2026-03-01/examples/WorkspacesPurgeLakeData.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "OIAutoRest5123",
+    "workspaceName": "aztest5048",
+    "body": {
+      "table": "AuxiliaryLogs_CL",
+      "timeRange": {
+        "startTime": "2026-03-01T00:00:00Z",
+        "endTime": "2026-03-02T00:00:00Z"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "body": {
+        "operationId": "purgelakedata-7d7cf277-9113-4ab3-8359-d0364b74d01d"
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/OIAutoRest5123/providers/Microsoft.OperationalInsights/workspaces/aztest5048/operations/purgelakedata-7d7cf277-9113-4ab3-8359-d0364b74d01d?api-version=2026-03-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "WorkspacePurge_PurgeLakeData",
+  "title": "WorkspacesPurgeLakeData"
+}

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/stable/2026-03-01/openapi.json
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/stable/2026-03-01/openapi.json
@@ -3463,6 +3463,79 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/purgeLakeData": {
+      "post": {
+        "operationId": "WorkspacePurge_PurgeLakeData",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Purges data lake data in a Log Analytics workspace for a table over a specified time range.\n\nThis operation deletes data lake data (Auxiliary tables, or Analytics tables mirrored to the data lake) for the specified table within the given time range. The operation is long-running; poll the URL returned in the Azure-AsyncOperation response header to track its status.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the workspace.",
+            "required": true,
+            "type": "string",
+            "minLength": 4,
+            "maxLength": 63,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9-]+[A-Za-z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Describes the body of a request to purge data lake data in a single table of an Log Analytics Workspace",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkspacePurgeLakeDataBody"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/WorkspacePurgeResponse"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "WorkspacesPurgeLakeData": {
+            "$ref": "./examples/WorkspacesPurgeLakeData.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/regenerateSharedKey": {
       "post": {
         "operationId": "SharedKeys_Regenerate",
@@ -8691,6 +8764,44 @@
           "description": "When filtering over custom dimensions, this key will be used as the name of the custom dimension."
         }
       }
+    },
+    "WorkspacePurgeLakeDataBody": {
+      "type": "object",
+      "description": "Describes the body of a request to purge data lake data in a Log Analytics workspace.",
+      "properties": {
+        "table": {
+          "type": "string",
+          "description": "The name of the table from which to purge data lake data. Must be an Auxiliary table, or an Analytics table that is mirrored to the data lake."
+        },
+        "timeRange": {
+          "$ref": "#/definitions/WorkspacePurgeLakeDataTimeRange",
+          "description": "The time range over which data lake data is purged."
+        }
+      },
+      "required": [
+        "table",
+        "timeRange"
+      ]
+    },
+    "WorkspacePurgeLakeDataTimeRange": {
+      "type": "object",
+      "description": "The time range over which a data lake purge request operates.",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The inclusive start of the time range, in UTC. Must fall on an hour boundary (minutes and seconds must be zero)."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exclusive end of the time range, in UTC. Must fall on an hour boundary and be earlier than the start of the current hour."
+        }
+      },
+      "required": [
+        "startTime",
+        "endTime"
+      ]
     },
     "WorkspacePurgeResponse": {
       "type": "object",


### PR DESCRIPTION
Adds the `purgeLakeData` long-running action to the OperationalInsights 2026-03-01 API (purges data lake data - Auxiliary tables, or Analytics tables mirrored to the data lake - for a table over a specified UTC time range).

Includes:
- TypeSpec operation + models (WorkspacePurgeLakeDataBody, WorkspacePurgeLakeDataTimeRange)
- Regenerated openapi.json
- WorkspacesPurgeLakeData example
- client customization (@@clientLocation)