### PR TITLE
Move lease.yaml path

### DIFF
--- a/.github/arm-leases/azurearcdata/Microsoft.AzureArcData/AzureArcData/lease.yaml
+++ b/.github/arm-leases/azurearcdata/Microsoft.AzureArcData/AzureArcData/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.AzureArcData
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/azuredependencymap/Microsoft.DependencyMap/DependencyMap/lease.yaml
+++ b/.github/arm-leases/azuredependencymap/Microsoft.DependencyMap/DependencyMap/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DependencyMap
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/dashboard/Microsoft.Dashboard/Dashboard/lease.yaml
+++ b/.github/arm-leases/dashboard/Microsoft.Dashboard/Dashboard/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.Dashboard
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/databasefleetmanager/Microsoft.DatabaseFleetManager/DatabaseFleetManager/lease.yaml
+++ b/.github/arm-leases/databasefleetmanager/Microsoft.DatabaseFleetManager/DatabaseFleetManager/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DatabaseFleetManager
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/databasewatcher/Microsoft.DatabaseWatcher/DatabaseWatcher/lease.yaml
+++ b/.github/arm-leases/databasewatcher/Microsoft.DatabaseWatcher/DatabaseWatcher/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DatabaseWatcher
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/devcenter/Microsoft.DevCenter/DevCenter/lease.yaml
+++ b/.github/arm-leases/devcenter/Microsoft.DevCenter/DevCenter/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DevCenter
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/devopsinfrastructure/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/lease.yaml
+++ b/.github/arm-leases/devopsinfrastructure/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DevOpsInfrastructure
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/elastic/Microsoft.Elastic/Elastic/lease.yaml
+++ b/.github/arm-leases/elastic/Microsoft.Elastic/Elastic/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.Elastic
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/ews/Microsoft.SecretSyncController/SecretSyncController/lease.yaml
+++ b/.github/arm-leases/ews/Microsoft.SecretSyncController/SecretSyncController/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.SecretSyncController
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/fist/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/lease.yaml
+++ b/.github/arm-leases/fist/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.IoTFirmwareDefense
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/fluidrelay/Microsoft.FluidRelay/FluidRelay/lease.yaml
+++ b/.github/arm-leases/fluidrelay/Microsoft.FluidRelay/FluidRelay/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.FluidRelay
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/healthbot/Microsoft.HealthBot/HealthBot/lease.yaml
+++ b/.github/arm-leases/healthbot/Microsoft.HealthBot/HealthBot/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.HealthBot
-  startdate: "2026-07-06"
+  startdate: "2026-07-17"
   duration: P180D
   reviewer: "@tejaswiminnu"


### PR DESCRIPTION
Updated the startdate for the following resource providers to "2026-07-17" and move folder:
- `.github/arm-leases/dashboard/Microsoft.Dashboard/Dashboard/lease.yaml`
- `.github/arm-leases/devcenter/Microsoft.DevCenter/DevCenter/lease.yaml`
- `.github/arm-leases/devopsinfrastructure/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/lease.yaml`
- `.github/arm-leases/elastic/Microsoft.Elastic/Elastic/lease.yaml`
- `.github/arm-leases/fist/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/lease.yaml`
- `.github/arm-leases/fluidrelay/Microsoft.FluidRelay/FluidRelay/lease.yaml`

Only Updated the startdate for the following resource providers to "2026-07-17":
- `.github/arm-leases/azurearcdata/Microsoft.AzureArcData/AzureArcData/lease.yaml`
- `.github/arm-leases/azuredependencymap/Microsoft.DependencyMap/DependencyMap/lease.yaml`
- `.github/arm-leases/databasefleetmanager/Microsoft.DatabaseFleetManager/DatabaseFleetManager/lease.yaml`
- `.github/arm-leases/databasewatcher/Microsoft.DatabaseWatcher/DatabaseWatcher/lease.yaml`
- `.github/arm-leases/ews/Microsoft.SecretSyncController/SecretSyncController/lease.yaml`
- `.github/arm-leases/healthbot/Microsoft.HealthBot/HealthBot/lease.yaml`