### PR TITLE
Suppress @azure-tools/typespec-azure-core/no-unnamed-types violations

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -227,7 +227,7 @@ model PromptAgentDefinition extends AgentDefinition {
     """)
   tools?: OpenAI.Tool[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @doc("""
     How the model should select which tool (or tools) to use when generating a response.
     See the `tools` parameter to see how to specify which tools the model can call.

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
@@ -169,7 +169,7 @@ model AgentEvaluation {
 @discriminator("role")
 @removed(Versions.v1)
 model Message {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   @doc("The role of the message author. Known values: 'system', 'assistant', 'developer', 'user'.")
   role: "system" | "assistant" | "developer" | "user" | string;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
@@ -7,7 +7,7 @@ namespace Azure.AI.Projects;
 alias EvaluatorsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.evaluations_v1_preview>;
 
 alias ListEvaluatorVersionsParameters = {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   @doc("Filter evaluators by type. Possible values: 'all', 'custom', 'builtin'.")
   @Http.query
   type?: EvaluatorType | "all";

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
@@ -102,7 +102,7 @@ interface Conversations {
       @query include?: string[];
 
       /** The items to add to the conversation. You may add up to 20 items at a time. */
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
       @maxItems(20)
       items: OpenAI.Item[];
     },

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -75,7 +75,7 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
   type: "azure_ai_source";
 
   /** Data schema scenario. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   scenario:
     | "red_team"
     | "responses"
@@ -102,7 +102,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
 /** Adding Azure AI Source type to data source for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 #suppress "deprecated" "Deprecated status inherited from source OpenAI specification"
 @@changePropertyType(
   OpenAI.Eval.data_source_config,
@@ -117,7 +117,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
 /** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.Eval.testing_criteria,
   (
@@ -150,7 +150,7 @@ model Eval is OpenAI.Eval {
 /** Adding Azure AI Source type to data source for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 #suppress "deprecated" "Deprecated status inherited from source OpenAI specification"
 @@changePropertyType(
   OpenAI.CreateEvalRequest.data_source_config,
@@ -165,7 +165,7 @@ model Eval is OpenAI.Eval {
 /** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.CreateEvalRequest.testing_criteria,
   (
@@ -273,7 +273,7 @@ model ResponseRetrievalItemGenerationParams extends ItemGenerationParams {
 
   /** The source from which JSONL content is read. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: OpenAI.EvalJsonlFileContentSource | OpenAI.EvalJsonlFileIdSource;
 }
 
@@ -441,7 +441,7 @@ model TargetCompletionEvalRunDataSource extends EvalRunDataSource {
 
   /** The source configuration for inline or file data. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: OpenAI.EvalJsonlFileContentSource | OpenAI.EvalJsonlFileIdSource;
 
   /** The target configuration for the evaluation. */
@@ -464,7 +464,7 @@ model EvalCsvRunDataSource extends EvalRunDataSource {
 
   /** The source of the CSV data, either inline content or a file reference. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: EvalCsvFileIdSource;
 }
 
@@ -493,13 +493,13 @@ model AzureAIBenchmarkPreviewEvalRunDataSource extends EvalRunDataSource {
    * inference parameters are auto-filled from the benchmark specification stored in eval group properties.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   target: AzureAIModelTarget | AzureAIAgentTarget;
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.EvalRun.data_source,
 
@@ -529,7 +529,7 @@ model EvalRun is OpenAI.EvalRun {
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "Imported from OpenAI spec."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.CreateEvalRunRequest.data_source,
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
@@ -13,7 +13,7 @@ alias EvalQueryParameters = {
   @doc("Number of runs to retrieve.")
   limit?: integer = 20;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query
   @doc("Sort order for runs by timestamp. Use `asc` for ascending order or `desc` for descending order. Defaults to `asc`.")
   order?: "asc" | "desc" = "asc";
@@ -22,7 +22,7 @@ alias EvalQueryParameters = {
 alias RunListQueryParameters = {
   ...EvalQueryParameters;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query
   @doc("Filter runs by status. One of `queued` | `in_progress` | `failed` | `completed` | `canceled`.")
   status?: "queued" | "in_progress" | "completed" | "canceled" | "failed";
@@ -35,7 +35,7 @@ alias EvalListQueryParameters = {
    * Evals can be ordered by creation time or last updated time.
    * Use `created_at` for creation time or `updated_at` for last updated time.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query(#{ explode: true })
   order_by?: "created_at" | "updated_at" = "created_at";
 };
@@ -47,7 +47,7 @@ alias EvalRunOutputItemsQueryParameters = {
    * Filter output items by status. Use `failed` to filter by failed output
    * items or `pass` to filter by passed output items.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query(#{ explode: true })
   status?: "fail" | "pass";
 };

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -93,7 +93,7 @@ namespace Azure.AI.Projects {
        * optional `memory_limit` setting.
        * If not provided, the service assumes auto.
        */
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Copying existing union type."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Copying existing union type."
       container?: string | OpenAI.AutoCodeInterpreterToolParam,
     }
   );
@@ -187,7 +187,7 @@ namespace Azure.AI.Projects {
     {
       /** The information about the creator of the item */
       #suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary suppression to allow union type."
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "This is required due to a conflict with the service."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "This is required due to a conflict with the service."
       @removed(Versions.v1)
       created_by?: CreatedBy | string,
 
@@ -230,7 +230,7 @@ namespace Azure.AI.Projects {
     @doc("ID of the previous action if this action follows another.")
     previous_action_id?: string;
 
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     @doc("Status of the action (e.g., 'in_progress', 'completed', 'failed', 'cancelled').")
     status: "completed" | "failed" | "in_progress" | "cancelled";
   }

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
@@ -73,7 +73,7 @@ namespace Azure.AI.Projects {
     /**The status of the item. One of `in_progress`, `completed`, or
   `incomplete`. Populated when items are returned via API.*/
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Auto-suppressed warnings non-applicable rules during import."
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     status: "in_progress" | "completed" | "incomplete";
   }
 
@@ -95,7 +95,7 @@ namespace Azure.AI.Projects {
     /**The status of the item. One of `in_progress`, `completed`, or
   `incomplete`. Populated when items are returned via API.*/
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Auto-suppressed warnings non-applicable rules during import."
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     status: "in_progress" | "completed" | "incomplete";
   }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -775,7 +775,7 @@ namespace Azure.AI.Projects {
   model MemorySearchToolCallItemResource extends OpenAI.OutputItem {
     type: "memory_search_call";
 
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     @doc("""
       The status of the memory search tool call. One of `in_progress`,
       `searching`, `completed`, `incomplete` or `failed`,
@@ -801,7 +801,7 @@ namespace Azure.AI.Projects {
   // Tool Call Output Content Type
   // ==============================================================================
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Output can be multiple types"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Output can be multiple types"
   @doc("The output content from a tool call, which can be a dictionary, string, or array.")
   union ToolCallOutputContent {
     @doc("A dictionary/object output.")

--- a/specification/ai/DocumentIntelligence/routes.tsp
+++ b/specification/ai/DocumentIntelligence/routes.tsp
@@ -114,7 +114,7 @@ model DocumentClassifierAnalyzeRequestParams {
 @doc("Analyze from stream request parameters.")
 model AnalyzeFromStreamRequestParams {
   #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "This union cannot be open"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing clients"
   @doc("Input content type.")
   @header
   contentType:

--- a/specification/ai/ModelInference/models/chat_completions.tsp
+++ b/specification/ai/ModelInference/models/chat_completions.tsp
@@ -434,7 +434,7 @@ model ChatRequestUserMessage extends ChatRequestMessage {
   role: ChatRole.user;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @doc("The contents of the user message, with available input types varying by selected model.")
   content: string | ChatMessageContentItem[];
 }
@@ -529,8 +529,9 @@ model ChatResponseMessage {
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
 alias ChatCompletionsToolChoice =
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   | ChatCompletionsToolChoicePreset
   | ChatCompletionsNamedToolChoice;
 

--- a/specification/ai/OpenAI.Assistants/common/models.tsp
+++ b/specification/ai/OpenAI.Assistants/common/models.tsp
@@ -171,7 +171,7 @@ model AssistantsApiResponseFormatJsonSchema
   type: ApiResponseFormat.jsonSchema;
 
   /** The JSON schema that the model must output. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @encodedName("application/json", "json_schema")
   jsonSchema: {
     /** A description of what the response format is for, used by the model to determine how to respond in the format. */

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -79,7 +79,7 @@ model RequestSession {
 
   /** Maximum number of tokens to generate in the response. Default is unlimited. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_response_output_tokens?: int32 | "inf";
 
   /**
@@ -673,7 +673,7 @@ model AudioInputTranscriptionOptions {
    * 'whisper-1', 'gpt-4o-transcribe', 'gpt-4o-mini-transcribe',
    * 'mai-transcribe-1', 'azure-speech'.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   @typeChangedFrom(
     Versions.v2026_04_10,
 
@@ -723,7 +723,7 @@ union Modality {
 @discriminator("model")
 @usage(RequestUsage)
 model EouDetection {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   @typeChangedFrom(
     Versions.v2026_06_01_preview,
 
@@ -989,7 +989,7 @@ model AzureSemanticVadMultilingual extends TurnDetection {
 @usage(RequestUsage)
 model AudioNoiseReduction {
   /** The type of noise reduction model. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   type: "azure_deep_noise_suppression" | "near_field" | "far_field" | string;
 }
 

--- a/specification/ai/data-plane/VoiceLive/items.tsp
+++ b/specification/ai/data-plane/VoiceLive/items.tsp
@@ -262,7 +262,7 @@ model ResponseCancelledDetails extends ResponseStatusDetails {
   // Narrow the discriminator to a literal in each child:
   type: "cancelled";
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   reason: "turn_detected" | "client_cancelled" | string;
 }
 
@@ -270,7 +270,7 @@ model ResponseCancelledDetails extends ResponseStatusDetails {
 @usage(ResponseUsage)
 model ResponseIncompleteDetails extends ResponseStatusDetails {
   type: "incomplete";
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   reason: "max_output_tokens" | "content_filter" | string;
 }
 
@@ -531,7 +531,7 @@ model ResponseWebSearchCallItem extends ResponseItem {
   type: ItemType.web_search_call;
 
   /** The status of the web search tool call. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to match source."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to match source."
   status: "in_progress" | "searching" | "completed" | "failed" | string;
 }
 
@@ -568,7 +568,7 @@ model ResponseFileSearchCallItem extends ResponseItem {
   queries?: string[];
 
   /** The status of the file search tool call. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to match source."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to match source."
   status:
     | "in_progress"
     | "searching"

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -267,7 +267,7 @@ model Response {
    * inclusive of tool calls, that was used in this response.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_output_tokens?: int32 | "inf";
 
   /**
@@ -1123,7 +1123,7 @@ model ServerEventResponseAnimationBlendshapeDelta extends ServerEvent {
   output_index: int32;
   content_index: int32;
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   frames: float32[][] | string;
   frame_index: int32;
 }
@@ -1258,7 +1258,7 @@ model ResponseCreateParams {
    * given model. Defaults to `inf`.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_output_tokens?: int32 | "inf";
 
   /** Create the response with pre-generated assistant message. The message item would be

--- a/specification/ai/data-plane/VoiceLive/tools.tsp
+++ b/specification/ai/data-plane/VoiceLive/tools.tsp
@@ -96,7 +96,7 @@ model MCPServer extends Tool {
   headers?: Record<string>;
   allowed_tools?: string[];
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "require_approval is represented this way in OpenAI style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   require_approval?: MCPApprovalType | Record<string[]>;
 }
 

--- a/specification/apicenter/ApiCenter.DataApi/models/api.tsp
+++ b/specification/apicenter/ApiCenter.DataApi/models/api.tsp
@@ -50,7 +50,7 @@ model Api {
   @doc("Points of contact for the API.")
   contacts?: Contact[];
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
   @doc("The custom metadata defined for API entities.")
   customProperties?: {};
 

--- a/specification/apicenter/ApiCenter.DataApi/models/environment.tsp
+++ b/specification/apicenter/ApiCenter.DataApi/models/environment.tsp
@@ -36,7 +36,7 @@ model Environment {
   @doc("Onboarding information for this environment.")
   onboarding?: EnvironmentOnboardingModel;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
   @doc("The custom metadata defined for environment entities.")
   customProperties?: {};
 }

--- a/specification/app/data-plane/DynamicSessions/routes.tsp
+++ b/specification/app/data-plane/DynamicSessions/routes.tsp
@@ -86,6 +86,7 @@ interface SessionResourceFiles {
       contentType: "multipart/form-data";
 
       /** Multipart body */
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
       @multipartBody body: {
         /** The file to upload. */
         file: HttpPart<bytes>;

--- a/specification/appconfiguration/data-plane/AppConfiguration/models.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/models.tsp
@@ -351,14 +351,14 @@ alias SyncTokenHeader = {
 
 #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
 alias ContentTypeHeader<T extends string> = {
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Avoiding creating a bunch of types for each content type."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Avoiding creating a bunch of types for each content type."
   @doc("Content-Type header")
   @header("Content-Type")
   contentType?: T | "application/problem+json";
 };
 
 alias PutKeyValueRequestContentType = {
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
   @doc("Content-Type header")
   @header("Content-Type")

--- a/specification/appconfiguration/data-plane/AppConfiguration/routes.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/routes.tsp
@@ -268,7 +268,7 @@ op getSnapshot is StandardOps.ResourceRead<
 @put
 op createSnapshot is Foundations.LongRunningOperation<
   {
-    #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
     @doc("Content-Type header")
     @header("Content-Type")
@@ -300,7 +300,7 @@ op createSnapshot is Foundations.LongRunningOperation<
 op updateSnapshot is AppConfigOperation<
   {
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
-    #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
     @doc("Content-Type header")
     @header("Content-Type")
     contentType: "application/merge-patch+json" | "application/json";

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
@@ -540,7 +540,7 @@ model DrillStartRequest {
   @doc("Mode of starting the Drill")
   mode: DrillMode;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @doc("Inputs needed for the Recovery Orchestration Plan")
   @removed(Versions.v2026_04_01_preview)
   recoveryPlanInputs: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
@@ -180,7 +180,7 @@ model Batch {
   cancelledAt?: utcDateTime;
 
   /** The request counts for different statuses within the batch. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @encodedName("application/json", "request_counts")
   requestCounts?: {
     /** Total number of requests in the batch. */

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -60,7 +60,7 @@ model ChatCompletionsJsonSchemaResponseFormat
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "this represents the case-sensitive wire format"
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicitly required, nullable types"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   json_schema: {
     /** A description of what the response format is for, used by the model to determine how to respond in the format. */
     description?: string;
@@ -395,7 +395,7 @@ model PredictionContent {
    * can be returned much more quickly.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   content: string | ChatMessageTextContentItem[];
 }
 

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
@@ -151,7 +151,7 @@ model ChatRequestSystemMessage extends ChatRequestMessage {
   role: ChatRole.system;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The contents of the system message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string)
   content: string | ChatMessageTextContentItem[];
@@ -171,7 +171,7 @@ model ChatRequestDeveloperMessage extends ChatRequestMessage {
 
   /** An array of content parts with a defined type. For developer messages, only type `text` is supported. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   content: string | ChatMessageTextContentItem[];
 
   /** An optional name for the participant. Provides the model information to differentiate between participants of the same role. */
@@ -185,7 +185,7 @@ model ChatRequestUserMessage extends ChatRequestMessage {
   role: ChatRole.user;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The contents of the user message, with available input types varying by selected model.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, ChatMessageContent)
   @typeChangedFrom(
@@ -193,7 +193,9 @@ model ChatRequestUserMessage extends ChatRequestMessage {
     string | ChatMessageTextContentItem[] | ChatMessageImageContentItem[]
   )
   content:
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
     | string
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
     | (
         | ChatMessageTextContentItem
         | ChatMessageImageContentItem
@@ -211,10 +213,11 @@ model ChatRequestAssistantMessage extends ChatRequestMessage {
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "explicitly nullable in mirrored API"
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The content of the message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string | null)
   content:
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
     | string
     | ChatMessageTextContentItem[]
     | ChatMessageRefusalContentItem[]
@@ -255,7 +258,7 @@ model ChatRequestToolMessage extends ChatRequestMessage {
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "explicitly nullable in mirrored API"
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The content of the message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string | null)
   content: string | ChatMessageTextContentItem[] | null;

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/common.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/common.tsp
@@ -25,7 +25,7 @@ model CompletionsUsage {
   @encodedName("application/json", "total_tokens")
   totalTokens: int32;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("Details of the prompt tokens.")
   @added(ServiceApiVersions.v2024_10_01_Preview)
   @encodedName("application/json", "prompt_tokens_details")
@@ -41,7 +41,7 @@ model CompletionsUsage {
   };
 
   /** Breakdown of tokens used in a completion. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @added(ServiceApiVersions.v2024_09_01_Preview)
   @encodedName("application/json", "completion_tokens_details")
   completionTokensDetails?: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/mongodb_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/mongodb_options.tsp
@@ -60,7 +60,7 @@ model MongoDBChatExtensionParameters {
    * Note that content and vector field mappings are required for MongoDB.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "this represents the case-sensitive wire format"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   fields_mapping: {
     content_fields: string[];
     vector_fields: string[];
@@ -71,11 +71,12 @@ model MongoDBChatExtensionParameters {
   };
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("""
     The vectorization source to use with the MongoDB chat extension.
     """)
   embedding_dependency:
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
     | OnYourDataEndpointVectorizationSource
     | OnYourDataDeploymentNameVectorizationSource;
 }

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/functions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/functions.tsp
@@ -36,7 +36,7 @@ union FunctionCallPreset {
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
 alias FunctionCallConfig = FunctionCallPreset | FunctionName;
 
 @doc("""

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/tools.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/tools.tsp
@@ -8,8 +8,9 @@ using TypeSpec.Versioning;
 // tool_choice: "auto" | "none" | { "type": "function", "name": string }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
 alias ChatCompletionsToolSelection =
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   | ChatCompletionsToolSelectionPreset
   | ChatCompletionsNamedToolSelection;
 
@@ -83,7 +84,7 @@ model ChatCompletionsFunctionToolDefinition
   @doc("The object name, which is always 'function'.")
   type: "function";
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The function definition details for the function tool.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, FunctionDefinition)
   function: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
@@ -18,7 +18,7 @@ model CreateUploadRequest {
    *
    * Use 'assistants' for Assistants and Message files, 'vision' for Assistants image file inputs, 'batch' for Batch API, and 'fine-tune' for Fine-tuning.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   purpose: string | "assistants" | "batch" | "fine-tune" | "vision";
 
   /** The number of bytes in the file you are uploading. */
@@ -71,8 +71,9 @@ model Upload {
 
   // Reference: https://platform.openai.com/docs/api-reference/files/object#files/object-purpose
   /** The intended purpose of the file. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   purpose:
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
     | string
     | "batch"
     | "batch_output"
@@ -83,7 +84,7 @@ model Upload {
     | "vision";
 
   /** The status of the Upload. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   status: string | "pending" | "completed" | "cancelled" | "expired";
 
   // Tool customization: 'created' and fields ending in '_at' are Unix encoded utcDateTime

--- a/specification/cognitiveservices/OpenAI.Inference/routes/files.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/files.tsp
@@ -42,6 +42,7 @@ op listFiles(@query purpose?: FilePurpose): FileListResponse;
 @route("/files")
 op uploadFile(
   @header contentType: "multipart/form-data",
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   @multipartBody file: {
     /** The file data (not filename) to upload. */
     @clientName("Data", "csharp") file: HttpPart<bytes>;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -2761,6 +2761,7 @@ model ManagedClusterNATGatewayProfile {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_04_02_preview)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   outboundIPPrefixes?: {
     /**
      * A list of public IP prefix resources.
@@ -2778,6 +2779,7 @@ model ManagedClusterNATGatewayProfile {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_04_02_preview)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   outboundIPs?: {
     /**
      * A list of public IP resources.

--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/HostPool.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/HostPool.tsp
@@ -37,7 +37,7 @@ interface AppAttachPackageInfo {
   /**
    * Gets information from a package given the path to the package.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("importAppAttachPackageInfo")
   @list
   `import` is ArmResourceActionSync<
@@ -54,7 +54,7 @@ interface MSIXImages {
    * Expands and Lists MSIX packages in an Image, given the Image Path.
    * This action uses incorrect Msix casing intentionally to match the previous APIs.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("expandMsixImage")
   @list
   expand is ArmResourceActionSync<

--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/SessionHostManagement.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/SessionHostManagement.tsp
@@ -41,7 +41,7 @@ interface InitiateSessionHostUpdate {
   /**
    * Initiates a hostpool update or schedule an update for the future.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("initiateSessionHostUpdate")
   post is ArmResourceActionSync<
     SessionHostManagement,

--- a/specification/discovery/Discovery.Workspace/_tool.tsp
+++ b/specification/discovery/Discovery.Workspace/_tool.tsp
@@ -319,6 +319,7 @@ model RunResult {
   createdBy?: string;
 
   @doc("Details provided by the tool (rather than the platform).")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   toolReport?: {
     /** Percentage compete */
     percentageComplete: int32;

--- a/specification/extendedlocation/resource-manager/Microsoft.ExtendedLocation/CustomLocations/client.tsp
+++ b/specification/extendedlocation/resource-manager/Microsoft.ExtendedLocation/CustomLocations/client.tsp
@@ -151,6 +151,7 @@ op resourceSyncRulesUpdate(
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   tags?: Record<string>,
 ):
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   | {
       statusCode: 200;
       body: Microsoft.ExtendedLocation.resourceSyncRule;

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
@@ -16,6 +16,7 @@ namespace Microsoft.GuestConfiguration;
 @error
 model ErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   error?: {
     /**
      * Error code.

--- a/specification/keyvault/data-plane/Administration/common/common.tsp
+++ b/specification/keyvault/data-plane/Administration/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Certificates/common/common.tsp
+++ b/specification/keyvault/data-plane/Certificates/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Keys/common/common.tsp
+++ b/specification/keyvault/data-plane/Keys/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Secrets/common/common.tsp
+++ b/specification/keyvault/data-plane/Secrets/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/SecurityDomain/common/common.tsp
+++ b/specification/keyvault/data-plane/SecurityDomain/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
+++ b/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
@@ -687,6 +687,7 @@ model ProtectionGroupResources {
 
   @doc("Rules to match resources")
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   matchRules?: {
     @doc("rules to match")
     @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/community/community.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/community/community.tsp
@@ -210,7 +210,7 @@ model CommunityBaseModel {
   @identifiers(#[])
   governedServiceList?: GovernedServiceItem[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @added(Microsoft.Mission.Versions.v2025_05_01_preview)
   @doc("Policy override setting for the community. Specifies whether to apply enclave-specific policies or disable policy enforcement.")
   policyOverride?: "Enclave" | "None" | string;

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/postActions/approvalspostactions.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/postActions/approvalspostactions.tsp
@@ -15,11 +15,11 @@ model ApprovalCallbackRequest {
   @doc("Resource Id of the item being approved or rejected")
   resourceId: armResourceIdentifier;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Resource request action indicating action which needed to be performed upon calling approval-callback post action")
   resourceRequestAction: "Create" | "Delete" | "Update" | "Reset" | string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Approval status indicating 'Approved' or 'Rejected'")
   approvalStatus: "Approved" | "Rejected" | string;
 
@@ -31,7 +31,7 @@ model ApprovalCallbackRequest {
 // Define a model for the approval initator callback request
 @doc("Request body for calling post-action")
 model ApprovalActionRequest {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Approval status indicating 'Approved' or 'Rejected'")
   approvalStatus: "Approved" | "Rejected" | string;
 }
@@ -45,7 +45,7 @@ model ApprovalActionResponse {
 
 @doc("Request body for calling post-action")
 model ApprovalDeletionCallbackRequest {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Resource request action indicating action which needed to be performed upon calling approval-deletion-callback post action")
   resourceRequestAction: "Create" | "Delete" | "Update" | string;
 }

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/governedserviceitem.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/governedserviceitem.tsp
@@ -70,11 +70,11 @@ model GovernedServiceItem {
   @visibility(Lifecycle.Read)
   serviceName?: string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Governance option for this service (Allow, Deny, ExceptionOnly, or NotApplicable).")
   option?: "Allow" | "Deny" | "ExceptionOnly" | "NotApplicable" | string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Initiative enforcement (Enabled or Disabled).")
   enforcement?: "Enabled" | "Disabled" | string;
 
@@ -82,7 +82,7 @@ model GovernedServiceItem {
   @doc("Policies set to auditOnly (True or False).")
   auditOnly?: boolean;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @added(Microsoft.Mission.Versions.v2025_05_01_preview)
   @doc("Enforcement mode for policy. AuditOnly, Enforce, or None.")
   policyAction?: "AuditOnly" | "Enforce" | "None" | string;

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/maintenancemodeconfiguration.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/maintenancemodeconfiguration.tsp
@@ -5,14 +5,14 @@ namespace Microsoft.Mission;
 
 @doc("Maintenance Mode")
 model MaintenanceModeConfigurationModel {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Current mode of Maintenance Mode Configuration")
   mode: "On" | "CanNotDelete" | "Off" | "General" | "Advanced" | string = "Off";
 
   @doc("The user, group or service principal object affected by Maintenance Mode")
   principals?: Principal[] = #[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Justification for entering or exiting Maintenance Mode")
   justification?: "Networking" | "Governance" | "Off" | string = "Off";
 }

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/principal.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/principal.tsp
@@ -6,7 +6,7 @@ model Principal {
   @doc("The object id associated with the principal")
   id: string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("The type of the object id. We currently allow users, groups, and service principals")
   type: "User" | "Group" | "ServicePrincipal" | string;
 }

--- a/specification/onlineexperimentation/OnlineExperimentation.Management/OnlineExperimentationWorkspace.tsp
+++ b/specification/onlineexperimentation/OnlineExperimentation.Management/OnlineExperimentationWorkspace.tsp
@@ -47,7 +47,7 @@ model OnlineExperimentationWorkspacePatch {
   /**
    * Updatable properties of the online experimentation workspace resource.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   properties?: {
     /**
      * The resource identifier of the Log Analytics workspace which online experimentation workspace uses for generating experiment analysis results.

--- a/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
@@ -445,7 +445,7 @@ interface StacItems {
      * This union allows the request body to accept either a single Item or a collection of Items.
      */
     #suppress "@azure-tools/typespec-autorest/union-unsupported" ""
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backcompatibility with existing clients"
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
     @body
     body: StacItemOrStacItemCollection,
   ):

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.stac.spec.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.stac.spec.tsp
@@ -910,7 +910,7 @@ model StacLink {
    * Specifies the HTTP method that the resource expects.
    * Default: GET.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   method?: "GET" | "POST" | string = "GET";
 
   /**

--- a/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
+++ b/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
@@ -215,6 +215,7 @@ model ErrorResponse {
   /**
    * The error object.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   error?: {
     /**
      * Error code

--- a/specification/purview/data-plane/datamap/routes.tsp
+++ b/specification/purview/data-plane/datamap/routes.tsp
@@ -69,6 +69,7 @@ op AtlasImportOperation<
       TraitLocation.Parameters,
       TraitContext.Action
     >,
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   TResponse &
     TraitProperties<
       Traits &

--- a/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
+++ b/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
@@ -1329,6 +1329,7 @@ model ScheduleEntityRequestResponse {
    * Trigger configuration defining execution timing and scheduling behavior
    */
   @doc("Trigger configuration for execution timing and scheduling")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   trigger?: {
     /**
      * Trigger type classification (Manual, TimeBased, EventDriven)
@@ -1340,6 +1341,7 @@ model ScheduleEntityRequestResponse {
      * Type-specific configuration properties for trigger behavior
      */
     @doc("Type-specific trigger configuration properties")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
     typeProperties: {
       /**
        * Time zone identifier for schedule evaluation (e.g., 'UTC', 'America/New_York')
@@ -1365,6 +1367,7 @@ model ScheduleEntityRequestResponse {
    * Execution scope defining the data products and assets targeted for quality scanning
    */
   @doc("Execution scope for data quality scanning")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   scope?: {
     /**
      * Collection of data product and asset pairs that define the scanning boundary
@@ -1413,6 +1416,7 @@ model ScheduleEntityRequestResponse {
    * Reference to the parent business domain that governs this schedule
    */
   @doc("Reference to the governing business domain")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   businessDomain?: {
     /**
      * Reference type classification for business domain
@@ -2423,6 +2427,7 @@ model DataSourceEntity {
    * Reference to the business domain that governs this data source.
    */
   @doc("Business domain governance reference for this data source.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   businessDomain?: {
     /**
      * Type classification for the business domain reference.
@@ -2475,6 +2480,7 @@ model DataSourceEntity {
    * Authentication credential information for accessing the data source.
    */
   @doc("Authentication credential configuration for data source access.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   credential?: {
     /**
      * Type of credential (e.g., ServicePrincipal, ManagedIdentity, UsernamePassword).
@@ -2499,6 +2505,7 @@ model DataSourceEntity {
    * Consolidated configuration properties covering all supported data source types.
    */
   @doc("Combined configuration properties for all supported data source platforms.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   typeProperties?: {
     // ---------- Azure SQL ----------
     @doc("Azure SQL server name (for AzureSqlDatabase).")
@@ -2856,6 +2863,7 @@ model ProfileEntity {
    * Type-specific configuration properties including location definitions and access parameters
    */
   @doc("Type-specific profiling configuration properties")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   typeProperties: {
     /**
      * Collection of data location definitions specifying where profiling should be performed
@@ -2893,6 +2901,7 @@ model ProfileEntity {
    * Profiling configuration including key column definitions and analysis parameters
    */
   @doc("Profiling configuration with key columns and parameters")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   configuration: {
     /**
      * Collection of key columns that serve as primary identifiers for profiling analysis

--- a/specification/storage/data-plane/BlobStorage/Common/models.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/models.tsp
@@ -2738,6 +2738,7 @@ alias BodyParameter = {
 /** The multipart body parameter. */
 alias MultipartBodyParameter = {
   /** The body of the request. */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   @multipartBody body: {
     body: HttpPart<bytes>;
   };

--- a/specification/storagemover/StorageMover.Management/models.tsp
+++ b/specification/storagemover/StorageMover.Management/models.tsp
@@ -775,6 +775,7 @@ model JobDefinitionProperties {
    * The list of cloud endpoints to migrate.
    */
   @added(Versions.v2025_07_01)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline model to avoid breaking changes."
   sourceTargetMap?: {
     @visibility(Lifecycle.Read)
     @added(Versions.v2025_07_01)


### PR DESCRIPTION
Update all existing `no-unnamed-union` and `no-unnamed-types` suppressions to use the new rule name `@azure-tools/typespec-azure-core/no-unnamed-types`, and add suppressions for newly detected violations.

Companion to: https://github.com/Azure/typespec-azure/pull/4880