### PR TITLE
[ServiceBus] Add 2026-07-01-preview API version

### DIFF
--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationCompleteMigration.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationCompleteMigration.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "MigrationConfigs_CompleteMigration",
+  "title": "MigrationConfigurationsCompleteMigration"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationCreateAndStartMigration.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationCreateAndStartMigration.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "parameters": {
+      "properties": {
+        "postMigrationName": "sdk-PostMigration-5919",
+        "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Initiating",
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Accepted",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Initiating",
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Accepted",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_CreateAndStartMigration",
+  "title": "MigrationConfigurationsStartMigration"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "MigrationConfigs_Delete",
+  "title": "MigrationConfigurationsDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Active",
+          "pendingReplicationOperationsCount": 0,
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Succeeded",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_Get",
+  "title": "MigrationConfigurationsGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationList.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-9259",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Namespace-9259",
+            "type": "Microsoft.ServiceBus/Namespaces/migrationconfigurations",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9259/migrationConfigs/sdk-Namespace-9259",
+            "properties": {
+              "migrationState": "Active",
+              "postMigrationName": "sdk-PostMigration-9423",
+              "provisioningState": "Succeeded",
+              "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7454"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_List",
+  "title": "MigrationConfigurationsList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationRevert.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Migrationconfigurations/SBMigrationconfigurationRevert.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "MigrationConfigs_Revert",
+  "title": "MigrationConfigurationsRevert"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resourceAssociation1",
+        "type": "Microsoft.ServiceBus/Namespaces/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "devProfile",
+            "accessRules": [
+              {
+                "name": "inVpnRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "10"
+          },
+          "provisioningState": "Updating",
+          "resourceAssociation": {
+            "name": "association1",
+            "accessMode": "EnforcedMode"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+  "title": "NetworkSecurityPerimeterConfigurationassociationProxyName"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resourceAssociation1",
+            "type": "Microsoft.ServiceBus/Namespaces/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "devProfile",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "10"
+              },
+              "provisioningState": "Updating",
+              "resourceAssociation": {
+                "name": "association1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfiguration_List",
+  "title": "NamspaceNetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionCreate.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-8396/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-2847"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "testing",
+          "status": "Rejected"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "privateEndpointConnectionName": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateEndpointConnectionName",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/privateEndpointConnectionName",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateEndPointConnectionList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-7182/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/privateEndpointConnections/5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-7182/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5705-new"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateLinkResourcesGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/PrivateLinkResourcesGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.ServiceBus/namespaces/privateLinkResources",
+            "id": "subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.servicebus.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-Namespace-6914",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-1788",
+        "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-Namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-1788",
+        "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-AuthRules-1788",
+            "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1789",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "NameSpaceAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-1788",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-1788",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=#############################################",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=#############################################",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "NameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceCheckNameAvailability.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "parameters": {
+      "name": "sdk-Namespace-2924"
+    },
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "NameSpaceCheckNameAvailability"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceCreate.json
@@ -1,0 +1,117 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace2924",
+    "parameters": {
+      "location": "South Central US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "premiumMessagingPartitions": 2
+      },
+      "sku": {
+        "name": "Premium",
+        "capacity": 4,
+        "tier": "Premium"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "NameSpaceDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceGet.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "privateEndpointConnectionName",
+              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+              "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample/privateEndpointConnections/privateEndpointConnectionName",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.Network/privateEndpoints/NamespaceSample"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:59.35Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "NameSpaceGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceList.json
@@ -1,0 +1,881 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:40:17.27Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T07:15:30.78Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:50:38.98Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-41dc63f4-0b08-4029-b3ef-535a131bfa65.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:42:58.003Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-df52cf51-e831-4bf2-bd92-e9885f68a996",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-df52cf51-e831-4bf2-bd92-e9885f68a996",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:17:54.997Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-df52cf51-e831-4bf2-bd92-e9885f68a996",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-df52cf51-e831-4bf2-bd92-e9885f68a996.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:44:39.737Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "SBPremium",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/SBPremium",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T22:01:00.42Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sbpremium",
+              "premiumMessagingPartitions": 1,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://SBPremium.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-10-10T22:01:00.42Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 1,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-ns2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/sadfsadfsadf/providers/Microsoft.ServiceBus/namespaces/rrama-ns2",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T04:14:00.013Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-ns2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-ns2.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-03T22:53:32.927Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-20e57600-29d0-4035-ac85-74f4c54dcda1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-20e57600-29d0-4035-ac85-74f4c54dcda1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:30:49.16Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-20e57600-29d0-4035-ac85-74f4c54dcda1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-20e57600-29d0-4035-ac85-74f4c54dcda1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:17:58.483Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T18:07:30.05Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-3e538a1a-58fb-4315-b2ce-76f5c944114c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:42:57.747Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "prem-ns123",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/prem-ns123",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T00:02:39.997Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:prem-ns123",
+              "premiumMessagingPartitions": 2,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://prem-ns123.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-09-13T00:02:39.997Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 4,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:01:58.73Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T03:02:59.8Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:22:45.327Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:08:01.207Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-c05e9df3-7737-44ee-a321-15f6e0545b97",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-c05e9df3-7737-44ee-a321-15f6e0545b97",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:29:19.75Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-c05e9df3-7737-44ee-a321-15f6e0545b97",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-c05e9df3-7737-44ee-a321-15f6e0545b97.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:10:35.527Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:34:35.363Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-dcb4152c-231b-4c16-a683-07cc6b38fa46.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:33:00.957Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-f501f5e6-1f24-439b-8982-9af665156d40",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-f501f5e6-1f24-439b-8982-9af665156d40",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:25:55.707Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-f501f5e6-1f24-439b-8982-9af665156d40",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-f501f5e6-1f24-439b-8982-9af665156d40.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T07:42:59.687Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:32:08.227Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:32:57.77Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:54:05.103Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:43:50.313Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-6520cc09-01ac-40a3-bc09-c5c431116e92",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-6520cc09-01ac-40a3-bc09-c5c431116e92",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:49:59.243Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-6520cc09-01ac-40a3-bc09-c5c431116e92",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-6520cc09-01ac-40a3-bc09-c5c431116e92.servicebus.windows-int.net:443",
+              "updatedAt": "2017-02-11T08:15:36.95Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:23:32.083Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-bfba6d5c-a425-42d9-85db-0f4da770e29a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:02:57.433Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "SBPrem",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/SBPrem",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T22:16:30.87Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sbprem",
+              "premiumMessagingPartitions": 2,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://SBPrem.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-10-10T22:16:30.87Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 1,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-43b136b4-8716-40b2-97c5-0d77cac0062c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-43b136b4-8716-40b2-97c5-0d77cac0062c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:14:50.577Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-43b136b4-8716-40b2-97c5-0d77cac0062c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-43b136b4-8716-40b2-97c5-0d77cac0062c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:23:01.067Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-7c0443de-5f88-450c-b574-83f60a097dd1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-7c0443de-5f88-450c-b574-83f60a097dd1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T04:07:15.397Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-7c0443de-5f88-450c-b574-83f60a097dd1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-7c0443de-5f88-450c-b574-83f60a097dd1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:03:03.097Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:33:50.45Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-62dd7753-a5f9-42fd-a354-ca38a4505d69.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:35:33.053Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-ae18a18c-97ab-4089-965d-8acbf4794091",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-ae18a18c-97ab-4089-965d-8acbf4794091",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:43:36.517Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-ae18a18c-97ab-4089-965d-8acbf4794091",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-ae18a18c-97ab-4089-965d-8acbf4794091.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T12:40:30.587Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:46:03.773Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:43:54.56Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:59:12.1Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:33:52.23Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:45:09.27Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-d9337efd-9b27-454c-b2a5-dcfea56920d9.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:20:31.863Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:34:36.447Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:15:31.607Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-d447fb03-c7da-40fe-b5eb-14f36888837b",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-d447fb03-c7da-40fe-b5eb-14f36888837b",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T00:53:46.697Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-d447fb03-c7da-40fe-b5eb-14f36888837b",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-d447fb03-c7da-40fe-b5eb-14f36888837b.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T11:09:41.26Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "ReproSB",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/ReproSB",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-02-27T19:29:34.523Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:reprosb",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://ReproSB.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-27T19:29:58.64Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-4c90097f-19a8-42e7-bb3c-4ac088994719",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-4c90097f-19a8-42e7-bb3c-4ac088994719",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:35:32.61Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-4c90097f-19a8-42e7-bb3c-4ac088994719",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-4c90097f-19a8-42e7-bb3c-4ac088994719.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:13:52.27Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-1-23-17",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-1-23-17",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-01-23T22:54:40.907Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-1-23-17",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-1-23-17.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-04T00:53:28.777Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:43:25.71Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T11:05:31.89Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-be903820-3533-46e8-90e4-72c132411848",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-be903820-3533-46e8-90e4-72c132411848",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:24:01.923Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-be903820-3533-46e8-90e4-72c132411848",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-be903820-3533-46e8-90e4-72c132411848.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:09:42.513Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-namespace1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-namespace1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T00:47:22.963Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-namespace1",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://rrama-namespace1.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-08-05T00:47:27.297Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:38:02.517Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:03:55.96Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:42:40.01Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:33:02.363Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T04:28:10.71Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:43:51.587Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sdk-Namespace-2924",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-25T22:26:36.76Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-25T22:26:59.35Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "rrama-sb1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-sb1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-01T21:47:34.903Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-sb1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-sb1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-02T02:10:03.083Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "WhackWhack",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/WhackWhack",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T23:39:01.347Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:whackwhack",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://WhackWhack.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-04T00:56:32.687Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:51:27.73Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:19:43.383Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T01:14:25.613Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T12:33:01.727Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo1",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-28T23:54:26.927Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo1",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://bn3-rrama-foo1.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-28T23:54:26.927Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo3",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo3",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-29T00:24:09.907Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo3",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://bn3-rrama-foo3.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-29T00:24:33.233Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo2",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-28T23:57:40.82Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo2",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://bn3-rrama-foo2.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-28T23:57:40.82Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "db3-rrama-foo2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/db3-rrama-foo2",
+            "location": "North Europe",
+            "properties": {
+              "createdAt": "2017-04-29T00:10:43.463Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:db3-rrama-foo2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://db3-rrama-foo2.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-29T00:11:09.133Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "NameSpaceList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceListByResourceGroup.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceListByResourceGroup.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Namespace-2924",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-25T22:26:36.76Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-25T22:26:59.35Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "NameSpaceListByResourceGroup"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNameSpaceUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "parameters": {
+      "location": "South Central US",
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "Location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ServiceBus/namespaces/NamespaceSample?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "NameSpaceUpdate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNamespaceCreateWithIpAddressTypeDualStack.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNamespaceCreateWithIpAddressTypeDualStack.json
@@ -1,0 +1,136 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace2924",
+    "parameters": {
+      "location": "South Central US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "ipAddressType": "DualStack",
+        "premiumMessagingPartitions": 2,
+        "publicNetworkAccess": "Enabled"
+      },
+      "sku": {
+        "name": "Premium",
+        "capacity": 4,
+        "tier": "Premium"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NameSpaceCreateWithIpAddressTypeDualStack"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNamespaceFailover.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/SBNamespaceFailover.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRFailoverSample",
+    "parameters": {
+      "properties": {
+        "force": true,
+        "primaryLocation": "centralus"
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "location": "https://management.azure.com/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/EHNamespaceFailover/eastus?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Failover",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetCreate.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "virtualNetworkRules": [
+          {
+            "ignoreMissingVnetServiceEndpoint": true,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "publicNetworkAccess": "Enabled",
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetGet.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Allow",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "publicNetworkAccess": "Enabled",
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourcegroupid/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkrulesets/default",
+            "properties": {
+              "defaultAction": "Deny",
+              "ipRules": [
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.1"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.2"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.3"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.4"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.5"
+                }
+              ],
+              "virtualNetworkRules": [
+                {
+                  "ignoreMissingVnetServiceEndpoint": true,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListNetworkRuleSets",
+  "title": "NameSpaceNetworkRuleSetList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-Namespace-7982",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-5800",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Queues_CreateOrUpdateAuthorizationRule",
+  "title": "QueueAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Queues_DeleteAuthorizationRule",
+  "title": "QueueAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-Namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-5800",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Queues_GetAuthorizationRule",
+  "title": "QueueAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-AuthRules-5800",
+            "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queues_ListAuthorizationRules",
+  "title": "QueueAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-5800",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Queues_ListKeys",
+  "title": "QueueAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-5800",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Queues_RegenerateKeys",
+  "title": "QueueAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueCreate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "parameters": {
+      "properties": {
+        "enablePartitioning": true
+      }
+    },
+    "queueName": "sdk-Queues-5647",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Queues-5647",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-Queues-5647",
+        "properties": {
+          "accessedAt": "2017-05-26T18:07:34.227Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T18:07:33.68Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableExpress": false,
+          "enablePartitioning": true,
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 163840,
+          "messageCount": 0,
+          "requiresDuplicateDetection": false,
+          "requiresSession": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "updatedAt": "2017-05-26T18:07:34.227Z"
+        }
+      }
+    }
+  },
+  "operationId": "Queues_CreateOrUpdate",
+  "title": "QueueCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-183",
+    "queueName": "sdk-Queues-8708",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Queues_Delete",
+  "title": "QueueDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "queueName": "sdk-Queues-5647",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Queues-5647",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-Queues-5647",
+        "properties": {
+          "accessedAt": "0001-01-01T00:00:00Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T18:07:32.4592931Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableExpress": false,
+          "enablePartitioning": true,
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 163840,
+          "messageCount": 0,
+          "requiresDuplicateDetection": false,
+          "requiresSession": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "updatedAt": "2017-05-26T18:07:34.6243761Z"
+        }
+      }
+    }
+  },
+  "operationId": "Queues_Get",
+  "title": "QueueGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueListByNameSpace.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Queues/SBQueueListByNameSpace.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-queues-5647",
+            "type": "Microsoft.ServiceBus/Namespaces/Queues",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-queues-5647",
+            "properties": {
+              "accessedAt": "0001-01-01T00:00:00Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "createdAt": "2017-05-26T18:07:32.4592931Z",
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "duplicateDetectionHistoryTimeWindow": "PT10M",
+              "enableExpress": false,
+              "enablePartitioning": true,
+              "lockDuration": "PT1M",
+              "maxDeliveryCount": 10,
+              "maxMessageSizeInKilobytes": 10240,
+              "maxSizeInMegabytes": 163840,
+              "messageCount": 0,
+              "requiresDuplicateDetection": false,
+              "requiresSession": false,
+              "sizeInBytes": 0,
+              "status": "Active",
+              "updatedAt": "2017-05-26T18:07:34.6243761Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queues_ListByNamespace",
+  "title": "QueueListByNameSpace"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {},
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "1=1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateOrUpdate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate_CorrelationFilter.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate_CorrelationFilter.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {
+      "properties": {
+        "correlationFilter": {
+          "properties": {
+            "topicHint": "Crop"
+          }
+        },
+        "filterType": "CorrelationFilter"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "correlationFilter": {
+            "properties": {
+              "queueHint": "Crop"
+            }
+          },
+          "filterType": "CorrelationFilter"
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateCorrelationFilter"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate_SqlFilter.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleCreate_SqlFilter.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {
+      "properties": {
+        "filterType": "SqlFilter",
+        "sqlFilter": {
+          "sqlExpression": "myproperty=test"
+        }
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "myproperty=test"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateSqlFilter"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleDelete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Rules_Delete",
+  "title": "RulesDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "1=1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_Get",
+  "title": "RulesGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleListBySubscription.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Rules/RuleListBySubscription.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Rules-6571",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+            "properties": {
+              "action": {},
+              "filterType": "SqlFilter",
+              "sqlFilter": {
+                "compatibilityLevel": 20,
+                "sqlExpression": "1=1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Rules_ListBySubscriptions",
+  "title": "RulesListBySubscriptions"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/SBOperations_List.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/SBOperations_List.json
@@ -1,0 +1,303 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ServiceBus/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/register/action",
+            "display": {
+              "operation": "Registers the ServiceBus Resource Provider",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "ServiceBus Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Namespace Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/read",
+            "display": {
+              "operation": "Get Namespace Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Namespace Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "Get Namespace Listkeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/write",
+            "display": {
+              "operation": "Create or Update Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/read",
+            "display": {
+              "operation": "Get Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/Delete",
+            "display": {
+              "operation": "Delete Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Queue Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/read",
+            "display": {
+              "operation": " Get Queue Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Queue Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List Queue keys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/write",
+            "display": {
+              "operation": "Create or Update Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/read",
+            "display": {
+              "operation": "Get Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/Delete",
+            "display": {
+              "operation": "Delete Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Topic Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/read",
+            "display": {
+              "operation": " Get Topic Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Topic Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List Topic keys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/write",
+            "display": {
+              "operation": "Create or Update TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
+            "display": {
+              "operation": "Get TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/Delete",
+            "display": {
+              "operation": "Delete TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/write",
+            "display": {
+              "operation": "Create or Update Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/read",
+            "display": {
+              "operation": "Get Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/Delete",
+            "display": {
+              "operation": "Delete Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionCreate.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "parameters": {
+      "properties": {
+        "enableBatchedOperations": true
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-2178",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Subscriptions-2178",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+        "properties": {
+          "accessedAt": "2021-01-04T18:02:20.5992764Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferDeadLetterMessageCount": 0,
+            "transferMessageCount": 0
+          },
+          "createdAt": "2021-01-04T18:02:20.5992764Z",
+          "deadLetteringOnFilterEvaluationExceptions": true,
+          "deadLetteringOnMessageExpiration": true,
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "enableBatchedOperations": true,
+          "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+          "forwardTo": "sdk-Topics-3065",
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "messageCount": 0,
+          "requiresSession": false,
+          "status": "Active",
+          "updatedAt": "2021-01-04T18:02:20.5992764Z"
+        }
+      }
+    }
+  },
+  "operationId": "Subscriptions_CreateOrUpdate",
+  "title": "SubscriptionCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5882",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-3670",
+    "topicName": "sdk-Topics-1804"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Subscriptions_Delete",
+  "title": "SubscriptionDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-2178",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Subscriptions-2178",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+        "properties": {
+          "accessedAt": "2021-01-04T18:02:20.5992764Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferDeadLetterMessageCount": 0,
+            "transferMessageCount": 0
+          },
+          "createdAt": "2021-01-04T18:02:20.5992764Z",
+          "deadLetteringOnFilterEvaluationExceptions": true,
+          "deadLetteringOnMessageExpiration": true,
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "enableBatchedOperations": true,
+          "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+          "forwardTo": "sdk-Topics-3065",
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "messageCount": 0,
+          "requiresSession": false,
+          "status": "Active",
+          "updatedAt": "2021-01-04T18:02:20.5992764Z"
+        }
+      }
+    }
+  },
+  "operationId": "Subscriptions_Get",
+  "title": "SubscriptionGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionListByTopic.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Subscriptions/SBSubscriptionListByTopic.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Subscriptions-2178",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+            "properties": {
+              "accessedAt": "2021-01-04T18:02:20.5992764Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "countDetails": {
+                "activeMessageCount": 0,
+                "deadLetterMessageCount": 0,
+                "scheduledMessageCount": 0,
+                "transferDeadLetterMessageCount": 0,
+                "transferMessageCount": 0
+              },
+              "createdAt": "2021-01-04T18:02:20.5992764Z",
+              "deadLetteringOnFilterEvaluationExceptions": true,
+              "deadLetteringOnMessageExpiration": true,
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "enableBatchedOperations": true,
+              "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+              "forwardTo": "sdk-Topics-3065",
+              "lockDuration": "PT1M",
+              "maxDeliveryCount": 10,
+              "messageCount": 0,
+              "requiresSession": false,
+              "status": "Active",
+              "updatedAt": "2021-01-04T18:02:20.5992764Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Subscriptions_ListByTopic",
+  "title": "SubscriptionListByTopic"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-4310",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdateAuthorizationRule",
+  "title": "TopicAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Topics_DeleteAuthorizationRule",
+  "title": "TopicAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-4310",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Topics_GetAuthorizationRule",
+  "title": "TopicAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-AuthRules-4310",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListAuthorizationRules",
+  "title": "TopicAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules5067",
+    "namespaceName": "sdk-Namespace8408",
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093",
+    "topicName": "sdk-Topics2075"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-4310",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Topics_ListKeys",
+  "title": "TopicAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules5067",
+    "namespaceName": "sdk-Namespace8408",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093",
+    "topicName": "sdk-Topics2075"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-4310",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Topics_RegenerateKeys",
+  "title": "TopicAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicCreate.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "parameters": {
+      "properties": {
+        "enableExpress": true
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Topics-5488",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-Topics-5488",
+        "properties": {
+          "accessedAt": "2017-05-26T20:50:34.32Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T20:50:34.1Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "enableExpress": true,
+          "enablePartitioning": false,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 10240,
+          "requiresDuplicateDetection": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "subscriptionCount": 0,
+          "supportOrdering": true,
+          "updatedAt": "2017-05-26T20:50:34.32Z"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "TopicCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Topics_Delete",
+  "title": "TopicDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicGet.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Topics-5488",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-Topics-5488",
+        "properties": {
+          "accessedAt": "0001-01-01T00:00:00Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T20:50:31.4442694Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "enableExpress": true,
+          "enablePartitioning": false,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 10240,
+          "requiresDuplicateDetection": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "subscriptionCount": 0,
+          "supportOrdering": true,
+          "updatedAt": "2017-05-26T20:52:32.2092264Z"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Get",
+  "title": "TopicGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicListByNameSpace.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/Topics/SBTopicListByNameSpace.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-topics-5488",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-topics-5488",
+            "properties": {
+              "accessedAt": "0001-01-01T00:00:00Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "createdAt": "2017-05-26T20:50:31.4442694Z",
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "duplicateDetectionHistoryTimeWindow": "PT10M",
+              "enableBatchedOperations": true,
+              "enableExpress": true,
+              "enablePartitioning": false,
+              "maxMessageSizeInKilobytes": 10240,
+              "maxSizeInMegabytes": 10240,
+              "requiresDuplicateDetection": false,
+              "sizeInBytes": 0,
+              "status": "Active",
+              "subscriptionCount": 0,
+              "supportOrdering": true,
+              "updatedAt": "2017-05-26T20:52:32.2092264Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListByNamespace",
+  "title": "TopicGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4879",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-4879",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-4879",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+  "title": "DisasterRecoveryConfigsAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleListAll.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1067",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1067",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1684",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1684",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-4879",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+  "title": "NameSpaceAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aliasPrimaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "aliasSecondaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "keyName": "sdk-Authrules-1746",
+        "primaryKey": "############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListKeys",
+  "title": "DisasterRecoveryConfigsAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasCheckNameAvailability.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasCheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "parameters": {
+      "name": "sdk-DisasterRecovery-9474"
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+  "title": "AliasNameAvailability"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasCreate.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "alias": "sdk-Namespace-8860",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "parameters": {
+      "properties": {
+        "alternateName": "alternameforAlias-Namespace-8860",
+        "partnerNamespace": "sdk-Namespace-37"
+      }
+    },
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-8860",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-Namespace-8860",
+        "properties": {
+          "alternateName": "alternameforAlias-Namespace-8860",
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-8860",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-Namespace-8860",
+        "properties": {
+          "alternateName": "alternameforAlias-Namespace-8860",
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+  "title": "SBAliasCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "SouthCentralUS",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_Delete",
+  "title": "SBAliasDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasFailOver.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasFailOver.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_FailOver",
+  "title": "SBAliasFailOver"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-37/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-8860",
+          "pendingReplicationOperationsCount": 0,
+          "provisioningState": "Accepted",
+          "role": "Secondary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_Get",
+  "title": "SBAliasGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBAliasList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-DisasterRecovery-3814",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+            "properties": {
+              "partnerNamespace": "sdk-Namespace-37",
+              "provisioningState": "Accepted",
+              "role": "Primary"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_List",
+  "title": "SBAliasList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBEHAliasBreakPairing.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-07-01-preview/disasterRecoveryConfigs/SBEHAliasBreakPairing.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_BreakPairing",
+  "title": "SBEHAliasBreakPairing"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/main.tsp
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/main.tsp
@@ -55,6 +55,12 @@ enum Versions {
    * The 2026-01-01 API version.
    */
   v2026_01_01: "2026-01-01",
+
+  /**
+   * The 2026-07-01-preview API version.
+   */
+  @previewVersion
+  v2026_07_01_preview: "2026-07-01-preview",
 }
 
 interface Operations

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationCompleteMigration.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationCompleteMigration.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "MigrationConfigs_CompleteMigration",
+  "title": "MigrationConfigurationsCompleteMigration"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationCreateAndStartMigration.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationCreateAndStartMigration.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "parameters": {
+      "properties": {
+        "postMigrationName": "sdk-PostMigration-5919",
+        "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Initiating",
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Accepted",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Initiating",
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Accepted",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_CreateAndStartMigration",
+  "title": "MigrationConfigurationsStartMigration"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "MigrationConfigs_Delete",
+  "title": "MigrationConfigurationsDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-41",
+        "type": "Microsoft.ServiceBus/Namespaces/disasterrecoveryconfigs",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-41/migrationConfigs/$default",
+        "properties": {
+          "migrationState": "Active",
+          "pendingReplicationOperationsCount": 0,
+          "postMigrationName": "sdk-PostMigration-5919",
+          "provisioningState": "Succeeded",
+          "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4028"
+        }
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_Get",
+  "title": "MigrationConfigurationsGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationList.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-9259",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Namespace-9259",
+            "type": "Microsoft.ServiceBus/Namespaces/migrationconfigurations",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9259/migrationConfigs/sdk-Namespace-9259",
+            "properties": {
+              "migrationState": "Active",
+              "postMigrationName": "sdk-PostMigration-9423",
+              "provisioningState": "Succeeded",
+              "targetNamespace": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7454"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MigrationConfigs_List",
+  "title": "MigrationConfigurationsList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationRevert.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Migrationconfigurations/SBMigrationconfigurationRevert.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "configName": "$default",
+    "namespaceName": "sdk-Namespace-41",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "MigrationConfigs_Revert",
+  "title": "MigrationConfigurationsRevert"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resourceAssociation1",
+        "type": "Microsoft.ServiceBus/Namespaces/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "devProfile",
+            "accessRules": [
+              {
+                "name": "inVpnRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "10"
+          },
+          "provisioningState": "Updating",
+          "resourceAssociation": {
+            "name": "association1",
+            "accessMode": "EnforcedMode"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+  "title": "NetworkSecurityPerimeterConfigurationassociationProxyName"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resourceAssociation1",
+            "type": "Microsoft.ServiceBus/Namespaces/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/networkSecurityPerimeterConfigurations/resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "devProfile",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "10"
+              },
+              "provisioningState": "Updating",
+              "resourceAssociation": {
+                "name": "association1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfiguration_List",
+  "title": "NamspaceNetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceAssociationName": "resourceAssociation1",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionCreate.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-8396/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-2847"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "testing",
+          "status": "Rejected"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "NameSpacePrivateEndPointConnectionCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionDelete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "privateEndpointConnectionName": "928c44d5-b7c6-423b-b6fa-811e0c27b3e0",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "NameSpacePrivateEndPointConnectionDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "privateEndpointConnectionName": "privateEndpointConnectionName",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateEndpointConnectionName",
+        "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+        "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateEndpointConnections/privateEndpointConnectionName",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5828"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "NameSpacePrivateEndPointConnectionGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateEndPointConnectionList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5828",
+    "resourceGroupName": "SDK-ServiceBus-4794",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "type": "Microsoft.ServiceBus/Namespaces/PrivateEndpointConnections",
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-7182/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5705-new/privateEndpointConnections/5dc668b3-70e4-437f-b61c-a3c1e594be7a",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/SDK-ServiceBus-7182/providers/Microsoft.Network/privateEndpoints/sdk-Namespace-5705-new"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateLinkResourcesGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/PrivateLinkResourcesGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace",
+            "type": "Microsoft.ServiceBus/namespaces/privateLinkResources",
+            "id": "subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/SDK-ServiceBus-4794/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5828/privateLinkResources/namespace",
+            "properties": {
+              "groupId": "namespace",
+              "requiredMembers": [
+                "namespace"
+              ],
+              "requiredZoneNames": [
+                "privatelink.servicebus.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "NameSpacePrivateLinkResourcesGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleCreate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-Namespace-6914",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-1788",
+        "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Namespaces_DeleteAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-Namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-1788",
+        "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetAuthorizationRule",
+  "title": "NameSpaceAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1788",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-AuthRules-1788",
+            "type": "Microsoft.ServiceBus/Namespaces/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6914/AuthorizationRules/sdk-AuthRules-1789",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListAuthorizationRules",
+  "title": "NameSpaceAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleListKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-1788",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=############################################",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListKeys",
+  "title": "NameSpaceAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-1788",
+    "namespaceName": "sdk-namespace-6914",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-1788",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=#############################################",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6914.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-1788;SharedAccessKey=#############################################",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKeys",
+  "title": "NameSpaceAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceCheckNameAvailability.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "parameters": {
+      "name": "sdk-Namespace-2924"
+    },
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "NameSpaceCheckNameAvailability"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceCreate.json
@@ -1,0 +1,117 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace2924",
+    "parameters": {
+      "location": "South Central US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "premiumMessagingPartitions": 2
+      },
+      "sku": {
+        "name": "Premium",
+        "capacity": 4,
+        "tier": "Premium"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceDelete.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "NameSpaceDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceGet.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-2924",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "privateEndpointConnectionName",
+              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
+              "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/namespaces/NamespaceSample/privateEndpointConnections/privateEndpointConnectionName",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.Network/privateEndpoints/NamespaceSample"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:59.35Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "NameSpaceGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceList.json
@@ -1,0 +1,881 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:40:17.27Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-91f08e47-2b04-4943-b0cd-a5fb02b88f20",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-91f08e47-2b04-4943-b0cd-a5fb02b88f20.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T07:15:30.78Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:50:38.98Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-41dc63f4-0b08-4029-b3ef-535a131bfa65",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-41dc63f4-0b08-4029-b3ef-535a131bfa65.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:42:58.003Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-df52cf51-e831-4bf2-bd92-e9885f68a996",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-df52cf51-e831-4bf2-bd92-e9885f68a996",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:17:54.997Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-df52cf51-e831-4bf2-bd92-e9885f68a996",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-df52cf51-e831-4bf2-bd92-e9885f68a996.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:44:39.737Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "SBPremium",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/SBPremium",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T22:01:00.42Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sbpremium",
+              "premiumMessagingPartitions": 1,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://SBPremium.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-10-10T22:01:00.42Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 1,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-ns2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/sadfsadfsadf/providers/Microsoft.ServiceBus/namespaces/rrama-ns2",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T04:14:00.013Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-ns2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-ns2.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-03T22:53:32.927Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-20e57600-29d0-4035-ac85-74f4c54dcda1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-20e57600-29d0-4035-ac85-74f4c54dcda1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:30:49.16Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-20e57600-29d0-4035-ac85-74f4c54dcda1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-20e57600-29d0-4035-ac85-74f4c54dcda1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:17:58.483Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T18:07:30.05Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-3e538a1a-58fb-4315-b2ce-76f5c944114c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-3e538a1a-58fb-4315-b2ce-76f5c944114c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:42:57.747Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "prem-ns123",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/prem-ns123",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-13T00:02:39.997Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:prem-ns123",
+              "premiumMessagingPartitions": 2,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://prem-ns123.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-09-13T00:02:39.997Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 4,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:01:58.73Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-4e1bfdf1-0cff-4e86-ae80-cdcac4873039",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-4e1bfdf1-0cff-4e86-ae80-cdcac4873039.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T03:02:59.8Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:22:45.327Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-6b90b7f3-7aa0-48c9-bc30-b299dcb66c03.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:08:01.207Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-c05e9df3-7737-44ee-a321-15f6e0545b97",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-c05e9df3-7737-44ee-a321-15f6e0545b97",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:29:19.75Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-c05e9df3-7737-44ee-a321-15f6e0545b97",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-c05e9df3-7737-44ee-a321-15f6e0545b97.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:10:35.527Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:34:35.363Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-dcb4152c-231b-4c16-a683-07cc6b38fa46",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-dcb4152c-231b-4c16-a683-07cc6b38fa46.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:33:00.957Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-f501f5e6-1f24-439b-8982-9af665156d40",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-f501f5e6-1f24-439b-8982-9af665156d40",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:25:55.707Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-f501f5e6-1f24-439b-8982-9af665156d40",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-f501f5e6-1f24-439b-8982-9af665156d40.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T07:42:59.687Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:32:08.227Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-fe2ed660-2cd6-46f2-a9c3-7e11551a1f30.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:32:57.77Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:54:05.103Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-8a5e3b4e-4e97-4d85-9083-cd33536c9d71",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-8a5e3b4e-4e97-4d85-9083-cd33536c9d71.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:43:50.313Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-6520cc09-01ac-40a3-bc09-c5c431116e92",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-6520cc09-01ac-40a3-bc09-c5c431116e92",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:49:59.243Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-6520cc09-01ac-40a3-bc09-c5c431116e92",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-6520cc09-01ac-40a3-bc09-c5c431116e92.servicebus.windows-int.net:443",
+              "updatedAt": "2017-02-11T08:15:36.95Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:23:32.083Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-bfba6d5c-a425-42d9-85db-0f4da770e29a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-bfba6d5c-a425-42d9-85db-0f4da770e29a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:02:57.433Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "SBPrem",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/SBPrem",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T22:16:30.87Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sbprem",
+              "premiumMessagingPartitions": 2,
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://SBPrem.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-10-10T22:16:30.87Z"
+            },
+            "sku": {
+              "name": "Premium",
+              "capacity": 1,
+              "tier": "Premium"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-43b136b4-8716-40b2-97c5-0d77cac0062c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-43b136b4-8716-40b2-97c5-0d77cac0062c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:14:50.577Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-43b136b4-8716-40b2-97c5-0d77cac0062c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-43b136b4-8716-40b2-97c5-0d77cac0062c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:23:01.067Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-7c0443de-5f88-450c-b574-83f60a097dd1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-7c0443de-5f88-450c-b574-83f60a097dd1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T04:07:15.397Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-7c0443de-5f88-450c-b574-83f60a097dd1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-7c0443de-5f88-450c-b574-83f60a097dd1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:03:03.097Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T01:33:50.45Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-62dd7753-a5f9-42fd-a354-ca38a4505d69",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-62dd7753-a5f9-42fd-a354-ca38a4505d69.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:35:33.053Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-ae18a18c-97ab-4089-965d-8acbf4794091",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-ae18a18c-97ab-4089-965d-8acbf4794091",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:43:36.517Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-ae18a18c-97ab-4089-965d-8acbf4794091",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-ae18a18c-97ab-4089-965d-8acbf4794091.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T12:40:30.587Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:46:03.773Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-8e3b56c1-0ee8-4e13-ae88-5cadf6e2ce11.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T04:43:54.56Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:59:12.1Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-7ffca4b4-4728-4fb0-b2d0-1e7c016e3a44.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:33:52.23Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:45:09.27Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-d9337efd-9b27-454c-b2a5-dcfea56920d9",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-d9337efd-9b27-454c-b2a5-dcfea56920d9.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:20:31.863Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T02:34:36.447Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-ad5ae732-abea-4e62-9de0-c90de0ddec0a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-ad5ae732-abea-4e62-9de0-c90de0ddec0a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:15:31.607Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-d447fb03-c7da-40fe-b5eb-14f36888837b",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-d447fb03-c7da-40fe-b5eb-14f36888837b",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T00:53:46.697Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-d447fb03-c7da-40fe-b5eb-14f36888837b",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-d447fb03-c7da-40fe-b5eb-14f36888837b.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T11:09:41.26Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "ReproSB",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/ReproSB",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-02-27T19:29:34.523Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:reprosb",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://ReproSB.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-27T19:29:58.64Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-4c90097f-19a8-42e7-bb3c-4ac088994719",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-4c90097f-19a8-42e7-bb3c-4ac088994719",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:35:32.61Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-4c90097f-19a8-42e7-bb3c-4ac088994719",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-4c90097f-19a8-42e7-bb3c-4ac088994719.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T09:13:52.27Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-1-23-17",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-1-23-17",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-01-23T22:54:40.907Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-1-23-17",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-1-23-17.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-04T00:53:28.777Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:43:25.71Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-5191e541-8e4e-4229-9fdc-b89f6c3e7f12",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-5191e541-8e4e-4229-9fdc-b89f6c3e7f12.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T11:05:31.89Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-be903820-3533-46e8-90e4-72c132411848",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-be903820-3533-46e8-90e4-72c132411848",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T03:24:01.923Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-be903820-3533-46e8-90e4-72c132411848",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-be903820-3533-46e8-90e4-72c132411848.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T10:09:42.513Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "rrama-namespace1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-namespace1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T00:47:22.963Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-namespace1",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://rrama-namespace1.servicebus.windows-int.net:443/",
+              "updatedAt": "2016-08-05T00:47:27.297Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T00:38:02.517Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-a3c38e9b-32a3-4c51-85d7-263150a8dda9",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-a3c38e9b-32a3-4c51-85d7-263150a8dda9.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T05:03:55.96Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-23T03:42:40.01Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-70d3fa25-6bbe-4a6b-a381-a52cf0d539e6.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T06:33:02.363Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T04:28:10.71Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-e6536f77-0d1b-4a6b-8f42-29cc15b2930a",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-e6536f77-0d1b-4a6b-8f42-29cc15b2930a.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:43:51.587Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sdk-Namespace-2924",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-25T22:26:36.76Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-25T22:26:59.35Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "rrama-sb1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-sb1",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-01T21:47:34.903Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:rrama-sb1",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://rrama-sb1.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-02T02:10:03.083Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "WhackWhack",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/WhackWhack",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-10-10T23:39:01.347Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:whackwhack",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://WhackWhack.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-04T00:56:32.687Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-09-16T17:51:27.73Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-66ed32d6-611e-4bb0-8e1a-a6d0fc65427c.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T08:19:43.383Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2016-08-05T01:14:25.613Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:ns-e0cab401-6df8-465d-8d4a-da9a9e55cf0e",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://NS-e0cab401-6df8-465d-8d4a-da9a9e55cf0e.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-02-11T12:33:01.727Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo1",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo1",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-28T23:54:26.927Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo1",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://bn3-rrama-foo1.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-28T23:54:26.927Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo3",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo3",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-29T00:24:09.907Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo3",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://bn3-rrama-foo3.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-29T00:24:33.233Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "bn3-rrama-foo2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/bn3-rrama-foo2",
+            "location": "East US 2",
+            "properties": {
+              "createdAt": "2017-04-28T23:57:40.82Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:bn3-rrama-foo2",
+              "provisioningState": "Created",
+              "serviceBusEndpoint": "https://bn3-rrama-foo2.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-28T23:57:40.82Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          },
+          {
+            "name": "db3-rrama-foo2",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/db3-rrama-foo2",
+            "location": "North Europe",
+            "properties": {
+              "createdAt": "2017-04-29T00:10:43.463Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:db3-rrama-foo2",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://db3-rrama-foo2.servicebus.int7.windows-int.net:443/",
+              "updatedAt": "2017-04-29T00:11:09.133Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_List",
+  "title": "NameSpaceList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceListByResourceGroup.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceListByResourceGroup.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Namespace-2924",
+            "type": "Microsoft.ServiceBus/Namespaces",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+            "location": "South Central US",
+            "properties": {
+              "createdAt": "2017-05-25T22:26:36.76Z",
+              "disableLocalAuth": false,
+              "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+              "provisioningState": "Succeeded",
+              "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+              "updatedAt": "2017-05-25T22:26:59.35Z"
+            },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "NameSpaceListByResourceGroup"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNameSpaceUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3285",
+    "parameters": {
+      "location": "South Central US",
+      "tags": {
+        "tag3": "value3",
+        "tag4": "value4"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "Location": "https://management.azure.com/subscriptions/SampleSubscription/resourceGroups/ResurceGroupSample/providers/Microsoft.ServiceBus/namespaces/NamespaceSample?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "NameSpaceUpdate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNamespaceCreateWithIpAddressTypeDualStack.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNamespaceCreateWithIpAddressTypeDualStack.json
@@ -1,0 +1,136 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace2924",
+    "parameters": {
+      "location": "South Central US",
+      "properties": {
+        "geoDataReplication": {
+          "locations": [
+            {
+              "locationName": "eastus",
+              "roleType": "Primary"
+            },
+            {
+              "locationName": "southcentralus",
+              "roleType": "Secondary"
+            }
+          ],
+          "maxReplicationLagDurationInSeconds": 300
+        },
+        "ipAddressType": "DualStack",
+        "premiumMessagingPartitions": 2,
+        "publicNetworkAccess": "Enabled"
+      },
+      "sku": {
+        "name": "Premium",
+        "capacity": 4,
+        "tier": "Premium"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-2924",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2924",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T22:26:36.76Z",
+          "disableLocalAuth": false,
+          "geoDataReplication": {
+            "locations": [
+              {
+                "locationName": "eastus",
+                "roleType": "Primary"
+              },
+              {
+                "locationName": "southcentralus",
+                "roleType": "Secondary"
+              }
+            ],
+            "maxReplicationLagDurationInSeconds": 300
+          },
+          "ipAddressType": "DualStack",
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-2924",
+          "minimumTlsVersion": "1.2",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "premiumMessagingPartitions": 2,
+          "provisioningState": "Created",
+          "publicNetworkAccess": "Enabled",
+          "serviceBusEndpoint": "https://sdk-Namespace-2924.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T22:26:36.76Z"
+        },
+        "sku": {
+          "name": "Premium",
+          "capacity": 4,
+          "tier": "Premium"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "NameSpaceCreateWithIpAddressTypeDualStack"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNamespaceFailover.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/SBNamespaceFailover.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "NamespaceGeoDRFailoverSample",
+    "parameters": {
+      "properties": {
+        "force": true,
+        "primaryLocation": "centralus"
+      }
+    },
+    "resourceGroupName": "ResurceGroupSample",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status",
+        "location": "https://management.azure.com/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResurceGroupSample/providers/Microsoft.EventHub/EHNamespaceFailover/eastus?api-version=2026-07-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_Failover",
+  "title": "NameSpaceCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetCreate.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "parameters": {
+      "properties": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.1"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.2"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.3"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.4"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "1.1.1.5"
+          }
+        ],
+        "virtualNetworkRules": [
+          {
+            "ignoreMissingVnetServiceEndpoint": true,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+            }
+          },
+          {
+            "ignoreMissingVnetServiceEndpoint": false,
+            "subnet": {
+              "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "publicNetworkAccess": "Enabled",
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/854d368f-1828-428f-8f3c-f2affa9b2f7d/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetGet.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkruleset/default",
+        "properties": {
+          "defaultAction": "Allow",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.1"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.2"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.3"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.4"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "1.1.1.5"
+            }
+          ],
+          "publicNetworkAccess": "Enabled",
+          "virtualNetworkRules": [
+            {
+              "ignoreMissingVnetServiceEndpoint": true,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+              }
+            },
+            {
+              "ignoreMissingVnetServiceEndpoint": false,
+              "subnet": {
+                "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/alitest/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_GetNetworkRuleSet",
+  "title": "NameSpaceNetworkRuleSetGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6019",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.ServiceBus/Namespaces/NetworkRuleSet",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourcegroupid/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9659/networkrulesets/default",
+            "properties": {
+              "defaultAction": "Deny",
+              "ipRules": [
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.1"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.2"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.3"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.4"
+                },
+                {
+                  "action": "Allow",
+                  "ipMask": "1.1.1.5"
+                }
+              ],
+              "virtualNetworkRules": [
+                {
+                  "ignoreMissingVnetServiceEndpoint": true,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet2"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet3"
+                  }
+                },
+                {
+                  "ignoreMissingVnetServiceEndpoint": false,
+                  "subnet": {
+                    "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourcegroups/resourcegroupid/providers/Microsoft.Network/virtualNetworks/myvn/subnets/subnet6"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListNetworkRuleSets",
+  "title": "NameSpaceNetworkRuleSetList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-Namespace-7982",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-5800",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Queues_CreateOrUpdateAuthorizationRule",
+  "title": "QueueAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Queues_DeleteAuthorizationRule",
+  "title": "QueueAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-Namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-5800",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Queues_GetAuthorizationRule",
+  "title": "QueueAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-AuthRules-5800",
+            "type": "Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-7982/queues/sdk-Queues-2317/authorizationRules/sdk-AuthRules-5800",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queues_ListAuthorizationRules",
+  "title": "QueueAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-5800",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Queues_ListKeys",
+  "title": "QueueAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-5800",
+    "namespaceName": "sdk-namespace-7982",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "queueName": "sdk-Queues-2317",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-5800",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "primaryKey": "############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-7982.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-5800;SharedAccessKey=############################################;EntityPath=sdk-Queues-2317",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "Queues_RegenerateKeys",
+  "title": "QueueAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueCreate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "parameters": {
+      "properties": {
+        "enablePartitioning": true
+      }
+    },
+    "queueName": "sdk-Queues-5647",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Queues-5647",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-Queues-5647",
+        "properties": {
+          "accessedAt": "2017-05-26T18:07:34.227Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T18:07:33.68Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableExpress": false,
+          "enablePartitioning": true,
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 163840,
+          "messageCount": 0,
+          "requiresDuplicateDetection": false,
+          "requiresSession": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "updatedAt": "2017-05-26T18:07:34.227Z"
+        }
+      }
+    }
+  },
+  "operationId": "Queues_CreateOrUpdate",
+  "title": "QueueCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-183",
+    "queueName": "sdk-Queues-8708",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Queues_Delete",
+  "title": "QueueDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "queueName": "sdk-Queues-5647",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Queues-5647",
+        "type": "Microsoft.ServiceBus/Namespaces/Queues",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-Queues-5647",
+        "properties": {
+          "accessedAt": "0001-01-01T00:00:00Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T18:07:32.4592931Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableExpress": false,
+          "enablePartitioning": true,
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 163840,
+          "messageCount": 0,
+          "requiresDuplicateDetection": false,
+          "requiresSession": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "updatedAt": "2017-05-26T18:07:34.6243761Z"
+        }
+      }
+    }
+  },
+  "operationId": "Queues_Get",
+  "title": "QueueGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueListByNameSpace.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Queues/SBQueueListByNameSpace.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-3174",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-queues-5647",
+            "type": "Microsoft.ServiceBus/Namespaces/Queues",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3174/queues/sdk-queues-5647",
+            "properties": {
+              "accessedAt": "0001-01-01T00:00:00Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "createdAt": "2017-05-26T18:07:32.4592931Z",
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "duplicateDetectionHistoryTimeWindow": "PT10M",
+              "enableExpress": false,
+              "enablePartitioning": true,
+              "lockDuration": "PT1M",
+              "maxDeliveryCount": 10,
+              "maxMessageSizeInKilobytes": 10240,
+              "maxSizeInMegabytes": 163840,
+              "messageCount": 0,
+              "requiresDuplicateDetection": false,
+              "requiresSession": false,
+              "sizeInBytes": 0,
+              "status": "Active",
+              "updatedAt": "2017-05-26T18:07:34.6243761Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queues_ListByNamespace",
+  "title": "QueueListByNameSpace"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {},
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "1=1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateOrUpdate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate_CorrelationFilter.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate_CorrelationFilter.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {
+      "properties": {
+        "correlationFilter": {
+          "properties": {
+            "topicHint": "Crop"
+          }
+        },
+        "filterType": "CorrelationFilter"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "correlationFilter": {
+            "properties": {
+              "queueHint": "Crop"
+            }
+          },
+          "filterType": "CorrelationFilter"
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateCorrelationFilter"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate_SqlFilter.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleCreate_SqlFilter.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "parameters": {
+      "properties": {
+        "filterType": "SqlFilter",
+        "sqlFilter": {
+          "sqlExpression": "myproperty=test"
+        }
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/resourceGroupName/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "myproperty=test"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_CreateOrUpdate",
+  "title": "RulesCreateSqlFilter"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleDelete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Rules_Delete",
+  "title": "RulesDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "ruleName": "sdk-Rules-6571",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Rules-6571",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+        "properties": {
+          "action": {},
+          "filterType": "SqlFilter",
+          "sqlFilter": {
+            "compatibilityLevel": 20,
+            "sqlExpression": "1=1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Rules_Get",
+  "title": "RulesGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleListBySubscription.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Rules/RuleListBySubscription.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1319",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-8691",
+    "topicName": "sdk-Topics-2081"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Rules-6571",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1319/topics/sdk-Topics-2081/subscriptions/sdk-Subscriptions-8691/rules/sdk-Rules-6571",
+            "properties": {
+              "action": {},
+              "filterType": "SqlFilter",
+              "sqlFilter": {
+                "compatibilityLevel": 20,
+                "sqlExpression": "1=1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Rules_ListBySubscriptions",
+  "title": "RulesListBySubscriptions"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/SBOperations_List.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/SBOperations_List.json
@@ -1,0 +1,303 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ServiceBus/checkNameAvailability/action",
+            "display": {
+              "operation": "Get namespace availability.",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Non Resource Operation"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/register/action",
+            "display": {
+              "operation": "Registers the ServiceBus Resource Provider",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "ServiceBus Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/write",
+            "display": {
+              "operation": "Create Or Update Namespace ",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/read",
+            "display": {
+              "operation": "Get Namespace Resource",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/Delete",
+            "display": {
+              "operation": "Delete Namespace",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Namespace Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/read",
+            "display": {
+              "operation": "Get Namespace Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Namespace Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "Get Namespace Listkeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/write",
+            "display": {
+              "operation": "Create or Update Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/read",
+            "display": {
+              "operation": "Get Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/Delete",
+            "display": {
+              "operation": "Delete Queue",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Queue Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/read",
+            "display": {
+              "operation": " Get Queue Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Queue Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List Queue keys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/queues/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Queue AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/write",
+            "display": {
+              "operation": "Create or Update Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/read",
+            "display": {
+              "operation": "Get Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/Delete",
+            "display": {
+              "operation": "Delete Topic",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/write",
+            "display": {
+              "operation": "Create or Update Topic Authorization Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/read",
+            "display": {
+              "operation": " Get Topic Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/delete",
+            "display": {
+              "operation": "Delete Topic Authorization Rules",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/listkeys/action",
+            "display": {
+              "operation": "List Topic keys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/authorizationRules/regenerateKeys/action",
+            "display": {
+              "operation": "Resource Regeneratekeys",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Topic AuthorizationRules"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/write",
+            "display": {
+              "operation": "Create or Update TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
+            "display": {
+              "operation": "Get TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/Delete",
+            "display": {
+              "operation": "Delete TopicSubscription",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "TopicSubscription"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/write",
+            "display": {
+              "operation": "Create or Update Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/read",
+            "display": {
+              "operation": "Get Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/Delete",
+            "display": {
+              "operation": "Delete Rule",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Rule"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/metricDefinitions/read",
+            "display": {
+              "operation": "Get Namespace metrics",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace metrics"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Namespace diagnostic settings",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/diagnosticSettings/write",
+            "display": {
+              "operation": "Create or Update Namespace diagnostic settings",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace diagnostic settings"
+            }
+          },
+          {
+            "name": "Microsoft.ServiceBus/namespaces/logDefinitions/read",
+            "display": {
+              "operation": "Get Namespace logs",
+              "provider": "Microsoft Azure ServiceBus",
+              "resource": "Namespace logs"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionCreate.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "parameters": {
+      "properties": {
+        "enableBatchedOperations": true
+      }
+    },
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-2178",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Subscriptions-2178",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+        "properties": {
+          "accessedAt": "2021-01-04T18:02:20.5992764Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferDeadLetterMessageCount": 0,
+            "transferMessageCount": 0
+          },
+          "createdAt": "2021-01-04T18:02:20.5992764Z",
+          "deadLetteringOnFilterEvaluationExceptions": true,
+          "deadLetteringOnMessageExpiration": true,
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "enableBatchedOperations": true,
+          "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+          "forwardTo": "sdk-Topics-3065",
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "messageCount": 0,
+          "requiresSession": false,
+          "status": "Active",
+          "updatedAt": "2021-01-04T18:02:20.5992764Z"
+        }
+      }
+    }
+  },
+  "operationId": "Subscriptions_CreateOrUpdate",
+  "title": "SubscriptionCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-5882",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-3670",
+    "topicName": "sdk-Topics-1804"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Subscriptions_Delete",
+  "title": "SubscriptionDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "subscriptionName": "sdk-Subscriptions-2178",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Subscriptions-2178",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+        "properties": {
+          "accessedAt": "2021-01-04T18:02:20.5992764Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferDeadLetterMessageCount": 0,
+            "transferMessageCount": 0
+          },
+          "createdAt": "2021-01-04T18:02:20.5992764Z",
+          "deadLetteringOnFilterEvaluationExceptions": true,
+          "deadLetteringOnMessageExpiration": true,
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "enableBatchedOperations": true,
+          "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+          "forwardTo": "sdk-Topics-3065",
+          "lockDuration": "PT1M",
+          "maxDeliveryCount": 10,
+          "messageCount": 0,
+          "requiresSession": false,
+          "status": "Active",
+          "updatedAt": "2021-01-04T18:02:20.5992764Z"
+        }
+      }
+    }
+  },
+  "operationId": "Subscriptions_Get",
+  "title": "SubscriptionGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionListByTopic.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Subscriptions/SBSubscriptionListByTopic.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1349",
+    "resourceGroupName": "ResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-8740"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-Subscriptions-2178",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/Subscriptions",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1349/topics/sdk-Topics-8740/subscriptions/sdk-Subscriptions-2178",
+            "properties": {
+              "accessedAt": "2021-01-04T18:02:20.5992764Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "countDetails": {
+                "activeMessageCount": 0,
+                "deadLetterMessageCount": 0,
+                "scheduledMessageCount": 0,
+                "transferDeadLetterMessageCount": 0,
+                "transferMessageCount": 0
+              },
+              "createdAt": "2021-01-04T18:02:20.5992764Z",
+              "deadLetteringOnFilterEvaluationExceptions": true,
+              "deadLetteringOnMessageExpiration": true,
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "enableBatchedOperations": true,
+              "forwardDeadLetteredMessagesTo": "sdk-Topics-3065",
+              "forwardTo": "sdk-Topics-3065",
+              "lockDuration": "PT1M",
+              "maxDeliveryCount": 10,
+              "messageCount": 0,
+              "requiresSession": false,
+              "status": "Active",
+              "updatedAt": "2021-01-04T18:02:20.5992764Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Subscriptions_ListByTopic",
+  "title": "SubscriptionListByTopic"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleCreate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "parameters": {
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-4310",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdateAuthorizationRule",
+  "title": "TopicAuthorizationRuleCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Topics_DeleteAuthorizationRule",
+  "title": "TopicAuthorizationRuleDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-AuthRules-4310",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-AuthRules-4310",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Topics_GetAuthorizationRule",
+  "title": "TopicAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-6261",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-1984"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-AuthRules-4310",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-6261/topics/sdk-Topics-1984/authorizationRules/sdk-AuthRules-4310",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListAuthorizationRules",
+  "title": "TopicAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules5067",
+    "namespaceName": "sdk-Namespace8408",
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093",
+    "topicName": "sdk-Topics2075"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-4310",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Topics_ListKeys",
+  "title": "TopicAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleRegenerateKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicAuthorizationRuleRegenerateKey.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules5067",
+    "namespaceName": "sdk-Namespace8408",
+    "parameters": {
+      "keyType": "PrimaryKey"
+    },
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "e2f361f0-3b27-4503-a9cc-21cfba380093",
+    "topicName": "sdk-Topics2075"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "sdk-AuthRules-4310",
+        "primaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "primaryKey": "#############################################",
+        "secondaryConnectionString": "Endpoint=sb://sdk-namespace-6261.servicebus.windows-int.net/;SharedAccessKeyName=sdk-AuthRules-4310;SharedAccessKey=#############################################;EntityPath=sdk-Topics-1984",
+        "secondaryKey": "#############################################"
+      }
+    }
+  },
+  "operationId": "Topics_RegenerateKeys",
+  "title": "TopicAuthorizationRuleRegenerateKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicCreate.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "parameters": {
+      "properties": {
+        "enableExpress": true
+      }
+    },
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Topics-5488",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-Topics-5488",
+        "properties": {
+          "accessedAt": "2017-05-26T20:50:34.32Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T20:50:34.1Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "enableExpress": true,
+          "enablePartitioning": false,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 10240,
+          "requiresDuplicateDetection": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "subscriptionCount": 0,
+          "supportOrdering": true,
+          "updatedAt": "2017-05-26T20:50:34.32Z"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "TopicCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Topics_Delete",
+  "title": "TopicDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicGet.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "ArunMonocle",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4",
+    "topicName": "sdk-Topics-5488"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Topics-5488",
+        "type": "Microsoft.ServiceBus/Namespaces/Topics",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-Topics-5488",
+        "properties": {
+          "accessedAt": "0001-01-01T00:00:00Z",
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "createdAt": "2017-05-26T20:50:31.4442694Z",
+          "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "enableExpress": true,
+          "enablePartitioning": false,
+          "maxMessageSizeInKilobytes": 10240,
+          "maxSizeInMegabytes": 10240,
+          "requiresDuplicateDetection": false,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "subscriptionCount": 0,
+          "supportOrdering": true,
+          "updatedAt": "2017-05-26T20:52:32.2092264Z"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Get",
+  "title": "TopicGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicListByNameSpace.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/Topics/SBTopicListByNameSpace.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-1617",
+    "resourceGroupName": "Default-ServiceBus-WestUS",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-topics-5488",
+            "type": "Microsoft.ServiceBus/Namespaces/Topics",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1617/topics/sdk-topics-5488",
+            "properties": {
+              "accessedAt": "0001-01-01T00:00:00Z",
+              "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+              "createdAt": "2017-05-26T20:50:31.4442694Z",
+              "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+              "duplicateDetectionHistoryTimeWindow": "PT10M",
+              "enableBatchedOperations": true,
+              "enableExpress": true,
+              "enablePartitioning": false,
+              "maxMessageSizeInKilobytes": 10240,
+              "maxSizeInMegabytes": 10240,
+              "requiresDuplicateDetection": false,
+              "sizeInBytes": 0,
+              "status": "Active",
+              "subscriptionCount": 0,
+              "supportOrdering": true,
+              "updatedAt": "2017-05-26T20:52:32.2092264Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListByNamespace",
+  "title": "TopicGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4879",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-4879",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Authrules-4879",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+        "properties": {
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+  "title": "DisasterRecoveryConfigsAuthorizationRuleGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListAll.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListAll.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "RootManageSharedAccessKey",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/RootManageSharedAccessKey",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Manage",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1067",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1067",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-1684",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-1684",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          },
+          {
+            "name": "sdk-Authrules-4879",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig/AuthorizationRules",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/exampleResourceGroup/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-9080/disasterRecoveryConfigs/sdk-DisasterRecovery-4047/AuthorizationRules/sdk-Authrules-4879",
+            "properties": {
+              "rights": [
+                "Listen",
+                "Send"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+  "title": "NameSpaceAuthorizationRuleListAll"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListKey.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-4047",
+    "api-version": "2026-07-01-preview",
+    "authorizationRuleName": "sdk-Authrules-1746",
+    "namespaceName": "sdk-Namespace-2702",
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aliasPrimaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "aliasSecondaryConnectionString": "Endpoint=sb://sdk-disasterrecovery-4047.servicebus.windows-int.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=############################################",
+        "keyName": "sdk-Authrules-1746",
+        "primaryKey": "############################################",
+        "secondaryKey": "############################################"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_ListKeys",
+  "title": "DisasterRecoveryConfigsAuthorizationRuleListKey"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasCheckNameAvailability.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasCheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-9080",
+    "parameters": {
+      "name": "sdk-DisasterRecovery-9474"
+    },
+    "resourceGroupName": "exampleResourceGroup",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+  "title": "AliasNameAvailability"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasCreate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasCreate.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "alias": "sdk-Namespace-8860",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "parameters": {
+      "properties": {
+        "alternateName": "alternameforAlias-Namespace-8860",
+        "partnerNamespace": "sdk-Namespace-37"
+      }
+    },
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-Namespace-8860",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-Namespace-8860",
+        "properties": {
+          "alternateName": "alternameforAlias-Namespace-8860",
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-8860",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-Namespace-8860",
+        "properties": {
+          "alternateName": "alternameforAlias-Namespace-8860",
+          "partnerNamespace": "sdk-Namespace-37",
+          "provisioningState": "Accepted",
+          "role": "Primary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+  "title": "SBAliasCreate"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasDelete.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "SouthCentralUS",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_Delete",
+  "title": "SBAliasDelete"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasFailOver.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasFailOver.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_FailOver",
+  "title": "SBAliasFailOver"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasGet.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sdk-DisasterRecovery-3814",
+        "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-37/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+        "properties": {
+          "partnerNamespace": "sdk-Namespace-8860",
+          "pendingReplicationOperationsCount": 0,
+          "provisioningState": "Accepted",
+          "role": "Secondary"
+        }
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_Get",
+  "title": "SBAliasGet"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasList.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBAliasList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sdk-DisasterRecovery-3814",
+            "type": "Microsoft.ServiceBus/Namespaces/DisasterRecoveryConfig",
+            "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ardsouzatestRG/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-8860/disasterRecoveryConfig/sdk-DisasterRecovery-3814",
+            "properties": {
+              "partnerNamespace": "sdk-Namespace-37",
+              "provisioningState": "Accepted",
+              "role": "Primary"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DisasterRecoveryConfigs_List",
+  "title": "SBAliasList"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBEHAliasBreakPairing.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/examples/disasterRecoveryConfigs/SBEHAliasBreakPairing.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "alias": "sdk-DisasterRecovery-3814",
+    "api-version": "2026-07-01-preview",
+    "namespaceName": "sdk-Namespace-8860",
+    "resourceGroupName": "ardsouzatestRG",
+    "subscriptionId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "DisasterRecoveryConfigs_BreakPairing",
+  "title": "SBEHAliasBreakPairing"
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/servicebus.json
@@ -1,0 +1,7136 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ServiceBusManagementClient",
+    "version": "2026-07-01-preview",
+    "description": "Azure Service Bus client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "DisasterRecoveryConfigs"
+    },
+    {
+      "name": "Namespaces"
+    },
+    {
+      "name": "Namespaces AuthorizationRule"
+    },
+    {
+      "name": "Queues"
+    },
+    {
+      "name": "Topics"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "ArmDisasterRecoveries"
+    },
+    {
+      "name": "MigrationConfigs"
+    },
+    {
+      "name": "Rules"
+    },
+    {
+      "name": "Subscriptions"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ServiceBus/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/SBOperations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceBus/checkNameAvailability": {
+      "post": {
+        "operationId": "Namespaces_CheckNameAvailability",
+        "description": "Check the give namespace name availability.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailability"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceCheckNameAvailability": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceBus/namespaces": {
+      "get": {
+        "operationId": "Namespaces_List",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets all the available namespaces within the subscription, irrespective of the resource groups.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceList": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces": {
+      "get": {
+        "operationId": "Namespaces_ListByResourceGroup",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets the available namespaces within a resource group.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceListByResourceGroup": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}": {
+      "get": {
+        "operationId": "Namespaces_Get",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets a description for the specified namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceGet": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdate",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Creates or updates a service namespace. Once created, this namespace's resource manifest is immutable. This operation is idempotent.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBNamespace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'SBNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceCreate": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceCreate.json"
+          },
+          "NameSpaceCreateWithIpAddressTypeDualStack": {
+            "$ref": "./examples/NameSpaces/SBNamespaceCreateWithIpAddressTypeDualStack.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/SBNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Namespaces_Update",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Updates a service namespace. Once created, this namespace's resource manifest is immutable. This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBNamespaceUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceUpdate": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_Delete",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Deletes an existing namespace. This operation also removes all associated resources under the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceDelete": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules": {
+      "get": {
+        "operationId": "Namespaces_ListAuthorizationRules",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Gets the authorization rules for a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleListAll": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "Namespaces_GetAuthorizationRule",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Gets an authorization rule for a namespace by rule name.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639392.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleGet": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Creates or updates an authorization rule for a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639410.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The shared access authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBAuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleCreate": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Namespaces_DeleteAuthorizationRule",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Deletes a namespace authorization rule.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639417.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleDelete": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "Namespaces_ListKeys",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Gets the primary and secondary connection strings for the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639398.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleListKey": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "Namespaces_RegenerateKeys",
+        "tags": [
+          "Namespaces AuthorizationRule"
+        ],
+        "description": "Regenerates the primary or secondary connection strings for the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt718977.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate the authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/NameSpaces/SBNameSpaceAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_List",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Gets all Alias(Disaster Recovery configurations)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecoveryListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBAliasList": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_Get",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Retrieves Alias(Disaster Recovery configuration) for primary or secondary namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBAliasGet": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DisasterRecoveryConfigs_CreateOrUpdate",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Creates or updates a new Alias(Disaster Recovery configuration)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required to create an Alias(Disaster Recovery configuration)",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ArmDisasterRecovery' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "201": {
+            "description": "Resource 'ArmDisasterRecovery' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ArmDisasterRecovery"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBAliasCreate": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DisasterRecoveryConfigs_Delete",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Deletes an Alias(Disaster Recovery configuration)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBAliasDelete": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_ListAuthorizationRules",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets the authorization rules for a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceAuthorizationRuleListAll": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "DisasterRecoveryConfigs_GetAuthorizationRule",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets an authorization rule for a namespace by rule name.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639392.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DisasterRecoveryConfigsAuthorizationRuleGet": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_ListKeys",
+        "tags": [
+          "DisasterRecoveryConfigs"
+        ],
+        "description": "Gets the primary and secondary connection strings for the namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639398.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DisasterRecoveryConfigsAuthorizationRuleListKey": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/breakPairing": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_BreakPairing",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "This operation disables the Disaster Recovery and stops replicating changes from primary to secondary namespaces",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBEHAliasBreakPairing": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBEHAliasBreakPairing.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}/failover": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_FailOver",
+        "tags": [
+          "ArmDisasterRecoveries"
+        ],
+        "description": "Invokes GEO DR failover and reconfigure the alias to point to the secondary namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "The Disaster Recovery configuration name",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required to create an Alias(Disaster Recovery configuration)",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/NamespaceFailoverProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SBAliasFailOver": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasFailOver.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/disasterRecoveryConfigs/CheckNameAvailability": {
+      "post": {
+        "operationId": "DisasterRecoveryConfigs_CheckNameAvailability",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Check the give namespace name availability.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters to check availability of the given namespace name",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailability"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AliasNameAvailability": {
+            "$ref": "./examples/disasterRecoveryConfigs/SBAliasCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/failover": {
+      "post": {
+        "operationId": "Namespaces_Failover",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "GeoDR Failover",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for updating a namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FailOver"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceCreate": {
+            "$ref": "./examples/NameSpaces/SBNamespaceFailover.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FailOver"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/migrationConfigurations": {
+      "get": {
+        "operationId": "MigrationConfigs_List",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "Gets all migrationConfigurations",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrationConfigListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsList": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/migrationConfigurations/{configName}": {
+      "get": {
+        "operationId": "MigrationConfigs_Get",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "Retrieves Migration Config",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The configuration name. Should always be $default.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "$default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationConfigurationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "$default",
+                  "value": "$default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrationConfigProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsGet": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "MigrationConfigs_CreateAndStartMigration",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "Creates Migration configuration and starts migration of entities from Standard to Premium namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The configuration name. Should always be $default.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "$default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationConfigurationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "$default",
+                  "value": "$default"
+                }
+              ]
+            }
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required to create Migration Configuration",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrationConfigProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MigrationConfigProperties' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MigrationConfigProperties"
+            }
+          },
+          "201": {
+            "description": "Resource 'MigrationConfigProperties' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MigrationConfigProperties"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsStartMigration": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationCreateAndStartMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrationConfigProperties"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "MigrationConfigs_Delete",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "Deletes a MigrationConfiguration",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The configuration name. Should always be $default.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "$default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationConfigurationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "$default",
+                  "value": "$default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsDelete": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/migrationConfigurations/{configName}/revert": {
+      "post": {
+        "operationId": "MigrationConfigs_Revert",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "This operation reverts Migration",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The configuration name. Should always be $default.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "$default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationConfigurationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "$default",
+                  "value": "$default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsRevert": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationRevert.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/migrationConfigurations/{configName}/upgrade": {
+      "post": {
+        "operationId": "MigrationConfigs_CompleteMigration",
+        "tags": [
+          "MigrationConfigs"
+        ],
+        "description": "This operation Completes Migration of entities by pointing the connection strings to Premium namespace and any entities created after the operation will be under Premium Namespace. CompleteMigration operation will fail when entity migration is in-progress.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The configuration name. Should always be $default.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "$default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationConfigurationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "$default",
+                  "value": "$default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrationConfigurationsCompleteMigration": {
+            "$ref": "./examples/Migrationconfigurations/SBMigrationconfigurationCompleteMigration.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkRuleSets": {
+      "get": {
+        "operationId": "Namespaces_ListNetworkRuleSets",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets list of NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetList": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkRuleSets/default": {
+      "get": {
+        "operationId": "Namespaces_GetNetworkRuleSet",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetGet": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdateNetworkRuleSet",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Create or update NetworkRuleSet for a Namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The Namespace IpFilterRule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkRuleSet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkRuleSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceNetworkRuleSetCreate": {
+            "$ref": "./examples/NameSpaces/VirtualNetworkRule/SBNetworkRuleSetCreate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfiguration_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets list of current NetworkSecurityPerimeterConfiguration for Namespace",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamspaceNetworkSecurityPerimeterConfigurationList": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations/{resourceAssociationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_GetResourceAssociationName",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Return a NetworkSecurityPerimeterConfigurations resourceAssociationName",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "resourceAssociationName",
+            "in": "path",
+            "description": "The ResourceAssociation Name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationassociationProxyName": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationAssociationproxy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations/{resourceAssociationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Refreshes any information about the association.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "resourceAssociationName",
+            "in": "path",
+            "description": "The ResourceAssociation Name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationList": {
+            "$ref": "./examples/NameSpaces/NetworkSecurityPerimeterConfigurationReconcile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the available PrivateEndpointConnections within a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpaceCreate": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets a description for the specified Private Endpoint Connection.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionGet": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Creates or updates PrivateEndpointConnections of service namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update Status of PrivateEndPoint Connection to namespace resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionCreate": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes an existing Private Endpoint Connection.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The PrivateEndpointConnection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateEndPointConnectionDelete": {
+            "$ref": "./examples/NameSpaces/PrivateEndPointConnectionDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_Get",
+        "tags": [
+          "Namespaces"
+        ],
+        "description": "Gets lists of resources that supports Privatelinks.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NameSpacePrivateLinkResourcesGet": {
+            "$ref": "./examples/NameSpaces/PrivateLinkResourcesGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues": {
+      "get": {
+        "operationId": "Queues_ListByNamespace",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Gets the queues within a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639415.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBQueueListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueListByNameSpace": {
+            "$ref": "./examples/Queues/SBQueueListByNameSpace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}": {
+      "get": {
+        "operationId": "Queues_Get",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Returns a description for the specified queue.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639380.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBQueue"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueGet": {
+            "$ref": "./examples/Queues/SBQueueGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Queues_CreateOrUpdate",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Creates or updates a Service Bus queue. This operation is idempotent.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639395.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update a queue resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBQueue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBQueue' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBQueue"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueCreate": {
+            "$ref": "./examples/Queues/SBQueueCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Queues_Delete",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Deletes a queue from the specified namespace in a resource group.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639411.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueDelete": {
+            "$ref": "./examples/Queues/SBQueueDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}/authorizationRules": {
+      "get": {
+        "operationId": "Queues_ListAuthorizationRules",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Gets all authorization rules for a queue.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt705607.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleListAll": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "Queues_GetAuthorizationRule",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Gets an authorization rule for a queue by rule name.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt705611.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleGet": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Queues_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Creates an authorization rule for a queue.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The shared access authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBAuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleCreate": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Queues_DeleteAuthorizationRule",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Deletes a queue authorization rule.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt705609.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleDelete": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "Queues_ListKeys",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Primary and secondary connection strings to the queue.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt705608.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleListKey": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "Queues_RegenerateKeys",
+        "tags": [
+          "Queues"
+        ],
+        "description": "Regenerates the primary or secondary connection strings to the queue.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt705606.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "The queue name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate the authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/Queues/SBQueueAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics": {
+      "get": {
+        "operationId": "Topics_ListByNamespace",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Gets all the topics in a namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639388.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBTopicListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicGet": {
+            "$ref": "./examples/Topics/SBTopicListByNameSpace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}": {
+      "get": {
+        "operationId": "Topics_Get",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Returns a description for the specified topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639399.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicGet": {
+            "$ref": "./examples/Topics/SBTopicGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Topics_CreateOrUpdate",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Creates a topic in the specified namespace.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639409.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a topic resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicCreate": {
+            "$ref": "./examples/Topics/SBTopicCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Topics_Delete",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Deletes a topic from the specified namespace and resource group.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639404.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicDelete": {
+            "$ref": "./examples/Topics/SBTopicDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/authorizationRules": {
+      "get": {
+        "operationId": "Topics_ListAuthorizationRules",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Gets authorization rules for a topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleListAll": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/authorizationRules/{authorizationRuleName}": {
+      "get": {
+        "operationId": "Topics_GetAuthorizationRule",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Returns the specified authorization rule.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720676.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleGet": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Topics_CreateOrUpdateAuthorizationRule",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Creates an authorization rule for the specified topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720678.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The shared access authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBAuthorizationRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleCreate": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Topics_DeleteAuthorizationRule",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Deletes a topic authorization rule.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleDelete": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/authorizationRules/{authorizationRuleName}/listKeys": {
+      "post": {
+        "operationId": "Topics_ListKeys",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Gets the primary and secondary connection strings for the topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720677.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleListKey": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleListKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/authorizationRules/{authorizationRuleName}/regenerateKeys": {
+      "post": {
+        "operationId": "Topics_RegenerateKeys",
+        "tags": [
+          "Topics"
+        ],
+        "description": "Regenerates primary or secondary connection strings for the topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt720679.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "authorizationRuleName",
+            "in": "path",
+            "description": "The authorization rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to regenerate the authorization rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateAccessKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicAuthorizationRuleRegenerateKey": {
+            "$ref": "./examples/Topics/SBTopicAuthorizationRuleRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/subscriptions": {
+      "get": {
+        "operationId": "Subscriptions_ListByTopic",
+        "tags": [
+          "Subscriptions"
+        ],
+        "description": "List all the subscriptions under a specified topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639400.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBSubscriptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SubscriptionListByTopic": {
+            "$ref": "./examples/Subscriptions/SBSubscriptionListByTopic.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/subscriptions/{subscriptionName}": {
+      "get": {
+        "operationId": "Subscriptions_Get",
+        "tags": [
+          "Subscriptions"
+        ],
+        "description": "Returns a subscription description for the specified topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639402.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SBSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SubscriptionGet": {
+            "$ref": "./examples/Subscriptions/SBSubscriptionGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Subscriptions_CreateOrUpdate",
+        "tags": [
+          "Subscriptions"
+        ],
+        "description": "Creates a topic subscription.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639385.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a subscription resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SBSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SBSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SubscriptionCreate": {
+            "$ref": "./examples/Subscriptions/SBSubscriptionCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Subscriptions_Delete",
+        "tags": [
+          "Subscriptions"
+        ],
+        "description": "Deletes a subscription from the specified topic.",
+        "externalDocs": {
+          "url": "https://msdn.microsoft.com/en-us/library/azure/mt639381.aspx"
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SubscriptionDelete": {
+            "$ref": "./examples/Subscriptions/SBSubscriptionDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/subscriptions/{subscriptionName}/rules": {
+      "get": {
+        "operationId": "Rules_ListBySubscriptions",
+        "tags": [
+          "Rules"
+        ],
+        "description": "List all the rules within given topic-subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skip parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 1000
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RulesListBySubscriptions": {
+            "$ref": "./examples/Rules/RuleListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/subscriptions/{subscriptionName}/rules/{ruleName}": {
+      "get": {
+        "operationId": "Rules_Get",
+        "tags": [
+          "Rules"
+        ],
+        "description": "Retrieves the description for the specified rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Rule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RulesGet": {
+            "$ref": "./examples/Rules/RuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Rules_CreateOrUpdate",
+        "tags": [
+          "Rules"
+        ],
+        "description": "Creates a new rule and updates an existing rule",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create a rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Rule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Rule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Rule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RulesCreateCorrelationFilter": {
+            "$ref": "./examples/Rules/RuleCreate_CorrelationFilter.json"
+          },
+          "RulesCreateOrUpdate": {
+            "$ref": "./examples/Rules/RuleCreate.json"
+          },
+          "RulesCreateSqlFilter": {
+            "$ref": "./examples/Rules/RuleCreate_SqlFilter.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Rules_Delete",
+        "tags": [
+          "Rules"
+        ],
+        "description": "Deletes an existing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "The namespace name",
+            "required": true,
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 50
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "The topic name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "subscriptionName",
+            "in": "path",
+            "description": "The subscription name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The rule name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RulesDelete": {
+            "$ref": "./examples/Rules/RuleDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessKeys": {
+      "type": "object",
+      "description": "Namespace/ServiceBus Connection String",
+      "properties": {
+        "primaryConnectionString": {
+          "type": "string",
+          "description": "Primary connection string of the created namespace authorization rule.",
+          "readOnly": true
+        },
+        "secondaryConnectionString": {
+          "type": "string",
+          "description": "Secondary connection string of the created namespace authorization rule.",
+          "readOnly": true
+        },
+        "aliasPrimaryConnectionString": {
+          "type": "string",
+          "description": "Primary connection string of the alias if GEO DR is enabled",
+          "readOnly": true
+        },
+        "aliasSecondaryConnectionString": {
+          "type": "string",
+          "description": "Secondary  connection string of the alias if GEO DR is enabled",
+          "readOnly": true
+        },
+        "primaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit primary key for signing and validating the SAS token.",
+          "readOnly": true
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "A base64-encoded 256-bit primary key for signing and validating the SAS token.",
+          "readOnly": true
+        },
+        "keyName": {
+          "type": "string",
+          "description": "A string that describes the authorization rule.",
+          "readOnly": true
+        }
+      }
+    },
+    "AccessRights": {
+      "type": "string",
+      "enum": [
+        "Manage",
+        "Send",
+        "Listen"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRights",
+        "modelAsString": false
+      }
+    },
+    "Action": {
+      "type": "object",
+      "description": "Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.",
+      "properties": {
+        "sqlExpression": {
+          "type": "string",
+          "description": "SQL expression. e.g. MyProperty='ABC'"
+        },
+        "compatibilityLevel": {
+          "type": "integer",
+          "format": "int32",
+          "description": "This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+        },
+        "requiresPreprocessing": {
+          "type": "boolean",
+          "description": "Value that indicates whether the rule action requires preprocessing.",
+          "default": true
+        }
+      }
+    },
+    "ArmDisasterRecovery": {
+      "type": "object",
+      "description": "Single item in List or Get Alias(Disaster Recovery configuration) operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ArmDisasterRecoveryProperties",
+          "description": "Properties required to the Create Or Update Alias(Disaster Recovery configurations)",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ArmDisasterRecoveryListResult": {
+      "type": "object",
+      "description": "The response of a ArmDisasterRecovery list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ArmDisasterRecovery items on this page",
+          "items": {
+            "$ref": "#/definitions/ArmDisasterRecovery"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ArmDisasterRecoveryProperties": {
+      "type": "object",
+      "description": "Properties required to the Create Or Update Alias(Disaster Recovery configurations)",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateDR",
+          "description": "Provisioning state of the Alias(Disaster Recovery configuration) - possible values 'Accepted' or 'Succeeded' or 'Failed'",
+          "readOnly": true
+        },
+        "pendingReplicationOperationsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of entities pending to be replicated.",
+          "readOnly": true
+        },
+        "partnerNamespace": {
+          "type": "string",
+          "description": "ARM Id of the Primary/Secondary eventhub namespace name, which is part of GEO DR pairing"
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Primary/Secondary eventhub namespace name, which is part of GEO DR pairing"
+        },
+        "role": {
+          "$ref": "#/definitions/RoleDisasterRecovery",
+          "description": "role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'",
+          "readOnly": true
+        }
+      }
+    },
+    "CheckNameAvailability": {
+      "type": "object",
+      "description": "Description of a Check Name availability request properties.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Name to check the namespace name availability and The namespace name can contain only letters, numbers, and hyphens. The namespace must start with a letter, and it must end with a letter or number."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "CheckNameAvailabilityResult": {
+      "type": "object",
+      "description": "Description of a Check Name availability request properties.",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "The detailed info regarding the reason associated with the namespace.",
+          "readOnly": true
+        },
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "Value indicating namespace is availability, true if the namespace is available; otherwise, false."
+        },
+        "reason": {
+          "$ref": "#/definitions/UnavailableReason",
+          "description": "The reason for unavailability of a namespace."
+        }
+      }
+    },
+    "ConfidentialCompute": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/Mode",
+          "description": "Setting to Enable or Disable Confidential Compute"
+        }
+      }
+    },
+    "ConnectionState": {
+      "type": "object",
+      "description": "ConnectionState information.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkConnectionStatus",
+          "description": "Status of the connection."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the connection state."
+        }
+      }
+    },
+    "CorrelationFilter": {
+      "type": "object",
+      "description": "Represents the correlation filter expression.",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "description": "dictionary object for custom filters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Identifier of the correlation."
+        },
+        "messageId": {
+          "type": "string",
+          "description": "Identifier of the message."
+        },
+        "to": {
+          "type": "string",
+          "description": "Address to send to."
+        },
+        "replyTo": {
+          "type": "string",
+          "description": "Address of the queue to reply to."
+        },
+        "label": {
+          "type": "string",
+          "description": "Application specific label."
+        },
+        "sessionId": {
+          "type": "string",
+          "description": "Session identifier."
+        },
+        "replyToSessionId": {
+          "type": "string",
+          "description": "Session identifier to reply to."
+        },
+        "contentType": {
+          "type": "string",
+          "description": "Content type of the message."
+        },
+        "requiresPreprocessing": {
+          "type": "boolean",
+          "description": "Value that indicates whether the rule action requires preprocessing.",
+          "default": true
+        }
+      }
+    },
+    "DefaultAction": {
+      "type": "string",
+      "description": "Default Action for Network Rule Set",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "DefaultAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "Encryption": {
+      "type": "object",
+      "description": "Properties to configure Encryption",
+      "properties": {
+        "keyVaultProperties": {
+          "type": "array",
+          "description": "Properties of KeyVault",
+          "items": {
+            "$ref": "#/definitions/KeyVaultProperties"
+          },
+          "x-ms-client-name": "KeyVaultProperties"
+        },
+        "keySource": {
+          "type": "string",
+          "description": "Enumerates the possible value of keySource for Encryption",
+          "default": "Microsoft.KeyVault",
+          "enum": [
+            "Microsoft.KeyVault"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "requireInfrastructureEncryption": {
+          "type": "boolean",
+          "description": "Enable Infrastructure Encryption (Double Encryption)"
+        }
+      }
+    },
+    "EndPointProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Private Endpoint Connection.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "EndPointProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "EntityStatus": {
+      "type": "string",
+      "description": "Entity status.",
+      "enum": [
+        "Active",
+        "Disabled",
+        "Restoring",
+        "SendDisabled",
+        "ReceiveDisabled",
+        "Creating",
+        "Deleting",
+        "Renaming",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "EntityStatus",
+        "modelAsString": false
+      }
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "description": "The resource management error additional info.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type.",
+          "readOnly": true
+        },
+        "info": {
+          "description": "The additional info.",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "description": "The resource management error response.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorResponseError",
+          "description": "The error object."
+        }
+      }
+    },
+    "ErrorResponseError": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/ErrorResponse"
+          },
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "#/definitions/ErrorAdditionalInfo"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "FailOver": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FailOverProperties",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "FailOverProperties": {
+      "type": "object",
+      "properties": {
+        "primaryLocation": {
+          "type": "string",
+          "description": "Query parameter for the new primary location after failover."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "If Force is false then graceful failover is attempted after ensuring no data loss. If Force flag is set to true, Forced failover is attempted with possible data loss."
+        }
+      }
+    },
+    "FailoverPropertiesProperties": {
+      "type": "object",
+      "description": "Safe failover is to indicate the service should wait for pending replication to finish before switching to the secondary.",
+      "properties": {
+        "IsSafeFailover": {
+          "type": "boolean",
+          "description": "Safe failover is to indicate the service should wait for pending replication to finish before switching to the secondary."
+        }
+      }
+    },
+    "FilterType": {
+      "type": "string",
+      "description": "Rule filter types",
+      "enum": [
+        "SqlFilter",
+        "CorrelationFilter"
+      ],
+      "x-ms-enum": {
+        "name": "FilterType",
+        "modelAsString": false
+      }
+    },
+    "GeoDRRoleType": {
+      "type": "string",
+      "description": "GeoDR Role Types",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "GeoDRRoleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Primary",
+            "value": "Primary"
+          },
+          {
+            "name": "Secondary",
+            "value": "Secondary"
+          }
+        ]
+      }
+    },
+    "GeoDataReplicationProperties": {
+      "type": "object",
+      "description": "GeoDR Replication properties",
+      "properties": {
+        "maxReplicationLagDurationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum acceptable lag for data replication operations from the primary replica to a quorum of secondary replicas.  When the lag exceeds the configured amount, operations on the primary replica will be failed. The allowed values are 0 and 5 minutes to 1 day."
+        },
+        "locations": {
+          "type": "array",
+          "description": "A list of regions where replicas of the namespace are maintained.",
+          "items": {
+            "$ref": "#/definitions/NamespaceReplicaLocation"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Properties to configure User Assigned Identities for Bring your Own Keys",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "ObjectId from the KeyVault",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "TenantId from the KeyVault",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityType",
+          "description": "Type of managed service identity."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "Properties for User Assigned Identities",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "IpAddressType": {
+      "type": "string",
+      "description": "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6 (dual stack).",
+      "enum": [
+        "IPv4",
+        "DualStack"
+      ],
+      "x-ms-enum": {
+        "name": "IpAddressType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "The namespace supports IPv4 addresses only."
+          },
+          {
+            "name": "DualStack",
+            "value": "DualStack",
+            "description": "The namespace supports both IPv4 and IPv6 addresses (dual stack)."
+          }
+        ]
+      }
+    },
+    "KeyType": {
+      "type": "string",
+      "description": "The access key to regenerate.",
+      "enum": [
+        "PrimaryKey",
+        "SecondaryKey"
+      ],
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": false
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Properties to configure keyVault Properties",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the Key from KeyVault"
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "description": "Uri of KeyVault"
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "Version of KeyVault"
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentityProperties"
+        }
+      }
+    },
+    "ManagedServiceIdentityType": {
+      "type": "string",
+      "description": "Type of managed service identity.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedServiceIdentityType",
+        "modelAsString": false
+      }
+    },
+    "MessageCountDetails": {
+      "type": "object",
+      "description": "Message Count Details.",
+      "properties": {
+        "activeMessageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of active messages in the queue, topic, or subscription.",
+          "readOnly": true
+        },
+        "deadLetterMessageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of messages that are dead lettered.",
+          "readOnly": true
+        },
+        "scheduledMessageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of scheduled messages.",
+          "readOnly": true
+        },
+        "transferMessageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of messages transferred to another queue, topic, or subscription.",
+          "readOnly": true
+        },
+        "transferDeadLetterMessageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of messages transferred into dead letters.",
+          "readOnly": true
+        }
+      }
+    },
+    "MigrationConfigListResult": {
+      "type": "object",
+      "description": "The response of a MigrationConfigProperties list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MigrationConfigProperties items on this page",
+          "items": {
+            "$ref": "#/definitions/MigrationConfigProperties"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MigrationConfigProperties": {
+      "type": "object",
+      "description": "Single item in List or Get Migration Config operation",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MigrationConfigPropertiesProperties",
+          "description": "Properties required to the Create Migration Configuration",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MigrationConfigPropertiesProperties": {
+      "type": "object",
+      "description": "Properties required to the Create Migration Configuration",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of Migration ConfigurationProvisioning state of Migration Configuration",
+          "readOnly": true
+        },
+        "pendingReplicationOperationsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of entities pending to be replicated.",
+          "readOnly": true
+        },
+        "targetNamespace": {
+          "type": "string",
+          "description": "Existing premium Namespace ARM Id name which has no entities, will be used for migration"
+        },
+        "postMigrationName": {
+          "type": "string",
+          "description": "Name to access Standard Namespace after migration"
+        },
+        "migrationState": {
+          "type": "string",
+          "description": "State in which Standard to Premium Migration is, possible values : Unknown, Reverting, Completing, Initiating, Syncing, Active",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "targetNamespace",
+        "postMigrationName"
+      ]
+    },
+    "Mode": {
+      "type": "string",
+      "description": "Setting to Enable or Disable Confidential Compute",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "Mode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "NWRuleSetIpRules": {
+      "type": "object",
+      "description": "Description of NetWorkRuleSet - IpRules resource.",
+      "properties": {
+        "ipMask": {
+          "type": "string",
+          "description": "IP Mask"
+        },
+        "action": {
+          "type": "string",
+          "description": "The IP Filter Action",
+          "default": "Allow",
+          "enum": [
+            "Allow"
+          ],
+          "x-ms-enum": {
+            "name": "NetworkRuleIPAction",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Allow",
+                "value": "Allow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NWRuleSetVirtualNetworkRules": {
+      "type": "object",
+      "description": "Description of VirtualNetworkRules - NetworkRules resource.",
+      "properties": {
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "Subnet properties"
+        },
+        "ignoreMissingVnetServiceEndpoint": {
+          "type": "boolean",
+          "description": "Value that indicates whether to ignore missing VNet Service Endpoint"
+        }
+      }
+    },
+    "NamespaceFailoverProperties": {
+      "type": "object",
+      "description": "Safe failover is to indicate the service should wait for pending replication to finish before switching to the secondary.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FailoverPropertiesProperties",
+          "description": "Safe failover is to indicate the service should wait for pending replication to finish before switching to the secondary.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "NamespaceReplicaLocation": {
+      "type": "object",
+      "description": "Namespace replication properties",
+      "properties": {
+        "locationName": {
+          "type": "string",
+          "description": "Azure regions where a replica of the namespace is maintained"
+        },
+        "roleType": {
+          "$ref": "#/definitions/GeoDRRoleType",
+          "description": "GeoDR Role Types"
+        }
+      }
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "Description of NetworkRuleSet resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkRuleSetProperties",
+          "description": "NetworkRuleSet properties",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkRuleSetListResult": {
+      "type": "object",
+      "description": "The response of a NetworkRuleSet list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkRuleSet items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkRuleSet"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkRuleSetProperties": {
+      "type": "object",
+      "description": "NetworkRuleSet properties",
+      "properties": {
+        "trustedServiceAccessEnabled": {
+          "type": "boolean",
+          "description": "Value that indicates whether Trusted Service Access is Enabled or not."
+        },
+        "defaultAction": {
+          "$ref": "#/definitions/DefaultAction",
+          "description": "Default Action for Network Rule Set"
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "description": "List VirtualNetwork Rules",
+          "items": {
+            "$ref": "#/definitions/NWRuleSetVirtualNetworkRules"
+          }
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "List of IpRules",
+          "items": {
+            "$ref": "#/definitions/NWRuleSetIpRules"
+          }
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccessFlag",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "NetworkSecurityPerimeter related information",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified identifier of the resource",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Guid of the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Network Security Perimeter related configurations of a given namespace",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Properties of the Network Security Perimeter Configuration",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "Result of the List NetworkSecurityPerimeterConfiguration operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityPerimeterConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of NetworkSecurityPerimeterConfiguration",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of NetworkSecurityPerimeter configuration propagation",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of Provisioning Issues if any",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "NetworkSecurityPerimeter related information"
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation",
+          "description": "Information about resource association",
+          "readOnly": true
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesProfile",
+          "description": "Information about current network profile",
+          "readOnly": true
+        },
+        "isBackingResource": {
+          "type": "boolean",
+          "description": "True if the ServiceBus namespace is backed by another Azure resource and not visible to end users.",
+          "readOnly": true
+        },
+        "applicableFeatures": {
+          "type": "array",
+          "description": "Indicates that the NSP controls related to backing association are only applicable to a specific feature in backing resource's data plane.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "parentAssociationName": {
+          "type": "string",
+          "description": "Source Resource Association name",
+          "readOnly": true
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM Id of source resource",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesProfile": {
+      "type": "object",
+      "description": "Information about current network profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "accessRulesVersion": {
+          "type": "string",
+          "description": "Current access rules version"
+        },
+        "accessRules": {
+          "type": "array",
+          "description": "List of Access Rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRule"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation": {
+      "type": "object",
+      "description": "Information about resource association",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access Mode of the resource association"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of NetworkSecurityPerimeter configuration propagation",
+      "enum": [
+        "Unknown",
+        "Creating",
+        "Updating",
+        "Accepted",
+        "InvalidResponse",
+        "Succeeded",
+        "SucceededWithIssues",
+        "Failed",
+        "Deleting",
+        "Deleted",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "InvalidResponse",
+            "value": "InvalidResponse"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "SucceededWithIssues",
+            "value": "SucceededWithIssues"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      }
+    },
+    "NspAccessRule": {
+      "type": "object",
+      "description": "Information of Access Rule in Network Profile",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified identifier of the resource",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules"
+              }
+            ]
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/NspAccessRuleProperties",
+          "description": "Properties of Access Rule",
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NspAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound"
+          }
+        ]
+      }
+    },
+    "NspAccessRuleProperties": {
+      "type": "object",
+      "description": "Properties of Access Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NspAccessRuleDirection",
+          "description": "Direction of Access Rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes in the CIDR format for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRulePropertiesSubscriptionsItem"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "NetworkSecurityPerimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          },
+          "readOnly": true
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "FQDN for outbound rules",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRulePropertiesSubscriptionsItem": {
+      "type": "object",
+      "description": "Subscription for inbound rule",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of subscription"
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "A Service Bus REST API operation",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "readOnly": true
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "Display of the operation"
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin of the operation"
+        },
+        "properties": {
+          "description": "Properties of the operation",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "OperationDisplay": {
+      "type": "object",
+      "description": "Operation display payload",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Resource provider of the operation",
+          "readOnly": true
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource of the operation",
+          "readOnly": true
+        },
+        "operation": {
+          "type": "string",
+          "description": "Localized friendly name for the operation",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized friendly description for the operation",
+          "readOnly": true
+        }
+      }
+    },
+    "OperationListResult": {
+      "type": "object",
+      "description": "The list of available operations.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of operations.",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results, if any."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PlatformCapabilities": {
+      "type": "object",
+      "properties": {
+        "confidentialCompute": {
+          "$ref": "#/definitions/ConfidentialCompute"
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "PrivateEndpoint information.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier for Private Endpoint."
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the PrivateEndpointConnection.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection resource.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The Private Endpoint resource for this Connection."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/ConnectionState",
+          "description": "Details about the state of the connection."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/EndPointProvisioningState",
+          "description": "Provisioning state of the Private Endpoint Connection."
+        }
+      }
+    },
+    "PrivateLinkConnectionStatus": {
+      "type": "string",
+      "description": "Status of the connection.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateLinkConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "Information of the private link resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Properties of the private link resource.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of the resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource"
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of PrivateLinkResource",
+      "properties": {
+        "groupId": {
+          "type": "string"
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "Required Members",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "Required Zone Names",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourcesListResult": {
+      "type": "object",
+      "description": "The response of a PrivateLinkResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningIssue": {
+      "type": "object",
+      "description": "Describes Provisioning issue for given NetworkSecurityPerimeterConfiguration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the issue"
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Properties of Provisioning Issue",
+          "readOnly": true
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Properties of Provisioning Issue",
+      "properties": {
+        "issueType": {
+          "type": "string",
+          "description": "Type of Issue"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue"
+        }
+      }
+    },
+    "ProvisioningStateDR": {
+      "type": "string",
+      "description": "Provisioning state of the Alias(Disaster Recovery configuration) - possible values 'Accepted' or 'Succeeded' or 'Failed'",
+      "enum": [
+        "Accepted",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningStateDR",
+        "modelAsString": false
+      }
+    },
+    "RegenerateAccessKeyParameters": {
+      "type": "object",
+      "description": "Parameters supplied to the Regenerate Authorization Rule operation, specifies which key needs to be reset.",
+      "properties": {
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "The access key to regenerate."
+        },
+        "key": {
+          "type": "string",
+          "description": "Optional, if the key value provided, is reset for KeyType value or autogenerate Key value set for keyType"
+        }
+      },
+      "required": [
+        "keyType"
+      ]
+    },
+    "ResourceAssociationAccessMode": {
+      "type": "string",
+      "description": "Access Mode of the resource association",
+      "enum": [
+        "NoAssociationMode",
+        "EnforcedMode",
+        "LearningMode",
+        "AuditMode",
+        "UnspecifiedMode"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NoAssociationMode",
+            "value": "NoAssociationMode"
+          },
+          {
+            "name": "EnforcedMode",
+            "value": "EnforcedMode"
+          },
+          {
+            "name": "LearningMode",
+            "value": "LearningMode"
+          },
+          {
+            "name": "AuditMode",
+            "value": "AuditMode"
+          },
+          {
+            "name": "UnspecifiedMode",
+            "value": "UnspecifiedMode"
+          }
+        ]
+      }
+    },
+    "ResourceNamespacePatch": {
+      "type": "object",
+      "description": "The Resource definition.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "RoleDisasterRecovery": {
+      "type": "string",
+      "description": "role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'",
+      "enum": [
+        "Primary",
+        "PrimaryNotReplicating",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "RoleDisasterRecovery",
+        "modelAsString": false
+      }
+    },
+    "Rule": {
+      "type": "object",
+      "description": "Description of Rule Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/Ruleproperties",
+          "description": "Properties of Rule resource",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RuleListResult": {
+      "type": "object",
+      "description": "The response of a Rule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Rule items on this page",
+          "items": {
+            "$ref": "#/definitions/Rule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Ruleproperties": {
+      "type": "object",
+      "description": "Description of Rule Resource.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/Action",
+          "description": "Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+        },
+        "filterType": {
+          "$ref": "#/definitions/FilterType",
+          "description": "Filter type that is evaluated against a BrokeredMessage."
+        },
+        "sqlFilter": {
+          "$ref": "#/definitions/SqlFilter",
+          "description": "Properties of sqlFilter"
+        },
+        "correlationFilter": {
+          "$ref": "#/definitions/CorrelationFilter",
+          "description": "Properties of correlationFilter"
+        }
+      }
+    },
+    "SBAuthorizationRule": {
+      "type": "object",
+      "description": "Description of a namespace authorization rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SBAuthorizationRuleProperties",
+          "description": "AuthorizationRule properties.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SBAuthorizationRuleListResult": {
+      "type": "object",
+      "description": "The response of a SBAuthorizationRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SBAuthorizationRule items on this page",
+          "items": {
+            "$ref": "#/definitions/SBAuthorizationRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SBAuthorizationRuleProperties": {
+      "type": "object",
+      "description": "AuthorizationRule properties.",
+      "properties": {
+        "rights": {
+          "type": "array",
+          "description": "The rights associated with the rule.",
+          "items": {
+            "$ref": "#/definitions/AccessRights"
+          }
+        }
+      },
+      "required": [
+        "rights"
+      ]
+    },
+    "SBClientAffineProperties": {
+      "type": "object",
+      "description": "Properties specific to client affine subscriptions.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "Indicates the Client ID of the application that created the client-affine subscription."
+        },
+        "isDurable": {
+          "type": "boolean",
+          "description": "For client-affine subscriptions, this value indicates whether the subscription is durable or not."
+        },
+        "isShared": {
+          "type": "boolean",
+          "description": "For client-affine subscriptions, this value indicates whether the subscription is shared or not."
+        }
+      }
+    },
+    "SBNamespace": {
+      "type": "object",
+      "description": "Description of a namespace resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SBNamespaceProperties",
+          "description": "Properties of the namespace.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/SBSku",
+          "description": "Properties of SKU"
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Properties of BYOK Identity description"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "SBNamespaceListResult": {
+      "type": "object",
+      "description": "The response of a SBNamespace list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SBNamespace items on this page",
+          "items": {
+            "$ref": "#/definitions/SBNamespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SBNamespaceProperties": {
+      "type": "object",
+      "description": "Properties of the namespace.",
+      "properties": {
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "The minimum TLS version for the cluster to support, e.g. '1.2'"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the namespace.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the namespace.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was created",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was updated.",
+          "readOnly": true
+        },
+        "serviceBusEndpoint": {
+          "type": "string",
+          "description": "Endpoint you can use to perform Service Bus operations.",
+          "readOnly": true
+        },
+        "metricId": {
+          "type": "string",
+          "description": "Identifier for Azure Insights metrics",
+          "readOnly": true
+        },
+        "zoneRedundant": {
+          "type": "boolean",
+          "description": "Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Properties of BYOK Encryption description"
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This property disables SAS authentication for the Service Bus namespace."
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Alternate name for namespace"
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "premiumMessagingPartitions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of partitions of a Service Bus namespace. This property is only applicable to Premium SKU namespaces. The default value is 1 and possible values are 1, 2 and 4"
+        },
+        "platformCapabilities": {
+          "$ref": "#/definitions/PlatformCapabilities"
+        },
+        "geoDataReplication": {
+          "$ref": "#/definitions/GeoDataReplicationProperties",
+          "description": "Geo Data Replication settings for the namespace"
+        },
+        "ipAddressType": {
+          "$ref": "#/definitions/IpAddressType",
+          "description": "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6 (dual stack)."
+        }
+      }
+    },
+    "SBNamespaceUpdateParameters": {
+      "type": "object",
+      "description": "Description of a namespace resource.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/SBSku",
+          "description": "Properties of SKU"
+        },
+        "properties": {
+          "$ref": "#/definitions/SBNamespaceUpdateProperties",
+          "description": "Properties of the namespace.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Properties of BYOK Identity description"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceNamespacePatch"
+        }
+      ]
+    },
+    "SBNamespaceUpdateProperties": {
+      "type": "object",
+      "description": "Properties of the namespace.",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the namespace.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the namespace.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was created",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the namespace was updated.",
+          "readOnly": true
+        },
+        "serviceBusEndpoint": {
+          "type": "string",
+          "description": "Endpoint you can use to perform Service Bus operations.",
+          "readOnly": true
+        },
+        "metricId": {
+          "type": "string",
+          "description": "Identifier for Azure Insights metrics",
+          "readOnly": true
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Properties of BYOK Encryption description"
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This property disables SAS authentication for the Service Bus namespace."
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Alternate name for namespace"
+        }
+      }
+    },
+    "SBQueue": {
+      "type": "object",
+      "description": "Description of queue Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SBQueueProperties",
+          "description": "Queue Properties",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SBQueueListResult": {
+      "type": "object",
+      "description": "The response of a SBQueue list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SBQueue items on this page",
+          "items": {
+            "$ref": "#/definitions/SBQueue"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SBQueueProperties": {
+      "type": "object",
+      "description": "The Queue Properties definition.",
+      "properties": {
+        "countDetails": {
+          "$ref": "#/definitions/MessageCountDetails",
+          "description": "Message Count Details.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was updated.",
+          "readOnly": true
+        },
+        "accessedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time a message was sent, or the last time there was a receive request to this queue.",
+          "readOnly": true
+        },
+        "sizeInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The size of the queue, in bytes.",
+          "readOnly": true
+        },
+        "messageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of messages in the queue.",
+          "readOnly": true
+        },
+        "lockDuration": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute."
+        },
+        "maxSizeInMegabytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum size of the queue in megabytes, which is the size of memory allocated for the queue. Default is 1024."
+        },
+        "maxMessageSizeInKilobytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum size (in KB) of the message payload that can be accepted by the queue. This property is only used in Premium today and default is 1024."
+        },
+        "requiresDuplicateDetection": {
+          "type": "boolean",
+          "description": "A value indicating if this queue requires duplicate detection."
+        },
+        "requiresSession": {
+          "type": "boolean",
+          "description": "A value that indicates whether the queue supports the concept of sessions."
+        },
+        "defaultMessageTimeToLive": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
+        },
+        "deadLetteringOnMessageExpiration": {
+          "type": "boolean",
+          "description": "A value that indicates whether this queue has dead letter support when a message expires."
+        },
+        "duplicateDetectionHistoryTimeWindow": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 timeSpan structure that defines the duration of the duplicate detection history. The default value is 10 minutes."
+        },
+        "maxDeliveryCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum delivery count. A message is automatically deadlettered after this number of deliveries. default value is 10."
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus",
+          "description": "Enumerates the possible values for the status of a messaging entity."
+        },
+        "enableBatchedOperations": {
+          "type": "boolean",
+          "description": "Value that indicates whether server-side batched operations are enabled."
+        },
+        "autoDeleteOnIdle": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8061 timeSpan idle interval after which the queue is automatically deleted. The minimum duration is 5 minutes."
+        },
+        "enablePartitioning": {
+          "type": "boolean",
+          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers."
+        },
+        "enableExpress": {
+          "type": "boolean",
+          "description": "A value that indicates whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage."
+        },
+        "forwardTo": {
+          "type": "string",
+          "description": "Queue/Topic name to forward the messages"
+        },
+        "forwardDeadLetteredMessagesTo": {
+          "type": "string",
+          "description": "Queue/Topic name to forward the Dead Letter message"
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "Gets and Sets Metadata of User."
+        }
+      }
+    },
+    "SBSku": {
+      "type": "object",
+      "description": "SKU of the namespace.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "Name of this SKU."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The billing tier of this particular SKU."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Messaging units for your service bus premium namespace. Valid capacities are {1, 2, 4, 8, 16} multiples of your properties.premiumMessagingPartitions setting. For example, If properties.premiumMessagingPartitions is 1 then possible capacity values are 1, 2, 4, 8, and 16. If properties.premiumMessagingPartitions is 4 then possible capacity values are 4, 8, 16, 32 and 64"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SBSubscription": {
+      "type": "object",
+      "description": "Description of subscription resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SBSubscriptionProperties",
+          "description": "Properties of subscriptions resource.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SBSubscriptionListResult": {
+      "type": "object",
+      "description": "The response of a SBSubscription list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SBSubscription items on this page",
+          "items": {
+            "$ref": "#/definitions/SBSubscription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SBSubscriptionProperties": {
+      "type": "object",
+      "description": "Description of Subscription Resource.",
+      "properties": {
+        "messageCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of messages.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the message was created.",
+          "readOnly": true
+        },
+        "accessedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time there was a receive request to this subscription.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was updated.",
+          "readOnly": true
+        },
+        "countDetails": {
+          "$ref": "#/definitions/MessageCountDetails",
+          "description": "Message count details",
+          "readOnly": true
+        },
+        "lockDuration": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8061 lock duration timespan for the subscription. The default value is 1 minute."
+        },
+        "requiresSession": {
+          "type": "boolean",
+          "description": "Value indicating if a subscription supports the concept of sessions."
+        },
+        "defaultMessageTimeToLive": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
+        },
+        "deadLetteringOnFilterEvaluationExceptions": {
+          "type": "boolean",
+          "description": "Value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
+        },
+        "deadLetteringOnMessageExpiration": {
+          "type": "boolean",
+          "description": "Value that indicates whether a subscription has dead letter support when a message expires."
+        },
+        "duplicateDetectionHistoryTimeWindow": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 timeSpan structure that defines the duration of the duplicate detection history. The default value is 10 minutes."
+        },
+        "maxDeliveryCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of maximum deliveries."
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus",
+          "description": "Enumerates the possible values for the status of a messaging entity."
+        },
+        "enableBatchedOperations": {
+          "type": "boolean",
+          "description": "Value that indicates whether server-side batched operations are enabled."
+        },
+        "autoDeleteOnIdle": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8061 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes."
+        },
+        "forwardTo": {
+          "type": "string",
+          "description": "Queue/Topic name to forward the messages"
+        },
+        "forwardDeadLetteredMessagesTo": {
+          "type": "string",
+          "description": "Queue/Topic name to forward the Dead Letter message"
+        },
+        "isClientAffine": {
+          "type": "boolean",
+          "description": "Value that indicates whether the subscription has an affinity to the client id."
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "Gets and Sets Metadata of User."
+        },
+        "clientAffineProperties": {
+          "$ref": "#/definitions/SBClientAffineProperties",
+          "description": "Properties specific to client affine subscriptions."
+        }
+      }
+    },
+    "SBTopic": {
+      "type": "object",
+      "description": "Description of topic resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SBTopicProperties",
+          "description": "Properties of topic resource.",
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SBTopicListResult": {
+      "type": "object",
+      "description": "The response of a SBTopic list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SBTopic items on this page",
+          "items": {
+            "$ref": "#/definitions/SBTopic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SBTopicProperties": {
+      "type": "object",
+      "description": "The Topic Properties definition.",
+      "properties": {
+        "sizeInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Size of the topic, in bytes.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time the message was created.",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The exact time the message was updated.",
+          "readOnly": true
+        },
+        "accessedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time the message was sent, or a request was received, for this topic.",
+          "readOnly": true
+        },
+        "subscriptionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of subscriptions.",
+          "readOnly": true
+        },
+        "countDetails": {
+          "$ref": "#/definitions/MessageCountDetails",
+          "description": "Message count details",
+          "readOnly": true
+        },
+        "defaultMessageTimeToLive": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
+        },
+        "maxSizeInMegabytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum size of the topic in megabytes, which is the size of the memory allocated for the topic. Default is 1024."
+        },
+        "maxMessageSizeInKilobytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum size (in KB) of the message payload that can be accepted by the topic. This property is only used in Premium today and default is 1024."
+        },
+        "requiresDuplicateDetection": {
+          "type": "boolean",
+          "description": "Value indicating if this topic requires duplicate detection."
+        },
+        "duplicateDetectionHistoryTimeWindow": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO8601 timespan structure that defines the duration of the duplicate detection history. The default value is 10 minutes."
+        },
+        "enableBatchedOperations": {
+          "type": "boolean",
+          "description": "Value that indicates whether server-side batched operations are enabled."
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus",
+          "description": "Enumerates the possible values for the status of a messaging entity."
+        },
+        "supportOrdering": {
+          "type": "boolean",
+          "description": "Value that indicates whether the topic supports ordering."
+        },
+        "autoDeleteOnIdle": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO 8601 timespan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes."
+        },
+        "enablePartitioning": {
+          "type": "boolean",
+          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled."
+        },
+        "enableExpress": {
+          "type": "boolean",
+          "description": "Value that indicates whether Express Entities are enabled. An express topic holds a message in memory temporarily before writing it to persistent storage."
+        },
+        "userMetadata": {
+          "type": "string",
+          "description": "Gets and Sets Metadata of User."
+        }
+      }
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "Name of this SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": false
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The billing tier of this particular SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": false
+      }
+    },
+    "SqlFilter": {
+      "type": "object",
+      "description": "Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.",
+      "properties": {
+        "sqlExpression": {
+          "type": "string",
+          "description": "The SQL expression. e.g. MyProperty='ABC'"
+        },
+        "compatibilityLevel": {
+          "type": "integer",
+          "format": "int32",
+          "description": "This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+        },
+        "requiresPreprocessing": {
+          "type": "boolean",
+          "description": "Value that indicates whether the rule action requires preprocessing.",
+          "default": true
+        }
+      }
+    },
+    "Subnet": {
+      "type": "object",
+      "description": "Properties supplied for Subnet",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID of Virtual Network Subnet"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "TlsVersion": {
+      "type": "string",
+      "description": "The minimum TLS version for the cluster to support, e.g. '1.3'",
+      "enum": [
+        "1.0",
+        "1.1",
+        "1.2",
+        "1.3"
+      ],
+      "x-ms-enum": {
+        "name": "TlsVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "1.0",
+            "value": "1.0"
+          },
+          {
+            "name": "1.1",
+            "value": "1.1"
+          },
+          {
+            "name": "1.2",
+            "value": "1.2"
+          },
+          {
+            "name": "1.3",
+            "value": "1.3"
+          }
+        ]
+      }
+    },
+    "UnavailableReason": {
+      "type": "string",
+      "description": "Specifies the reason for the unavailability of the service.",
+      "enum": [
+        "None",
+        "InvalidName",
+        "SubscriptionIsDisabled",
+        "NameInUse",
+        "NameInLockdown",
+        "TooManyNamespaceInCurrentSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "UnavailableReason",
+        "modelAsString": false
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "Recognized Dictionary value.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "Principal Id of user assigned identity",
+          "readOnly": true,
+          "x-ms-client-name": "PrincipalId"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Client Id of user assigned identity",
+          "readOnly": true,
+          "x-ms-client-name": "ClientId"
+        }
+      }
+    },
+    "UserAssignedIdentityProperties": {
+      "type": "object",
+      "properties": {
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "ARM ID of user Identity selected for encryption"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/readme.md
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/readme.md
@@ -26,7 +26,16 @@ These are the global settings for the ServiceBus API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-01
+tag: package-2026-07-preview
+```
+
+### Tag: package-2026-07-preview
+
+These settings apply only when `--tag=package-2026-07-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-07-preview'
+input-file:
+- ./preview/2026-07-01-preview/servicebus.json
 ```
 
 ### Tag: package-2026-01
@@ -301,5 +310,3 @@ directive:
     from: servicebus.json
     reason: Suppress it for now to avoid breaking change because it is referenced by many files.Will update in next api version.Please scope the suppression to the Namespaces PATCH operation only.
 ```
-
-

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/readme.md
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the ServiceBus API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-07-preview
+tag: package-2026-01
 ```
 
 ### Tag: package-2026-07-preview


### PR DESCRIPTION
## Purpose of this PR

- [x] New API version for an existing resource provider.
- [ ] New resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [ ] Other, please clarify.

## Summary

- Adds the `2026-07-01-preview` Service Bus ARM API version.
- Carries forward the complete `2026-01-01` stable API surface without feature changes.
- Copies all 73 stable examples and updates their API version.
- Adds the generated preview OpenAPI and updates the AutoRest README tag.

## Validation

- `npx tsv specification\servicebus\resource-manager\Microsoft.ServiceBus\ServiceBus`
- TypeSpec validation and compilation succeeded.
- The generated preview output is identical to `2026-01-01` after normalizing the API-version string.

## Due diligence checklist

- [x] I confirm this PR modifies Azure Resource Manager (ARM) specifications, not data-plane specifications.
- [ ] I have reviewed the Resource Provider guidelines, ARM resource provider contract, and REST guidelines.
- [ ] A release plan has been created.