### PR TITLE
[Authorization] Add RBAC role-assignment api-version 2026-08-01 (AgentUser/AgentServicePrincipal principalType)

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateById.json
@@ -41,4 +41,3 @@
   "operationId": "RoleAssignments_CreateById",
   "title": "Create or update role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateById.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_CreateById",
+  "title": "Create or update role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResource.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for resource"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResource.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for resource"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResourceGroup.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for resource group"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for resource group"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForSubscription.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for subscription"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_CreateForSubscription.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for subscription"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Delete.json
@@ -23,4 +23,3 @@
   "operationId": "RoleAssignments_Delete",
   "title": "Delete role assignment"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Delete.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "roleAssignmentName": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RoleAssignments_Delete",
+  "title": "Delete role assignment"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_DeleteById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_DeleteById.json
@@ -22,4 +22,3 @@
   "operationId": "RoleAssignments_DeleteById",
   "title": "Delete role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_DeleteById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_DeleteById.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RoleAssignments_DeleteById",
+  "title": "Delete role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Get.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Get.json
@@ -22,4 +22,3 @@
   "operationId": "RoleAssignments_Get",
   "title": "Get role assignment by scope and name"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Get.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "roleAssignmentName": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Get",
+  "title": "Get role assignment by scope and name"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_GetById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_GetById.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_GetById",
+  "title": "Get role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_GetById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_GetById.json
@@ -21,4 +21,3 @@
   "operationId": "RoleAssignments_GetById",
   "title": "Get role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResource.json
@@ -51,4 +51,3 @@
   "operationId": "RoleAssignments_ListForResource",
   "title": "List role assignments for a resource"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResource.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "testrg",
+    "resourceProviderNamespace": "Microsoft.DocumentDb",
+    "resourceType": "databaseAccounts",
+    "resourceName": "test-db-account",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          },
+          {
+            "name": "96786e4b-dede-4c2e-8736-8ab911987f08",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/96786e4b-dede-4c2e-8736-8ab911987f08",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+            }
+          },
+          {
+            "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForResource",
+  "title": "List role assignments for a resource"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResourceGroup.json
@@ -37,4 +37,3 @@
   "operationId": "RoleAssignments_ListForResourceGroup",
   "title": "List role assignments for resource group"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForResourceGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          },
