### PR TITLE
[Event Hubs] Add 2026-07-01-preview API version

### DIFF
--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/FabricShortcut.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/FabricShortcut.tsp
@@ -1,0 +1,225 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./Eventhub.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using Azure.Core;
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+namespace Microsoft.EventHub;
+
+/**
+ * A Microsoft Fabric shortcut attached to an Event Hub.
+ */
+@added(Versions.v2026_07_01_preview)
+@parentResource(Eventhub)
+model FabricShortcut
+  is Azure.ResourceManager.ProxyResource<FabricShortcutProperties> {
+  ...ResourceNameParameter<
+    Resource = FabricShortcut,
+    KeyName = "fabricShortcutName",
+    SegmentName = "fabricShortcuts",
+    NamePattern = ""
+  >;
+
+  /**
+   * The geo-location where the resource lives.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "The service returns the parent namespace location in the existing ARM resource envelope."
+  @visibility(Lifecycle.Read)
+  location?: string;
+}
+
+/**
+ * Properties of a Microsoft Fabric shortcut.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "The service does not expose a provisioning state for this proxy resource."
+@added(Versions.v2026_07_01_preview)
+model FabricShortcutProperties {
+  /**
+   * Microsoft Fabric workspace and artifact configuration.
+   */
+  configuration: FabricShortcutConfiguration;
+
+  /**
+   * The type of the shortcut.
+   */
+  shortcutType?: FabricShortcutType;
+
+  /**
+   * The current shortcut status. Only Pending can be supplied on create or update.
+   */
+  shortcutStatus?: FabricShortcutStatus;
+
+  /**
+   * A description of the current shortcut status.
+   */
+  @visibility(Lifecycle.Read)
+  statusDescription?: string;
+
+  /**
+   * The UTC time when the shortcut was created.
+   */
+  @visibility(Lifecycle.Read)
+  createdAt?: utcDateTime;
+
+  /**
+   * The UTC time when the shortcut was last modified.
+   */
+  @visibility(Lifecycle.Read)
+  modifiedAt?: utcDateTime;
+}
+
+/**
+ * Microsoft Fabric workspace and artifact configuration.
+ */
+@added(Versions.v2026_07_01_preview)
+model FabricShortcutConfiguration {
+  /**
+   * The Microsoft Fabric tenant ID.
+   */
+  tenantId: uuid;
+
+  /**
+   * The Microsoft Fabric workspace ID.
+   */
+  workspaceId: uuid;
+
+  /**
+   * The Microsoft Fabric artifact ID.
+   */
+  artifactId: uuid;
+
+  /**
+   * The Microsoft Fabric premium capacity ID.
+   */
+  premiumCapacityId?: string;
+
+  /**
+   * The resource ID of the Log Analytics workspace.
+   */
+  logAnalyticsResourceId?: string;
+
+  /**
+   * The Microsoft Fabric workspace name.
+   */
+  workspaceName?: string;
+
+  /**
+   * The Microsoft Fabric artifact name.
+   */
+  artifactName?: string;
+}
+
+/**
+ * The type of Microsoft Fabric shortcut.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service validates the value against this fixed set and rejects unknown values."
+@added(Versions.v2026_07_01_preview)
+union FabricShortcutType {
+  /**
+   * An entity shortcut.
+   */
+  Entity: "Entity",
+
+  /**
+   * A network shortcut.
+   */
+  Network: "Network",
+}
+
+/**
+ * The status of a Microsoft Fabric shortcut.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service validates the value against this fixed set and rejects unknown values."
+@added(Versions.v2026_07_01_preview)
+union FabricShortcutStatus {
+  /**
+   * The shortcut is awaiting approval.
+   */
+  Pending: "Pending",
+
+  /**
+   * The shortcut is approved.
+   */
+  Approved: "Approved",
+
+  /**
+   * The shortcut is rejected.
+   */
+  Rejected: "Rejected",
+}
+
+@added(Versions.v2026_07_01_preview)
+@armResourceOperations
+interface FabricShortcuts {
+  /**
+   * Gets a Microsoft Fabric shortcut.
+   */
+  get is ArmResourceRead<FabricShortcut, Error = ErrorResponse>;
+
+  /**
+   * Creates or updates a Microsoft Fabric shortcut.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "The service returns 200 for both create and update."
+  createOrUpdate is ArmResourceCreateOrReplaceSync<
+    FabricShortcut,
+    Response = ArmResourceUpdatedResponse<FabricShortcut>,
+    Error = ErrorResponse
+  >;
+
+  /**
+   * Lists Microsoft Fabric shortcuts for an Event Hub.
+   */
+  listByEventHub is ArmResourceListByParent<
+    FabricShortcut,
+    Error = ErrorResponse
+  >;
+
+  /**
+   * Deletes a Microsoft Fabric shortcut.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-delete-operation-response-codes" "The service returns 200 when the shortcut is deleted."
+  delete is ArmResourceDeleteSync<
+    FabricShortcut,
+    Response = ArmDeletedResponse,
+    Error = ErrorResponse
+  >;
+
+  /**
+   * Approves a Microsoft Fabric shortcut.
+   */
+  @action("approve")
+  approve is ArmResourceActionSync<
+    FabricShortcut,
+    void,
+    ArmResponse<FabricShortcut>,
+    Error = ErrorResponse
+  >;
+
+  /**
+   * Rejects a Microsoft Fabric shortcut.
+   */
+  @action("reject")
+  reject is ArmResourceActionSync<
+    FabricShortcut,
+    void,
+    ArmResponse<FabricShortcut>,
+    Error = ErrorResponse
+  >;
+}
+
+@@doc(FabricShortcut.name, "The Microsoft Fabric shortcut name.");
+@@doc(
+  FabricShortcut.properties,
+  "Properties of the Microsoft Fabric shortcut."
+);
+@@doc(
+  FabricShortcuts.createOrUpdate::parameters.resource,
+  "The Microsoft Fabric shortcut."
+);

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/FabricShortcut.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/FabricShortcut.tsp
@@ -24,13 +24,13 @@ model FabricShortcut
     Resource = FabricShortcut,
     KeyName = "fabricShortcutName",
     SegmentName = "fabricShortcuts",
-    NamePattern = ""
+    NamePattern = "^.+$"
   >;
 
   /**
    * The geo-location where the resource lives.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "The service returns the parent namespace location in the existing ARM resource envelope."
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "The backend resource model returns location as a read-only top-level ARM envelope property, not as a Fabric shortcut property."
   @visibility(Lifecycle.Read)
   location?: string;
 }
@@ -38,7 +38,7 @@ model FabricShortcut
 /**
  * Properties of a Microsoft Fabric shortcut.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "The service does not expose a provisioning state for this proxy resource."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "The synchronous backend contract does not define or return provisioningState; shortcut lifecycle is reported through the read-only shortcutStatus property."
 @added(Versions.v2026_07_01_preview)
 model FabricShortcutProperties {
   /**
@@ -103,7 +103,11 @@ model FabricShortcutConfiguration {
   /**
    * The resource ID of the Log Analytics workspace.
    */
