### PR TITLE
Expose Batch data-plane LRO option models as public in Python client

### DIFF
--- a/specification/batch/data-plane/Batch/client.tsp
+++ b/specification/batch/data-plane/Batch/client.tsp
@@ -330,6 +330,11 @@ interface BatchClient {
 @@clientName(BatchClient.getNodeFile, "download_node_file", "python");
 
 @@clientName(BatchClient.listSubTasks, "list_subtasks", "python");
+// Re-export LRO option models so they are public in azure.batch.models
+@@access(Azure.Batch.BatchJobTerminateOptions, Access.public, "python");
+@@access(Azure.Batch.BatchNodeDeallocateOptions, Access.public, "python");
+@@access(Azure.Batch.BatchNodeRebootOptions, Access.public, "python");
+@@access(Azure.Batch.BatchNodeReimageOptions, Access.public, "python");
 // Python LRO private methods
 @@access(Azure.Batch.Pools.removeNodes, Access.internal, "python");
 @@clientName(BatchClient.removeNodes, "removeNodesInternal", "python");


### PR DESCRIPTION
Adds Python client customizations (@@access ... public) to re-export the Batch data-plane long-running-operation option models (BatchJobTerminateOptions, BatchNodeDeallocateOptions, BatchNodeRebootOptions, BatchNodeReimageOptions) so they are public in zure.batch.models.

Spec-only change: touches only client.tsp; no wire contract or API surface change. The referenced models already exist in main.