+          {
+            "name": "96786e4b-dede-4c2e-8736-8ab911987f08",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/96786e4b-dede-4c2e-8736-8ab911987f08",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForResourceGroup",
+  "title": "List role assignments for resource group"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForScope.json
@@ -25,4 +25,3 @@
   "operationId": "RoleAssignments_ListForScope",
   "title": "List role assignments for scope"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForScope.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForScope",
+  "title": "List role assignments for scope"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForSubscription.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForSubscription",
+  "title": "List role assignments for subscription"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/examples/2026-08-01/RoleAssignments_ListForSubscription.json
@@ -25,4 +25,3 @@
   "operationId": "RoleAssignments_ListForSubscription",
   "title": "List role assignments for subscription"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/main.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/main.tsp
@@ -40,4 +40,9 @@ enum Versions {
    * The 2022-04-01 API version.
    */
   v2022_04_01: "2022-04-01",
+
+  /**
+   * The 2026-08-01 API version. Adds the AgentUser / AgentServicePrincipal principal types.
+   */
+  v2026_08_01: "2026-08-01",
 }

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -1,15 +1,61 @@
-﻿import "@typespec/rest";
+import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-resource-manager";
 import "../Common/main.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Foundations;
 using Microsoft.Common;
 
 namespace Microsoft.RoleAssignment;
+
+/**
+ * The principal type of the assigned principal ID.
+ */
+union PrincipalType {
+  string,
+
+  /**
+   * User
+   */
+  User: "User",
+
+  /**
+   * Group
+   */
+  Group: "Group",
+
+  /**
+   * ServicePrincipal
+   */
+  ServicePrincipal: "ServicePrincipal",
+
+  /**
+   * ForeignGroup
+   */
+  ForeignGroup: "ForeignGroup",
+
+  /**
+   * Device
+   */
+  Device: "Device",
+
+  /**
+   * AgentUser (agentic identity derived from a User). Available from api-version 2026-08-01.
+   */
+  @added(Versions.v2026_08_01)
+  AgentUser: "AgentUser",
+
+  /**
+   * AgentServicePrincipal (agentic identity derived from a ServicePrincipal). Available from api-version 2026-08-01.
+   */
+  @added(Versions.v2026_08_01)
+  AgentServicePrincipal: "AgentServicePrincipal",
+}
 
 /**
  * Role assignment properties.

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -14,9 +14,9 @@ using Microsoft.Common;
 namespace Microsoft.RoleAssignment;
 
 /**
- * The principal type of the assigned principal ID.
+ * The principal type of the assigned principal ID (role-assignment surface, api-version 2026-08-01 and later).
  */
-union PrincipalType {
+union RoleAssignmentPrincipalType {
   string,
 
   /**
@@ -45,15 +45,13 @@ union PrincipalType {
   Device: "Device",
 
   /**
-   * AgentUser (agentic identity derived from a User). Available from api-version 2026-08-01.
+   * AgentUser (agentic identity derived from a User).
    */
-  @added(Versions.v2026_08_01)
   AgentUser: "AgentUser",
 
   /**
-   * AgentServicePrincipal (agentic identity derived from a ServicePrincipal). Available from api-version 2026-08-01.
+   * AgentServicePrincipal (agentic identity derived from a ServicePrincipal).
    */
-  @added(Versions.v2026_08_01)
   AgentServicePrincipal: "AgentServicePrincipal",
 }
 
@@ -81,7 +79,8 @@ model RoleAssignmentProperties {
   /**
    * The principal type of the assigned principal ID.
    */
-  principalType?: PrincipalType = PrincipalType.User;
+  @typeChangedFrom(Versions.v2026_08_01, PrincipalType)
+  principalType?: RoleAssignmentPrincipalType = RoleAssignmentPrincipalType.User;
 
   /**
    * Description of role assignment

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
@@ -217,6 +217,29 @@ input-file:
   - preview/2021-12-01-preview/authorization-AccessReviewCalls.json
 ```
 
+### Tag: package-2026-08-01
+
+These settings apply only when `--tag=package-2026-08-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-08-01'
+input-file:
+  - stable/2015-07-01/ClassicAdmin.json
+  - stable/2022-04-01/authorization-DenyAssignmentCalls.json
+  - stable/2022-04-01/authorization-ProviderOperationsCalls.json
+  - stable/2026-08-01/authorization-RoleAssignmentsCalls.json
+  - stable/2022-04-01/authorization-RoleDefinitionsCalls.json
+  - stable/2022-04-01/common-types.json
+  - stable/2020-10-01/EligibleChildResources.json
+  - stable/2020-10-01/RoleAssignmentSchedule.json
+  - stable/2020-10-01/RoleAssignmentScheduleInstance.json
+  - stable/2020-10-01/RoleAssignmentScheduleRequest.json
+  - stable/2020-10-01/RoleEligibilitySchedule.json
+  - stable/2020-10-01/RoleEligibilityScheduleInstance.json
+  - stable/2020-10-01/RoleEligibilityScheduleRequest.json
+  - stable/2020-10-01/RoleManagementPolicy.json
+  - stable/2020-10-01/RoleManagementPolicyAssignment.json
+```
+
 ### Tag: package-2022-04-01
 
 These settings apply only when `--tag=package-2022-04-01` is specified on the command line.

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
@@ -113,7 +113,7 @@ input-file:
   - stable/2015-07-01/ClassicAdmin.json
   - preview/2024-07-01-preview/authorization-DenyAssignmentCalls.json
   - stable/2022-04-01/authorization-ProviderOperationsCalls.json
-  - stable/2022-04-01/authorization-RoleAssignmentsCalls.json
+  - stable/2026-08-01/authorization-RoleAssignmentsCalls.json
   - preview/2022-05-01-preview/authorization-RoleDefinitionsCalls.json
   - preview/2024-09-01-preview/openapi.json
   - preview/2021-12-01-preview/authorization-AccessReviewCalls.json

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/authorization-RoleAssignmentsCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/authorization-RoleAssignmentsCalls.json
@@ -1,0 +1,812 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AuthorizationManagementClient",
+    "version": "2026-08-01",
+    "description": "Role based access control provides you a way to apply granular level policy administration down to individual resources or resource groups. These operations enable you to manage role assignments. A role assignment grants access to Azure Active Directory users.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "RoleAssignments"
+    }
+  ],
+  "paths": {
+    "/{roleAssignmentId}": {
+      "get": {
+        "operationId": "RoleAssignments_GetById",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Get a role assignment by ID.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The fully qualified ID of the role assignment including scope, resource name, and resource type. Format: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example: /subscriptions/<SUB_ID>/resourcegroups/<RESOURCE_GROUP>/providers/Microsoft.Authorization/roleAssignments/<ROLE_ASSIGNMENT_NAME>",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get role assignment by ID": {
+            "$ref": "./examples/RoleAssignments_GetById.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RoleAssignments_CreateById",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Create or update a role assignment by ID.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The fully qualified ID of the role assignment including scope, resource name, and resource type. Format: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example: /subscriptions/<SUB_ID>/resourcegroups/<RESOURCE_GROUP>/providers/Microsoft.Authorization/roleAssignments/<ROLE_ASSIGNMENT_NAME>",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentCreateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RoleAssignment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "201": {
+            "description": "Resource 'RoleAssignment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update role assignment by ID": {
+            "$ref": "./examples/RoleAssignments_CreateById.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RoleAssignments_DeleteById",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Delete a role assignment by ID.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The fully qualified ID of the role assignment including scope, resource name, and resource type. Format: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example: /subscriptions/<SUB_ID>/resourcegroups/<RESOURCE_GROUP>/providers/Microsoft.Authorization/roleAssignments/<ROLE_ASSIGNMENT_NAME>",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete role assignment by ID": {
+            "$ref": "./examples/RoleAssignments_DeleteById.json"
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Authorization/roleAssignments": {
+      "get": {
+        "operationId": "RoleAssignments_ListForScope",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "List all role assignments that apply to a scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all role assignments at or above the scope. Use $filter=principalId eq {id} to return all role assignments at, above or below the scope for the specified principal.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "The skipToken to apply on the operation. Use $skipToken={skiptoken} to return paged role assignments following the skipToken passed. Only supported on provider level calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List role assignments for scope": {
+            "$ref": "./examples/RoleAssignments_ListForScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}": {
+      "get": {
+        "operationId": "RoleAssignments_Get",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Get a role assignment by scope and name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "roleAssignmentName",
+            "in": "path",
+            "description": "The name of the role assignment. It can be any valid GUID.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get role assignment by scope and name": {
+            "$ref": "./examples/RoleAssignments_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RoleAssignments_Create",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Create or update a role assignment by scope and name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "roleAssignmentName",
+            "in": "path",
+            "description": "The name of the role assignment. It can be any valid GUID.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the role assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentCreateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RoleAssignment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "201": {
+            "description": "Resource 'RoleAssignment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create role assignment for resource": {
+            "$ref": "./examples/RoleAssignments_CreateForResource.json"
+          },
+          "Create role assignment for resource group": {
+            "$ref": "./examples/RoleAssignments_CreateForResourceGroup.json"
+          },
+          "Create role assignment for subscription": {
+            "$ref": "./examples/RoleAssignments_CreateForSubscription.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RoleAssignments_Delete",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "Delete a role assignment by scope and name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "roleAssignmentName",
+            "in": "path",
+            "description": "The name of the role assignment. It can be any valid GUID.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignment"
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete role assignment": {
+            "$ref": "./examples/RoleAssignments_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/roleAssignments": {
+      "get": {
+        "operationId": "RoleAssignments_ListForSubscription",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "List all role assignments that apply to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all role assignments at or above the scope. Use $filter=principalId eq {id} to return all role assignments at, above or below the scope for the specified principal.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List role assignments for subscription": {
+            "$ref": "./examples/RoleAssignments_ListForSubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/roleAssignments": {
+      "get": {
+        "operationId": "RoleAssignments_ListForResource",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "List all role assignments that apply to a resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the target subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the resource group. The name is case insensitive.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceProviderNamespace",
+            "in": "path",
+            "description": "The namespace of the resource provider.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The resource type of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource to get role assignments for.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all role assignments at or above the scope. Use $filter=principalId eq {id} to return all role assignments at, above or below the scope for the specified principal.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List role assignments for a resource": {
+            "$ref": "./examples/RoleAssignments_ListForResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/roleAssignments": {
+      "get": {
+        "operationId": "RoleAssignments_ListForResourceGroup",
+        "tags": [
+          "RoleAssignments"
+        ],
+        "description": "List all role assignments that apply to a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all role assignments at or above the scope. Use $filter=principalId eq {id} to return all role assignments at, above or below the scope for the specified principal.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "Tenant ID for cross-tenant request",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List role assignments for resource group": {
+            "$ref": "./examples/RoleAssignments_ListForResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "RoleAssignment": {
+      "type": "object",
+      "description": "Role Assignments",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoleAssignmentProperties",
+          "description": "Role assignment properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RoleAssignmentCreateParameters": {
+      "type": "object",
+      "description": "Role assignment create parameters.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoleAssignmentProperties",
+          "description": "Role assignment properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "RoleAssignmentListResult": {
+      "type": "object",
+      "description": "Role assignment list operation result.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RoleAssignment items on this page",
+          "items": {
+            "$ref": "#/definitions/RoleAssignment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "description": "Role assignment properties.",
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "The role assignment scope.",
+          "readOnly": true
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "principalType": {
+          "type": "string",
+          "description": "The principal type of the assigned principal ID.",
+          "default": "User",
+          "enum": [
+            "User",
+            "Group",
+            "ServicePrincipal",
+            "ForeignGroup",
+            "Device",
+            "AgentUser",
+            "AgentServicePrincipal"
+          ],
+          "x-ms-enum": {
+            "name": "PrincipalType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "User"
+              },
+              {
+                "name": "Group",
+                "value": "Group",
+                "description": "Group"
+              },
+              {
+                "name": "ServicePrincipal",
+                "value": "ServicePrincipal",
+                "description": "ServicePrincipal"
+              },
+              {
+                "name": "ForeignGroup",
+                "value": "ForeignGroup",
+                "description": "ForeignGroup"
+              },
+              {
+                "name": "Device",
+                "value": "Device",
+                "description": "Device"
+              },
+              {
+                "name": "AgentUser",
+                "value": "AgentUser",
+                "description": "AgentUser (agentic identity derived from a User). Available from api-version 2026-08-01."
+              },
+              {
+                "name": "AgentServicePrincipal",
+                "value": "AgentServicePrincipal",
+                "description": "AgentServicePrincipal (agentic identity derived from a ServicePrincipal). Available from api-version 2026-08-01."
+              }
+            ]
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of role assignment"
+        },
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently the only accepted value is '2.0'"
+        },
+        "createdOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time it was created",
+          "readOnly": true
+        },
+        "updatedOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time it was updated",
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "Id of the user who created the assignment",
+          "readOnly": true
+        },
+        "updatedBy": {
+          "type": "string",
+          "description": "Id of the user who updated the assignment",
+          "readOnly": true
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "description": "Id of the delegated managed identity resource"
+        }
+      },
+      "required": [
+        "roleDefinitionId",
+        "principalId"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/authorization-RoleAssignmentsCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/authorization-RoleAssignmentsCalls.json
@@ -722,7 +722,7 @@
             "AgentServicePrincipal"
           ],
           "x-ms-enum": {
-            "name": "PrincipalType",
+            "name": "RoleAssignmentPrincipalType",
             "modelAsString": true,
             "values": [
               {
@@ -753,12 +753,12 @@
               {
                 "name": "AgentUser",
                 "value": "AgentUser",
-                "description": "AgentUser (agentic identity derived from a User). Available from api-version 2026-08-01."
+                "description": "AgentUser (agentic identity derived from a User)."
               },
               {
                 "name": "AgentServicePrincipal",
                 "value": "AgentServicePrincipal",
-                "description": "AgentServicePrincipal (agentic identity derived from a ServicePrincipal). Available from api-version 2026-08-01."
+                "description": "AgentServicePrincipal (agentic identity derived from a ServicePrincipal)."
               }
             ]
           }

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateById.json
@@ -41,4 +41,3 @@
   "operationId": "RoleAssignments_CreateById",
   "title": "Create or update role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateById.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_CreateById",
+  "title": "Create or update role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResource.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for resource"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResource.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for resource"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResourceGroup.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for resource group"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for resource group"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForSubscription.json
@@ -42,4 +42,3 @@
   "operationId": "RoleAssignments_Create",
   "title": "Create role assignment for subscription"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_CreateForSubscription.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "parameters": {
+      "properties": {
+        "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+        "principalType": "User",
+        "roleDefinitionId": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d"
+      }
+    },
+    "roleAssignmentName": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Create",
+  "title": "Create role assignment for subscription"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Delete.json
@@ -23,4 +23,3 @@
   "operationId": "RoleAssignments_Delete",
   "title": "Delete role assignment"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Delete.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "roleAssignmentName": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RoleAssignments_Delete",
+  "title": "Delete role assignment"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_DeleteById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_DeleteById.json
@@ -22,4 +22,3 @@
   "operationId": "RoleAssignments_DeleteById",
   "title": "Delete role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_DeleteById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_DeleteById.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RoleAssignments_DeleteById",
+  "title": "Delete role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Get.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Get.json
@@ -22,4 +22,3 @@
   "operationId": "RoleAssignments_Get",
   "title": "Get role assignment by scope and name"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Get.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "roleAssignmentName": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_Get",
+  "title": "Get role assignment by scope and name"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_GetById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_GetById.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "roleAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "type": "Microsoft.Authorization/roleAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+        "properties": {
+          "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+          "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "principalType": "User",
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+        }
+      }
+    }
+  },
+  "operationId": "RoleAssignments_GetById",
+  "title": "Get role assignment by ID"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_GetById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_GetById.json
@@ -21,4 +21,3 @@
   "operationId": "RoleAssignments_GetById",
   "title": "Get role assignment by ID"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResource.json
@@ -51,4 +51,3 @@
   "operationId": "RoleAssignments_ListForResource",
   "title": "List role assignments for a resource"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResource.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "testrg",
+    "resourceProviderNamespace": "Microsoft.DocumentDb",
+    "resourceType": "databaseAccounts",
+    "resourceName": "test-db-account",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          },
+          {
+            "name": "96786e4b-dede-4c2e-8736-8ab911987f08",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/96786e4b-dede-4c2e-8736-8ab911987f08",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+            }
+          },
+          {
+            "name": "05c5a614-a7d6-4502-b150-c2fb455033ff",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account/providers/Microsoft.Authorization/roleAssignments/05c5a614-a7d6-4502-b150-c2fb455033ff",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.DocumentDb/databaseAccounts/test-db-account"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForResource",
+  "title": "List role assignments for a resource"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResourceGroup.json
@@ -37,4 +37,3 @@
   "operationId": "RoleAssignments_ListForResourceGroup",
   "title": "List role assignments for resource group"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForResourceGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          },
+          {
+            "name": "96786e4b-dede-4c2e-8736-8ab911987f08",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg/providers/Microsoft.Authorization/roleAssignments/96786e4b-dede-4c2e-8736-8ab911987f08",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/testrg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForResourceGroup",
+  "title": "List role assignments for resource group"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForScope.json
@@ -25,4 +25,3 @@
   "operationId": "RoleAssignments_ListForScope",
   "title": "List role assignments for scope"
 }
-

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForScope.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "api-version": "2026-08-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForScope",
+  "title": "List role assignments for scope"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForSubscription.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01",
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/roleAssignments/b0f43c54-e787-4862-89b1-a653fa9cf747",
+            "properties": {
+              "principalId": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+              "principalType": "User",
+              "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0b5fe924-9a61-425c-96af-cfe6e287ca2d",
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RoleAssignments_ListForSubscription",
+  "title": "List role assignments for subscription"
+}
+

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-08-01/examples/RoleAssignments_ListForSubscription.json
@@ -25,4 +25,3 @@
   "operationId": "RoleAssignments_ListForSubscription",
   "title": "List role assignments for subscription"
 }
-


### PR DESCRIPTION
## Summary (DRAFT / WIP)

Adds a new **GA (stable) api-version `2026-08-01`** to the `Microsoft.Authorization` RoleAssignment surface that exposes two agentic-identity principal types on `RoleAssignment.principalType`:

- `AgentUser` (agentic identity derived from a User)
- `AgentServicePrincipal` (agentic identity derived from a ServicePrincipal)

This lets customers assign Azure RBAC roles to Microsoft Entra Agent identities. Pairs with the PAS service change (internal DA PR 16474854).

## Approach — why a RoleAssignment-scoped union
The shared `Microsoft.Common` `PrincipalType` union is imported by multiple services (RoleAssignment, Authorization/schedules, RoleManagementAlerts, ...), each with its **own** `Versions` enum. Version-scoping the agent values on the shared union with `@added(Microsoft.RoleAssignment.Versions.v2026_08_01)` **breaks** those sibling services at compile time (`Namespace Microsoft doesn't have member RoleAssignment`). So the agent values are added on a **RoleAssignment-scoped `PrincipalType` union** (base values + `@added(Versions.v2026_08_01)`), leaving `Common` untouched.

## Validation (`tsp compile`)
- ✅ `stable/2022-04-01` swagger is **unchanged** (no agent values).
- ✅ `stable/2026-08-01` swagger contains `AgentUser` + `AgentServicePrincipal`.
- ✅ The `Authorization` sibling service still compiles.

## TODO before ready
- [ ] Add an example demonstrating an `AgentServicePrincipal` assignment on 2026-08-01.
- [ ] Confirm breaking-change / LintDiff / Avocado gates (AddedEnumValue on the new version).
- [ ] Align with ARM onboarding of `2026-08-01` and the paired PAS service rollout.

_Co-authored-by: Copilot_