-  logAnalyticsResourceId?: string;
+  logAnalyticsResourceId?: armResourceIdentifier<[
+    {
+      type: "Microsoft.OperationalInsights/workspaces";
+    }
+  ]>;
 
   /**
    * The Microsoft Fabric workspace name.

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
@@ -1,0 +1,215 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./Cluster.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+namespace Microsoft.EventHub;
+
+/**
+ * Upgrade preferences for an Event Hubs Dedicated cluster.
+ */
+@added(Versions.v2026_07_01_preview)
+@singleton("default")
+@parentResource(Cluster)
+model UpgradePreferences
+  is Azure.ResourceManager.ProxyResource<UpgradePreferencesProperties> {
+  ...ResourceNameParameter<
+    Resource = UpgradePreferences,
+    KeyName = "upgradePreferencesName",
+    SegmentName = "upgradePreferences",
+    NamePattern = ""
+  >;
+}
+
+/**
+ * Upgrade preference properties for an Event Hubs Dedicated cluster.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "The service does not expose a provisioning state for this proxy resource."
+@added(Versions.v2026_07_01_preview)
+model UpgradePreferencesProperties {
+  /**
+   * Recurring weekly maintenance windows in UTC. At least one window must be supplied when preferences are created or updated. A maximum of two windows can be configured, and their combined duration must be at least 16 hours per week.
+   */
+  @minItems(1)
+  @maxItems(2)
+  @identifiers(#[])
+  maintenanceWindows?: MaintenanceWindow[];
+
+  /**
+   * Date-specific exceptions to the recurring maintenance windows.
+   */
+  @identifiers(#[])
+  exceptionWindows?: ExceptionWindow[];
+
+  /**
+   * The current cluster upgrade status.
+   */
+  @visibility(Lifecycle.Read)
+  upgradeStatus?: UpgradeStatus;
+}
+
+/**
+ * A recurring weekly maintenance window in UTC.
+ */
+@added(Versions.v2026_07_01_preview)
+model MaintenanceWindow {
+  /**
+   * The UTC day of the week on which the maintenance window starts.
+   */
+  dayOfWeek: UpgradePreferenceDayOfWeek;
+
+  /**
+   * The UTC time of day at which the maintenance window starts, represented as an ISO 8601 duration since midnight.
+   */
+  startTimeOfDay: duration;
+
+  /**
+   * The maintenance window duration in minutes. The value must be between 480 and 1440 in 60-minute increments.
+   */
+  @minValue(480)
+  @maxValue(1440)
+  durationMinutes: int32;
+}
+
+/**
+ * A date-specific exception to the recurring maintenance windows.
+ */
+@added(Versions.v2026_07_01_preview)
+model ExceptionWindow {
+  /**
+   * The UTC date on which the exception starts.
+   */
+  date: plainDate;
+
+  /**
+   * Whether the exception blocks or allows upgrades.
+   */
+  action: ExceptionWindowAction;
+
+  /**
+   * The UTC time of day at which the exception starts, represented as an ISO 8601 duration since midnight.
+   */
+  startTimeOfDay: duration;
+
+  /**
+   * The exception duration in minutes. Allow exceptions must be between 480 and 1440 minutes in 60-minute increments. Block exceptions must be 1440 minutes.
+   */
+  @minValue(480)
+  @maxValue(1440)
+  durationMinutes: int32;
+}
+
+/**
+ * The current upgrade orchestration state for the cluster.
+ */
+@added(Versions.v2026_07_01_preview)
+model UpgradeStatus {
+  /**
+   * Whether at least one deferred upgrade is waiting for the cluster.
+   */
+  pendingUpgrade: boolean;
+
+  /**
+   * Whether an upgrade-now override is currently active.
+   */
+  inProgress: boolean;
+
+  /**
+   * The estimated UTC time when the current upgrade will complete.
+   */
+  completesAt?: utcDateTime;
+}
+
+/**
+ * A day of the week.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service validates the value against this fixed set and rejects unknown values."
+@added(Versions.v2026_07_01_preview)
+union UpgradePreferenceDayOfWeek {
+  /** Sunday. */
+  Sunday: "Sunday",
+
+  /** Monday. */
+  Monday: "Monday",
+
+  /** Tuesday. */
+  Tuesday: "Tuesday",
+
+  /** Wednesday. */
+  Wednesday: "Wednesday",
+
+  /** Thursday. */
+  Thursday: "Thursday",
+
+  /** Friday. */
+  Friday: "Friday",
+
+  /** Saturday. */
+  Saturday: "Saturday",
+}
+
+/**
+ * The action performed by an exception window.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service validates the value against this fixed set and rejects unknown values."
+@added(Versions.v2026_07_01_preview)
+union ExceptionWindowAction {
+  /**
+   * Prevent upgrades during the exception window.
+   */
+  Block: "Block",
+
+  /**
+   * Allow upgrades during the exception window.
+   */
+  Allow: "Allow",
+}
+
+#suppress "@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation" "Upgrade preferences are a singleton resource that does not support deletion."
+@added(Versions.v2026_07_01_preview)
+@armResourceOperations
+interface UpgradePreferencesOperations {
+  /**
+   * Gets the upgrade preferences for an Event Hubs Dedicated cluster.
+   */
+  get is ArmResourceRead<UpgradePreferences, Error = ErrorResponse>;
+
+  /**
+   * Creates or updates the upgrade preferences for an Event Hubs Dedicated cluster.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "The service returns 200 for both create and update."
+  createOrUpdate is ArmResourceCreateOrReplaceSync<
+    UpgradePreferences,
+    Response = ArmResourceUpdatedResponse<UpgradePreferences>,
+    Error = ErrorResponse
+  >;
+
+  /**
+   * Starts an immediate eight-hour upgrade override when an upgrade is pending.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-post-operation-response-codes" "The service returns 200 when an upgrade starts and 204 when no upgrade is pending."
+  @action("upgradeNow")
+  upgradeNow is ArmResourceActionSync<
+    UpgradePreferences,
+    void,
+    ArmResponse<UpgradePreferences> | NoContentResponse,
+    Error = ErrorResponse
+  >;
+}
+
+@@doc(UpgradePreferences.name, "The upgrade preferences resource name.");
+@@doc(
+  UpgradePreferences.properties,
+  "Upgrade preference properties for the Event Hubs Dedicated cluster."
+);
+@@doc(
+  UpgradePreferencesOperations.createOrUpdate::parameters.resource,
+  "The upgrade preferences."
+);

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
@@ -24,7 +24,7 @@ model UpgradePreferences
     Resource = UpgradePreferences,
     KeyName = "upgradePreferencesName",
     SegmentName = "upgradePreferences",
-    NamePattern = ""
+    NamePattern = "^default$"
   >;
 }
 

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/UpgradePreferences.tsp
@@ -133,25 +133,25 @@ model UpgradeStatus {
 #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service validates the value against this fixed set and rejects unknown values."
 @added(Versions.v2026_07_01_preview)
 union UpgradePreferenceDayOfWeek {
-  /** Sunday. */
+  /** The maintenance window occurs on Sunday. */
   Sunday: "Sunday",
 
-  /** Monday. */
+  /** The maintenance window occurs on Monday. */
   Monday: "Monday",
 
-  /** Tuesday. */
+  /** The maintenance window occurs on Tuesday. */
   Tuesday: "Tuesday",
 
-  /** Wednesday. */
+  /** The maintenance window occurs on Wednesday. */
   Wednesday: "Wednesday",
 
-  /** Thursday. */
+  /** The maintenance window occurs on Thursday. */
   Thursday: "Thursday",
 
-  /** Friday. */
+  /** The maintenance window occurs on Friday. */
   Friday: "Friday",
 
-  /** Saturday. */
+  /** The maintenance window occurs on Saturday. */
   Saturday: "Saturday",
 }
 

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupCreate.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "parameters": {
+      "properties": {
+        "clientAppGroupIdentifier": "SASKeyName=KeyName",
+        "isEnabled": true,
+        "policies": [
+          {
+            "name": "ThrottlingPolicy1",
+            "type": "ThrottlingPolicy",
+            "metricId": "IncomingMessages",
+            "rateLimitThreshold": 7912
+          },
+          {
+            "name": "ThrottlingPolicy2",
+            "type": "ThrottlingPolicy",
+            "metricId": "IncomingBytes",
+            "rateLimitThreshold": 3951729
+          },
+          {
+            "name": "ThrottlingPolicy3",
+            "type": "ThrottlingPolicy",
+            "metricId": "OutgoingBytes",
+            "rateLimitThreshold": 245175
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appGroup1",
+        "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "clientAppGroupIdentifier": "SASKeyName=KeyName",
+          "isEnabled": true,
+          "policies": [
+            {
+              "name": "ThrottlingPolicy1",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingMessages",
+              "rateLimitThreshold": 7912
+            },
+            {
+              "name": "ThrottlingPolicy2",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingBytes",
+              "rateLimitThreshold": 3951729
+            },
+            {
+              "name": "ThrottlingPolicy3",
+              "type": "ThrottlingPolicy",
+              "metricId": "OutgoingBytes",
+              "rateLimitThreshold": 245175
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_CreateOrUpdateApplicationGroup",
+  "title": "ApplicationGroupCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ApplicationGroup_Delete",
+  "title": "ApplicationGroupDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appGroup1",
+        "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "clientAppGroupIdentifier": "SASKeyName=KeyName",
+          "isEnabled": true,
+          "policies": [
+            {
+              "name": "ThrottlingPolicy1",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingMessages",
+              "rateLimitThreshold": 7912
+            },
+            {
+              "name": "ThrottlingPolicy2",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingBytes",
+              "rateLimitThreshold": 3951729
+            },
+            {
+              "name": "ThrottlingPolicy3",
+              "type": "ThrottlingPolicy",
+              "metricId": "OutgoingBytes",
+              "rateLimitThreshold": 245175
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_Get",
+  "title": "ApplicationGroupGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupListByNamespace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ApplicationGroup/ApplicationGroupListByNamespace.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "appGroup1",
+            "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "clientAppGroupIdentifier": "SASKeyName=KeyName",
+              "isEnabled": true,
+              "policies": [
+                {
+                  "name": "ThrottlingPolicy1",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingMessages",
+                  "rateLimitThreshold": 7912
+                },
+                {
+                  "name": "ThrottlingPolicy2",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingBytes",
+                  "rateLimitThreshold": 3951729
+                },
+                {
+                  "name": "ThrottlingPolicy3",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "OutgoingBytes",
+                  "rateLimitThreshold": 245175
+                }
+              ]
+            }
+          },
+          {
+            "name": "appGroup2",
+            "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup2",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "clientAppGroupIdentifier": "AADAppID=Guid",
+              "isEnabled": false,
+              "policies": [
+                {
+                  "name": "ThrottlingPolicy1",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingMessages",
+                  "rateLimitThreshold": 9984
+                },
+                {
+                  "name": "ThrottlingPolicy2",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingBytes",
+                  "rateLimitThreshold": 7823412
+                },
+                {
+                  "name": "ThrottlingPolicy3",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "OutgoingBytes",
+                  "rateLimitThreshold": 331665
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_ListByNamespace",
+  "title": "ListApplicationGroups"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Clusters_Delete",
+  "title": "ClusterDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Clusters_Get",
+  "title": "ClusterGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterPatch.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterPatch.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "location": "South Central US",
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-06-01T21:37:04.46Z",
+          "metricId": "SN6-008",
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-06-01T21:37:53.413Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-06-01T21:37:04.46Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-06-01T21:37:53.413Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Clusters_Update",
+  "title": "ClusterPatch"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterPut.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterPut.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "location": "South Central US",
+      "sku": {
+        "name": "Dedicated",
+        "capacity": 1
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 1
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 1
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Clusters_CreateOrUpdate",
+  "title": "ClusterPut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterQuotaConfigurationGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterQuotaConfigurationGet.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    }
+  },
+  "operationId": "Configuration_Get",
+  "title": "ClustersQuotasConfigurationGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterQuotaConfigurationPatch.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClusterQuotaConfigurationPatch.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "settings": {
+        "eventhub-per-namespace-quota": "20",
+        "namespaces-per-cluster-quota": "200"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Configuration_Patch",
+  "title": "ClustersQuotasConfigurationPatch"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClustersListByResourceGroup.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClustersListByResourceGroup.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testCluster",
+            "type": "Microsoft.EventHub/Clusters",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/clusters/testCluster",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T23:17:25.24Z",
+              "metricId": "SN6-008",
+              "updatedAt": "2016-09-13T23:17:28.223Z"
+            },
+            "sku": {
+              "name": "Dedicated",
+              "capacity": 4
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListByResourceGroup",
+  "title": "ClustersListByResourceGroup"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClustersListBySubscription.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ClustersListBySubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testCluster",
+            "type": "Microsoft.EventHub/Clusters",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/clusters/testCluster",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T23:17:25.24Z",
+              "metricId": "SN6-008",
+              "updatedAt": "2016-09-13T23:17:28.223Z"
+            },
+            "sku": {
+              "name": "Dedicated",
+              "capacity": 4
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListBySubscription",
+  "title": "ClustersListBySubscription"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ListAvailableClustersGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ListAvailableClustersGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "location": "westus"
+          },
+          {
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListAvailableClusterRegion",
+  "title": "ListAvailableClusters"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ListNamespacesInClusterGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/ListNamespacesInClusterGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/namespaces/rrama-int7-ns1"
+          },
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/namespaces/rrama-ehns2-int7"
+          },
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.EventHub/namespaces/db3-rrama-foo1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListNamespaces",
+  "title": "ListNamespacesInCluster"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesCreateOrUpdate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesCreateOrUpdate.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resource": {
+      "properties": {
+        "exceptionWindows": [
+          {
+            "action": "Allow",
+            "date": "2026-08-22",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT4H"
+          }
+        ],
+        "maintenanceWindows": [
+          {
+            "dayOfWeek": "Saturday",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT2H"
+          },
+          {
+            "dayOfWeek": "Sunday",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT2H"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "exceptionWindows": [
+            {
+              "action": "Allow",
+              "date": "2026-08-22",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT4H"
+            }
+          ],
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT2H"
+            },
+            {
+              "dayOfWeek": "Sunday",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "inProgress": false,
+            "pendingUpgrade": false
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    }
+  },
+  "operationId": "UpgradePreferencesOperations_CreateOrUpdate",
+  "title": "Create or update cluster upgrade preferences"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesGet.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "exceptionWindows": [
+            {
+              "action": "Block",
+              "date": "2026-08-15",
+              "durationMinutes": 1440,
+              "startTimeOfDay": "PT0S"
+            }
+          ],
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 960,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "completesAt": "2026-07-02T20:00:00Z",
+            "inProgress": true,
+            "pendingUpgrade": true
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    }
+  },
+  "operationId": "UpgradePreferencesOperations_Get",
+  "title": "Get cluster upgrade preferences"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesUpgradeNow.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/Clusters/UpgradePreferencesUpgradeNow.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 960,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "completesAt": "2026-07-02T20:00:00Z",
+            "inProgress": true,
+            "pendingUpgrade": true
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "UpgradePreferencesOperations_UpgradeNow",
+  "title": "Start an upgrade immediately"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupCreate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "parameters": {
+      "properties": {
+        "userMetadata": "New consumergroup"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-ConsumerGroup-5563",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-ConsumerGroup-5563",
+        "properties": {
+          "createdAt": "2017-05-25T03:43:09.4536234Z",
+          "updatedAt": "2017-05-25T03:43:09.4536234Z"
+        }
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_CreateOrUpdate",
+  "title": "ConsumerGroupCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ConsumerGroups_Delete",
+  "title": "ConsumerGroupDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupGet.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-ConsumerGroup-5563",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-ConsumerGroup-5563",
+        "properties": {
+          "createdAt": "2017-05-25T03:43:08.7152556Z",
+          "updatedAt": "2017-05-25T03:43:08.7152556Z"
+        }
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_Get",
+  "title": "ConsumerGroupGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupListByEventHub.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/ConsumerGroup/EHConsumerGroupListByEventHub.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "$Default",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/$Default",
+            "properties": {
+              "createdAt": "2017-05-25T03:42:52.287Z",
+              "updatedAt": "2017-05-25T03:42:52.287Z"
+            }
+          },
+          {
+            "name": "sdk-consumergroup-5563",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-consumergroup-5563",
+            "properties": {
+              "createdAt": "2017-05-25T03:43:09.314Z",
+              "updatedAt": "2017-05-25T03:43:09.314Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_ListByEventHub",
+  "title": "ConsumerGroupsListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EHOperations_List.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EHOperations_List.json
@@ -1,0 +1,215 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.EventHub/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/register/action",
+            "display": {
+              "operation": "Registers the EventHub Resource Provider",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/read",
+            "display": {
+              "operation": "Get Namespace Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Namespace Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Namespace Authorization Rule",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "Get Namespace Listkeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/write",
+            "display": {
+              "operation": "Create or Update EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/read",
+            "display": {
+              "operation": "Get EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/Delete",
+            "display": {
+              "operation": "Delete EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/read",
+            "display": {
+              "operation": " Get EventHub Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update EventHub Authorization Rule",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/delete",
+            "display": {
+              "operation": "Delete EventHub Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List EventHub keys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/write",
+            "display": {
+              "operation": "Create or Update ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+            "display": {
+              "operation": "Get ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/Delete",
+            "display": {
+              "operation": "Delete ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "EHOperations_List"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-2513",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdateAuthorizationRule",
+  "title": "EventHubAuthorizationRuleCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EventHubs_DeleteAuthorizationRule",
+  "title": "EventHubAuthorizationRuleDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-2513",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_GetAuthorizationRule",
+  "title": "EventHubAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Authrules-2513",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventHubs_ListAuthorizationRules",
+  "title": "EventHubAuthorizationRuleListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-2513",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-960.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-2513;SharedAccessKey=############################################;EntityPath=sdk-EventHub-532",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-960.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-2513;SharedAccessKey=############################################;EntityPath=sdk-EventHub-532",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "EventHubs_ListKeys",
+  "title": "EventHubAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleRegenerateKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1534",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-namespace-960",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-1534",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-9027.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1534;SharedAccessKey=#############################################;EntityPath=sdk-EventHub-1647",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-9027.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1534;SharedAccessKey=#############################################;EntityPath=sdk-EventHub-1647",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "EventHubs_RegenerateKeys",
+  "title": "EventHubAuthorizationRuleRegenerateKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubCreate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "partitionCount": 4,
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 7,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Delete",
+            "retentionTimeInHours": 168
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EventHubs_Delete",
+  "title": "EventHubDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubGet.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-10",
+    "namespaceName": "sdk-Namespace-716",
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "messageRetentionInDays": 4,
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Compact",
+            "retentionTimeInHours": 96,
+            "tombstoneRetentionTimeInHours": 1
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_Get",
+  "title": "EventHubGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubListByNameSpace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubListByNameSpace.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-eventhub-10",
+    "namespaceName": "sdk-Namespace-5357",
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-eventhub-10",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs",
+            "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-eventhub-10",
+            "properties": {
+              "captureDescription": {
+                "destination": {
+                  "name": "EventHubArchive.AzureBlockBlob",
+                  "properties": {
+                    "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                    "blobContainer": "container",
+                    "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+                  }
+                },
+                "enabled": true,
+                "encoding": "Avro",
+                "intervalInSeconds": 120,
+                "sizeLimitInBytes": 10485763
+              },
+              "createdAt": "2017-06-28T02:45:55.877Z",
+              "messageRetentionInDays": 4,
+              "partitionCount": 4,
+              "partitionIds": [
+                "0",
+                "1",
+                "2",
+                "3"
+              ],
+              "retentionDescription": {
+                "cleanupPolicy": "Delete",
+                "retentionTimeInHours": 96,
+                "tombstoneRetentionTimeInHours": 1
+              },
+              "status": "Active",
+              "updatedAt": "2017-06-28T02:46:05.877Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventHubs_ListByNamespace",
+  "title": "EventHubsListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithCompactPolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithCompactPolicyCreate.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "Compact",
+          "minCompactionLagTimeInMinutes": 10,
+          "tombstoneRetentionTimeInHours": 1
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Compact",
+            "minCompactionLagTimeInMinutes": 10,
+            "retentionTimeInHours": -1,
+            "tombstoneRetentionTimeInHours": 1
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithCompactPolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithDeleteOrCompactPolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithDeleteOrCompactPolicyCreate.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "DeleteOrCompact",
+          "retentionTimeInHours": 24
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "DeleteOrCompact",
+            "retentionTimeInHours": 24
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithDeleteOrCompactPolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithDeletePolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/EventHubs/EHEventHubWithDeletePolicyCreate.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "Delete",
+          "retentionTimeInHours": 24
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Delete",
+            "retentionTimeInHours": 24
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithDeletePolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutApprove.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutApprove.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Approved",
+          "shortcutType": "Entity",
+          "statusDescription": "Approved by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Approve",
+  "title": "Approve a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutCreate.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resource": {
+      "properties": {
+        "configuration": {
+          "artifactId": "33333333-3333-3333-3333-333333333333",
+          "artifactName": "orders-eventstream",
+          "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+          "tenantId": "11111111-1111-1111-1111-111111111111",
+          "workspaceId": "22222222-2222-2222-2222-222222222222",
+          "workspaceName": "contoso-workspace"
+        },
+        "shortcutStatus": "Pending",
+        "shortcutType": "Entity"
+      }
+    },
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:00:00Z",
+          "shortcutStatus": "Pending",
+          "shortcutType": "Entity",
+          "statusDescription": "Pending approval"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_CreateOrUpdate",
+  "title": "Create or update a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "FabricShortcuts_Delete",
+  "title": "Delete a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Approved",
+          "shortcutType": "Entity",
+          "statusDescription": "Approved by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Get",
+  "title": "Get a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+            "location": "southcentralus",
+            "name": "orders-shortcut",
+            "properties": {
+              "configuration": {
+                "artifactId": "33333333-3333-3333-3333-333333333333",
+                "artifactName": "orders-eventstream",
+                "tenantId": "11111111-1111-1111-1111-111111111111",
+                "workspaceId": "22222222-2222-2222-2222-222222222222",
+                "workspaceName": "contoso-workspace"
+              },
+              "createdAt": "2026-07-01T12:00:00Z",
+              "modifiedAt": "2026-07-01T12:05:00Z",
+              "shortcutStatus": "Approved",
+              "shortcutType": "Entity",
+              "statusDescription": "Approved by the Event Hubs owner"
+            },
+            "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_ListByEventHub",
+  "title": "List Fabric shortcuts for an Event Hub"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutReject.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/FabricShortcuts/FabricShortcutReject.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Rejected",
+          "shortcutType": "Entity",
+          "statusDescription": "Rejected by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Reject",
+  "title": "Reject a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-1746",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules/sdk-Authrules-1746",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-8929",
+    "namespaceName": "sdk-Namespace-8980",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-1746",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules/sdk-Authrules-1746",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules?api-version=2017-04-01/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1746",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules?api-version=2017-04-01/sdk-Authrules-1746",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "ListAuthorizationRules"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-1746",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-2702.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1746;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-2702.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1746;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-8929",
+    "namespaceName": "sdk-Namespace-8980",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-8929",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-8980.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-8929;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-8980.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-8929;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "NameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceCheckNameAvailability.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "parameters": {
+      "name": "sdk-Namespace-8458"
+    },
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "NamespacesCheckNameAvailability"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceCreate.json
@@ -1,0 +1,200 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {},
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": [
+            {
+              "identity": {
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+              },
+              "keyName": "Samplekey",
+              "keyVaultUri": "https://aprao-keyvault-user.vault-int.azure-int.net/"
+            }
+          ]
+        },
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        }
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "NameSpaceDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceGet.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "privateEndpointConnectionName",
+              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+              "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample/privateEndpointConnections/privateEndpointConnectionName",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.Network/privateEndpoints/NamespaceSample"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443",
+          "updatedAt": "2021-01-30T00:30:55.143Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "NameSpaceGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceList.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NamespaceSample",
+            "type": "Microsoft.EventHub/Namespaces",
+            "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+            "identity": {
+              "type": "SystemAssigned, UserAssigned",
+              "principalId": "PrincipalIdGUID",
+              "tenantId": "TenantIdGUID",
+              "userAssignedIdentities": {
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+                  "clientId": "ClientIdGUID",
+                  "principalId": "PrincipalIdGUID"
+                },
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+                  "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+                  "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+                }
+              }
+            },
+            "location": "East US",
+            "properties": {
+              "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+              "createdAt": "2021-01-30T00:28:38.963Z",
+              "disableLocalAuth": false,
+              "encryption": {
+                "keySource": "Microsoft.KeyVault",
+                "keyVaultProperties": [
+                  {
+                    "identity": {
+                      "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                    },
+                    "keyName": "Samplekey",
+                    "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                    "keyVersion": ""
+                  }
+                ],
+                "requireInfrastructureEncryption": false
+              },
+              "isAutoInflateEnabled": false,
+              "maximumThroughputUnits": 0,
+              "metricId": "MetricGUID:NamespaceSample",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+              "updatedAt": "2021-01-30T00:30:55.143Z",
+              "zoneRedundant": false
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 0,
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "NamespacesListBySubscription"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceListByResourceGroup.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceListByResourceGroup.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NamespaceSample",
+            "type": "Microsoft.EventHub/Namespaces",
+            "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+            "identity": {
+              "type": "SystemAssigned, UserAssigned",
+              "principalId": "PrincipalIdGUID",
+              "tenantId": "TenantIdGUID",
+              "userAssignedIdentities": {
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+                  "clientId": "ClientIdGUID",
+                  "principalId": "PrincipalIdGUID"
+                },
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+                  "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+                  "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+                }
+              }
+            },
+            "location": "East US",
+            "properties": {
+              "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+              "createdAt": "2021-01-30T00:28:38.963Z",
+              "disableLocalAuth": false,
+              "encryption": {
+                "keySource": "Microsoft.KeyVault",
+                "keyVaultProperties": [
+                  {
+                    "identity": {
+                      "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                    },
+                    "keyName": "Samplekey",
+                    "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                    "keyVersion": ""
+                  }
+                ],
+                "requireInfrastructureEncryption": false
+              },
+              "isAutoInflateEnabled": false,
+              "maximumThroughputUnits": 0,
+              "metricId": "MetricGUID:NamespaceSample",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+              "updatedAt": "2021-01-30T00:30:55.143Z",
+              "zoneRedundant": false
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "NamespaceListByResourceGroup"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceUpdate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNameSpaceUpdate.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": null
+        }
+      },
+      "location": "East US"
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "ActivatingIdentity",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-01-30T00:31:13.657Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US",
+        "tags": {},
+        "identity": {
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            }
+          }
+        },
+        "properties": {
+          "isAutoInflateEnabled": false,
+          "disableLocalAuth": false,
+          "maximumThroughputUnits": 0,
+          "zoneRedundant": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": "",
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                }
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "provisioningState": "ActivatingIdentity",
+          "metricId": "MetricGUID:NamespaceSample",
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "updatedAt": "2021-01-30T00:31:13.657Z",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "Location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "NamespacesUpdate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNamespaceCreateWithIpAddressTypeDualStack.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNamespaceCreateWithIpAddressTypeDualStack.json
@@ -1,0 +1,212 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {},
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": [
+            {
+              "identity": {
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+              },
+              "keyName": "Samplekey",
+              "keyVaultUri": "https://aprao-keyvault-user.vault-int.azure-int.net/"
+            }
+          ]
+        },
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "ipAddressType": "DualStack",
+        "publicNetworkAccess": "Enabled"
+      },
+      "sku": {
+        "name": "Standard",
+        "capacity": 1,
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceCreateWithIpAddressTypeDualStack"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNamespaceFailover.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/EHNamespaceFailover.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRFailoverSample",
+    "parameters": {
+      "properties": {
+        "force": true,
+        "primaryLocation": "centralus"
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/EHNamespaceFailover/eastus?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Failover",
+  "title": "NameSpaceCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NamespaceWithGeoDRCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NamespaceWithGeoDRCreate.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRCreateSample",
+    "parameters": {
+      "location": "East US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "westus",
+              "roleType": "Secondary"
+            },
+            {
+              "locationName": "centralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 60
+        }
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceGeoDRCreateSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceGeoDRCreateSample",
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "replicaState": "Active",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "westus",
+                "replicaState": "Active",
+                "roleType": "Secondary"
+              },
+              {
+                "locationName": "centralus",
+                "replicaState": "Creating",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 60
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceGeoDRCreateSample",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceGeoDRCreateSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceGeoDRCreateSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceGeoDRCreateSample",
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "replicaState": "Active",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "westus",
+                "replicaState": "Active",
+                "roleType": "Secondary"
+              },
+              {
+                "locationName": "centralus",
+                "replicaState": "Creating",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 60
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceGeoDRCreateSample",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceGeoDRCreateSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceWithGeoDRCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resourceAssociation1",
+        "type": "Microsoft.EventHub/Namespaces/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "devProfile",
+            "accessRules": [
+              {
+                "name": "inVpnRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "10"
+          },
+          "provisioningState": "Updating",
+          "resourceAssociation": {
+            "name": "association1",
+            "accessMode": "EnforcedMode"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+  "title": "NetworkSecurityPerimeterConfigurationassociationProxyName"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resourceAssociation1",
+            "type": "Microsoft.EventHub/Namespaces/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "devProfile",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "10"
+              },
+              "provisioningState": "Updating",
+              "resourceAssociation": {
+                "name": "association1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfiguration_List",
+  "title": "NamspaceNetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_CreateOrUpdate",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionCreate.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-8396/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-2847"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "testing",
+          "status": "Rejected"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "privateEndpointConnectionName": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateEndpointConnectionName",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/privateEndpointConnectionName",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-7182/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/privateEndpointConnections/5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-7182/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5705-new"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "PrivateEndPointConnectionList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateLinkResourcesGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/PrivateLinkResourcesGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.EventHub/namespaces/privateLinkResources",
+            "id": "subscriptions/subID/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.EventHub.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetCreate.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "virtualNetworkRules": [
+          {
+            "ignoreMissingVnetServiceEndpoint": true,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetGet.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/subscriptionid/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+            "id": "/subscriptions/subscriptionid/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+            "properties": {
+              "defaultAction": "Deny",
+              "ipRules": [
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.1"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.2"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.3"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.4"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.5"
+                }
+              ],
+              "virtualNetworkRules": [
+                {
+                  "ignoreMissingVnetServiceEndpoint": true,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryCreate.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "parameters": {
+      "properties": {
+        "groupProperties": {},
+        "schemaCompatibility": "Forward",
+        "schemaType": "Avro"
+      }
+    },
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testSchemaGroup1",
+        "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+        "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+          "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+          "groupProperties": {},
+          "schemaCompatibility": "Forward",
+          "schemaType": "Avro",
+          "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+        }
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_CreateOrUpdate",
+  "title": "SchemaRegistryCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "SchemaRegistry_Delete",
+  "title": "SchemaRegistryDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testSchemaGroup1",
+        "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+        "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+          "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+          "groupProperties": {},
+          "schemaCompatibility": "Forward",
+          "schemaType": "Avro",
+          "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+        }
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_Get",
+  "title": "SchemaRegistryGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryListByNamespace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/SchemaRegistry/SchemaRegistryListByNamespace.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testSchemaGroup1",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+              "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+              "groupProperties": {},
+              "schemaCompatibility": "Forward",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+            }
+          },
+          {
+            "name": "testSchemaGroup2",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup2",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:10:33.6974319Z",
+              "eTag": "d01173a4-08c5-43c9-b30f-d9666196a907",
+              "groupProperties": {},
+              "schemaCompatibility": "None",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:10:33.6974319Z"
+            }
+          },
+          {
+            "name": "testSchemaGroup3",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup3",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:13:30.8938585Z",
+              "eTag": "2c1c3d08-2fb8-4a4e-91f4-6e8b940c1b7c",
+              "groupProperties": {},
+              "schemaCompatibility": "Backward",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:13:30.8938585Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_ListByNamespace",
+  "title": "SchemaRegistryListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4879",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-4879",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-4879",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleListAll.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1067",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1067",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1684",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1684",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-4879",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+  "title": "ListAuthorizationRules"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aliasPrimaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "aliasSecondaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "keyName": "sdk-Authrules-1746",
+        "primaryKey": "############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasBreakPairing.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasBreakPairing.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_BreakPairing",
+  "title": "EHAliasBreakPairing"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasCheckNameAvailability.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasCheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "parameters": {
+      "name": "sdk-DisasterRecovery-9474"
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+  "title": "NamespacesCheckNameAvailability"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasCreate.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "parameters": {
+      "properties": {
+        "partnerNamespace": "sdk-Namespace-37"
+      }
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleResourceGroup/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleResourceGroup/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+  "title": "EHAliasCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5849",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_Delete",
+  "title": "EHAliasDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasFailOver.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasFailOver.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_FailOver",
+  "title": "EHAliasFailOver"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-37/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-8859",
+          "pendingReplicationOperationsCount": 0,
+          "provisioningState": "Accepted",
+          "role": "Secondary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_Get",
+  "title": "EHAliasGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/examples/2026-07-01-preview/disasterRecoveryConfigs/EHAliasList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-DisasterRecovery-3814",
+            "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+            "properties": {
+              "partnerNamespace": "sdk-Namespace-37",
+              "provisioningState": "Accepted",
+              "role": "Primary"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_List",
+  "title": "EHAliasList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/main.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/main.tsp
@@ -24,6 +24,8 @@ import "./Eventhub.tsp";
 import "./ConsumerGroup.tsp";
 import "./SchemaGroup.tsp";
 import "./ApplicationGroup.tsp";
+import "./FabricShortcut.tsp";
+import "./UpgradePreferences.tsp";
 import "./routes.tsp";
 import "./client.tsp";
 
@@ -56,6 +58,11 @@ enum Versions {
    * The 2026-01-01 API version.
    */
   v2026_01_01: "2026-01-01",
+
+  /**
+   * The 2026-07-01-preview API version.
+   */
+  v2026_07_01_preview: "2026-07-01-preview",
 }
 
 interface Operations

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupCreate.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "parameters": {
+      "properties": {
+        "clientAppGroupIdentifier": "SASKeyName=KeyName",
+        "isEnabled": true,
+        "policies": [
+          {
+            "name": "ThrottlingPolicy1",
+            "type": "ThrottlingPolicy",
+            "metricId": "IncomingMessages",
+            "rateLimitThreshold": 7912
+          },
+          {
+            "name": "ThrottlingPolicy2",
+            "type": "ThrottlingPolicy",
+            "metricId": "IncomingBytes",
+            "rateLimitThreshold": 3951729
+          },
+          {
+            "name": "ThrottlingPolicy3",
+            "type": "ThrottlingPolicy",
+            "metricId": "OutgoingBytes",
+            "rateLimitThreshold": 245175
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appGroup1",
+        "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "clientAppGroupIdentifier": "SASKeyName=KeyName",
+          "isEnabled": true,
+          "policies": [
+            {
+              "name": "ThrottlingPolicy1",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingMessages",
+              "rateLimitThreshold": 7912
+            },
+            {
+              "name": "ThrottlingPolicy2",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingBytes",
+              "rateLimitThreshold": 3951729
+            },
+            {
+              "name": "ThrottlingPolicy3",
+              "type": "ThrottlingPolicy",
+              "metricId": "OutgoingBytes",
+              "rateLimitThreshold": 245175
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_CreateOrUpdateApplicationGroup",
+  "title": "ApplicationGroupCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ApplicationGroup_Delete",
+  "title": "ApplicationGroupDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "applicationGroupName": "appGroup1",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appGroup1",
+        "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "clientAppGroupIdentifier": "SASKeyName=KeyName",
+          "isEnabled": true,
+          "policies": [
+            {
+              "name": "ThrottlingPolicy1",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingMessages",
+              "rateLimitThreshold": 7912
+            },
+            {
+              "name": "ThrottlingPolicy2",
+              "type": "ThrottlingPolicy",
+              "metricId": "IncomingBytes",
+              "rateLimitThreshold": 3951729
+            },
+            {
+              "name": "ThrottlingPolicy3",
+              "type": "ThrottlingPolicy",
+              "metricId": "OutgoingBytes",
+              "rateLimitThreshold": 245175
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_Get",
+  "title": "ApplicationGroupGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupListByNamespace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ApplicationGroup/ApplicationGroupListByNamespace.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "contoso-ua-test-eh-system-1",
+    "resourceGroupName": "contosotest",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "appGroup1",
+            "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup1",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "clientAppGroupIdentifier": "SASKeyName=KeyName",
+              "isEnabled": true,
+              "policies": [
+                {
+                  "name": "ThrottlingPolicy1",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingMessages",
+                  "rateLimitThreshold": 7912
+                },
+                {
+                  "name": "ThrottlingPolicy2",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingBytes",
+                  "rateLimitThreshold": 3951729
+                },
+                {
+                  "name": "ThrottlingPolicy3",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "OutgoingBytes",
+                  "rateLimitThreshold": 245175
+                }
+              ]
+            }
+          },
+          {
+            "name": "appGroup2",
+            "type": "Microsoft.EventHub/Namespaces/ApplicationGroups",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contosotest/providers/Microsoft.EventHub/namespaces/contoso-ua-test-eh-system-1/applicationgroups/appGroup2",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "clientAppGroupIdentifier": "AADAppID=Guid",
+              "isEnabled": false,
+              "policies": [
+                {
+                  "name": "ThrottlingPolicy1",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingMessages",
+                  "rateLimitThreshold": 9984
+                },
+                {
+                  "name": "ThrottlingPolicy2",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "IncomingBytes",
+                  "rateLimitThreshold": 7823412
+                },
+                {
+                  "name": "ThrottlingPolicy3",
+                  "type": "ThrottlingPolicy",
+                  "metricId": "OutgoingBytes",
+                  "rateLimitThreshold": 331665
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ApplicationGroup_ListByNamespace",
+  "title": "ListApplicationGroups"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Clusters_Delete",
+  "title": "ClusterDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Clusters_Get",
+  "title": "ClusterGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterPatch.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterPatch.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "location": "South Central US",
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-06-01T21:37:04.46Z",
+          "metricId": "SN6-008",
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-06-01T21:37:53.413Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-06-01T21:37:04.46Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-06-01T21:37:53.413Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 4
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Clusters_Update",
+  "title": "ClusterPatch"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterPut.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterPut.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "location": "South Central US",
+      "sku": {
+        "name": "Dedicated",
+        "capacity": 1
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 1
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCluster",
+        "type": "Microsoft.EventHub/Clusters",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/clusters/testCluster",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-24T23:23:27.877Z",
+          "metricId": "SN6-008",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "updatedAt": "2017-05-24T23:23:27.877Z"
+        },
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 1
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Clusters_CreateOrUpdate",
+  "title": "ClusterPut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterQuotaConfigurationGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterQuotaConfigurationGet.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    }
+  },
+  "operationId": "Configuration_Get",
+  "title": "ClustersQuotasConfigurationGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterQuotaConfigurationPatch.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClusterQuotaConfigurationPatch.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "parameters": {
+      "settings": {
+        "eventhub-per-namespace-quota": "20",
+        "namespaces-per-cluster-quota": "200"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "settings": {
+          "eventhub-per-namespace-quota": "20",
+          "namespaces-per-cluster-quota": "200"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Configuration_Patch",
+  "title": "ClustersQuotasConfigurationPatch"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClustersListByResourceGroup.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClustersListByResourceGroup.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testCluster",
+            "type": "Microsoft.EventHub/Clusters",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/clusters/testCluster",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T23:17:25.24Z",
+              "metricId": "SN6-008",
+              "updatedAt": "2016-09-13T23:17:28.223Z"
+            },
+            "sku": {
+              "name": "Dedicated",
+              "capacity": 4
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListByResourceGroup",
+  "title": "ClustersListByResourceGroup"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClustersListBySubscription.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ClustersListBySubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testCluster",
+            "type": "Microsoft.EventHub/Clusters",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/clusters/testCluster",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T23:17:25.24Z",
+              "metricId": "SN6-008",
+              "updatedAt": "2016-09-13T23:17:28.223Z"
+            },
+            "sku": {
+              "name": "Dedicated",
+              "capacity": 4
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListBySubscription",
+  "title": "ClustersListBySubscription"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ListAvailableClustersGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ListAvailableClustersGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "location": "westus"
+          },
+          {
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListAvailableClusterRegion",
+  "title": "ListAvailableClusters"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ListNamespacesInClusterGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/ListNamespacesInClusterGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "testCluster",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/namespaces/rrama-int7-ns1"
+          },
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-EventHub-SouthCentralUS/providers/Microsoft.EventHub/namespaces/rrama-ehns2-int7"
+          },
+          {
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.EventHub/namespaces/db3-rrama-foo1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clusters_ListNamespaces",
+  "title": "ListNamespacesInCluster"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesCreateOrUpdate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesCreateOrUpdate.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resource": {
+      "properties": {
+        "exceptionWindows": [
+          {
+            "action": "Allow",
+            "date": "2026-08-22",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT4H"
+          }
+        ],
+        "maintenanceWindows": [
+          {
+            "dayOfWeek": "Saturday",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT2H"
+          },
+          {
+            "dayOfWeek": "Sunday",
+            "durationMinutes": 480,
+            "startTimeOfDay": "PT2H"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "exceptionWindows": [
+            {
+              "action": "Allow",
+              "date": "2026-08-22",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT4H"
+            }
+          ],
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT2H"
+            },
+            {
+              "dayOfWeek": "Sunday",
+              "durationMinutes": 480,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "inProgress": false,
+            "pendingUpgrade": false
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    }
+  },
+  "operationId": "UpgradePreferencesOperations_CreateOrUpdate",
+  "title": "Create or update cluster upgrade preferences"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesGet.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "exceptionWindows": [
+            {
+              "action": "Block",
+              "date": "2026-08-15",
+              "durationMinutes": 1440,
+              "startTimeOfDay": "PT0S"
+            }
+          ],
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 960,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "completesAt": "2026-07-02T20:00:00Z",
+            "inProgress": true,
+            "pendingUpgrade": true
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    }
+  },
+  "operationId": "UpgradePreferencesOperations_Get",
+  "title": "Get cluster upgrade preferences"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesUpgradeNow.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/Clusters/UpgradePreferencesUpgradeNow.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "clusterName": "contoso-cluster",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/clusters/contoso-cluster/upgradePreferences/default",
+        "name": "default",
+        "properties": {
+          "maintenanceWindows": [
+            {
+              "dayOfWeek": "Saturday",
+              "durationMinutes": 960,
+              "startTimeOfDay": "PT2H"
+            }
+          ],
+          "upgradeStatus": {
+            "completesAt": "2026-07-02T20:00:00Z",
+            "inProgress": true,
+            "pendingUpgrade": true
+          }
+        },
+        "type": "Microsoft.EventHub/clusters/upgradePreferences"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "UpgradePreferencesOperations_UpgradeNow",
+  "title": "Start an upgrade immediately"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupCreate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "parameters": {
+      "properties": {
+        "userMetadata": "New consumergroup"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-ConsumerGroup-5563",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-ConsumerGroup-5563",
+        "properties": {
+          "createdAt": "2017-05-25T03:43:09.4536234Z",
+          "updatedAt": "2017-05-25T03:43:09.4536234Z"
+        }
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_CreateOrUpdate",
+  "title": "ConsumerGroupCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ConsumerGroups_Delete",
+  "title": "ConsumerGroupDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupGet.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "consumerGroupName": "sdk-ConsumerGroup-5563",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-ConsumerGroup-5563",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-ConsumerGroup-5563",
+        "properties": {
+          "createdAt": "2017-05-25T03:43:08.7152556Z",
+          "updatedAt": "2017-05-25T03:43:08.7152556Z"
+        }
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_Get",
+  "title": "ConsumerGroupGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupListByEventHub.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/ConsumerGroup/EHConsumerGroupListByEventHub.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6681",
+    "namespaceName": "sdk-Namespace-2661",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "$Default",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/$Default",
+            "properties": {
+              "createdAt": "2017-05-25T03:42:52.287Z",
+              "updatedAt": "2017-05-25T03:42:52.287Z"
+            }
+          },
+          {
+            "name": "sdk-consumergroup-5563",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/ConsumerGroups",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2661/eventhubs/sdk-EventHub-6681/consumergroups/sdk-consumergroup-5563",
+            "properties": {
+              "createdAt": "2017-05-25T03:43:09.314Z",
+              "updatedAt": "2017-05-25T03:43:09.314Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConsumerGroups_ListByEventHub",
+  "title": "ConsumerGroupsListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EHOperations_List.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EHOperations_List.json
@@ -1,0 +1,215 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.EventHub/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/register/action",
+            "display": {
+              "operation": "Registers the EventHub Resource Provider",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/read",
+            "display": {
+              "operation": "Get Namespace Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Namespace Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Namespace Authorization Rule",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "Get Namespace Listkeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/write",
+            "display": {
+              "operation": "Create or Update EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/read",
+            "display": {
+              "operation": "Get EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/Delete",
+            "display": {
+              "operation": "Delete EventHub",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/read",
+            "display": {
+              "operation": " Get EventHub Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update EventHub Authorization Rule",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/delete",
+            "display": {
+              "operation": "Delete EventHub Authorization Rules",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List EventHub keys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "EventHub AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/write",
+            "display": {
+              "operation": "Create or Update ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+            "display": {
+              "operation": "Get ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/Delete",
+            "display": {
+              "operation": "Delete ConsumerGroup",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "ConsumerGroup"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.EventHub/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure EventHub",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "EHOperations_List"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-2513",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdateAuthorizationRule",
+  "title": "EventHubAuthorizationRuleCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EventHubs_DeleteAuthorizationRule",
+  "title": "EventHubAuthorizationRuleDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-2513",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_GetAuthorizationRule",
+  "title": "EventHubAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-Namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Authrules-2513",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-960/eventhubs/sdk-EventHub-532/authorizationRules/sdk-Authrules-2513",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventHubs_ListAuthorizationRules",
+  "title": "EventHubAuthorizationRuleListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-2513",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-namespace-960",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-2513",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-960.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-2513;SharedAccessKey=############################################;EntityPath=sdk-EventHub-532",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-960.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-2513;SharedAccessKey=############################################;EntityPath=sdk-EventHub-532",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "EventHubs_ListKeys",
+  "title": "EventHubAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleRegenerateKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1534",
+    "eventHubName": "sdk-EventHub-532",
+    "namespaceName": "sdk-namespace-960",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-1534",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-9027.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1534;SharedAccessKey=#############################################;EntityPath=sdk-EventHub-1647",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-9027.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1534;SharedAccessKey=#############################################;EntityPath=sdk-EventHub-1647",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "EventHubs_RegenerateKeys",
+  "title": "EventHubAuthorizationRuleRegenerateKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubCreate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "partitionCount": 4,
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 7,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Delete",
+            "retentionTimeInHours": 168
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EventHubs_Delete",
+  "title": "EventHubDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubGet.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-10",
+    "namespaceName": "sdk-Namespace-716",
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "messageRetentionInDays": 4,
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Compact",
+            "retentionTimeInHours": 96,
+            "tombstoneRetentionTimeInHours": 1
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_Get",
+  "title": "EventHubGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubListByNameSpace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubListByNameSpace.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-eventhub-10",
+    "namespaceName": "sdk-Namespace-5357",
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-eventhub-10",
+            "type": "Microsoft.EventHub/Namespaces/EventHubs",
+            "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-eventhub-10",
+            "properties": {
+              "captureDescription": {
+                "destination": {
+                  "name": "EventHubArchive.AzureBlockBlob",
+                  "properties": {
+                    "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                    "blobContainer": "container",
+                    "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+                  }
+                },
+                "enabled": true,
+                "encoding": "Avro",
+                "intervalInSeconds": 120,
+                "sizeLimitInBytes": 10485763
+              },
+              "createdAt": "2017-06-28T02:45:55.877Z",
+              "messageRetentionInDays": 4,
+              "partitionCount": 4,
+              "partitionIds": [
+                "0",
+                "1",
+                "2",
+                "3"
+              ],
+              "retentionDescription": {
+                "cleanupPolicy": "Delete",
+                "retentionTimeInHours": 96,
+                "tombstoneRetentionTimeInHours": 1
+              },
+              "status": "Active",
+              "updatedAt": "2017-06-28T02:46:05.877Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventHubs_ListByNamespace",
+  "title": "EventHubsListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithCompactPolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithCompactPolicyCreate.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "Compact",
+          "minCompactionLagTimeInMinutes": 10,
+          "tombstoneRetentionTimeInHours": 1
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Compact",
+            "minCompactionLagTimeInMinutes": 10,
+            "retentionTimeInHours": -1,
+            "tombstoneRetentionTimeInHours": 1
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithCompactPolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithDeleteOrCompactPolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithDeleteOrCompactPolicyCreate.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "DeleteOrCompact",
+          "retentionTimeInHours": 24
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "DeleteOrCompact",
+            "retentionTimeInHours": 24
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithDeleteOrCompactPolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithDeletePolicyCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/EventHubs/EHEventHubWithDeletePolicyCreate.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "sdk-EventHub-6547",
+    "namespaceName": "sdk-Namespace-5357",
+    "parameters": {
+      "properties": {
+        "captureDescription": {
+          "destination": {
+            "name": "EventHubArchive.AzureBlockBlob",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+            },
+            "properties": {
+              "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+              "blobContainer": "container",
+              "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+            }
+          },
+          "enabled": true,
+          "encoding": "Avro",
+          "intervalInSeconds": 120,
+          "sizeLimitInBytes": 10485763
+        },
+        "messageRetentionInDays": 4,
+        "messageTimestampDescription": {
+          "timestampType": "LogAppend"
+        },
+        "partitionCount": 4,
+        "retentionDescription": {
+          "cleanupPolicy": "Delete",
+          "retentionTimeInHours": 24
+        },
+        "status": "Active",
+        "userMetadata": "key"
+      }
+    },
+    "resourceGroupName": "Default-NotificationHubs-AustraliaEast",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-EventHub-10",
+        "type": "Microsoft.EventHub/Namespaces/EventHubs",
+        "id": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-NotificationHubs-AustraliaEast/providers/Microsoft.EventHub/namespaces/sdk-Namespace-716/eventhubs/sdk-EventHub-10",
+        "properties": {
+          "captureDescription": {
+            "destination": {
+              "name": "EventHubArchive.AzureBlockBlob",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2"
+              },
+              "properties": {
+                "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                "blobContainer": "container",
+                "storageAccountResourceId": "/subscriptions/e2f361f0-3b27-4503-a9cc-21cfba380093/resourceGroups/Default-Storage-SouthCentralUS/providers/Microsoft.ClassicStorage/storageAccounts/arjunteststorage"
+              }
+            },
+            "enabled": true,
+            "encoding": "Avro",
+            "intervalInSeconds": 120,
+            "sizeLimitInBytes": 10485763
+          },
+          "createdAt": "2017-06-28T02:45:55.877Z",
+          "identifier": "identifierIDGUID",
+          "messageRetentionInDays": 4,
+          "messageTimestampDescription": {
+            "timestampType": "LogAppend"
+          },
+          "partitionCount": 4,
+          "partitionIds": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "retentionDescription": {
+            "cleanupPolicy": "Delete",
+            "retentionTimeInHours": 24
+          },
+          "status": "Active",
+          "updatedAt": "2017-06-28T02:46:05.877Z",
+          "userMetadata": "key"
+        }
+      }
+    }
+  },
+  "operationId": "EventHubs_CreateOrUpdate",
+  "title": "EHEventHubWithDeletePolicyCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutApprove.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutApprove.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Approved",
+          "shortcutType": "Entity",
+          "statusDescription": "Approved by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Approve",
+  "title": "Approve a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutCreate.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resource": {
+      "properties": {
+        "configuration": {
+          "artifactId": "33333333-3333-3333-3333-333333333333",
+          "artifactName": "orders-eventstream",
+          "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+          "tenantId": "11111111-1111-1111-1111-111111111111",
+          "workspaceId": "22222222-2222-2222-2222-222222222222",
+          "workspaceName": "contoso-workspace"
+        },
+        "shortcutStatus": "Pending",
+        "shortcutType": "Entity"
+      }
+    },
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:00:00Z",
+          "shortcutStatus": "Pending",
+          "shortcutType": "Entity",
+          "statusDescription": "Pending approval"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_CreateOrUpdate",
+  "title": "Create or update a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "FabricShortcuts_Delete",
+  "title": "Delete a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "premiumCapacityId": "44444444-4444-4444-4444-444444444444",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Approved",
+          "shortcutType": "Entity",
+          "statusDescription": "Approved by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Get",
+  "title": "Get a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+            "location": "southcentralus",
+            "name": "orders-shortcut",
+            "properties": {
+              "configuration": {
+                "artifactId": "33333333-3333-3333-3333-333333333333",
+                "artifactName": "orders-eventstream",
+                "tenantId": "11111111-1111-1111-1111-111111111111",
+                "workspaceId": "22222222-2222-2222-2222-222222222222",
+                "workspaceName": "contoso-workspace"
+              },
+              "createdAt": "2026-07-01T12:00:00Z",
+              "modifiedAt": "2026-07-01T12:05:00Z",
+              "shortcutStatus": "Approved",
+              "shortcutType": "Entity",
+              "statusDescription": "Approved by the Event Hubs owner"
+            },
+            "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_ListByEventHub",
+  "title": "List Fabric shortcuts for an Event Hub"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutReject.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/FabricShortcuts/FabricShortcutReject.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "eventHubName": "orders",
+    "fabricShortcutName": "orders-shortcut",
+    "namespaceName": "contoso-eventhub",
+    "resourceGroupName": "contoso-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.EventHub/namespaces/contoso-eventhub/eventhubs/orders/fabricShortcuts/orders-shortcut",
+        "location": "southcentralus",
+        "name": "orders-shortcut",
+        "properties": {
+          "configuration": {
+            "artifactId": "33333333-3333-3333-3333-333333333333",
+            "artifactName": "orders-eventstream",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "workspaceId": "22222222-2222-2222-2222-222222222222",
+            "workspaceName": "contoso-workspace"
+          },
+          "createdAt": "2026-07-01T12:00:00Z",
+          "modifiedAt": "2026-07-01T12:05:00Z",
+          "shortcutStatus": "Rejected",
+          "shortcutType": "Entity",
+          "statusDescription": "Rejected by the Event Hubs owner"
+        },
+        "type": "Microsoft.EventHub/namespaces/eventhubs/fabricShortcuts"
+      }
+    }
+  },
+  "operationId": "FabricShortcuts_Reject",
+  "title": "Reject a Fabric shortcut"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-1746",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules/sdk-Authrules-1746",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-8929",
+    "namespaceName": "sdk-Namespace-8980",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-1746",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules/sdk-Authrules-1746",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules?api-version=2017-04-01/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1746",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.EventHub/namespaces/sdk-Namespace-2702/AuthorizationRules?api-version=2017-04-01/sdk-Authrules-1746",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "ListAuthorizationRules"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-1746",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-2702.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1746;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-2702.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-1746;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-8929",
+    "namespaceName": "sdk-Namespace-8980",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-Authrules-8929",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-8980.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-8929;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-8980.servicebus.windows-int.net/;SharedAccessKeyName=sdk-Authrules-8929;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "NameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceCheckNameAvailability.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "parameters": {
+      "name": "sdk-Namespace-8458"
+    },
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "NamespacesCheckNameAvailability"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceCreate.json
@@ -1,0 +1,200 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {},
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": [
+            {
+              "identity": {
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+              },
+              "keyName": "Samplekey",
+              "keyVaultUri": "https://aprao-keyvault-user.vault-int.azure-int.net/"
+            }
+          ]
+        },
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        }
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "NameSpaceDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceGet.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "privateEndpointConnectionName",
+              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+              "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample/privateEndpointConnections/privateEndpointConnectionName",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.Network/privateEndpoints/NamespaceSample"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443",
+          "updatedAt": "2021-01-30T00:30:55.143Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "NameSpaceGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceList.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NamespaceSample",
+            "type": "Microsoft.EventHub/Namespaces",
+            "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+            "identity": {
+              "type": "SystemAssigned, UserAssigned",
+              "principalId": "PrincipalIdGUID",
+              "tenantId": "TenantIdGUID",
+              "userAssignedIdentities": {
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+                  "clientId": "ClientIdGUID",
+                  "principalId": "PrincipalIdGUID"
+                },
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+                  "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+                  "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+                }
+              }
+            },
+            "location": "East US",
+            "properties": {
+              "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+              "createdAt": "2021-01-30T00:28:38.963Z",
+              "disableLocalAuth": false,
+              "encryption": {
+                "keySource": "Microsoft.KeyVault",
+                "keyVaultProperties": [
+                  {
+                    "identity": {
+                      "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                    },
+                    "keyName": "Samplekey",
+                    "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                    "keyVersion": ""
+                  }
+                ],
+                "requireInfrastructureEncryption": false
+              },
+              "isAutoInflateEnabled": false,
+              "maximumThroughputUnits": 0,
+              "metricId": "MetricGUID:NamespaceSample",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+              "updatedAt": "2021-01-30T00:30:55.143Z",
+              "zoneRedundant": false
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 0,
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "NamespacesListBySubscription"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceListByResourceGroup.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceListByResourceGroup.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NamespaceSample",
+            "type": "Microsoft.EventHub/Namespaces",
+            "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+            "identity": {
+              "type": "SystemAssigned, UserAssigned",
+              "principalId": "PrincipalIdGUID",
+              "tenantId": "TenantIdGUID",
+              "userAssignedIdentities": {
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+                  "clientId": "ClientIdGUID",
+                  "principalId": "PrincipalIdGUID"
+                },
+                "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+                  "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+                  "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+                }
+              }
+            },
+            "location": "East US",
+            "properties": {
+              "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+              "createdAt": "2021-01-30T00:28:38.963Z",
+              "disableLocalAuth": false,
+              "encryption": {
+                "keySource": "Microsoft.KeyVault",
+                "keyVaultProperties": [
+                  {
+                    "identity": {
+                      "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                    },
+                    "keyName": "Samplekey",
+                    "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                    "keyVersion": ""
+                  }
+                ],
+                "requireInfrastructureEncryption": false
+              },
+              "isAutoInflateEnabled": false,
+              "maximumThroughputUnits": 0,
+              "metricId": "MetricGUID:NamespaceSample",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+              "updatedAt": "2021-01-30T00:30:55.143Z",
+              "zoneRedundant": false
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "NamespaceListByResourceGroup"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceUpdate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNameSpaceUpdate.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": null
+        }
+      },
+      "location": "East US"
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "ActivatingIdentity",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-01-30T00:31:13.657Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US",
+        "tags": {},
+        "identity": {
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            }
+          }
+        },
+        "properties": {
+          "isAutoInflateEnabled": false,
+          "disableLocalAuth": false,
+          "maximumThroughputUnits": 0,
+          "zoneRedundant": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": "",
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                }
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "provisioningState": "ActivatingIdentity",
+          "metricId": "MetricGUID:NamespaceSample",
+          "createdAt": "2021-01-30T00:28:38.963Z",
+          "updatedAt": "2021-01-30T00:31:13.657Z",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "Location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "NamespacesUpdate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNamespaceCreateWithIpAddressTypeDualStack.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNamespaceCreateWithIpAddressTypeDualStack.json
@@ -1,0 +1,212 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceSample",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {},
+          "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": [
+            {
+              "identity": {
+                "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+              },
+              "keyName": "Samplekey",
+              "keyVaultUri": "https://aprao-keyvault-user.vault-int.azure-int.net/"
+            }
+          ]
+        },
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "ipAddressType": "DualStack",
+        "publicNetworkAccess": "Enabled"
+      },
+      "sku": {
+        "name": "Standard",
+        "capacity": 1,
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "PrincipalIdGUID",
+          "tenantId": "TenantIdGUID",
+          "userAssignedIdentities": {
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1": {
+              "clientId": "ClientIdGUID",
+              "principalId": "PrincipalIdGUID"
+            },
+            "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud2": {
+              "clientId": "6a35400f-6ccb-4817-8f1a-ce19ea4523bc",
+              "principalId": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": [
+              {
+                "identity": {
+                  "userAssignedIdentity": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ud1"
+                },
+                "keyName": "Samplekey",
+                "keyVaultUri": "https://sample-keyvault-user.vault-int.azure-int.net",
+                "keyVersion": ""
+              }
+            ],
+            "requireInfrastructureEncryption": false
+          },
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceSample",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://NamespaceSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceCreateWithIpAddressTypeDualStack"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNamespaceFailover.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/EHNamespaceFailover.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRFailoverSample",
+    "parameters": {
+      "properties": {
+        "force": true,
+        "primaryLocation": "centralus"
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/EHNamespaceFailover/eastus?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Failover",
+  "title": "NameSpaceCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NamespaceWithGeoDRCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NamespaceWithGeoDRCreate.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRCreateSample",
+    "parameters": {
+      "location": "East US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "westus",
+              "roleType": "Secondary"
+            },
+            {
+              "locationName": "centralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 60
+        }
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "SampleSubscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "NamespaceGeoDRCreateSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceGeoDRCreateSample",
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "replicaState": "Active",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "westus",
+                "replicaState": "Active",
+                "roleType": "Secondary"
+              },
+              {
+                "locationName": "centralus",
+                "replicaState": "Creating",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 60
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceGeoDRCreateSample",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceGeoDRCreateSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "NamespaceGeoDRCreateSample",
+        "type": "Microsoft.EventHub/Namespaces",
+        "id": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceGeoDRCreateSample",
+        "location": "East US",
+        "properties": {
+          "clusterArmId": "/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/clusters/enc-test",
+          "createdAt": "2021-02-16T22:36:06.107Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "replicaState": "Active",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "westus",
+                "replicaState": "Active",
+                "roleType": "Secondary"
+              },
+              {
+                "locationName": "centralus",
+                "replicaState": "Creating",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 60
+          },
+          "isAutoInflateEnabled": false,
+          "kafkaEnabled": false,
+          "maximumThroughputUnits": 0,
+          "metricId": "MetricGUID:NamespaceGeoDRCreateSample",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://NamespaceGeoDRCreateSample.servicebus.windows-int.net:443/",
+          "updatedAt": "2021-02-16T22:37:42.29Z",
+          "zoneRedundant": false
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NamespaceWithGeoDRCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resourceAssociation1",
+        "type": "Microsoft.EventHub/Namespaces/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "devProfile",
+            "accessRules": [
+              {
+                "name": "inVpnRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "10"
+          },
+          "provisioningState": "Updating",
+          "resourceAssociation": {
+            "name": "association1",
+            "accessMode": "EnforcedMode"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+  "title": "NetworkSecurityPerimeterConfigurationassociationProxyName"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resourceAssociation1",
+            "type": "Microsoft.EventHub/Namespaces/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "devProfile",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "10"
+              },
+              "provisioningState": "Updating",
+              "resourceAssociation": {
+                "name": "association1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfiguration_List",
+  "title": "NamspaceNetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_CreateOrUpdate",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionCreate.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-8396/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-2847"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "testing",
+          "status": "Rejected"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "privateEndpointConnectionName": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateEndpointConnectionName",
+        "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateEndpointConnections/privateEndpointConnectionName",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-EventHub-4794",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-7182/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5705-new/privateEndpointConnections/5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-EventHub-7182/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5705-new"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "PrivateEndPointConnectionList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateLinkResourcesGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/PrivateLinkResourcesGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "subID"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.EventHub/namespaces/privateLinkResources",
+            "id": "subscriptions/subID/resourceGroups/SDK-EventHub-4794/providers/Microsoft.EventHub/namespaces/sdk-Namespace-5828/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.EventHub.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetCreate.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "virtualNetworkRules": [
+          {
+            "ignoreMissingVnetServiceEndpoint": true,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetGet.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/subscriptionid/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "Subscription"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventHub/Namespaces/NetworkRuleSet",
+            "id": "/subscriptions/subscriptionid/resourceGroups/resourcegroupid/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9659/networkruleset/default",
+            "properties": {
+              "defaultAction": "Deny",
+              "ipRules": [
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.1"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.2"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.3"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.4"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.5"
+                }
+              ],
+              "virtualNetworkRules": [
+                {
+                  "ignoreMissingVnetServiceEndpoint": true,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/subscriptionid/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryCreate.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "parameters": {
+      "properties": {
+        "groupProperties": {},
+        "schemaCompatibility": "Forward",
+        "schemaType": "Avro"
+      }
+    },
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testSchemaGroup1",
+        "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+        "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+          "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+          "groupProperties": {},
+          "schemaCompatibility": "Forward",
+          "schemaType": "Avro",
+          "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+        }
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_CreateOrUpdate",
+  "title": "SchemaRegistryCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "SchemaRegistry_Delete",
+  "title": "SchemaRegistryDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "schemaGroupName": "testSchemaGroup1",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testSchemaGroup1",
+        "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+        "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+        "location": "EAST US 2 EUAP",
+        "properties": {
+          "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+          "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+          "groupProperties": {},
+          "schemaCompatibility": "Forward",
+          "schemaType": "Avro",
+          "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+        }
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_Get",
+  "title": "SchemaRegistryGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryListByNamespace.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/SchemaRegistry/SchemaRegistryListByNamespace.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "ali-ua-test-eh-system-1",
+    "resourceGroupName": "alitest",
+    "subscriptionId": "e8baea74-64ce-459b-bee3-5aa4c47b3ae3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testSchemaGroup1",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup1",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:08:11.1671879Z",
+              "eTag": "51ddcff4-a287-423c-b194-7a8ebbfd8366",
+              "groupProperties": {},
+              "schemaCompatibility": "Forward",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:08:11.1671879Z"
+            }
+          },
+          {
+            "name": "testSchemaGroup2",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup2",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:10:33.6974319Z",
+              "eTag": "d01173a4-08c5-43c9-b30f-d9666196a907",
+              "groupProperties": {},
+              "schemaCompatibility": "None",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:10:33.6974319Z"
+            }
+          },
+          {
+            "name": "testSchemaGroup3",
+            "type": "Microsoft.EventHub/Namespaces/SchemaGroups",
+            "id": "/subscriptions/e8baea74-64ce-459b-bee3-5aa4c47b3ae3/resourceGroups/alitest/providers/Microsoft.EventHub/namespaces/ali-ua-test-eh-system-1/schemagroups/testSchemaGroup3",
+            "location": "EAST US 2 EUAP",
+            "properties": {
+              "createdAtUtc": "2021-10-13T03:13:30.8938585Z",
+              "eTag": "2c1c3d08-2fb8-4a4e-91f4-6e8b940c1b7c",
+              "groupProperties": {},
+              "schemaCompatibility": "Backward",
+              "schemaType": "Avro",
+              "updatedAtUtc": "2021-10-13T03:13:30.8938585Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SchemaRegistry_ListByNamespace",
+  "title": "SchemaRegistryListAll"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4879",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-4879",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-4879",
+        "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListAll.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListAll.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1067",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1067",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1684",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1684",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-4879",
+            "type": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+  "title": "ListAuthorizationRules"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListKey.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aliasPrimaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "aliasSecondaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "keyName": "sdk-Authrules-1746",
+        "primaryKey": "############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasBreakPairing.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasBreakPairing.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_BreakPairing",
+  "title": "EHAliasBreakPairing"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasCheckNameAvailability.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasCheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "parameters": {
+      "name": "sdk-DisasterRecovery-9474"
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+  "title": "NamespacesCheckNameAvailability"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasCreate.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasCreate.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "parameters": {
+      "properties": {
+        "partnerNamespace": "sdk-Namespace-37"
+      }
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleResourceGroup/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleResourceGroup/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+  "title": "EHAliasCreate"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasDelete.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5849",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_Delete",
+  "title": "EHAliasDelete"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasFailOver.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasFailOver.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_FailOver",
+  "title": "EHAliasFailOver"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasGet.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-37/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-8859",
+          "pendingReplicationOperationsCount": 0,
+          "provisioningState": "Accepted",
+          "role": "Secondary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_Get",
+  "title": "EHAliasGet"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasList.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/EHAliasList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8859",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "exampleSubscriptionId"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-DisasterRecovery-3814",
+            "type": "Microsoft.EventHub/Namespaces/DisasterRecoveryConfig",
+            "id": "/subscriptions/exampleSubscriptionId/resourceGroups/exampleResourceGroup/providers/Microsoft.EventHub/namespaces/sdk-Namespace-8859/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+            "properties": {
+              "partnerNamespace": "sdk-Namespace-37",
+              "provisioningState": "Accepted",
+              "role": "Primary"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_List",
+  "title": "EHAliasList"
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
@@ -1,0 +1,7833 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "EventHubManagementClient",
+    "version": "2026-07-01-preview",
+    "description": "Azure Event Hubs client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Clusters"
+    },
+    {
+      "name": "DisasterRecoveryConfigs"
+    },
+    {
+      "name": "EHNamespaces"
+    },
+    {
+      "name": "NetworkRuleSets"
+    },
+    {
+      "name": "AuthorizationRules"
+    },
+    {
+      "name": "EventHubs"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "ArmDisasterRecoveries"
+    },
+    {
+      "name": "Eventhubs"
+    },
+    {
+      "name": "ConsumerGroups"
+    },
+    {
+      "name": "SchemaGroups"
+    },
+    {
+      "name": "ApplicationGroups"
+    },
+    {
+      "name": "FabricShortcuts"
+    },
+    {
+      "name": "UpgradePreferencesOperations"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.EventHub/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available Event Hub REST API operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHOperations_List": {
+            "$ref": "./examples/EHOperations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/availableClusterRegions": {
+      "get": {
+        "operationId": "Clusters_ListAvailableClusterRegion",
+        "description": "List the quantity of available pre-provisioned Event Hubs Clusters, indexed by Azure region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableClustersList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListAvailableClusters": {
+            "$ref": "./examples/Clusters/ListAvailableClustersGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/checkNameAvailability": {
+      "post": {
+        "operationId": "Namespaces_CheckNameAvailability",
+        "description": "Check the give Namespace name availability.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespacesCheckNameAvailability": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/clusters": {
+      "get": {
+        "operationId": "Clusters_ListBySubscription",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Lists the available Event Hubs Clusters within an ARM resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClustersListBySubscription": {
+            "$ref": "./examples/Clusters/ClustersListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/namespaces": {
+      "get": {
+        "operationId": "Namespaces_List",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Lists all the available Namespaces within a subscription, irrespective of the resource groups.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespacesListBySubscription": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters": {
+      "get": {
+        "operationId": "Clusters_ListByResourceGroup",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Lists the available Event Hubs Clusters within an ARM resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClustersListByResourceGroup": {
+            "$ref": "./examples/Clusters/ClustersListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}": {
+      "get": {
+        "operationId": "Clusters_Get",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Gets the resource description of the specified Event Hubs Cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClusterGet": {
+            "$ref": "./examples/Clusters/ClusterGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Clusters_CreateOrUpdate",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Creates or updates an instance of an Event Hubs Cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for creating a eventhub cluster resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Cluster' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "Resource 'Cluster' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClusterPut": {
+            "$ref": "./examples/Clusters/ClusterPut.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Clusters_Update",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Modifies mutable properties on the Event Hubs Cluster. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The properties of the Event Hubs Cluster which should be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "Resource 'Cluster' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClusterPatch": {
+            "$ref": "./examples/Clusters/ClusterPatch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Clusters_Delete",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Deletes an existing Event Hubs Cluster. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClusterDelete": {
+            "$ref": "./examples/Clusters/ClusterDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/namespaces": {
+      "get": {
+        "operationId": "Clusters_ListNamespaces",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "List all Event Hubs Namespace IDs in an Event Hubs Dedicated Cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespaceIdListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNamespacesInCluster": {
+            "$ref": "./examples/Clusters/ListNamespacesInClusterGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/quotaConfiguration/default": {
+      "get": {
+        "operationId": "Configuration_Get",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Get all Event Hubs Cluster settings - a collection of key/value pairs which represent the quotas and settings imposed on the cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterQuotaConfigurationProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClustersQuotasConfigurationGet": {
+            "$ref": "./examples/Clusters/ClusterQuotaConfigurationGet.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Configuration_Patch",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Replace all specified Event Hubs Cluster settings with those contained in the request body. Leaves the settings not specified in the request body unmodified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for creating an Event Hubs Cluster resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClusterQuotaConfigurationProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterQuotaConfigurationProperties"
+            }
+          },
+          "201": {
+            "description": "Resource 'ClusterQuotaConfigurationProperties' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ClusterQuotaConfigurationProperties"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClustersQuotasConfigurationPatch": {
+            "$ref": "./examples/Clusters/ClusterQuotaConfigurationPatch.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default": {
+      "get": {
+        "operationId": "UpgradePreferencesOperations_Get",
+        "tags": [
+          "UpgradePreferencesOperations"
+        ],
+        "description": "Gets the upgrade preferences for an Event Hubs Dedicated cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UpgradePreferences"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get cluster upgrade preferences": {
+            "$ref": "./examples/Clusters/UpgradePreferencesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "UpgradePreferencesOperations_CreateOrUpdate",
+        "tags": [
+          "UpgradePreferencesOperations"
+        ],
+        "description": "Creates or updates the upgrade preferences for an Event Hubs Dedicated cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The upgrade preferences.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpgradePreferences"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'UpgradePreferences' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/UpgradePreferences"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update cluster upgrade preferences": {
+            "$ref": "./examples/Clusters/UpgradePreferencesCreateOrUpdate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default/upgradeNow": {
+      "post": {
+        "operationId": "UpgradePreferencesOperations_UpgradeNow",
+        "tags": [
+          "UpgradePreferencesOperations"
+        ],
+        "description": "Starts an immediate eight-hour upgrade override when an upgrade is pending.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Event Hubs Cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UpgradePreferences"
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Start an upgrade immediately": {
+            "$ref": "./examples/Clusters/UpgradePreferencesUpgradeNow.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces": {
+      "get": {
+        "operationId": "Namespaces_ListByResourceGroup",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Lists the available Namespaces within a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceListByResourceGroup": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}": {
+      "get": {
+        "operationId": "Namespaces_Get",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Gets the description of the specified namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceGet": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdate",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Creates or updates a namespace. Once created, this namespace's resource manifest is immutable. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for creating a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EHNamespace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'EHNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceCreate": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceCreate.json"
+          },
+          "NamespaceCreateWithIpAddressTypeDualStack": {
+            "$ref": "./examples/NameSpaces/EHNamespaceCreateWithIpAddressTypeDualStack.json"
+          },
+          "NamespaceWithGeoDRCreate": {
+            "$ref": "./examples/NameSpaces/NamespaceWithGeoDRCreate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/EHNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Namespaces_Update",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Creates or updates a namespace. Once created, this namespace's resource manifest is immutable. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for updating a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/EHNamespace"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespacesUpdate": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_Delete",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Deletes an existing namespace. This operation also removes all associated resources under the namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceDelete": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/applicationGroups": {
+      "get": {
+        "operationId": "ApplicationGroup_ListByNamespace",
+        "tags": [
+          "ApplicationGroups"
+        ],
+        "description": "Gets a list of application groups for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListApplicationGroups": {
+            "$ref": "./examples/ApplicationGroup/ApplicationGroupListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/applicationGroups/{applicationGroupName}": {
+      "get": {
+        "operationId": "ApplicationGroup_Get",
+        "tags": [
+          "ApplicationGroups"
+        ],
+        "description": "Gets an ApplicationGroup for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "applicationGroupName",
+            "in": "path",
+            "description": "The Application Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ApplicationGroupGet": {
+            "$ref": "./examples/ApplicationGroup/ApplicationGroupGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ApplicationGroup_CreateOrUpdateApplicationGroup",
+        "tags": [
+          "ApplicationGroups"
+        ],
+        "description": "Creates or updates an ApplicationGroup for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "applicationGroupName",
+            "in": "path",
+            "description": "The Application Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The ApplicationGroup.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ApplicationGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ApplicationGroupCreate": {
+            "$ref": "./examples/ApplicationGroup/ApplicationGroupCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ApplicationGroup_Delete",
+        "tags": [
+          "ApplicationGroups"
+        ],
+        "description": "Deletes an ApplicationGroup for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "applicationGroupName",
+            "in": "path",
+            "description": "The Application Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ApplicationGroupDelete": {
+            "$ref": "./examples/ApplicationGroup/ApplicationGroupDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules": {
+      "get": {
+        "operationId": "Namespaces_ListAuthorizationRules",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Gets a list of authorization rules for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListAuthorizationRules": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "Namespaces_GetAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Gets an AuthorizationRule for a Namespace by rule name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleGet": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Creates or updates an AuthorizationRule for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The shared access AuthorizationRule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleCreate": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_DeleteAuthorizationRule",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Deletes an AuthorizationRule for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleDelete": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "Namespaces_ListKeys",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Gets the primary and secondary connection strings for the Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleListKey": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "Namespaces_RegenerateKeys",
+        "tags": [
+          "AuthorizationRules"
+        ],
+        "description": "Regenerates the primary or secondary connection strings for the specified Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required to regenerate the connection string.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/NameSpaces/EHNameSpaceAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_List",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Gets all Alias(Disaster Recovery configurations)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecoveryListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasList": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_Get",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Retrieves Alias(Disaster Recovery configuration) for primary or secondary namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasGet": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Creates or updates a new Alias(Disaster Recovery configuration)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required to create an Alias(Disaster Recovery configuration)",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ArmDisasterRecovery' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "201": {
+            "description": "Resource 'ArmDisasterRecovery' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasCreate": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DisasterRecoveryConfigs_Delete",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Deletes an Alias(Disaster Recovery configuration)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasDelete": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets a list of authorization rules for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListAuthorizationRules": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets an AuthorizationRule for a Namespace by rule name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleGet": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_ListKeys",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets the primary and secondary connection strings for the Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleListKey": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/breakPairing": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_BreakPairing",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "This operation disables the Disaster Recovery and stops replicating changes from primary to secondary namespaces",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasBreakPairing": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasBreakPairing.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/failover": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_FailOver",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Invokes GEO DR failover and reconfigure the alias to point to the secondary namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHAliasFailOver": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasFailOver.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/checkNameAvailability": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Check the give Namespace name availability.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters to check availability of the given Alias name",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespacesCheckNameAvailability": {
+            "$ref": "./examples/disasterRecoveryConfigs/EHAliasCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs": {
+      "get": {
+        "operationId": "EventHubs_ListByNamespace",
+        "tags": [
+          "Eventhubs"
+        ],
+        "description": "Gets all the Event Hubs in a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EventHubListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubsListAll": {
+            "$ref": "./examples/EventHubs/EHEventHubListByNameSpace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}": {
+      "get": {
+        "operationId": "EventHubs_Get",
+        "tags": [
+          "Eventhubs"
+        ],
+        "description": "Gets an Event Hubs description for the specified Event Hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Eventhub"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubGet": {
+            "$ref": "./examples/EventHubs/EHEventHubGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "EventHubs_CreateOrUpdate",
+        "tags": [
+          "Eventhubs"
+        ],
+        "description": "Creates or updates a new Event Hub as a nested resource within a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create an Event Hub resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Eventhub"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Eventhub' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Eventhub"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EHEventHubCreate": {
+            "$ref": "./examples/EventHubs/EHEventHubCreate.json"
+          },
+          "EHEventHubWithCompactPolicyCreate": {
+            "$ref": "./examples/EventHubs/EHEventHubWithCompactPolicyCreate.json"
+          },
+          "EHEventHubWithDeleteOrCompactPolicyCreate": {
+            "$ref": "./examples/EventHubs/EHEventHubWithDeleteOrCompactPolicyCreate.json"
+          },
+          "EHEventHubWithDeletePolicyCreate": {
+            "$ref": "./examples/EventHubs/EHEventHubWithDeletePolicyCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "EventHubs_Delete",
+        "tags": [
+          "Eventhubs"
+        ],
+        "description": "Deletes an Event Hub from the specified Namespace and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubDelete": {
+            "$ref": "./examples/EventHubs/EHEventHubDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules": {
+      "get": {
+        "operationId": "EventHubs_ListAuthorizationRules",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Gets the authorization rules for an Event Hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleListAll": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "EventHubs_GetAuthorizationRule",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Gets an AuthorizationRule for an Event Hub by rule name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleGet": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "EventHubs_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Creates or updates an AuthorizationRule for the specified Event Hub. Creation/update of the AuthorizationRule will take a few seconds to take effect.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The shared access AuthorizationRule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleCreate": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "EventHubs_DeleteAuthorizationRule",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Deletes an Event Hub AuthorizationRule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleDelete": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "EventHubs_ListKeys",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Gets the ACS and SAS connection strings for the Event Hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleListKey": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "EventHubs_RegenerateKeys",
+        "tags": [
+          "EventHubs"
+        ],
+        "description": "Regenerates the ACS and SAS connection strings for the Event Hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate the AuthorizationRule Keys (PrimaryKey/SecondaryKey).",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventHubAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/EventHubs/EHEventHubAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups": {
+      "get": {
+        "operationId": "ConsumerGroups_ListByEventHub",
+        "tags": [
+          "ConsumerGroups"
+        ],
+        "description": "Gets all the consumer groups in a Namespace. An empty feed is returned if no consumer group exists in the Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConsumerGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConsumerGroupsListAll": {
+            "$ref": "./examples/ConsumerGroup/EHConsumerGroupListByEventHub.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}": {
+      "get": {
+        "operationId": "ConsumerGroups_Get",
+        "tags": [
+          "ConsumerGroups"
+        ],
+        "description": "Gets a description for the specified consumer group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "consumerGroupName",
+            "in": "path",
+            "description": "The consumer group name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConsumerGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConsumerGroupGet": {
+            "$ref": "./examples/ConsumerGroup/EHConsumerGroupGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConsumerGroups_CreateOrUpdate",
+        "tags": [
+          "ConsumerGroups"
+        ],
+        "description": "Creates or updates an Event Hubs consumer group as a nested resource within a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "consumerGroupName",
+            "in": "path",
+            "description": "The consumer group name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update a consumer group resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConsumerGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConsumerGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConsumerGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConsumerGroupCreate": {
+            "$ref": "./examples/ConsumerGroup/EHConsumerGroupCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ConsumerGroups_Delete",
+        "tags": [
+          "ConsumerGroups"
+        ],
+        "description": "Deletes a consumer group from the specified Event Hub and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "consumerGroupName",
+            "in": "path",
+            "description": "The consumer group name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConsumerGroupDelete": {
+            "$ref": "./examples/ConsumerGroup/EHConsumerGroupDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts": {
+      "get": {
+        "operationId": "FabricShortcuts_ListByEventHub",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Lists Microsoft Fabric shortcuts for an Event Hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FabricShortcutListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Fabric shortcuts for an Event Hub": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}": {
+      "get": {
+        "operationId": "FabricShortcuts_Get",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Gets a Microsoft Fabric shortcut.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "fabricShortcutName",
+            "in": "path",
+            "description": "The Microsoft Fabric shortcut name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FabricShortcut"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Fabric shortcut": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FabricShortcuts_CreateOrUpdate",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Creates or updates a Microsoft Fabric shortcut.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "fabricShortcutName",
+            "in": "path",
+            "description": "The Microsoft Fabric shortcut name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The Microsoft Fabric shortcut.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FabricShortcut"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FabricShortcut' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FabricShortcut"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a Fabric shortcut": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FabricShortcuts_Delete",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Deletes a Microsoft Fabric shortcut.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "fabricShortcutName",
+            "in": "path",
+            "description": "The Microsoft Fabric shortcut name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Fabric shortcut": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}/approve": {
+      "post": {
+        "operationId": "FabricShortcuts_Approve",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Approves a Microsoft Fabric shortcut.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "fabricShortcutName",
+            "in": "path",
+            "description": "The Microsoft Fabric shortcut name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FabricShortcut"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Approve a Fabric shortcut": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutApprove.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}/reject": {
+      "post": {
+        "operationId": "FabricShortcuts_Reject",
+        "tags": [
+          "FabricShortcuts"
+        ],
+        "description": "Rejects a Microsoft Fabric shortcut.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "eventHubName",
+            "in": "path",
+            "description": "The Event Hub name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "fabricShortcutName",
+            "in": "path",
+            "description": "The Microsoft Fabric shortcut name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FabricShortcut"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Reject a Fabric shortcut": {
+            "$ref": "./examples/FabricShortcuts/FabricShortcutReject.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/failover": {
+      "post": {
+        "operationId": "Namespaces_Failover",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "GeoDR Failover",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for updating a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FailOver"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceCreate": {
+            "$ref": "./examples/NameSpaces/EHNamespaceFailover.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FailOver"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkRuleSets": {
+      "get": {
+        "operationId": "Namespaces_ListNetworkRuleSet",
+        "tags": [
+          "NetworkRuleSets"
+        ],
+        "description": "Gets NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetList": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkRuleSets/default": {
+      "get": {
+        "operationId": "Namespaces_GetNetworkRuleSet",
+        "tags": [
+          "NetworkRuleSets"
+        ],
+        "description": "Gets NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetGet": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+        "tags": [
+          "NetworkRuleSets"
+        ],
+        "description": "Create or update NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The Namespace IpFilterRule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkRuleSet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetCreate": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/EHNetworkRuleSetCreate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfiguration_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets list of current NetworkSecurityPerimeterConfiguration for Namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamspaceNetworkSecurityPerimeterConfigurationList": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations/{resourceAssociationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Return a NetworkSecurityPerimeterConfigurations resourceAssociationName",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resourceAssociationName",
+            "in": "path",
+            "description": "The ResourceAssociation Name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationassociationProxyName": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations/{resourceAssociationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Refreshes any information about the association.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resourceAssociationName",
+            "in": "path",
+            "description": "The ResourceAssociation Name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationList": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkSecurityPerimeterConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the available PrivateEndpointConnections within a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndPointConnectionList": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets a description for the specified Private Endpoint Connection name.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionGet": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Creates or updates PrivateEndpointConnections of service namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update Status of PrivateEndPoint Connection to namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionCreate": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes an existing namespace. This operation also removes all associated resources under the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionDelete": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_Get",
+        "tags": [
+          "EHNamespaces"
+        ],
+        "description": "Gets lists of resources that supports Privatelinks.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateLinkResourcesGet": {
+            "$ref": "./examples/NameSpaces/PrivateLinkResourcesGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/schemagroups": {
+      "get": {
+        "operationId": "SchemaRegistry_ListByNamespace",
+        "tags": [
+          "SchemaGroups"
+        ],
+        "description": "Gets all the Schema Groups in a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SchemaGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SchemaRegistryListAll": {
+            "$ref": "./examples/SchemaRegistry/SchemaRegistryListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/schemagroups/{schemaGroupName}": {
+      "get": {
+        "operationId": "SchemaRegistry_Get",
+        "tags": [
+          "SchemaGroups"
+        ],
+        "description": "Gets the details of an EventHub schema group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "schemaGroupName",
+            "in": "path",
+            "description": "The Schema Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SchemaGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SchemaRegistryGet": {
+            "$ref": "./examples/SchemaRegistry/SchemaRegistryGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SchemaRegistry_CreateOrUpdate",
+        "tags": [
+          "SchemaGroups"
+        ],
+        "description": "Creates or Updates an EventHub schema group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "schemaGroupName",
+            "in": "path",
+            "description": "The Schema Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create an Event Hub resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SchemaGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SchemaGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SchemaGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SchemaRegistryCreate": {
+            "$ref": "./examples/SchemaRegistry/SchemaRegistryCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SchemaRegistry_Delete",
+        "tags": [
+          "SchemaGroups"
+        ],
+        "description": "Deletes an EventHub schema group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The Namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "schemaGroupName",
+            "in": "path",
+            "description": "The Schema Group name ",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SchemaRegistryDelete": {
+            "$ref": "./examples/SchemaRegistry/SchemaRegistryDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessKeys": {
+      "type": "object",
+      "description": "Namespace/EventHub Connection String",
+      "properties": {
+        "primaryConnectionString": {
+          "type": "string",
+          "description": "Primary connection string of the created namespace AuthorizationRule.",
+          "readOnly": true
+        },
+        "secondaryConnectionString": {
+          "type": "string",
+          "description": "Secondary connection string of the created namespace AuthorizationRule.",
+          "readOnly": true
+        },
+        "aliasPrimaryConnectionString": {
+          "type": "string",
+          "description": "Primary connection string of the alias if GEO DR is enabled",
+          "readOnly": true
+        },
+        "aliasSecondaryConnectionString": {
+          "type": "string",
+          "description": "Secondary  connection string of the alias if GEO DR is enabled",
+          "readOnly": true
+        },
+        "primaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit primary key for signing and validating the SAS token.",
+          "readOnly": true
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit primary key for signing and validating the SAS token.",
+          "readOnly": true
+        },
+        "keyName": {
+          "type": "string",
+          "description": "A string that describes the AuthorizationRule.",
+          "readOnly": true
+        }
+      }
+    },
+    "AccessRights": {
+      "type": "string",
+      "enum": [
+        "Manage",
+        "Send",
+        "Listen"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRights",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Manage",
+            "value": "Manage"
+          },
+          {
+            "name": "Send",
+            "value": "Send"
+          },
+          {
+            "name": "Listen",
+            "value": "Listen"
+          }
+        ]
+      }
+    },
+    "ApplicationGroup": {
+      "type": "object",
+      "description": "The Application Group object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGroupProperties",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ApplicationGroupListResult": {
+      "type": "object",
+      "description": "The response of a ApplicationGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGroupPolicy": {
+      "type": "object",
+      "description": "Properties of the Application Group policy",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Name of this policy"
+        },
+        "type": {
+          "$ref": "#/definitions/ApplicationGroupPolicyType",
+          "description": "Application Group Policy types"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "ApplicationGroupPolicyType": {
+      "type": "string",
+      "description": "Application Group Policy types",
+      "enum": [
+        "ThrottlingPolicy"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGroupPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThrottlingPolicy",
+            "value": "ThrottlingPolicy"
+          }
+        ]
+      }
+    },
+    "ApplicationGroupProperties": {
+      "type": "object",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Determines if Application Group is allowed to create connection with namespace or not. Once the isEnabled is set to false, all the existing connections of application group gets dropped and no new connections will be allowed"
+        },
+        "clientAppGroupIdentifier": {
+          "type": "string",
+          "description": "The Unique identifier for application group.Supports SAS(SASKeyName=KeyName) or AAD(AADAppID=Guid)"
+        },
+        "policies": {
+          "type": "array",
+          "description": "List of group policies that define the behavior of application group. The policies can support resource governance scenarios such as limiting ingress or egress traffic.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGroupPolicy"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "clientAppGroupIdentifier"
+      ]
+    },
+    "ArmDisasterRecovery": {
+      "type": "object",
+      "description": "Single item in List or Get Alias(Disaster Recovery configuration) operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ArmDisasterRecoveryProperties",
+          "description": "Properties required to the Create Or Update Alias(Disaster Recovery configurations)",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ArmDisasterRecoveryListResult": {
+      "type": "object",
+      "description": "The response of a ArmDisasterRecovery list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ArmDisasterRecovery items on this page",
+          "items": {
+            "$ref": "#/definitions/ArmDisasterRecovery"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ArmDisasterRecoveryProperties": {
+      "type": "object",
+      "description": "Properties required to the Create Or Update Alias(Disaster Recovery configurations)",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateDR",
+          "description": "Provisioning state of the Alias(Disaster Recovery configuration) - possible values 'Accepted' or 'Succeeded' or 'Failed'",
+          "readOnly": true
+        },
+        "partnerNamespace": {
+          "type": "string",
+          "description": "ARM Id of the Primary/Secondary eventhub namespace name, which is part of GEO DR pairing"
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Alternate name specified when alias and namespace names are same."
+        },
+        "role": {
+          "$ref": "#/definitions/RoleDisasterRecovery",
+          "description": "role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'",
+          "readOnly": true
+        },
+        "pendingReplicationOperationsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of entities pending to be replicated.",
+          "readOnly": true
+        }
+      }
+    },
+    "AuthorizationRule": {
+      "type": "object",
+      "description": "Single item in a List or Get AuthorizationRule operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthorizationRuleProperties",
+          "description": "Properties supplied to create or update AuthorizationRule",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AuthorizationRuleListResult": {
+      "type": "object",
+      "description": "The response of a AuthorizationRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AuthorizationRule items on this page",
+          "items": {
+            "$ref": "#/definitions/AuthorizationRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthorizationRuleProperties": {
+      "type": "object",
+      "description": "Properties supplied to create or update AuthorizationRule",
+      "properties": {
+        "rights": {
+          "type": "array",
+          "description": "The rights associated with the rule.",
+          "items": {
+            "$ref": "#/definitions/AccessRights"
+          }
+        }
+      },
+      "required": [
+        "rights"
+      ]
+    },
+    "AvailableCluster": {
+      "type": "object",
+      "description": "Pre-provisioned and readily available Event Hubs Cluster count per region.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Location fo the Available Cluster"
+        }
+      }
+    },
+    "AvailableClustersList": {
+      "type": "object",
+      "description": "The response of the List Available Clusters operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The count of readily available and pre-provisioned Event Hubs Clusters per region.",
+          "items": {
+            "$ref": "#/definitions/AvailableCluster"
+          }
+        }
+      }
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "CaptureDescription": {
+      "type": "object",
+      "description": "Properties to configure capture description for eventhub",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "A value that indicates whether capture description is enabled."
+        },
+        "encoding": {
+          "$ref": "#/definitions/EncodingCaptureDescription",
+          "description": "Enumerates the possible values for the encoding format of capture description. Note: 'AvroDeflate' will be deprecated in New API Version"
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The time window allows you to set the frequency with which the capture to Azure Blobs will happen, value should between 60 to 900 seconds"
+        },
+        "sizeLimitInBytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The size window defines the amount of data built up in your Event Hub before an capture operation, value should be between 10485760 to 524288000 bytes"
+        },
+        "destination": {
+          "$ref": "#/definitions/Destination",
+          "description": "Properties of Destination where capture will be stored. (Storage Account, Blob Names)"
+        },
+        "skipEmptyArchives": {
+          "type": "boolean",
+          "description": "A value that indicates whether to Skip Empty Archives"
+        }
+      }
+    },
+    "CaptureIdentity": {
+      "type": "object",
+      "description": "A value that indicates whether capture description is enabled.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CaptureIdentityType",
+          "description": "Type of Azure Active Directory Managed Identity."
+        },
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "ARM ID of Managed User Identity. This property is required is the type is UserAssignedIdentity. If type is SystemAssigned, then the System Assigned Identity Associated with the namespace will be used."
+        }
+      }
+    },
+    "CaptureIdentityType": {
+      "type": "string",
+      "description": "Type of Azure Active Directory Managed Identity.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "CaptureIdentityType",
+        "modelAsString": false
+      }
+    },
+    "CheckNameAvailabilityParameter": {
+      "type": "object",
+      "description": "Parameter supplied to check Namespace name availability operation",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name to check the namespace name availability"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "CheckNameAvailabilityResult": {
+      "type": "object",
+      "description": "The Result of the CheckNameAvailability operation",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "The detailed info regarding the reason associated with the Namespace.",
+          "readOnly": true
+        },
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "Value indicating Namespace is availability, true if the Namespace is available; otherwise, false."
+        },
+        "reason": {
+          "$ref": "#/definitions/UnavailableReason",
+          "description": "The reason for unavailability of a Namespace."
+        }
+      }
+    },
+    "CleanupPolicyRetentionDescription": {
+      "type": "string",
+      "description": "Enumerates the possible values for cleanup policy",
+      "enum": [
+        "Delete",
+        "Compact",
+        "DeleteOrCompact"
+      ],
+      "x-ms-enum": {
+        "name": "CleanupPolicyRetentionDescription",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Delete",
+            "value": "Delete"
+          },
+          {
+            "name": "Compact",
+            "value": "Compact"
+          },
+          {
+            "name": "DeleteOrCompact",
+            "value": "DeleteOrCompact"
+          }
+        ]
+      }
+    },
+    "Cluster": {
+      "type": "object",
+      "description": "Single Event Hubs Cluster resource in List or Get operations.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ClusterProperties",
+          "description": "Event Hubs Cluster properties supplied in responses in List or Get operations.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ClusterSku",
+          "description": "Properties of the cluster SKU."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ClusterListResult": {
+      "type": "object",
+      "description": "The response of a Cluster list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Cluster items on this page",
+          "items": {
+            "$ref": "#/definitions/Cluster"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ClusterProperties": {
+      "type": "object",
+      "description": "Event Hubs Cluster properties supplied in responses in List or Get operations.",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "description": "The UTC time when the Event Hubs Cluster was created.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the Cluster.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "The UTC time when the Event Hubs Cluster was last updated.",
+          "readOnly": true
+        },
+        "metricId": {
+          "type": "string",
+          "description": "The metric ID of the cluster resource. Provided by the service and not modifiable by the user.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the Cluster resource",
+          "readOnly": true
+        },
+        "supportsScaling": {
+          "type": "boolean",
+          "description": "A value that indicates whether Scaling is Supported."
+        },
+        "platformCapabilities": {
+          "$ref": "#/definitions/PlatformCapabilities"
+        },
+        "zoneRedundant": {
+          "type": "boolean",
+          "description": "A value that indicates whether the cluster is zone redundant."
+        }
+      }
+    },
+    "ClusterQuotaConfigurationProperties": {
+      "type": "object",
+      "description": "Contains all settings for the cluster.",
+      "properties": {
+        "settings": {
+          "type": "object",
+          "description": "All possible Cluster settings - a collection of key/value paired settings which apply to quotas and configurations imposed on the cluster.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ClusterSku": {
+      "type": "object",
+      "description": "SKU parameters particular to a cluster instance.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ClusterSkuName",
+          "description": "Name of this SKU."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The quantity of Event Hubs Cluster Capacity Units contained in this cluster.",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ClusterSkuName": {
+      "type": "string",
+      "description": "Name of this SKU.",
+      "enum": [
+        "Dedicated"
+      ],
+      "x-ms-enum": {
+        "name": "ClusterSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Dedicated",
+            "value": "Dedicated"
+          }
+        ]
+      }
+    },
+    "ConfidentialCompute": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/Mode",
+          "description": "Setting to Enable or Disable Confidential Compute"
+        }
+      }
+    },
+    "ConnectionState": {
+      "type": "object",
+      "description": "ConnectionState information.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkConnectionStatus",
+          "description": "Status of the connection."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the connection state."
+        }
+      }
+    },
+    "ConsumerGroup": {
+      "type": "object",
+      "description": "Single item in List or Get Consumer group operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConsumerGroupProperties",
+          "description": "Single item in List or Get Consumer group operation",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConsumerGroupListResult": {
+      "type": "object",
+      "description": "The response of a ConsumerGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConsumerGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/ConsumerGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConsumerGroupProperties": {
+      "type": "object",
+      "description": "Single item in List or Get Consumer group operation",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the message was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was updated.",
+          "readOnly": true
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored."
+        }
+      }
+    },
+    "DefaultAction": {
+      "type": "string",
+      "description": "Default Action for Network Rule Set",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "DefaultAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "Destination": {
+      "type": "object",
+      "description": "Capture storage details for capture description",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name for capture destination"
+        },
+        "identity": {
+          "$ref": "#/definitions/CaptureIdentity",
+          "description": "A value that indicates whether capture description is enabled."
+        },
+        "properties": {
+          "$ref": "#/definitions/DestinationProperties",
+          "description": "Properties describing the storage account, blob container and archive name format for capture destination",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "DestinationProperties": {
+      "type": "object",
+      "description": "Properties describing the storage account, blob container and archive name format for capture destination",
+      "properties": {
+        "storageAccountResourceId": {
+          "type": "string",
+          "description": "Resource id of the storage account to be used to create the blobs"
+        },
+        "blobContainer": {
+          "type": "string",
+          "description": "Blob container Name"
+        },
+        "archiveNameFormat": {
+          "type": "string",
+          "description": "Blob naming convention for archive, e.g. {Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}. Here all the parameters (Namespace,EventHub .. etc) are mandatory irrespective of order"
+        },
+        "dataLakeSubscriptionId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Subscription Id of Azure Data Lake Store"
+        },
+        "dataLakeAccountName": {
+          "type": "string",
+          "description": "The Azure Data Lake Store name for the captured events"
+        },
+        "dataLakeFolderPath": {
+          "type": "string",
+          "description": "The destination folder path for the captured events"
+        }
+      }
+    },
+    "EHNamespace": {
+      "type": "object",
+      "description": "Single Namespace item in List or Get Operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EHNamespaceProperties",
+          "description": "Namespace properties supplied for create namespace operation.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Properties of sku resource"
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Properties of BYOK Identity description"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EHNamespaceIdContainer": {
+      "type": "object",
+      "description": "The full ARM ID of an Event Hubs Namespace",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "id parameter"
+        }
+      }
+    },
+    "EHNamespaceIdListResult": {
+      "type": "object",
+      "description": "The response of the List Namespace IDs operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Result of the List Namespace IDs operation",
+          "items": {
+            "$ref": "#/definitions/EHNamespaceIdContainer"
+          }
+        }
+      }
+    },
+    "EHNamespaceListResult": {
+      "type": "object",
+      "description": "The response of a EHNamespace list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EHNamespace items on this page",
+          "items": {
+            "$ref": "#/definitions/EHNamespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EHNamespaceProperties": {
+      "type": "object",
+      "description": "Namespace properties supplied for create namespace operation.",
+      "properties": {
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "The minimum TLS version for the cluster to support, e.g. '1.2'"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the Namespace.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the Namespace.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the Namespace was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the Namespace was updated.",
+          "readOnly": true
+        },
+        "serviceBusEndpoint": {
+          "type": "string",
+          "description": "Endpoint you can use to perform Service Bus operations.",
+          "readOnly": true
+        },
+        "clusterArmId": {
+          "type": "string",
+          "description": "Cluster ARM ID of the Namespace."
+        },
+        "metricId": {
+          "type": "string",
+          "description": "Identifier for Azure Insights metrics.",
+          "readOnly": true
+        },
+        "isAutoInflateEnabled": {
+          "type": "boolean",
+          "description": "Value that indicates whether AutoInflate is enabled for eventhub namespace."
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "maximumThroughputUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units. ( '0' if AutoInflateEnabled = true)",
+          "minimum": 0
+        },
+        "kafkaEnabled": {
+          "type": "boolean",
+          "description": "Value that indicates whether Kafka is enabled for eventhub namespace."
+        },
+        "zoneRedundant": {
+          "type": "boolean",
+          "description": "Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones."
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Properties of BYOK Encryption description"
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This property disables SAS authentication for the Event Hubs namespace."
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Alternate name specified when alias and namespace names are same."
+        },
+        "platformCapabilities": {
+          "$ref": "#/definitions/PlatformCapabilities"
+        },
+        "geoDataReplication": {
+          "$ref": "#/definitions/GeoDataReplicationProperties",
+          "description": "Geo Data Replication settings for the namespace"
+        },
+        "ipAddressType": {
+          "$ref": "#/definitions/IpAddressType",
+          "description": "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6 (dual stack)."
+        }
+      }
+    },
+    "EncodingCaptureDescription": {
+      "type": "string",
+      "description": "Enumerates the possible values for the encoding format of capture description. Note: 'AvroDeflate' will be deprecated in New API Version",
+      "enum": [
+        "Avro",
+        "AvroDeflate"
+      ],
+      "x-ms-enum": {
+        "name": "EncodingCaptureDescription",
+        "modelAsString": false
+      }
+    },
+    "Encryption": {
+      "type": "object",
+      "description": "Properties to configure Encryption",
+      "properties": {
+        "keyVaultProperties": {
+          "type": "array",
+          "description": "Properties of KeyVault",
+          "items": {
+            "$ref": "#/definitions/KeyVaultProperties"
+          },
+          "x-ms-client-name": "KeyVaultProperties"
+        },
+        "keySource": {
+          "type": "string",
+          "description": "Enumerates the possible value of keySource for Encryption",
+          "default": "Microsoft.KeyVault",
+          "enum": [
+            "Microsoft.KeyVault"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "requireInfrastructureEncryption": {
+          "type": "boolean",
+          "description": "Enable Infrastructure Encryption (Double Encryption)"
+        }
+      }
+    },
+    "EndPointProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Private Endpoint Connection.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "EndPointProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "EntityStatus": {
+      "type": "string",
+      "description": "Enumerates the possible values for the status of the Event Hub.",
+      "enum": [
+        "Active",
+        "Disabled",
+        "Restoring",
+        "SendDisabled",
+        "ReceiveDisabled",
+        "Creating",
+        "Deleting",
+        "Renaming",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "EntityStatus",
+        "modelAsString": false
+      }
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "description": "The resource management error additional info.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type.",
+          "readOnly": true
+        },
+        "info": {
+          "description": "The additional info.",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "description": "The error detail.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "#/definitions/ErrorAdditionalInfo"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "description": "Error response indicates Event Hub service is not able to process the incoming request. The reason is provided in the error message.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "The error object."
+        }
+      }
+    },
+    "EventHubListResult": {
+      "type": "object",
+      "description": "Paged collection of Eventhub items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Eventhub items on this page",
+          "items": {
+            "$ref": "#/definitions/Eventhub"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Eventhub": {
+      "type": "object",
+      "description": "Single item in List or Get Event Hub operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EventhubProperties",
+          "description": "Properties supplied to the Create Or Update Event Hub operation.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EventhubProperties": {
+      "type": "object",
+      "description": "Properties supplied to the Create Or Update Event Hub operation.",
+      "properties": {
+        "partitionIds": {
+          "type": "array",
+          "description": "Current number of shards on the Event Hub.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the Event Hub was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was updated.",
+          "readOnly": true
+        },
+        "messageRetentionInDays": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of days to retain the events for this Event Hub, value should be 1 to 7 days",
+          "minimum": 1
+        },
+        "partitionCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of partitions created for the Event Hub, allowed values are from 1 to 32 partitions.",
+          "minimum": 1
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus",
+          "description": "Enumerates the possible values for the status of the Event Hub."
+        },
+        "captureDescription": {
+          "$ref": "#/definitions/CaptureDescription",
+          "description": "Properties of capture description"
+        },
+        "retentionDescription": {
+          "$ref": "#/definitions/RetentionDescription",
+          "description": "Event Hub retention settings"
+        },
+        "messageTimestampDescription": {
+          "$ref": "#/definitions/MessageTimestampDescription",
+          "description": "Properties of MessageTimestamp Description"
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Denotes the unique identifier for event hub and is generated by service while creating topic. This identifier can be used in kafka runtime apis wherever a UUID is required e.g Fetch & Delete Topic. This identifier is not supported in AMQP runtime operations yet.",
+          "readOnly": true
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "Gets and Sets Metadata of User."
+        }
+      }
+    },
+    "ExceptionWindow": {
+      "type": "object",
+      "description": "A date-specific exception to the recurring maintenance windows.",
+      "properties": {
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "The UTC date on which the exception starts."
+        },
+        "action": {
+          "$ref": "#/definitions/ExceptionWindowAction",
+          "description": "Whether the exception blocks or allows upgrades."
+        },
+        "startTimeOfDay": {
+          "type": "string",
+          "format": "duration",
+          "description": "The UTC time of day at which the exception starts, represented as an ISO 8601 duration since midnight."
+        },
+        "durationMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The exception duration in minutes. Allow exceptions must be between 480 and 1440 minutes in 60-minute increments. Block exceptions must be 1440 minutes.",
+          "minimum": 480,
+          "maximum": 1440
+        }
+      },
+      "required": [
+        "date",
+        "action",
+        "startTimeOfDay",
+        "durationMinutes"
+      ]
+    },
+    "ExceptionWindowAction": {
+      "type": "string",
+      "description": "The action performed by an exception window.",
+      "enum": [
+        "Block",
+        "Allow"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionWindowAction",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "Prevent upgrades during the exception window."
+          },
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow upgrades during the exception window."
+          }
+        ]
+      }
+    },
+    "FabricShortcut": {
+      "type": "object",
+      "description": "A Microsoft Fabric shortcut attached to an Event Hub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FabricShortcutProperties",
+          "description": "Properties of the Microsoft Fabric shortcut."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FabricShortcutConfiguration": {
+      "type": "object",
+      "description": "Microsoft Fabric workspace and artifact configuration.",
+      "properties": {
+        "tenantId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The Microsoft Fabric tenant ID."
+        },
+        "workspaceId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The Microsoft Fabric workspace ID."
+        },
+        "artifactId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The Microsoft Fabric artifact ID."
+        },
+        "premiumCapacityId": {
+          "type": "string",
+          "description": "The Microsoft Fabric premium capacity ID."
+        },
+        "logAnalyticsResourceId": {
+          "type": "string",
+          "description": "The resource ID of the Log Analytics workspace."
+        },
+        "workspaceName": {
+          "type": "string",
+          "description": "The Microsoft Fabric workspace name."
+        },
+        "artifactName": {
+          "type": "string",
+          "description": "The Microsoft Fabric artifact name."
+        }
+      },
+      "required": [
+        "tenantId",
+        "workspaceId",
+        "artifactId"
+      ]
+    },
+    "FabricShortcutListResult": {
+      "type": "object",
+      "description": "The response of a FabricShortcut list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FabricShortcut items on this page",
+          "items": {
+            "$ref": "#/definitions/FabricShortcut"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FabricShortcutProperties": {
+      "type": "object",
+      "description": "Properties of a Microsoft Fabric shortcut.",
+      "properties": {
+        "configuration": {
+          "$ref": "#/definitions/FabricShortcutConfiguration",
+          "description": "Microsoft Fabric workspace and artifact configuration."
+        },
+        "shortcutType": {
+          "$ref": "#/definitions/FabricShortcutType",
+          "description": "The type of the shortcut."
+        },
+        "shortcutStatus": {
+          "$ref": "#/definitions/FabricShortcutStatus",
+          "description": "The current shortcut status. Only Pending can be supplied on create or update."
+        },
+        "statusDescription": {
+          "type": "string",
+          "description": "A description of the current shortcut status.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC time when the shortcut was created.",
+          "readOnly": true
+        },
+        "modifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC time when the shortcut was last modified.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "configuration"
+      ]
+    },
+    "FabricShortcutStatus": {
+      "type": "string",
+      "description": "The status of a Microsoft Fabric shortcut.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected"
+      ],
+      "x-ms-enum": {
+        "name": "FabricShortcutStatus",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The shortcut is awaiting approval."
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "The shortcut is approved."
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "The shortcut is rejected."
+          }
+        ]
+      }
+    },
+    "FabricShortcutType": {
+      "type": "string",
+      "description": "The type of Microsoft Fabric shortcut.",
+      "enum": [
+        "Entity",
+        "Network"
+      ],
+      "x-ms-enum": {
+        "name": "FabricShortcutType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Entity",
+            "value": "Entity",
+            "description": "An entity shortcut."
+          },
+          {
+            "name": "Network",
+            "value": "Network",
+            "description": "A network shortcut."
+          }
+        ]
+      }
+    },
+    "FailOver": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FailOverProperties",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "FailOverProperties": {
+      "type": "object",
+      "properties": {
+        "primaryLocation": {
+          "type": "string",
+          "description": "Query parameter for the new primary location after failover."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "If Force is false then graceful failover is attempted after ensuring no data loss. If Force flag is set to true, Forced failover is attempted with possible data loss."
+        }
+      }
+    },
+    "GeoDRRoleType": {
+      "type": "string",
+      "description": "GeoDR Role Types",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "GeoDRRoleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Primary",
+            "value": "Primary"
+          },
+          {
+            "name": "Secondary",
+            "value": "Secondary"
+          }
+        ]
+      }
+    },
+    "GeoDataReplicationProperties": {
+      "type": "object",
+      "description": "GeoDR Replication properties",
+      "properties": {
+        "maxReplicationLagDurationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum acceptable lag for data replication operations from the primary replica to a quorum of secondary replicas.  When the lag exceeds the configured amount, operations on the primary replica will be failed. The allowed values are 0 and 5 minutes to 1 day."
+        },
+        "locations": {
+          "type": "array",
+          "description": "A list of regions where replicas of the namespace are maintained.",
+          "items": {
+            "$ref": "#/definitions/NamespaceReplicaLocation"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Properties to configure Identity for Bring your Own Keys",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "ObjectId from the KeyVault",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "TenantId from the KeyVault",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityType",
+          "description": "Type of managed service identity."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "Properties for User Assigned Identities",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "IpAddressType": {
+      "type": "string",
+      "description": "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6 (dual stack).",
+      "enum": [
+        "IPv4",
+        "DualStack"
+      ],
+      "x-ms-enum": {
+        "name": "IpAddressType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "The namespace supports IPv4 addresses only."
+          },
+          {
+            "name": "DualStack",
+            "value": "DualStack",
+            "description": "The namespace supports both IPv4 and IPv6 addresses (dual stack)."
+          }
+        ]
+      }
+    },
+    "KeyType": {
+      "type": "string",
+      "description": "The access key to regenerate.",
+      "enum": [
+        "PrimaryKey",
+        "SecondaryKey"
+      ],
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PrimaryKey",
+            "value": "PrimaryKey"
+          },
+          {
+            "name": "SecondaryKey",
+            "value": "SecondaryKey"
+          }
+        ]
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Properties to configure keyVault Properties",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the Key from KeyVault",
+          "x-ms-client-name": "KeyName"
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "description": "Uri of KeyVault",
+          "x-ms-client-name": "KeyVaultUri"
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "Key Version",
+          "x-ms-client-name": "KeyVersion"
+        },
+        "identity": {
+          "$ref": "#/definitions/userAssignedIdentityProperties"
+        }
+      }
+    },
+    "MaintenanceWindow": {
+      "type": "object",
+      "description": "A recurring weekly maintenance window in UTC.",
+      "properties": {
+        "dayOfWeek": {
+          "$ref": "#/definitions/UpgradePreferenceDayOfWeek",
+          "description": "The UTC day of the week on which the maintenance window starts."
+        },
+        "startTimeOfDay": {
+          "type": "string",
+          "format": "duration",
+          "description": "The UTC time of day at which the maintenance window starts, represented as an ISO 8601 duration since midnight."
+        },
+        "durationMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maintenance window duration in minutes. The value must be between 480 and 1440 in 60-minute increments.",
+          "minimum": 480,
+          "maximum": 1440
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "startTimeOfDay",
+        "durationMinutes"
+      ]
+    },
+    "ManagedServiceIdentityType": {
+      "type": "string",
+      "description": "Type of managed service identity.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedServiceIdentityType",
+        "modelAsString": false
+      }
+    },
+    "MessageTimestampDescription": {
+      "type": "object",
+      "description": "Properties of MessageTimestamp Description",
+      "properties": {
+        "timestampType": {
+          "$ref": "#/definitions/TimestampType",
+          "description": "Denotes the type of timestamp the message will hold.Two types of timestamp types - \"AppendTime\" and \"CreateTime\". AppendTime refers the time in which message got appended inside broker log. CreateTime refers to the time in which the message was generated on source side and producers can set this timestamp while sending the message. Default value is AppendTime. If you are using AMQP protocol, CreateTime equals AppendTime and its behavior remains the same."
+        }
+      }
+    },
+    "MetricId": {
+      "type": "string",
+      "description": "Metric Id on which the throttle limit should be set, MetricId can be discovered by hovering over Metric in the Metrics section of Event Hub Namespace inside Azure Portal",
+      "enum": [
+        "IncomingBytes",
+        "OutgoingBytes",
+        "IncomingMessages",
+        "OutgoingMessages"
+      ],
+      "x-ms-enum": {
+        "name": "MetricId",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IncomingBytes",
+            "value": "IncomingBytes"
+          },
+          {
+            "name": "OutgoingBytes",
+            "value": "OutgoingBytes"
+          },
+          {
+            "name": "IncomingMessages",
+            "value": "IncomingMessages"
+          },
+          {
+            "name": "OutgoingMessages",
+            "value": "OutgoingMessages"
+          }
+        ]
+      }
+    },
+    "Mode": {
+      "type": "string",
+      "description": "Setting to Enable or Disable Confidential Compute",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "Mode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "NWRuleSetIpRules": {
+      "type": "object",
+      "description": "The response from the List namespace operation.",
+      "properties": {
+        "ipMask": {
+          "type": "string",
+          "description": "IP Mask"
+        },
+        "action": {
+          "$ref": "#/definitions/NetworkRuleIPAction",
+          "description": "The IP Filter Action"
+        }
+      }
+    },
+    "NWRuleSetVirtualNetworkRules": {
+      "type": "object",
+      "description": "The response from the List namespace operation.",
+      "properties": {
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "Subnet properties"
+        },
+        "ignoreMissingVnetServiceEndpoint": {
+          "type": "boolean",
+          "description": "Value that indicates whether to ignore missing Vnet Service Endpoint"
+        }
+      }
+    },
+    "NamespaceReplicaLocation": {
+      "type": "object",
+      "description": "Namespace replication properties",
+      "properties": {
+        "locationName": {
+          "type": "string",
+          "description": "Azure regions where a replica of the namespace is maintained"
+        },
+        "roleType": {
+          "$ref": "#/definitions/GeoDRRoleType",
+          "description": "GeoDR Role Types"
+        },
+        "replicaState": {
+          "type": "string",
+          "description": "state of Namespace replica.",
+          "readOnly": true
+        },
+        "clusterArmId": {
+          "type": "string",
+          "description": "Optional property that denotes the ARM ID of the Cluster. This is required, if a namespace replica should be placed in a Dedicated Event Hub Cluster"
+        }
+      }
+    },
+    "NetworkRuleIPAction": {
+      "type": "string",
+      "description": "The IP Filter Action",
+      "enum": [
+        "Allow"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkRuleIPAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          }
+        ]
+      }
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "Description of topic resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkRuleSetProperties",
+          "description": "NetworkRuleSet properties",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkRuleSetListResult": {
+      "type": "object",
+      "description": "Paged collection of NetworkRuleSet items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkRuleSet items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkRuleSet"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkRuleSetProperties": {
+      "type": "object",
+      "description": "NetworkRuleSet properties",
+      "properties": {
+        "trustedServiceAccessEnabled": {
+          "type": "boolean",
+          "description": "Value that indicates whether Trusted Service Access is Enabled or not."
+        },
+        "defaultAction": {
+          "$ref": "#/definitions/DefaultAction",
+          "description": "Default Action for Network Rule Set"
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "description": "List VirtualNetwork Rules",
+          "items": {
+            "$ref": "#/definitions/NWRuleSetVirtualNetworkRules"
+          }
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "List of IpRules",
+          "items": {
+            "$ref": "#/definitions/NWRuleSetIpRules"
+          }
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled. If value is SecuredByPerimeter then Inbound and Outbound communication is controlled by the network security perimeter and profile's access rules.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccessFlag",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "NetworkSecurityPerimeter related information",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of the resource"
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Guid of the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Network Security Perimeter related configurations of a given namespace",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Properties of the Network Security Perimeter Configuration",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "Result of the List NetworkSecurityPerimeterConfiguration operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A collection of NetworkSecurityPerimeterConfigurations",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of NetworkSecurityPerimeterConfiguration",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of NetworkSecurityPerimeter configuration propagation"
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of Provisioning Issues if any",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "NetworkSecurityPerimeter related information",
+          "readOnly": true
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation",
+          "description": "Information about resource association",
+          "readOnly": true
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesProfile",
+          "description": "Information about current network profile",
+          "readOnly": true
+        },
+        "isBackingResource": {
+          "type": "boolean",
+          "description": "True if the EventHub namespace is backed by another Azure resource and not visible to end users.",
+          "readOnly": true
+        },
+        "applicableFeatures": {
+          "type": "array",
+          "description": "Indicates that the NSP controls related to backing association are only applicable to a specific feature in backing resource's data plane.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "parentAssociationName": {
+          "type": "string",
+          "description": "Source Resource Association name",
+          "readOnly": true
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM Id of source resource",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesProfile": {
+      "type": "object",
+      "description": "Information about current network profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "accessRulesVersion": {
+          "type": "string",
+          "description": "Current access rules version"
+        },
+        "accessRules": {
+          "type": "array",
+          "description": "List of Access Rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRule"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation": {
+      "type": "object",
+      "description": "Information about resource association",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access Mode of the resource association"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of NetworkSecurityPerimeter configuration propagation",
+      "enum": [
+        "Unknown",
+        "Creating",
+        "Updating",
+        "Accepted",
+        "InvalidResponse",
+        "Succeeded",
+        "SucceededWithIssues",
+        "Failed",
+        "Deleting",
+        "Deleted",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "InvalidResponse",
+            "value": "InvalidResponse"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "SucceededWithIssues",
+            "value": "SucceededWithIssues"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      }
+    },
+    "NspAccessRule": {
+      "type": "object",
+      "description": "Information of Access Rule in Network Profile",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of the resource"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/NspAccessRuleProperties",
+          "description": "Properties of Access Rule",
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NspAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound"
+          }
+        ]
+      }
+    },
+    "NspAccessRuleProperties": {
+      "type": "object",
+      "description": "Properties of Access Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NspAccessRuleDirection",
+          "description": "Direction of Access Rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes in the CIDR format for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRulePropertiesSubscriptionsItem"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "NetworkSecurityPerimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          },
+          "readOnly": true
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "FQDN for outbound rules",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRulePropertiesSubscriptionsItem": {
+      "type": "object",
+      "description": "Subscription for inbound rule",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of subscription"
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "A Event Hub REST API operation",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "readOnly": true
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "Display of the operation"
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin of the operation"
+        },
+        "properties": {
+          "description": "Properties of the operation",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "OperationDisplay": {
+      "type": "object",
+      "description": "Operation display payload",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Resource provider of the operation",
+          "readOnly": true
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource of the operation",
+          "readOnly": true
+        },
+        "operation": {
+          "type": "string",
+          "description": "Localized friendly name for the operation",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized friendly description for the operation",
+          "readOnly": true
+        }
+      }
+    },
+    "OperationListResult": {
+      "type": "object",
+      "description": "Paged collection of Operation items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Operation items on this page",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PlatformCapabilities": {
+      "type": "object",
+      "properties": {
+        "confidentialCompute": {
+          "$ref": "#/definitions/ConfidentialCompute"
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "PrivateEndpoint information.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier for Private Endpoint."
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the PrivateEndpointConnection.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection resource.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The Private Endpoint resource for this Connection."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/ConnectionState",
+          "description": "Details about the state of the connection."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/EndPointProvisioningState",
+          "description": "Provisioning state of the Private Endpoint Connection."
+        }
+      }
+    },
+    "PrivateLinkConnectionStatus": {
+      "type": "string",
+      "description": "Status of the connection.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateLinkConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "Information of the private link resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Properties of the private link resource.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of the resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource"
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of PrivateLinkResource",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id."
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource Private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourcesListResult": {
+      "type": "object",
+      "description": "Paged collection of PrivateLinkResource items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningIssue": {
+      "type": "object",
+      "description": "Describes Provisioning issue for given NetworkSecurityPerimeterConfiguration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the issue"
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Properties of Provisioning Issue",
+          "readOnly": true
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Properties of Provisioning Issue",
+      "properties": {
+        "issueType": {
+          "type": "string",
+          "description": "Type of Issue"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue"
+        }
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Cluster.",
+      "enum": [
+        "Unknown",
+        "Creating",
+        "Deleting",
+        "Scaling",
+        "Active",
+        "Failed",
+        "Succeeded",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Scaling",
+            "value": "Scaling"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      }
+    },
+    "ProvisioningStateDR": {
+      "type": "string",
+      "description": "Provisioning state of the Alias(Disaster Recovery configuration) - possible values 'Accepted' or 'Succeeded' or 'Failed'",
+      "enum": [
+        "Accepted",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningStateDR",
+        "modelAsString": false
+      }
+    },
+    "RegenerateAccessKeyParameters": {
+      "type": "object",
+      "description": "Parameters supplied to the Regenerate Authorization Rule operation, specifies which key needs to be reset.",
+      "properties": {
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "The access key to regenerate."
+        },
+        "key": {
+          "type": "string",
+          "description": "Optional, if the key value provided, is set for KeyType or autogenerated Key value set for keyType"
+        }
+      },
+      "required": [
+        "keyType"
+      ]
+    },
+    "ResourceAssociationAccessMode": {
+      "type": "string",
+      "description": "Access Mode of the resource association",
+      "enum": [
+        "NoAssociationMode",
+        "EnforcedMode",
+        "LearningMode",
+        "AuditMode",
+        "UnspecifiedMode"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NoAssociationMode",
+            "value": "NoAssociationMode"
+          },
+          {
+            "name": "EnforcedMode",
+            "value": "EnforcedMode"
+          },
+          {
+            "name": "LearningMode",
+            "value": "LearningMode"
+          },
+          {
+            "name": "AuditMode",
+            "value": "AuditMode"
+          },
+          {
+            "name": "UnspecifiedMode",
+            "value": "UnspecifiedMode"
+          }
+        ]
+      }
+    },
+    "RetentionDescription": {
+      "type": "object",
+      "description": "Properties to configure retention settings for the  eventhub",
+      "properties": {
+        "cleanupPolicy": {
+          "$ref": "#/definitions/CleanupPolicyRetentionDescription",
+          "description": "Enumerates the possible values for cleanup policy"
+        },
+        "retentionTimeInHours": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of hours to retain the events for this Event Hub. This should be positive value upto namespace SKU max. -1 is a special case where retention time is infinite, but the size of an entity is restricted and its size depends on namespace SKU type."
+        },
+        "minCompactionLagTimeInMinutes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The minimum time a message will remain ineligible for compaction in the log. This value is used when cleanupPolicy is Compact or DeleteOrCompact."
+        },
+        "tombstoneRetentionTimeInHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of hours to retain the tombstone markers of a compacted Event Hub. This value is used when cleanupPolicy is Compact or DeleteOrCompact. Consumer must complete reading the tombstone marker within this specified amount of time if consumer begins from starting offset to ensure they get a valid snapshot for the specific key described by the tombstone marker within the compacted Event Hub"
+        }
+      }
+    },
+    "RoleDisasterRecovery": {
+      "type": "string",
+      "description": "role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'",
+      "enum": [
+        "Primary",
+        "PrimaryNotReplicating",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "RoleDisasterRecovery",
+        "modelAsString": false
+      }
+    },
+    "SchemaCompatibility": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Backward",
+        "Forward"
+      ],
+      "x-ms-enum": {
+        "name": "SchemaCompatibility",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "Backward",
+            "value": "Backward"
+          },
+          {
+            "name": "Forward",
+            "value": "Forward"
+          }
+        ]
+      }
+    },
+    "SchemaGroup": {
+      "type": "object",
+      "description": "Single item in List or Get Schema Group operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SchemaGroupProperties",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SchemaGroupListResult": {
+      "type": "object",
+      "description": "The response of a SchemaGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SchemaGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/SchemaGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SchemaGroupProperties": {
+      "type": "object",
+      "properties": {
+        "updatedAtUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the Schema Group was updated",
+          "readOnly": true
+        },
+        "createdAtUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the Schema Group was created.",
+          "readOnly": true
+        },
+        "eTag": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The ETag value.",
+          "readOnly": true
+        },
+        "groupProperties": {
+          "type": "object",
+          "description": "dictionary object for SchemaGroup group properties",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "schemaCompatibility": {
+          "$ref": "#/definitions/SchemaCompatibility"
+        },
+        "schemaType": {
+          "$ref": "#/definitions/SchemaType"
+        }
+      }
+    },
+    "SchemaType": {
+      "type": "string",
+      "enum": [
+        "Unknown",
+        "Avro",
+        "ProtoBuf",
+        "Json"
+      ],
+      "x-ms-enum": {
+        "name": "SchemaType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "Avro",
+            "value": "Avro"
+          },
+          {
+            "name": "ProtoBuf",
+            "value": "ProtoBuf"
+          },
+          {
+            "name": "Json",
+            "value": "Json"
+          }
+        ]
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "description": "SKU parameters supplied to the create namespace operation",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "Name of this SKU."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The billing tier of this particular SKU."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Event Hubs throughput units for Basic or Standard tiers, where value should be 0 to 20 throughput units. The Event Hubs premium units for Premium tier, where value should be 0 to 10 premium units.",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "Name of this SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium"
+          }
+        ]
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The billing tier of this particular SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium"
+          }
+        ]
+      }
+    },
+    "Subnet": {
+      "type": "object",
+      "description": "Properties supplied for Subnet",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID of Virtual Network Subnet"
+        }
+      }
+    },
+    "ThrottlingPolicy": {
+      "type": "object",
+      "description": "Properties of the throttling policy",
+      "properties": {
+        "rateLimitThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The Threshold limit above which the application group will be throttled.Rate limit is always per second."
+        },
+        "metricId": {
+          "$ref": "#/definitions/MetricId",
+          "description": "Metric Id on which the throttle limit should be set, MetricId can be discovered by hovering over Metric in the Metrics section of Event Hub Namespace inside Azure Portal"
+        }
+      },
+      "required": [
+        "rateLimitThreshold",
+        "metricId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationGroupPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "ThrottlingPolicy"
+    },
+    "TimestampType": {
+      "type": "string",
+      "description": "Denotes the type of timestamp the message will hold.Two types of timestamp types - \"AppendTime\" and \"CreateTime\". AppendTime refers the time in which message got appended inside broker log. CreateTime refers to the time in which the message was generated on source side and producers can set this timestamp while sending the message. Default value is AppendTime. If you are using AMQP protocol, CreateTime equals AppendTime and its behavior remains the same.",
+      "enum": [
+        "LogAppend",
+        "Create"
+      ],
+      "x-ms-enum": {
+        "name": "TimestampType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LogAppend",
+            "value": "LogAppend"
+          },
+          {
+            "name": "Create",
+            "value": "Create"
+          }
+        ]
+      }
+    },
+    "TlsVersion": {
+      "type": "string",
+      "description": "The minimum TLS version for the cluster to support, e.g. '1.2'",
+      "enum": [
+        "1.0",
+        "1.1",
+        "1.2",
+        "1.3"
+      ],
+      "x-ms-enum": {
+        "name": "TlsVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "1.0",
+            "value": "1.0"
+          },
+          {
+            "name": "1.1",
+            "value": "1.1"
+          },
+          {
+            "name": "1.2",
+            "value": "1.2"
+          },
+          {
+            "name": "1.3",
+            "value": "1.3"
+          }
+        ]
+      }
+    },
+    "UnavailableReason": {
+      "type": "string",
+      "description": "Specifies the reason for the unavailability of the service.",
+      "enum": [
+        "None",
+        "InvalidName",
+        "SubscriptionIsDisabled",
+        "NameInUse",
+        "NameInLockdown",
+        "TooManyNamespaceInCurrentSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "UnavailableReason",
+        "modelAsString": false
+      }
+    },
+    "UpgradePreferenceDayOfWeek": {
+      "type": "string",
+      "description": "A day of the week.",
+      "enum": [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday"
+      ],
+      "x-ms-enum": {
+        "name": "UpgradePreferenceDayOfWeek",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Sunday",
+            "value": "Sunday",
+            "description": "Sunday."
+          },
+          {
+            "name": "Monday",
+            "value": "Monday",
+            "description": "Monday."
+          },
+          {
+            "name": "Tuesday",
+            "value": "Tuesday",
+            "description": "Tuesday."
+          },
+          {
+            "name": "Wednesday",
+            "value": "Wednesday",
+            "description": "Wednesday."
+          },
+          {
+            "name": "Thursday",
+            "value": "Thursday",
+            "description": "Thursday."
+          },
+          {
+            "name": "Friday",
+            "value": "Friday",
+            "description": "Friday."
+          },
+          {
+            "name": "Saturday",
+            "value": "Saturday",
+            "description": "Saturday."
+          }
+        ]
+      }
+    },
+    "UpgradePreferences": {
+      "type": "object",
+      "description": "Upgrade preferences for an Event Hubs Dedicated cluster.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/UpgradePreferencesProperties",
+          "description": "Upgrade preference properties for the Event Hubs Dedicated cluster."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "UpgradePreferencesProperties": {
+      "type": "object",
+      "description": "Upgrade preference properties for an Event Hubs Dedicated cluster.",
+      "properties": {
+        "maintenanceWindows": {
+          "type": "array",
+          "description": "Recurring weekly maintenance windows in UTC. At least one window must be supplied when preferences are created or updated. A maximum of two windows can be configured, and their combined duration must be at least 16 hours per week.",
+          "minItems": 1,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/MaintenanceWindow"
+          },
+          "x-ms-identifiers": []
+        },
+        "exceptionWindows": {
+          "type": "array",
+          "description": "Date-specific exceptions to the recurring maintenance windows.",
+          "items": {
+            "$ref": "#/definitions/ExceptionWindow"
+          },
+          "x-ms-identifiers": []
+        },
+        "upgradeStatus": {
+          "$ref": "#/definitions/UpgradeStatus",
+          "description": "The current cluster upgrade status.",
+          "readOnly": true
+        }
+      }
+    },
+    "UpgradeStatus": {
+      "type": "object",
+      "description": "The current upgrade orchestration state for the cluster.",
+      "properties": {
+        "pendingUpgrade": {
+          "type": "boolean",
+          "description": "Whether at least one deferred upgrade is waiting for the cluster."
+        },
+        "inProgress": {
+          "type": "boolean",
+          "description": "Whether an upgrade-now override is currently active."
+        },
+        "completesAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The estimated UTC time when the current upgrade will complete."
+        }
+      },
+      "required": [
+        "pendingUpgrade",
+        "inProgress"
+      ]
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "Recognized Dictionary value.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "Principal Id of user assigned identity",
+          "readOnly": true,
+          "x-ms-client-name": "PrincipalId"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Client Id of user assigned identity",
+          "readOnly": true,
+          "x-ms-client-name": "ClientId"
+        }
+      }
+    },
+    "userAssignedIdentityProperties": {
+      "type": "object",
+      "properties": {
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "ARM ID of user Identity selected for encryption"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
@@ -3468,7 +3468,8 @@
             "in": "path",
             "description": "The Microsoft Fabric shortcut name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           }
         ],
         "responses": {
@@ -3531,7 +3532,8 @@
             "in": "path",
             "description": "The Microsoft Fabric shortcut name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           },
           {
             "name": "resource",
@@ -3603,7 +3605,8 @@
             "in": "path",
             "description": "The Microsoft Fabric shortcut name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           }
         ],
         "responses": {
@@ -3665,7 +3668,8 @@
             "in": "path",
             "description": "The Microsoft Fabric shortcut name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           }
         ],
         "responses": {
@@ -3730,7 +3734,8 @@
             "in": "path",
             "description": "The Microsoft Fabric shortcut name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           }
         ],
         "responses": {
@@ -6055,7 +6060,15 @@
         },
         "logAnalyticsResourceId": {
           "type": "string",
-          "description": "The resource ID of the Log Analytics workspace."
+          "format": "arm-id",
+          "description": "The resource ID of the Log Analytics workspace.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.OperationalInsights/workspaces"
+              }
+            ]
+          }
         },
         "workspaceName": {
           "type": "string",

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/preview/2026-07-01-preview/openapi.json
@@ -7699,37 +7699,37 @@
           {
             "name": "Sunday",
             "value": "Sunday",
-            "description": "Sunday."
+            "description": "The maintenance window occurs on Sunday."
           },
           {
             "name": "Monday",
             "value": "Monday",
-            "description": "Monday."
+            "description": "The maintenance window occurs on Monday."
           },
           {
             "name": "Tuesday",
             "value": "Tuesday",
-            "description": "Tuesday."
+            "description": "The maintenance window occurs on Tuesday."
           },
           {
             "name": "Wednesday",
             "value": "Wednesday",
-            "description": "Wednesday."
+            "description": "The maintenance window occurs on Wednesday."
           },
           {
             "name": "Thursday",
             "value": "Thursday",
-            "description": "Thursday."
+            "description": "The maintenance window occurs on Thursday."
           },
           {
             "name": "Friday",
             "value": "Friday",
-            "description": "Friday."
+            "description": "The maintenance window occurs on Friday."
           },
           {
             "name": "Saturday",
             "value": "Saturday",
-            "description": "Saturday."
+            "description": "The maintenance window occurs on Saturday."
           }
         ]
       }

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
@@ -273,12 +273,60 @@ These settings apply only when `--tag=package-2026-07-preview` is specified on t
 ``` yaml $(tag) == 'package-2026-07-preview'
 input-file:
 - preview/2026-07-01-preview/openapi.json
+- preview/2018-01-01-preview/virtualnetworkrules-preview.json
+- preview/2018-01-01-preview/ipfilterrules-preview.json
+- preview/2018-01-01-preview/sku.json
 ```
 
 ## Suppression
 
 ``` yaml
 directive:
+  - suppress: ResourceNameRestriction
+    from: openapi.json
+    reason: Existing Event Hub and cluster parent names and Fabric shortcut names have no service-enforced regular expression constraint.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default/upgradeNow"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}/approve"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}/reject"]
+  - suppress: PutResponseCodes
+    from: openapi.json
+    reason: The service returns 200 for both create and update for these resources.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default"].put
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}"].put
+  - suppress: PostResponseCodes
+    from: openapi.json
+    reason: Upgrade now returns 200 when an upgrade starts and 204 when no upgrade is pending.
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default/upgradeNow"].post
+  - suppress: RequestSchemaForTrackedResourcesMustHaveTags
+    from: openapi.json
+    reason: Fabric shortcuts are proxy resources and do not support tags.
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}"].put
+  - suppress: DeleteResponseCodes
+    from: openapi.json
+    reason: Fabric shortcut deletion returns 200 on success.
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}"].delete
+  - suppress: DeleteOperationResponses
+    from: openapi.json
+    reason: Fabric shortcut deletion returns an empty 200 response on success.
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/fabricShortcuts/{fabricShortcutName}"].delete.responses
+  - suppress: GuidUsage
+    from: openapi.json
+    reason: Microsoft Fabric tenant, workspace, and artifact identifiers are UUIDs by definition.
+    where: $.definitions["Azure.Core.uuid"].format
+  - suppress: TrackedResourcePatchOperation
+    from: openapi.json
+    reason: Fabric shortcuts are proxy resources and do not support tags or PATCH.
+    where: $.definitions.FabricShortcut
+  - suppress: NestedResourcesMustHaveListOperation
+    from: openapi.json
+    reason: Upgrade preferences are a singleton child resource and do not have a list operation.
+    where: $.definitions.UpgradePreferences
+
   - suppress: MissingTypeObject
     from: CheckNameAvailability.json
     reason: Not a mandatory check
@@ -556,5 +604,3 @@ See configuration in [readme.go.md](./readme.go.md)
 ## Java
 
 See configuration in [readme.java.md](./readme.java.md)
-
-

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
@@ -279,26 +279,9 @@ input-file:
 
 ``` yaml
 directive:
-  - suppress: MISSING_APIS_IN_DEFAULT_TAG
-    from: preview/2018-01-01-preview/virtualnetworkrules-preview.json
-    reason: These legacy child-resource routes are supported only by the 2018-01-01-preview controller and were replaced by networkRuleSets in current API versions.
-    where:
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules"]
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}"]
-  - suppress: MISSING_APIS_IN_DEFAULT_TAG
-    from: preview/2018-01-01-preview/ipfilterrules-preview.json
-    reason: These legacy child-resource routes are supported only by the 2018-01-01-preview controller and were replaced by networkRuleSets in current API versions.
-    where:
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules"]
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}"]
-  - suppress: MISSING_APIS_IN_DEFAULT_TAG
-    from: preview/2018-01-01-preview/sku.json
-    reason: The legacy SKU region discovery route is not implemented by the current Event Hubs SKU controller.
-    where: $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/sku/{sku}/regions"]
-
   - suppress: ResourceNameRestriction
     from: openapi.json
-    reason: Existing Event Hub and cluster parent names and Fabric shortcut names have no service-enforced regular expression constraint.
+    reason: The new child resource names are constrained, but existing namespace, Event Hub, and cluster parent names have no service-enforced regular expression constraint that can be added only to this preview version.
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default"]
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}/upgradePreferences/default/upgradeNow"]

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the EventHub API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-01
+tag: package-2026-07-preview
 ```
 
 ### Tag: package-2017-04
@@ -264,6 +264,15 @@ These settings apply only when `--tag=package-2026-01` is specified on the comma
 ``` yaml $(tag) == 'package-2026-01'
 input-file:
 - stable/2026-01-01/openapi.json
+```
+
+### Tag: package-2026-07-preview
+
+These settings apply only when `--tag=package-2026-07-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-07-preview'
+input-file:
+- preview/2026-07-01-preview/openapi.json
 ```
 
 ## Suppression
@@ -547,6 +556,5 @@ See configuration in [readme.go.md](./readme.go.md)
 ## Java
 
 See configuration in [readme.java.md](./readme.java.md)
-
 
 

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the EventHub API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-07-preview
+tag: package-2026-01
 ```
 
 ### Tag: package-2017-04

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/readme.md
@@ -273,15 +273,29 @@ These settings apply only when `--tag=package-2026-07-preview` is specified on t
 ``` yaml $(tag) == 'package-2026-07-preview'
 input-file:
 - preview/2026-07-01-preview/openapi.json
-- preview/2018-01-01-preview/virtualnetworkrules-preview.json
-- preview/2018-01-01-preview/ipfilterrules-preview.json
-- preview/2018-01-01-preview/sku.json
 ```
 
 ## Suppression
 
 ``` yaml
 directive:
+  - suppress: MISSING_APIS_IN_DEFAULT_TAG
+    from: preview/2018-01-01-preview/virtualnetworkrules-preview.json
+    reason: These legacy child-resource routes are supported only by the 2018-01-01-preview controller and were replaced by networkRuleSets in current API versions.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}"]
+  - suppress: MISSING_APIS_IN_DEFAULT_TAG
+    from: preview/2018-01-01-preview/ipfilterrules-preview.json
+    reason: These legacy child-resource routes are supported only by the 2018-01-01-preview controller and were replaced by networkRuleSets in current API versions.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}"]
+  - suppress: MISSING_APIS_IN_DEFAULT_TAG
+    from: preview/2018-01-01-preview/sku.json
+    reason: The legacy SKU region discovery route is not implemented by the current Event Hubs SKU controller.
+    where: $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.EventHub/sku/{sku}/regions"]
+
   - suppress: ResourceNameRestriction
     from: openapi.json
     reason: Existing Event Hub and cluster parent names and Fabric shortcut names have no service-enforced regular expression constraint.


### PR DESCRIPTION
## Summary

- Add the `2026-07-01-preview` Event Hubs management API version based on `2026-01-01`.
- Add Fabric Shortcut CRUD, list, approve, and reject APIs from internal PR 15914488.
- Add Dedicated cluster Upgrade Preferences get, create/update, and upgrade-now APIs from internal PR 16291983.
- Add TypeSpec source examples, generated examples, and the generated preview OpenAPI document.

## Validation

- TypeSpec compilation completed successfully.
- The generated OpenAPI document passed `oav validate-spec`.
- All `2026-01-01` operations and schemas remain unchanged in the new preview version.

## Purpose of this PR

- [x] New API version for an existing resource provider.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [ ] I have reviewed the Resource Provider guidelines, ARM resource provider contract, and REST guidelines.
- [ ] A release plan has been created.