### PR TITLE
Add moveIpConfigurations API to 2025-09-01 (port of #42941)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualNetwork.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualNetwork.tsp
@@ -2,10 +2,12 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "../Common/VirtualNetwork.tsp";
 
 using TypeSpec.Rest;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
@@ -136,6 +138,26 @@ interface VirtualNetworks {
     },
     Error = CloudError
   >;
+
+  /**
+   * Move IP configurations from one virtual network to another.
+   */
+  #suppress "@azure-tools/typespec-azure-core/invalid-final-state" "azure-async-operation used for LRO polling"
+  @added(Versions.v2025_09_01)
+  @tag("VirtualNetworks")
+  @action("moveIpConfigurations")
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  moveIpConfigurations is ArmResourceActionAsync<
+    VirtualNetwork,
+    MoveIpConfigurationsRequest,
+    Response = {
+      @body body: void;
+    },
+    LroHeaders = ArmAsyncOperationHeader<FinalResult = void> &
+      ArmLroLocationHeader<FinalResult = void> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -196,6 +218,10 @@ interface EffectiveConfigurations {
 @@doc(
   VirtualNetworks.updateTags::parameters.properties,
   "Parameters supplied to update virtual network tags."
+);
+@@doc(
+  VirtualNetworks.moveIpConfigurations::parameters.body,
+  "Parameters supplied to move IP configurations from one virtual network to another."
 );
 @@doc(
   EffectiveConfigurations.listNetworkManagerEffectiveConnectivityConfigurations::parameters.body,

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualNetworkMoveIpConfigurations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualNetworkMoveIpConfigurations.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "VirtualNetworks_MoveIpConfigurations",
+  "title": "Move IP Configurations",
+  "parameters": {
+    "api-version": "2025-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualNetworkName": "test-vnet",
+    "body": {
+      "moveIpConfigurationItems": [
+        {
+          "sourceIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"
+          },
+          "targetIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic2/ipConfigurations/ipconfig2"
+          }
+        },
+        {
+          "sourceIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic3/ipConfigurations/ipconfig3"
+          },
+          "targetIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic4/ipConfigurations/ipconfig4"
+          }
+        }
+      ]
+    }
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/11111111-1111-1111-1111-111111111111?api-version=2025-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/11111111-1111-1111-1111-111111111111?api-version=2025-09-01",
+        "Retry-After": 10
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -19683,6 +19683,55 @@ model VirtualNetworkDdosProtectionStatusResult
   is Azure.Core.Page<PublicIpDdosProtectionStatusResult>;
 
 /**
+ * Request body for the MoveIpConfigurations operation.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
+model MoveIpConfigurationsRequest {
+  /**
+   * A list of IP configuration move items.
+   */
+  @identifiers(#[])
+  moveIpConfigurationItems: MoveIpConfigurationItem[];
+}
+
+/**
+ * An item representing a source and target IP configuration for a move operation.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
+model MoveIpConfigurationItem {
+  /**
+   * The source IP configuration to move from.
+   */
+  sourceIpConfiguration: MoveIpConfigurationResourceReference;
+
+  /**
+   * The target IP configuration to move to.
+   */
+  targetIpConfiguration: MoveIpConfigurationResourceReference;
+}
+
+/**
+ * Reference to an IP configuration resource by ARM resource ID.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
+model MoveIpConfigurationResourceReference {
+  /**
+   * The ARM resource ID of the IP configuration.
+   */
+  id: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/networkInterfaces/ipConfigurations";
+    }
+  ]>;
+}
+
+/**
  * VirtualNetworkGateway properties.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -123,6 +123,16 @@ suppressions:
     reason: Not a standard azure resource.
     where:
       - $.definitions.GetServiceGatewayServicesResult
+  - code: ResourceNameRestriction
+    from: virtualNetwork.json
+    reason: The resource name parameter 'virtualNetworkName' is not defined with a 'pattern' restriction. Suppress it to avoid breaking change because it is referenced by all Virtual Network APIs.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"]
+  - code: PostResponseCodes
+    from: virtualNetwork.json
+    reason: LRO POST operation returns 200 with no schema for completion status and 202 for async acceptance. This is the standard TypeSpec ArmResourceActionAsync pattern for void LRO operations.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"].post
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -128,11 +128,6 @@ suppressions:
     reason: The resource name parameter 'virtualNetworkName' is not defined with a 'pattern' restriction. Suppress it to avoid breaking change because it is referenced by all Virtual Network APIs.
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"]
-  - code: PostResponseCodes
-    from: virtualNetwork.json
-    reason: LRO POST operation returns 200 with no schema for completion status and 202 for async acceptance. This is the standard TypeSpec ArmResourceActionAsync pattern for void LRO operations.
-    where:
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"].post
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -128,6 +128,11 @@ suppressions:
     reason: The resource name parameter 'virtualNetworkName' is not defined with a 'pattern' restriction. Suppress it to avoid breaking change because it is referenced by all Virtual Network APIs.
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"]
+  - code: PostResponseCodes
+    from: virtualNetwork.json
+    reason: LRO POST operation returns 200 with no schema for completion status and 202 for async acceptance. This is the standard TypeSpec ArmResourceActionAsync pattern for void LRO operations.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"].post
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualNetworkMoveIpConfigurations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualNetworkMoveIpConfigurations.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "VirtualNetworks_MoveIpConfigurations",
+  "title": "Move IP Configurations",
+  "parameters": {
+    "api-version": "2025-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualNetworkName": "test-vnet",
+    "body": {
+      "moveIpConfigurationItems": [
+        {
+          "sourceIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"
+          },
+          "targetIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic2/ipConfigurations/ipconfig2"
+          }
+        },
+        {
+          "sourceIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic3/ipConfigurations/ipconfig3"
+          },
+          "targetIpConfiguration": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic4/ipConfigurations/ipconfig4"
+          }
+        }
+      ]
+    }
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/11111111-1111-1111-1111-111111111111?api-version=2025-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/11111111-1111-1111-1111-111111111111?api-version=2025-09-01",
+        "Retry-After": 10
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
@@ -12215,6 +12215,80 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations": {
+      "post": {
+        "operationId": "VirtualNetworks_MoveIpConfigurations",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Move IP configurations from one virtual network to another.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to move IP configurations from one virtual network to another.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MoveIpConfigurationsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Move IP Configurations": {
+            "$ref": "./examples/VirtualNetworkMoveIpConfigurations.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets": {
       "get": {
         "operationId": "Subnets_List",
@@ -18506,6 +18580,62 @@
           "description": "String representing a friendly name for the resource."
         }
       }
+    },
+    "MoveIpConfigurationItem": {
+      "type": "object",
+      "description": "An item representing a source and target IP configuration for a move operation.",
+      "properties": {
+        "sourceIpConfiguration": {
+          "$ref": "#/definitions/MoveIpConfigurationResourceReference",
+          "description": "The source IP configuration to move from."
+        },
+        "targetIpConfiguration": {
+          "$ref": "#/definitions/MoveIpConfigurationResourceReference",
+          "description": "The target IP configuration to move to."
+        }
+      },
+      "required": [
+        "sourceIpConfiguration",
+        "targetIpConfiguration"
+      ]
+    },
+    "MoveIpConfigurationResourceReference": {
+      "type": "object",
+      "description": "Reference to an IP configuration resource by ARM resource ID.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of the IP configuration.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkInterfaces/ipConfigurations"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "MoveIpConfigurationsRequest": {
+      "type": "object",
+      "description": "Request body for the MoveIpConfigurations operation.",
+      "properties": {
+        "moveIpConfigurationItems": {
+          "type": "array",
+          "description": "A list of IP configuration move items.",
+          "items": {
+            "$ref": "#/definitions/MoveIpConfigurationItem"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "moveIpConfigurationItems"
+      ]
     },
     "NatGatewayListResult": {
       "type": "object",


### PR DESCRIPTION
Ports the `moveIpConfigurations` API from #42941 into the 2025-09-01 API version.

Adapted to `@added(Versions.v2025_09_01)` and emitted under stable/2025-09-01. Adds the operation (VirtualNetwork.tsp), request/item/reference models (models.tsp), suppressions (readme.md), swagger path + definitions (virtualNetwork.json), and example files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>