### PR TITLE
Fix C# failover property naming in client.tsp

### DIFF
--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -83,7 +83,6 @@ using Microsoft.EventHub;
 @@clientName(Encryption.keySource, "KeySource", "csharp");
 @@clientName(SchemaType, "EventHubsSchemaType", "csharp");
 @@clientName(SchemaCompatibility, "EventHubsSchemaCompatibility", "csharp");
-@@clientName(IpAddressType, "EventHubsIPAddressType", "csharp");
 @@clientName(ClusterProperties.createdAt, "CreatedOn", "csharp");
 @@alternateType(ClusterProperties.createdAt, utcDateTime, "csharp");
 @@clientName(ClusterProperties.updatedAt, "UpdatedOn", "csharp");
@@ -407,7 +406,7 @@ using Microsoft.EventHub;
   "csharp"
 );
 @@clientName(NetworkRuleSetProperties.ipRules, "IPRules", "csharp");
-@@clientName(IpAddressType, "EventHubIPAddressType", "csharp");
+@@clientName(IpAddressType, "EventHubsIPAddressType", "csharp");
 @@clientName(EHNamespaceProperties.ipAddressType, "IPAddressType", "csharp");
 @@clientName(NamespaceReplicaLocation.roleType, "RoleType", "csharp");
 @@clientName(

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -83,6 +83,7 @@ using Microsoft.EventHub;
 @@clientName(Encryption.keySource, "KeySource", "csharp");
 @@clientName(SchemaType, "EventHubsSchemaType", "csharp");
 @@clientName(SchemaCompatibility, "EventHubsSchemaCompatibility", "csharp");
+@@clientName(IpAddressType, "EventHubsIPAddressType", "csharp");
 @@clientName(ClusterProperties.createdAt, "CreatedOn", "csharp");
 @@alternateType(ClusterProperties.createdAt, utcDateTime, "csharp");
 @@clientName(ClusterProperties.updatedAt, "UpdatedOn", "csharp");
@@ -174,7 +175,7 @@ using Microsoft.EventHub;
   "EventHubsNamespaceGeoDataReplicationProperties",
   "csharp"
 );
-@@clientName(GeoDRRoleType, "EventHubsNamespaceGeoDRRoleType", "csharp");
+@@clientName(GeoDRRoleType, "EventHubsNamespaceGeoDrRoleType", "csharp");
 @@alternateType(
   NamespaceReplicaLocation.clusterArmId,
   Azure.Core.armResourceIdentifier,
@@ -185,6 +186,11 @@ using Microsoft.EventHub;
 @@clientName(
   NamespaceReplicaLocation,
   "EventHubsNamespaceReplicaLocation",
+  "csharp"
+);
+@@clientName(
+  NetworkRuleSetListResult,
+  "EventHubsNetworkRuleSetListResult",
   "csharp"
 );
 @@clientName(ErrorDetail, "EventHubsErrorDetail", "csharp");

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/client.tsp
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/client.tsp
@@ -161,6 +161,7 @@ using Microsoft.ServiceBus;
   "csharp"
 );
 @@clientName(FailOver, "ServiceBusNamespaceFailOver", "csharp");
+@@clientName(FailOverProperties.force, "IsForced", "csharp");
 @@clientName(
   SBNamespaces.privateLinkResourcesGet,
   "GetPrivateLinkResources",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
