### PR TITLE
Add TargetCompletion ItemGenerationParams to control agent run concurrency in evaluations

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -27068,6 +27068,19 @@
           }
         }
       },
+      "AgentRunParams": {
+        "type": "object",
+        "properties": {
+          "max_concurrency": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.",
+            "default": 1
+          }
+        },
+        "description": "Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run."
+      },
       "AgentSessionResource": {
         "type": "object",
         "required": [
@@ -27649,6 +27662,14 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
+          },
+          "run_params": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentRunParams"
+              }
+            ],
+            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -27688,6 +27709,14 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
+          },
+          "run_params": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentRunParams"
+              }
+            ],
+            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -27068,19 +27068,6 @@
           }
         }
       },
-      "AgentRunParams": {
-        "type": "object",
-        "properties": {
-          "max_concurrency": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "description": "The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.",
-            "default": 1
-          }
-        },
-        "description": "Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run."
-      },
       "AgentSessionResource": {
         "type": "object",
         "required": [
@@ -27662,14 +27649,6 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
-          },
-          "run_params": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentRunParams"
-              }
-            ],
-            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -27709,14 +27688,6 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
-          },
-          "run_params": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentRunParams"
-              }
-            ],
-            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -35570,6 +35541,7 @@
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
             "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
+            "target_completion": "#/components/schemas/TargetCompletionItemGenerationParams",
             "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
           }
         },
@@ -35588,7 +35560,8 @@
               "red_team_seed_prompts",
               "red_team_taxonomy",
               "synthetic_data_gen_preview",
-              "conversation_gen_preview"
+              "conversation_gen_preview",
+              "target_completion"
             ]
           }
         ],
@@ -78031,6 +78004,34 @@
           }
         ],
         "description": "Represents a data source for target-based completion evaluation configuration."
+      },
+      "TargetCompletionItemGenerationParams": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "target_completion"
+            ],
+            "description": "The type of item generation parameters, always `target_completion`."
+          },
+          "max_concurrency": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.",
+            "default": 1
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemGenerationParams"
+          }
+        ],
+        "description": "Represents the parameters for target completion item generation."
       },
       "TargetUpdate": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -78022,7 +78022,7 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1,
-            "description": "The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.",
+            "description": "The maximum number of target completions to execute concurrently. The services defaults to 1 if a value is not specified by the caller, which invokes the target sequentially.",
             "default": 1
           }
         },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -38411,16 +38411,6 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
-    AgentRunParams:
-      type: object
-      properties:
-        max_concurrency:
-          type: integer
-          format: int32
-          minimum: 1
-          description: The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.
-          default: 1
-      description: Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run.
     AgentSessionResource:
       type: object
       required:
@@ -38814,10 +38804,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-        run_params:
-          allOf:
-            - $ref: '#/components/schemas/AgentRunParams'
-          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/Target'
       description: Represents a target specifying an Azure AI agent.
@@ -38844,10 +38830,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-        run_params:
-          allOf:
-            - $ref: '#/components/schemas/AgentRunParams'
-          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/TargetUpdate'
       description: Represents a target specifying an Azure AI agent.
@@ -44298,6 +44280,7 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
+          target_completion: '#/components/schemas/TargetCompletionItemGenerationParams'
           synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
@@ -44311,6 +44294,7 @@ components:
             - red_team_taxonomy
             - synthetic_data_gen_preview
             - conversation_gen_preview
+            - target_completion
       description: The types of parameters for red team item generation.
     JobStatus:
       anyOf:
@@ -74294,6 +74278,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for target-based completion evaluation configuration.
+    TargetCompletionItemGenerationParams:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - target_completion
+          description: The type of item generation parameters, always `target_completion`.
+        max_concurrency:
+          type: integer
+          format: int32
+          minimum: 1
+          description: The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.
+          default: 1
+      allOf:
+        - $ref: '#/components/schemas/ItemGenerationParams'
+      description: Represents the parameters for target completion item generation.
     TargetUpdate:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -74292,7 +74292,7 @@ components:
           type: integer
           format: int32
           minimum: 1
-          description: The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.
+          description: The maximum number of target completions to execute concurrently. The services defaults to 1 if a value is not specified by the caller, which invokes the target sequentially.
           default: 1
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -38411,6 +38411,16 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentRunParams:
+      type: object
+      properties:
+        max_concurrency:
+          type: integer
+          format: int32
+          minimum: 1
+          description: The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.
+          default: 1
+      description: Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run.
     AgentSessionResource:
       type: object
       required:
