### PR TITLE
fix: Go and Python namespace extraction/validation

### DIFF
--- a/.github/namespace-format-rules.yml
+++ b/.github/namespace-format-rules.yml
@@ -27,5 +27,5 @@ typescript:
   description: "@azure/arm-{name} (lowercase)"
 
 python:
-  pattern: "^azure-mgmt-[a-z0-9]+$"
-  description: "azure-mgmt-{name} (lowercase)"
+  pattern: '^azure\.mgmt\.[a-z0-9]+$'
+  description: "azure.mgmt.{name} (dot-separated namespace, lowercase)"

--- a/.github/workflows/src/namespace-approval/detect-namespaces.js
+++ b/.github/workflows/src/namespace-approval/detect-namespaces.js
@@ -25,13 +25,14 @@ function readBaseVersion(file) {
 }
 
 /**
- * Extract namespace values from a parsed tspconfig options object.
+ * Extract namespace values from a parsed tspconfig object.
  * Returns a map of language → namespace (same logic as extractNamespaces but from raw config).
  *
  * @param {Record<string, Record<string, unknown>>} options - The options section of tspconfig
+ * @param {Record<string, unknown>} [fullConfig] - Full tspconfig (needed for Go template resolution)
  * @returns {Record<string, string>}
  */
-function extractNamespacesFromOptions(options) {
+function extractNamespacesFromOptions(options, fullConfig) {
   /** @type {Record<string, string>} */
   const namespaces = {};
   for (const [emitterKey, emitterOpts] of Object.entries(options)) {
@@ -55,6 +56,13 @@ function extractNamespacesFromOptions(options) {
     }
 
     const module = /** @type {string | undefined} */ (emitterOpts.module);
+    if (module && lang === "go" && fullConfig) {
+      const expanded = resolveGoModule(module, emitterOpts, fullConfig);
+      const goBase = "github.com/Azure/azure-sdk-for-go/";
+      namespaces[lang] = expanded.startsWith(goBase) ? expanded.slice(goBase.length) : expanded;
+      continue;
+    }
+
     if (module) {
       namespaces[lang] = module;
       continue;
@@ -97,6 +105,39 @@ function resolveLanguage(emitterKey) {
     }
   }
   return undefined;
+}
+
+/**
+ * Resolve template variables in a Go module path.
+ * Replaces {service-dir} with the emitter-level value if present, otherwise
+ * falls back to the global parameters.service-dir.default.
+ *
+ * @param {string} module - Raw module value (e.g. "github.com/Azure/azure-sdk-for-go/{service-dir}/armfoo")
+ * @param {Record<string, unknown>} emitterOpts - The emitter options object
+ * @param {Record<string, unknown>} config - The full tspconfig object
+ * @returns {string} Expanded module path
+ */
+function resolveGoModule(module, emitterOpts, config) {
+  return module.replace(
+    /\{([^}]+)\}/g,
+    (/** @type {string} */ match, /** @type {string} */ key) => {
+      // Check emitter-level option first
+      const emitterValue = emitterOpts[key];
+      if (typeof emitterValue === "string") {
+        return emitterValue;
+      }
+      // Fall back to global parameters.{varName}.default
+      const parameters = /** @type {Record<string, Record<string, unknown>> | undefined} */ (
+        config.parameters
+      );
+      const param = parameters?.[key];
+      if (param && typeof param.default === "string") {
+        return param.default;
+      }
+      // Cannot resolve - return as-is
+      return match;
+    },
+  );
 }
 
 /**
@@ -190,6 +231,20 @@ async function extractNamespaces(file, namespacesFound, artifactNames, core) {
     }
 
     const module = /** @type {string | undefined} */ (emitterOpts.module);
+    if (module && lang === "go") {
+      // Go module values contain template variables like {service-dir} that need expanding.
+      // Resolution order: emitter-level service-dir > global parameters.service-dir.default
+      const expanded = resolveGoModule(module, emitterOpts, config);
+      // Extract path after the Go SDK base URL for format validation
+      const goBase = "github.com/Azure/azure-sdk-for-go/";
+      if (expanded.startsWith(goBase)) {
+        namespacesFound[lang] = expanded.slice(goBase.length);
+      } else {
+        namespacesFound[lang] = expanded;
+      }
+      continue;
+    }
+
     if (module) {
       namespacesFound[lang] = module;
       continue;
@@ -282,7 +337,7 @@ export default async function detectNamespaces({ context, core }) {
       if (!baseOptions) {
         continue;
       }
-      const baseNamespaces = extractNamespacesFromOptions(baseOptions);
+      const baseNamespaces = extractNamespacesFromOptions(baseOptions, baseConfig);
       for (const [lang, ns] of Object.entries(namespacesFound)) {
         if (baseNamespaces[lang] === ns) {
           core.info(`Namespace unchanged for ${lang}: "${ns}", skipping`);

--- a/.github/workflows/test/namespace-approval/detect-namespaces.test.js
+++ b/.github/workflows/test/namespace-approval/detect-namespaces.test.js
@@ -1,5 +1,5 @@
 import { execFile } from "child_process";
-import { readFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { createMockContext, createMockCore } from "../mocks.js";
@@ -60,6 +60,8 @@ const { getChangedFilesStatuses } = await import("../../../shared/src/changed-fi
 
 /** @type {import("vitest").Mock} */
 const readFileMock = /** @type {any} */ (readFile);
+/** @type {import("vitest").Mock} */
+const writeFileMock = /** @type {any} */ (writeFile);
 /** @type {import("vitest").Mock} */
 const getChangedFilesStatusesMock = /** @type {any} */ (getChangedFilesStatuses);
 /** @type {import("vitest").Mock} */
@@ -217,6 +219,65 @@ describe("detect-namespaces", () => {
     await detectNamespaces(args());
 
     expect(core.setOutput).toHaveBeenCalledWith("results", "true");
+  });
+
+  it("should expand Go module template variables using emitter-level service-dir", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 50 }, action: "opened" };
+    const file = "specification/enclave/Enclave.Management/tspconfig.yaml";
+    mockFileStatuses([file]);
+    readFileMock.mockResolvedValue(
+      yaml.dump({
+        linter: { extends: ["@azure-tools/typespec-azure-resource-manager/all"] },
+        parameters: {
+          "service-dir": { default: "sdk/enclave" },
+        },
+        options: {
+          "@azure-tools/typespec-go": {
+            "service-dir": "sdk/resourcemanager/enclave",
+            module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armenclave",
+          },
+        },
+      }),
+    );
+    mockGitShowNotFound();
+
+    await detectNamespaces(args());
+
+    expect(core.setOutput).toHaveBeenCalledWith("results", "true");
+    // Verify the written results contain the expanded Go namespace
+    const writtenJson = String(writeFileMock.mock.lastCall?.[1]);
+    expect(writtenJson).toContain('"go": "sdk/resourcemanager/enclave/armenclave"');
+  });
+
+  it("should fall back to global parameters for Go module template variables", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 51 }, action: "opened" };
+    const file = "specification/enclave/Enclave.Management/tspconfig.yaml";
+    mockFileStatuses([file]);
+    readFileMock.mockResolvedValue(
+      yaml.dump({
+        linter: { extends: ["@azure-tools/typespec-azure-resource-manager/all"] },
+        parameters: {
+          "service-dir": { default: "sdk/resourcemanager/enclave" },
+        },
+        options: {
+          "@azure-tools/typespec-go": {
+            module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armenclave",
+          },
+        },
+      }),
+    );
+    mockGitShowNotFound();
+
+    await detectNamespaces(args());
+
+    expect(core.setOutput).toHaveBeenCalledWith("results", "true");
+    // Verify the written results contain the expanded Go namespace
+    const writtenJson2 = String(writeFileMock.mock.lastCall?.[1]);
+    expect(writtenJson2).toContain('"go": "sdk/resourcemanager/enclave/armenclave"');
   });
 
   it("should skip when no tspconfig.yaml changes detected", async () => {

--- a/.github/workflows/test/namespace-approval/validate-format.test.js
+++ b/.github/workflows/test/namespace-approval/validate-format.test.js
@@ -29,8 +29,8 @@ const rules = {
     description: "@azure/arm-{name}",
   },
   python: {
-    pattern: "^azure-mgmt-[a-z0-9]+$",
-    description: "azure-mgmt-{name}",
+    pattern: "^azure\\.mgmt\\.[a-z0-9]+$",
+    description: "azure.mgmt.{name}",
   },
 };
 
@@ -123,13 +123,18 @@ describe("validate-format", () => {
   });
 
   describe("python", () => {
-    it("should accept valid Python package name", () => {
-      const result = validateNamespaceFormat("python", "azure-mgmt-compute", rules);
+    it("should accept valid Python namespace", () => {
+      const result = validateNamespaceFormat("python", "azure.mgmt.compute", rules);
       expect(result.valid).toBe(true);
     });
 
     it("should reject non-mgmt prefix", () => {
-      const result = validateNamespaceFormat("python", "azure-compute", rules);
+      const result = validateNamespaceFormat("python", "azure.compute", rules);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject dash-separated package name format", () => {
+      const result = validateNamespaceFormat("python", "azure-mgmt-compute", rules);
       expect(result.valid).toBe(false);
     });
   });
@@ -147,7 +152,7 @@ describe("validate-format", () => {
       const namespaces = {
         dotnet: "Azure.ResourceManager.Compute",
         java: "INVALID-NAME",
-        python: "azure-mgmt-network",
+        python: "azure.mgmt.network",
       };
 
       const results = validateAllNamespaces(namespaces, rules);


### PR DESCRIPTION
## Fix Go and Python namespace extraction/validation

Fixes #44699

### Python
- Format rule updated from `azure-mgmt-{name}` (PyPI package name with dashes) to `azure.mgmt.{name}` (dot-separated namespace)
- Per Python team: `azure-mgmt-xxx` is the package name, `azure.mgmt.xxx` is the actual namespace in tspconfig

### Go
- Template variables like `{service-dir}` in the `module` field are now resolved before validation
- Resolution order: emitter-level `service-dir` option first, then global `parameters.service-dir.default`
- After expansion, strips the `github.com/Azure/azure-sdk-for-go/` prefix to get the path for format validation

### Example
```yaml
parameters:
  service-dir:
    default: sdk/enclave
options:
  "@azure-tools/typespec-go":
    service-dir: sdk/resourcemanager/enclave
    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armenclave"
```
Before: displayed raw `{service-dir}` in bot comment, failed format validation
After: resolves to `sdk/resourcemanager/enclave/armenclave`, passes format validation