### PR TITLE
Skip folder migration spec PRs from automated release plan creation

### DIFF
--- a/eng/tools/release-plan/src/index.ts
+++ b/eng/tools/release-plan/src/index.ts
@@ -12,10 +12,12 @@ import {
 } from "./release-plan.ts";
 import type { TypeSpecProjectInfo } from "./types.ts";
 import {
-  checkNewApiVersionLabel,
   createOctokit,
+  FOLDER_MIGRATION_LABEL,
+  getPullRequestLabels,
   getTypeSpecProjectInfoFromCommit,
   getTypeSpecProjectInfoFromPr,
+  NEW_API_VERSION_LABEL,
 } from "./typespec-project.ts";
 
 /**
@@ -34,6 +36,20 @@ export async function main(): Promise<void> {
     if (args.prNumber) {
       console.log(`Analyzing PR #${args.prNumber} in ${args.owner}/${args.repo}`);
 
+      const labels = await getPullRequestLabels({
+        octokit,
+        owner: args.owner,
+        repo: args.repo,
+        prNumber: args.prNumber,
+      });
+
+      if (labels.includes(FOLDER_MIGRATION_LABEL)) {
+        console.log(
+          `PR #${args.prNumber} has the '${FOLDER_MIGRATION_LABEL}' label. Skipping release plan processing.`,
+        );
+        process.exit(0);
+      }
+
       projectInfo = await getTypeSpecProjectInfoFromPr({
         prNumber: args.prNumber,
         owner: args.owner,
@@ -44,12 +60,7 @@ export async function main(): Promise<void> {
 
       resolvedPrNumber = args.prNumber;
 
-      hasNewApiVersionLabel = await checkNewApiVersionLabel({
-        octokit,
-        owner: args.owner,
-        repo: args.repo,
-        prNumber: args.prNumber,
-      });
+      hasNewApiVersionLabel = labels.includes(NEW_API_VERSION_LABEL);
     } else {
       const commitSha = args.commitSha as string;
       console.log(`Analyzing commit ${commitSha} in ${args.owner}/${args.repo}`);
@@ -61,6 +72,13 @@ export async function main(): Promise<void> {
         workspace: args.workspace,
         octokit,
       });
+
+      if (commitResult.isFolderMigration) {
+        console.log(
+          `Commit ${commitSha} is associated with a '${FOLDER_MIGRATION_LABEL}' labeled PR. Skipping release plan processing.`,
+        );
+        process.exit(0);
+      }
 
       projectInfo = commitResult.projectInfo;
       resolvedPrNumber = commitResult.prNumber;
@@ -172,10 +190,13 @@ export {
   createOctokit,
   detectApiVersions,
   findTspConfigDir,
+  FOLDER_MIGRATION_LABEL,
   getAssociatedPrNumber,
   getCommitChangedFiles,
   getPrChangedFiles,
+  getPullRequestLabels,
   getTypeSpecProjectInfoFromCommit,
   getTypeSpecProjectInfoFromPr,
+  NEW_API_VERSION_LABEL,
   parseApiVersion,
 } from "./typespec-project.ts";

--- a/eng/tools/release-plan/src/types.ts
+++ b/eng/tools/release-plan/src/types.ts
@@ -106,6 +106,7 @@ export interface CommitProjectInfoResult {
   projectInfo: TypeSpecProjectInfo | null;
   prNumber?: number;
   hasNewApiVersionLabel: boolean;
+  isFolderMigration?: boolean;
 }
 
 export interface CliArguments {

--- a/eng/tools/release-plan/src/typespec-project.ts
+++ b/eng/tools/release-plan/src/typespec-project.ts
@@ -9,6 +9,15 @@ import type {
   TypeSpecProjectInfo,
 } from "./types.ts";
 
+/** Label indicating that a spec PR introduces a new API version. */
+export const NEW_API_VERSION_LABEL = "new-api-version";
+
+/**
+ * Label indicating that a spec PR only migrates/renames folders. Release plan
+ * processing must be skipped entirely for PRs carrying this label.
+ */
+export const FOLDER_MIGRATION_LABEL = "FolderMigrationV2";
+
 /**
  * Identifies one TypeSpec project path and selected API version from a pull request.
  * Returns null when no specification files were modified, or when zero/multiple projects found.
@@ -57,7 +66,7 @@ export async function getTypeSpecProjectInfoFromPr(params: {
 
   const tspProjectPath = tspProjectPaths[0];
   const versionResult = detectApiVersions(
-    specFiles.map((f) => f.filename),
+    specFiles.filter((f) => f.status !== "renamed").map((f) => f.filename),
     tspProjectPath,
     workspace,
   );
@@ -95,12 +104,26 @@ export async function getTypeSpecProjectInfoFromCommit(params: {
   });
   console.log(`Associated PR number for commit ${commitSha}: ${associatedPrNumber ?? "none"}`);
   if (associatedPrNumber) {
-    const hasNewApiVersionLabel = await checkNewApiVersionLabel({
+    const labels = await getPullRequestLabels({
       octokit,
       owner,
       repo,
       prNumber: associatedPrNumber,
     });
+
+    if (labels.includes(FOLDER_MIGRATION_LABEL)) {
+      console.log(
+        `PR #${associatedPrNumber} has the '${FOLDER_MIGRATION_LABEL}' label. Skipping release plan processing.`,
+      );
+      return {
+        projectInfo: null,
+        prNumber: associatedPrNumber,
+        hasNewApiVersionLabel: false,
+        isFolderMigration: true,
+      };
+    }
+
+    const hasNewApiVersionLabel = labels.includes(NEW_API_VERSION_LABEL);
 
     const projectInfo = await getTypeSpecProjectInfoFromPr({
       prNumber: associatedPrNumber,
@@ -143,7 +166,7 @@ export async function getTypeSpecProjectInfoFromCommit(params: {
 
   const tspProjectPath = tspProjectPaths[0];
   const versionResult = detectApiVersions(
-    specFiles.map((f) => f.filename),
+    specFiles.filter((f) => f.status !== "renamed").map((f) => f.filename),
     tspProjectPath,
     workspace,
   );
@@ -162,12 +185,16 @@ export async function getTypeSpecProjectInfoFromCommit(params: {
   };
 }
 
-export async function checkNewApiVersionLabel(params: {
+/**
+ * Fetches the label names applied to a pull request.
+ * @returns Array of label names (empty when the PR has no labels)
+ */
+export async function getPullRequestLabels(params: {
   octokit: OctokitLike;
   owner: string;
   repo: string;
   prNumber: number;
-}): Promise<boolean> {
+}): Promise<string[]> {
   const { octokit, owner, repo, prNumber } = params;
 
   const pullRequest = await octokit.rest.pulls.get({
@@ -176,7 +203,7 @@ export async function checkNewApiVersionLabel(params: {
     pull_number: prNumber,
   });
 
-  return pullRequest.data.labels?.some((label) => label.name === "new-api-version") ?? false;
+  return pullRequest.data.labels?.map((label) => label.name) ?? [];
 }
 
 /**

--- a/eng/tools/release-plan/test/typespec-project.test.ts
+++ b/eng/tools/release-plan/test/typespec-project.test.ts
@@ -7,6 +7,7 @@ import {
   getAssociatedPrNumber,
   getCommitChangedFiles,
   getPrChangedFiles,
+  getPullRequestLabels,
   getTypeSpecProjectInfoFromCommit,
   getTypeSpecProjectInfoFromPr,
   parseApiVersion,
@@ -381,5 +382,100 @@ describe("TypeSpec project detection edge cases", () => {
     expect(result.hasNewApiVersionLabel).toBe(false);
     expect(result.projectInfo?.tspProjectPath).toBe("specification/bar");
     expect(result.projectInfo?.apiVersion).toBe("2025-09-01");
+  });
+
+  it("skips folder-migration PRs and does not fetch changed files", async () => {
+    const listPullRequestsAssociatedWithCommit = vi.fn().mockResolvedValueOnce({
+      data: [{ number: 321 }],
+    });
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { labels: [{ name: "FolderMigrationV2" }] } });
+    const listFiles = vi.fn();
+
+    const result = await getTypeSpecProjectInfoFromCommit({
+      commitSha: "mig123",
+      owner: "Azure",
+      repo: "azure-rest-api-specs",
+      workspace: process.cwd(),
+      octokit: {
+        rest: {
+          pulls: {
+            get,
+            listFiles,
+          },
+          repos: {
+            listPullRequestsAssociatedWithCommit,
+            getCommit: vi.fn(),
+          },
+        },
+      },
+    });
+
+    expect(result.isFolderMigration).toBe(true);
+    expect(result.projectInfo).toBeNull();
+    expect(result.prNumber).toBe(321);
+    expect(result.hasNewApiVersionLabel).toBe(false);
+    // Folder migration is detected before listing files, so no file lookup happens.
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+
+  it("ignores renamed files when detecting the API version", async () => {
+    const listPullRequestsAssociatedWithCommit = vi.fn().mockResolvedValueOnce({ data: [] });
+    const getCommit = vi.fn().mockResolvedValueOnce({
+      data: {
+        files: [
+          { filename: "specification/bar/tspconfig.yaml", status: "modified" },
+          // Renamed into a folder that looks like an older API version; must be ignored.
+          { filename: "specification/bar/2020-01-01/legacy.tsp", status: "renamed" },
+          { filename: "specification/bar/2025-09-01/main.tsp", status: "added" },
+        ],
+      },
+    });
+
+    const result = await getTypeSpecProjectInfoFromCommit({
+      commitSha: "rename1",
+      owner: "Azure",
+      repo: "azure-rest-api-specs",
+      workspace: process.cwd(),
+      octokit: {
+        rest: {
+          pulls: {
+            get: vi.fn(),
+            listFiles: vi.fn(),
+          },
+          repos: {
+            listPullRequestsAssociatedWithCommit,
+            getCommit,
+          },
+        },
+      },
+    });
+
+    expect(result.projectInfo?.apiVersion).toBe("2025-09-01");
+  });
+});
+
+describe("pull request label helpers", () => {
+  it("returns the list of label names", async () => {
+    const get = vi.fn().mockResolvedValueOnce({
+      data: { labels: [{ name: "new-api-version" }, { name: "FolderMigrationV2" }] },
+    });
+
+    const labels = await getPullRequestLabels({
+      octokit: {
+        rest: {
+          pulls: {
+            get,
+            listFiles: vi.fn(),
+          },
+        },
+      },
+      owner: "Azure",
+      repo: "azure-rest-api-specs",
+      prNumber: 7,
+    });
+
+    expect(labels).toEqual(["new-api-version", "FolderMigrationV2"]);
   });
 });


### PR DESCRIPTION
Skip any spec PR tagged using Folder migration label when running automation to create a release plan. It should also ignore all file changes that we only rename when searching for modified API version.