@@ -38804,6 +38814,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
+        run_params:
+          allOf:
+            - $ref: '#/components/schemas/AgentRunParams'
+          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/Target'
       description: Represents a target specifying an Azure AI agent.
@@ -38830,6 +38844,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
+        run_params:
+          allOf:
+            - $ref: '#/components/schemas/AgentRunParams'
+          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/TargetUpdate'
       description: Represents a target specifying an Azure AI agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -82788,7 +82788,7 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1,
-            "description": "The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.",
+            "description": "The maximum number of target completions to execute concurrently. The services defaults to 1 if a value is not specified by the caller, which invokes the target sequentially.",
             "default": 1
           }
         },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -30338,6 +30338,19 @@
           }
         }
       },
+      "AgentRunParams": {
+        "type": "object",
+        "properties": {
+          "max_concurrency": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.",
+            "default": 1
+          }
+        },
+        "description": "Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run."
+      },
       "AgentSessionResource": {
         "type": "object",
         "required": [
@@ -30953,6 +30966,14 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
+          },
+          "run_params": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentRunParams"
+              }
+            ],
+            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -30992,6 +31013,14 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
+          },
+          "run_params": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentRunParams"
+              }
+            ],
+            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -30338,19 +30338,6 @@
           }
         }
       },
-      "AgentRunParams": {
-        "type": "object",
-        "properties": {
-          "max_concurrency": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "description": "The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.",
-            "default": 1
-          }
-        },
-        "description": "Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run."
-      },
       "AgentSessionResource": {
         "type": "object",
         "required": [
@@ -30966,14 +30953,6 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
-          },
-          "run_params": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentRunParams"
-              }
-            ],
-            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -31013,14 +30992,6 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             }
-          },
-          "run_params": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentRunParams"
-              }
-            ],
-            "description": "The parameters used to control how the agent is invoked during evaluation, such as run concurrency."
           }
         },
         "allOf": [
@@ -40095,6 +40066,7 @@
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
             "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
+            "target_completion": "#/components/schemas/TargetCompletionItemGenerationParams",
             "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
           }
         },
@@ -40113,7 +40085,8 @@
               "red_team_seed_prompts",
               "red_team_taxonomy",
               "synthetic_data_gen_preview",
-              "conversation_gen_preview"
+              "conversation_gen_preview",
+              "target_completion"
             ]
           }
         ],
@@ -82797,6 +82770,34 @@
           }
         ],
         "description": "Represents a data source for target-based completion evaluation configuration."
+      },
+      "TargetCompletionItemGenerationParams": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "target_completion"
+            ],
+            "description": "The type of item generation parameters, always `target_completion`."
+          },
+          "max_concurrency": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.",
+            "default": 1
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemGenerationParams"
+          }
+        ],
+        "description": "Represents the parameters for target completion item generation."
       },
       "TargetUpdate": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -77496,7 +77496,7 @@ components:
           type: integer
           format: int32
           minimum: 1
-          description: The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.
+          description: The maximum number of target completions to execute concurrently. The services defaults to 1 if a value is not specified by the caller, which invokes the target sequentially.
           default: 1
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -40594,16 +40594,6 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
-    AgentRunParams:
-      type: object
-      properties:
-        max_concurrency:
-          type: integer
-          format: int32
-          minimum: 1
-          description: The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.
-          default: 1
-      description: Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run.
     AgentSessionResource:
       type: object
       required:
@@ -41018,10 +41008,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-        run_params:
-          allOf:
-            - $ref: '#/components/schemas/AgentRunParams'
-          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/Target'
       description: Represents a target specifying an Azure AI agent.
@@ -41048,10 +41034,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-        run_params:
-          allOf:
-            - $ref: '#/components/schemas/AgentRunParams'
-          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/TargetUpdate'
       description: Represents a target specifying an Azure AI agent.
@@ -47333,6 +47315,7 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
+          target_completion: '#/components/schemas/TargetCompletionItemGenerationParams'
           synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
@@ -47346,6 +47329,7 @@ components:
             - red_team_taxonomy
             - synthetic_data_gen_preview
             - conversation_gen_preview
+            - target_completion
       description: The types of parameters for red team item generation.
     JobStatus:
       anyOf:
@@ -77498,6 +77482,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for target-based completion evaluation configuration.
+    TargetCompletionItemGenerationParams:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - target_completion
+          description: The type of item generation parameters, always `target_completion`.
+        max_concurrency:
+          type: integer
+          format: int32
+          minimum: 1
+          description: The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially.
+          default: 1
+      allOf:
+        - $ref: '#/components/schemas/ItemGenerationParams'
+      description: Represents the parameters for target completion item generation.
     TargetUpdate:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -40594,6 +40594,16 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentRunParams:
