### PR TITLE
feat(chaos/2026-08-01-preview): add optional errorMessage to PermissionError

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_ListAll.json
@@ -69,7 +69,8 @@
                     "identity": {
                       "objectId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
                       "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
-                    }
+                    },
+                    "errorMessage": "The workspace managed identity is missing the required permissions to run this action on the target resource."
                   }
                 ],
                 "resource": []

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_ListAll.json
@@ -69,7 +69,8 @@
                     "identity": {
                       "objectId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
                       "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
-                    }
+                    },
+                    "errorMessage": "The workspace managed identity is missing the required permissions to run this action on the target resource."
                   }
                 ],
                 "resource": []

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
@@ -5491,6 +5491,11 @@
           "$ref": "#/definitions/EntraIdentity",
           "description": "The identity.",
           "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "The error message describing the permission validation failure, when the\nfailure carries a distinct message (for example, when the target could not\nbe read to evaluate access).",
+          "readOnly": true
         }
       },
       "required": [

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
@@ -336,6 +336,15 @@ model PermissionError {
    */
   @visibility(Lifecycle.Read)
   identity?: EntraIdentity;
+
+  /**
+   * The error message describing the permission validation failure, when the
+   * failure carries a distinct message (for example, when the target could not
+   * be read to evaluate access).
+   */
+  @added(Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read)
+  errorMessage?: string;
 }
 
 /**


### PR DESCRIPTION
Adds an optional, read-only `errorMessage` to the `PermissionError` model under `2026-08-01-preview` (`@added`, so `2025-01-01` and `2026-05-01-preview` are unaffected).

This surfaces the distinct, human-readable message a permission-validation failure can carry - notably the AccessIndeterminate case, where the workspace managed identity could not read the target resource to evaluate access (so `missingPermissions` is empty and the message is the only actionable content).

- `scenarioConfiguration.models.tsp`: `errorMessage?: string` on `PermissionError`
- regenerated `preview/2026-08-01-preview/openapi.json`
- populated `errorMessage` in the ScenarioRuns_ListAll example

Additive / optional / read-only on an unreleased preview -> non-breaking. Base = the in-flight `user/renzopretto/chaos-2026-08-01-preview` branch (NOT main).
