### PR TITLE
Fix AgentServer response model contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/readme.md
+++ b/specification/ai-foundry/data-plane/Foundry/readme.md
@@ -1,0 +1,5 @@
+# Foundry data-plane TypeSpec
+
+> see https://aka.ms/autorest
+
+This folder contains the TypeSpec for Foundry data-plane APIs.

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/client.tsp
@@ -230,6 +230,12 @@ namespace Azure.AI.Projects {
     }
   );
 
+  // ItemMessage spreads OpenAI.Message, whose content is an array. The Responses
+  // input contract also accepts string shorthand, and this client uses ItemMessage
+  // in the merged input/output item union.
+  @@withoutOmittedProperties(OpenAI.ItemMessage, "content");
+  @@copyProperties(OpenAI.ItemMessage, { content: string | OpenAI.MessageContent[] });
+
   // To avoid conflicts with Azure.Response
   @@clientName(OpenAI.Response, "ResponseObject");
 
@@ -262,7 +268,4 @@ namespace Azure.AI.Projects {
   @@access(UpdateAgentRequest, Access.public);
   @@usage(UpdateAgentRequest, Usage.input);
 
-  @@access(OpenAI.ItemCustomToolCallOutput, Access.public);
-  @@usage(OpenAI.ItemCustomToolCallOutput, Usage.input | Usage.output);
-  @@clientName(OpenAI.ItemCustomToolCallOutput, "OutputItemCustomToolCallOutput");
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/readme.md
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/readme.md
@@ -1,0 +1,5 @@
+# Agent service contracts SDK TypeSpec
+
+> see https://aka.ms/autorest
+
+This folder contains SDK-only TypeSpec projections for Azure AI Agent Service response model contracts. The REST API OpenAPI is emitted from the parent Foundry TypeSpec project.

--- a/specification/ai-foundry/data-plane/Foundry/suppressions.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/suppressions.yaml
@@ -9,6 +9,12 @@
     - "."
     - "**"
 
+- tool: TypeSpecValidation
+  reason: Design underway for folder structure and tool integration for this area
+  paths:
+    - "."
+    - "**"
+
 # Prior suppression currently superseded by the above:
 
 # - tool: TypeSpecValidation


### PR DESCRIPTION
Retargets the AgentServer response model contract fixes from the main-targeted draft PR to feature/foundry-release.\n\nChanges:\n- Removes stale OpenAI ItemCustomToolCallOutput C# customizations that no longer resolve.\n- Restores the AgentServer response input content override for SDK response creation payloads.\n- Adds Foundry readme files and TypeSpec validation suppression needed for the SDK-only contracts folder.\n\nLocal validation:\n- C# emitter: `npx tsp compile specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/client.tsp --emit @typespec/http-client-csharp --output-dir /tmp/foundry-csharp-emitter` completed with warnings only.\n- Python emitter: `npx tsp compile specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp --emit @azure-tools/typespec-python --output-dir /tmp/foundry-python-emitter` completed with warnings only.