+      type: object
+      properties:
+        max_concurrency:
+          type: integer
+          format: int32
+          minimum: 1
+          description: The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially.
+          default: 1
+      description: Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run.
     AgentSessionResource:
       type: object
       required:
@@ -41008,6 +41018,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
+        run_params:
+          allOf:
+            - $ref: '#/components/schemas/AgentRunParams'
+          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/Target'
       description: Represents a target specifying an Azure AI agent.
@@ -41034,6 +41048,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
+        run_params:
+          allOf:
+            - $ref: '#/components/schemas/AgentRunParams'
+          description: The parameters used to control how the agent is invoked during evaluation, such as run concurrency.
       allOf:
         - $ref: '#/components/schemas/TargetUpdate'
       description: Represents a target specifying an Azure AI agent.

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -220,6 +220,9 @@ union ItemGenerationParamsType {
 
   /** Parameters for conversation simulation item generation. */
   conversationGenPreview: "conversation_gen_preview",
+
+  /** Parameters for target completion item generation. */
+  targetCompletion: "target_completion",
 }
 
 /** The types of parameters for synthetic data generation item generation. */
@@ -330,9 +333,6 @@ model AzureAIAgentTarget extends Target {
   tool_descriptions?: ToolDescription[];
 
   tools?: OpenAI.Tool[];
-
-  /** The parameters used to control how the agent is invoked during evaluation, such as run concurrency. */
-  run_params?: AgentRunParams;
 }
 
 /** Description of a tool that can be used by an agent. */
@@ -357,13 +357,6 @@ model ModelSamplingParams {
 
   /** The maximum number of tokens allowed in the completion. */
   max_completion_tokens?: int32;
-}
-
-/** Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run. */
-model AgentRunParams {
-  /** The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially. */
-  @minValue(1)
-  max_concurrency?: int32 = 1;
 }
 
 /** Base class for run data sources with discriminator support. */
@@ -537,6 +530,16 @@ model ConversationGenPreviewItemGenerationParams extends ItemGenerationParams {
 
   /** Sampling parameters for the conversation generation. */
   sampling_params?: ModelSamplingParams;
+}
+
+/** Represents the parameters for target completion item generation. */
+model TargetCompletionItemGenerationParams extends ItemGenerationParams {
+  /** The type of item generation parameters, always `target_completion`. */
+  type: ItemGenerationParamsType.targetCompletion;
+
+  /** The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially. */
+  @minValue(1)
+  max_concurrency?: int32 = 1;
 }
 
 // ── Trace Source types ────────────────────────────────────────────────────────

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -537,7 +537,7 @@ model TargetCompletionItemGenerationParams extends ItemGenerationParams {
   /** The type of item generation parameters, always `target_completion`. */
   type: ItemGenerationParamsType.targetCompletion;
 
-  /** The maximum number of target completions to execute concurrently. Defaults to 1, which invokes the target sequentially. */
+  /** The maximum number of target completions to execute concurrently. The services defaults to 1 if a value is not specified by the caller, which invokes the target sequentially. */
   @minValue(1)
   max_concurrency?: int32 = 1;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -330,6 +330,9 @@ model AzureAIAgentTarget extends Target {
   tool_descriptions?: ToolDescription[];
 
   tools?: OpenAI.Tool[];
+
+  /** The parameters used to control how the agent is invoked during evaluation, such as run concurrency. */
+  run_params?: AgentRunParams;
 }
 
 /** Description of a tool that can be used by an agent. */
@@ -354,6 +357,13 @@ model ModelSamplingParams {
 
   /** The maximum number of tokens allowed in the completion. */
   max_completion_tokens?: int32;
+}
+
+/** Represents a set of parameters used to control how an Azure AI agent is invoked during an evaluation run. */
+model AgentRunParams {
+  /** The maximum number of agent runs to execute concurrently. Defaults to 1, which invokes the agent sequentially. */
+  @minValue(1)
+  max_concurrency?: int32 = 1;
 }
 
 /** Base class for run data sources with discriminator support. */


### PR DESCRIPTION
Add AgentRunParams model with a max_concurrency field and a run_params property on AzureAIAgentTarget, mirroring ModelSamplingParams on AzureAIModelTarget. Defaults to sequential (max_concurrency=1).


Copilot-Session: 4b17a6b5-6993-4837-a1e5-4e14c971d14f

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
