### PR TITLE
Foundry: include user_security_context from AOAI

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -17919,6 +17919,14 @@
                     "type": "object",
                     "unevaluatedProperties": {},
                     "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                  },
+                  "user_security_context": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AzureUserSecurityContext"
+                      }
+                    ],
+                    "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
                   }
                 }
               }
@@ -28824,6 +28832,28 @@
             "RedTeams=V1Preview"
           ]
         }
+      },
+      "AzureUserSecurityContext": {
+        "type": "object",
+        "properties": {
+          "application_name": {
+            "type": "string",
+            "description": "The name of the application. Sensitive personal information should not be included in this field."
+          },
+          "end_user_id": {
+            "type": "string",
+            "description": "This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field."
+          },
+          "end_user_tenant_id": {
+            "type": "string",
+            "description": "The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant."
+          },
+          "source_ip": {
+            "type": "string",
+            "description": "Captures the original client's IP address."
+          }
+        },
+        "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
       },
       "BaseCredentials": {
         "type": "object",
@@ -39881,89 +39911,6 @@
         ],
         "description": "Controls which (if any) tool is called by the model.\n`none` means the model will not call any tool and instead generates a message.\n`auto` means the model can pick between generating a message or calling one or more tools.\n`required` means the model must call one or more tools.\nSpecifying a particular tool via `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that tool.\n`none` is the default when no tools are present. `auto` is the default if tools are present."
       },
-      "OpenAI.ChatModel": {
-        "type": "string",
-        "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
-          "gpt-5.2",
-          "gpt-5.2-2025-12-11",
-          "gpt-5.2-chat-latest",
-          "gpt-5.2-pro",
-          "gpt-5.2-pro-2025-12-11",
-          "gpt-5.1",
-          "gpt-5.1-2025-11-13",
-          "gpt-5.1-codex",
-          "gpt-5.1-mini",
-          "gpt-5.1-chat-latest",
-          "gpt-5",
-          "gpt-5-mini",
-          "gpt-5-nano",
-          "gpt-5-2025-08-07",
-          "gpt-5-mini-2025-08-07",
-          "gpt-5-nano-2025-08-07",
-          "gpt-5-chat-latest",
-          "gpt-4.1",
-          "gpt-4.1-mini",
-          "gpt-4.1-nano",
-          "gpt-4.1-2025-04-14",
-          "gpt-4.1-mini-2025-04-14",
-          "gpt-4.1-nano-2025-04-14",
-          "o4-mini",
-          "o4-mini-2025-04-16",
-          "o3",
-          "o3-2025-04-16",
-          "o3-mini",
-          "o3-mini-2025-01-31",
-          "o1",
-          "o1-2024-12-17",
-          "o1-preview",
-          "o1-preview-2024-09-12",
-          "o1-mini",
-          "o1-mini-2024-09-12",
-          "gpt-4o",
-          "gpt-4o-2024-11-20",
-          "gpt-4o-2024-08-06",
-          "gpt-4o-2024-05-13",
-          "gpt-4o-audio-preview",
-          "gpt-4o-audio-preview-2024-10-01",
-          "gpt-4o-audio-preview-2024-12-17",
-          "gpt-4o-audio-preview-2025-06-03",
-          "gpt-4o-mini-audio-preview",
-          "gpt-4o-mini-audio-preview-2024-12-17",
-          "gpt-4o-search-preview",
-          "gpt-4o-mini-search-preview",
-          "gpt-4o-search-preview-2025-03-11",
-          "gpt-4o-mini-search-preview-2025-03-11",
-          "chatgpt-4o-latest",
-          "codex-mini-latest",
-          "gpt-4o-mini",
-          "gpt-4o-mini-2024-07-18",
-          "gpt-4-turbo",
-          "gpt-4-turbo-2024-04-09",
-          "gpt-4-0125-preview",
-          "gpt-4-turbo-preview",
-          "gpt-4-1106-preview",
-          "gpt-4-vision-preview",
-          "gpt-4",
-          "gpt-4-0314",
-          "gpt-4-0613",
-          "gpt-4-32k",
-          "gpt-4-32k-0314",
-          "gpt-4-32k-0613",
-          "gpt-3.5-turbo",
-          "gpt-3.5-turbo-16k",
-          "gpt-3.5-turbo-0301",
-          "gpt-3.5-turbo-0613",
-          "gpt-3.5-turbo-1106",
-          "gpt-3.5-turbo-0125",
-          "gpt-3.5-turbo-16k-0613"
-        ]
-      },
       "OpenAI.ChunkingStrategyRequestParam": {
         "type": "object",
         "required": [
@@ -40257,7 +40204,8 @@
         ],
         "properties": {
           "model": {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsCompaction"
+            "type": "string",
+            "description": "The model deployment to use for the compaction of this response."
           },
           "input": {
             "anyOf": [
@@ -43362,12 +43310,8 @@
             "description": "A list of messages comprising the conversation so far. Depending on the\n  [model](/docs/models) you use, different message types (modalities) are\n  supported, like [text](/docs/guides/text-generation),\n  [images](/docs/guides/vision), and [audio](/docs/guides/audio)."
           },
           "model": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModelIdsShared"
-              }
-            ],
-            "description": "Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI\n  offers a wide range of models with different capabilities, performance\n  characteristics, and price points. Refer to the [model guide](/docs/models)\n  to browse and compare available models."
+            "type": "string",
+            "description": "The model deployment to use for this chat completion."
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -43628,6 +43572,14 @@
             "maxItems": 128,
             "description": "Deprecated in favor of `tools`.\n  A list of functions the model may generate JSON inputs for.",
             "deprecated": true
+          },
+          "user_security_context": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureUserSecurityContext"
+              }
+            ],
+            "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
           }
         }
       },
@@ -43800,7 +43752,7 @@
           },
           "model": {
             "type": "string",
-            "description": "The model used for the chat completion."
+            "description": "The model deployment used for the creation of this chat completion."
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -61256,56 +61208,6 @@
           "name": "The model object",
           "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
-      },
-      "OpenAI.ModelIdsCompaction": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models."
-      },
-      "OpenAI.ModelIdsResponses": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsShared"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "o1-pro",
-              "o1-pro-2025-03-19",
-              "o3-pro",
-              "o3-pro-2025-06-10",
-              "o3-deep-research",
-              "o3-deep-research-2025-06-26",
-              "o4-mini-deep-research",
-              "o4-mini-deep-research-2025-06-26",
-              "computer-use-preview",
-              "computer-use-preview-2025-03-11",
-              "gpt-5-codex",
-              "gpt-5-pro",
-              "gpt-5-pro-2025-10-06",
-              "gpt-5.1-codex-max"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModelIdsShared": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "$ref": "#/components/schemas/OpenAI.ChatModel"
-          }
-        ]
       },
       "OpenAI.Moderation": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -24221,6 +24221,10 @@ paths:
                   type: object
                   unevaluatedProperties: {}
                   description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                user_security_context:
+                  allOf:
+                    - $ref: '#/components/schemas/AzureUserSecurityContext'
+                  description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
       x-oaiMeta:
         name: Create a model response
         group: responses
@@ -39558,6 +39562,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - RedTeams=V1Preview
+    AzureUserSecurityContext:
+      type: object
+      properties:
+        application_name:
+          type: string
+          description: The name of the application. Sensitive personal information should not be included in this field.
+        end_user_id:
+          type: string
+          description: This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field.
+        end_user_tenant_id:
+          type: string
+          description: The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant.
+        source_ip:
+          type: string
+          description: Captures the original client's IP address.
+      description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
     BaseCredentials:
       type: object
       required:
@@ -47313,87 +47333,6 @@ components:
         `required` means the model must call one or more tools.
         Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
         `none` is the default when no tools are present. `auto` is the default if tools are present.
-    OpenAI.ChatModel:
-      type: string
-      enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
-        - gpt-5.2
-        - gpt-5.2-2025-12-11
-        - gpt-5.2-chat-latest
-        - gpt-5.2-pro
-        - gpt-5.2-pro-2025-12-11
-        - gpt-5.1
-        - gpt-5.1-2025-11-13
-        - gpt-5.1-codex
-        - gpt-5.1-mini
-        - gpt-5.1-chat-latest
-        - gpt-5
-        - gpt-5-mini
-        - gpt-5-nano
-        - gpt-5-2025-08-07
-        - gpt-5-mini-2025-08-07
-        - gpt-5-nano-2025-08-07
-        - gpt-5-chat-latest
-        - gpt-4.1
-        - gpt-4.1-mini
-        - gpt-4.1-nano
-        - gpt-4.1-2025-04-14
-        - gpt-4.1-mini-2025-04-14
-        - gpt-4.1-nano-2025-04-14
-        - o4-mini
-        - o4-mini-2025-04-16
-        - o3
-        - o3-2025-04-16
-        - o3-mini
-        - o3-mini-2025-01-31
-        - o1
-        - o1-2024-12-17
-        - o1-preview
-        - o1-preview-2024-09-12
-        - o1-mini
-        - o1-mini-2024-09-12
-        - gpt-4o
-        - gpt-4o-2024-11-20
-        - gpt-4o-2024-08-06
-        - gpt-4o-2024-05-13
-        - gpt-4o-audio-preview
-        - gpt-4o-audio-preview-2024-10-01
-        - gpt-4o-audio-preview-2024-12-17
-        - gpt-4o-audio-preview-2025-06-03
-        - gpt-4o-mini-audio-preview
-        - gpt-4o-mini-audio-preview-2024-12-17
-        - gpt-4o-search-preview
-        - gpt-4o-mini-search-preview
-        - gpt-4o-search-preview-2025-03-11
-        - gpt-4o-mini-search-preview-2025-03-11
-        - chatgpt-4o-latest
-        - codex-mini-latest
-        - gpt-4o-mini
-        - gpt-4o-mini-2024-07-18
-        - gpt-4-turbo
-        - gpt-4-turbo-2024-04-09
-        - gpt-4-0125-preview
-        - gpt-4-turbo-preview
-        - gpt-4-1106-preview
-        - gpt-4-vision-preview
-        - gpt-4
-        - gpt-4-0314
-        - gpt-4-0613
-        - gpt-4-32k
-        - gpt-4-32k-0314
-        - gpt-4-32k-0613
-        - gpt-3.5-turbo
-        - gpt-3.5-turbo-16k
-        - gpt-3.5-turbo-0301
-        - gpt-3.5-turbo-0613
-        - gpt-3.5-turbo-1106
-        - gpt-3.5-turbo-0125
-        - gpt-3.5-turbo-16k-0613
     OpenAI.ChunkingStrategyRequestParam:
       type: object
       required:
@@ -47592,7 +47531,8 @@ components:
         - model
       properties:
         model:
-          $ref: '#/components/schemas/OpenAI.ModelIdsCompaction'
+          type: string
+          description: The model deployment to use for the compaction of this response.
         input:
           anyOf:
             - type: string
@@ -49689,13 +49629,8 @@ components:
               supported, like [text](/docs/guides/text-generation),
               [images](/docs/guides/vision), and [audio](/docs/guides/audio).
         model:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModelIdsShared'
-          description: |-
-            Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI
-              offers a wide range of models with different capabilities, performance
-              characteristics, and price points. Refer to the [model guide](/docs/models)
-              to browse and compare available models.
+          type: string
+          description: The model deployment to use for this chat completion.
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -49894,6 +49829,10 @@ components:
             Deprecated in favor of `tools`.
               A list of functions the model may generate JSON inputs for.
           deprecated: true
+        user_security_context:
+          allOf:
+            - $ref: '#/components/schemas/AzureUserSecurityContext'
+          description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
     OpenAI.CreateChatCompletionRequestAudio:
       type: object
       required:
@@ -50020,7 +49959,7 @@ components:
           description: The Unix timestamp (in seconds) of when the chat completion was created.
         model:
           type: string
-          description: The model used for the chat completion.
+          description: The model deployment used for the creation of this chat completion.
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -62174,35 +62113,6 @@ components:
             "created": 1686935002,
             "owned_by": "openai"
           }
-    OpenAI.ModelIdsCompaction:
-      anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
-        - type: string
-        - type: 'null'
-      description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
-    OpenAI.ModelIdsResponses:
-      anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsShared'
-        - type: string
-          enum:
-            - o1-pro
-            - o1-pro-2025-03-19
-            - o3-pro
-            - o3-pro-2025-06-10
-            - o3-deep-research
-            - o3-deep-research-2025-06-26
-            - o4-mini-deep-research
-            - o4-mini-deep-research-2025-06-26
-            - computer-use-preview
-            - computer-use-preview-2025-03-11
-            - gpt-5-codex
-            - gpt-5-pro
-            - gpt-5-pro-2025-10-06
-            - gpt-5.1-codex-max
-    OpenAI.ModelIdsShared:
-      anyOf:
-        - type: string
-        - $ref: '#/components/schemas/OpenAI.ChatModel'
     OpenAI.Moderation:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -20737,6 +20737,14 @@
                     "type": "object",
                     "unevaluatedProperties": {},
                     "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                  },
+                  "user_security_context": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AzureUserSecurityContext"
+                      }
+                    ],
+                    "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
                   }
                 }
               }
@@ -32128,6 +32136,28 @@
             "RedTeams=V1Preview"
           ]
         }
+      },
+      "AzureUserSecurityContext": {
+        "type": "object",
+        "properties": {
+          "application_name": {
+            "type": "string",
+            "description": "The name of the application. Sensitive personal information should not be included in this field."
+          },
+          "end_user_id": {
+            "type": "string",
+            "description": "This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field."
+          },
+          "end_user_tenant_id": {
+            "type": "string",
+            "description": "The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant."
+          },
+          "source_ip": {
+            "type": "string",
+            "description": "Captures the original client's IP address."
+          }
+        },
+        "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
       },
       "BaseCredentials": {
         "type": "object",
@@ -44498,89 +44528,6 @@
         ],
         "description": "Controls which (if any) tool is called by the model.\n`none` means the model will not call any tool and instead generates a message.\n`auto` means the model can pick between generating a message or calling one or more tools.\n`required` means the model must call one or more tools.\nSpecifying a particular tool via `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that tool.\n`none` is the default when no tools are present. `auto` is the default if tools are present."
       },
-      "OpenAI.ChatModel": {
-        "type": "string",
-        "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
-          "gpt-5.2",
-          "gpt-5.2-2025-12-11",
-          "gpt-5.2-chat-latest",
-          "gpt-5.2-pro",
-          "gpt-5.2-pro-2025-12-11",
-          "gpt-5.1",
-          "gpt-5.1-2025-11-13",
-          "gpt-5.1-codex",
-          "gpt-5.1-mini",
-          "gpt-5.1-chat-latest",
-          "gpt-5",
-          "gpt-5-mini",
-          "gpt-5-nano",
-          "gpt-5-2025-08-07",
-          "gpt-5-mini-2025-08-07",
-          "gpt-5-nano-2025-08-07",
-          "gpt-5-chat-latest",
-          "gpt-4.1",
-          "gpt-4.1-mini",
-          "gpt-4.1-nano",
-          "gpt-4.1-2025-04-14",
-          "gpt-4.1-mini-2025-04-14",
-          "gpt-4.1-nano-2025-04-14",
-          "o4-mini",
-          "o4-mini-2025-04-16",
-          "o3",
-          "o3-2025-04-16",
-          "o3-mini",
-          "o3-mini-2025-01-31",
-          "o1",
-          "o1-2024-12-17",
-          "o1-preview",
-          "o1-preview-2024-09-12",
-          "o1-mini",
-          "o1-mini-2024-09-12",
-          "gpt-4o",
-          "gpt-4o-2024-11-20",
-          "gpt-4o-2024-08-06",
-          "gpt-4o-2024-05-13",
-          "gpt-4o-audio-preview",
-          "gpt-4o-audio-preview-2024-10-01",
-          "gpt-4o-audio-preview-2024-12-17",
-          "gpt-4o-audio-preview-2025-06-03",
-          "gpt-4o-mini-audio-preview",
-          "gpt-4o-mini-audio-preview-2024-12-17",
-          "gpt-4o-search-preview",
-          "gpt-4o-mini-search-preview",
-          "gpt-4o-search-preview-2025-03-11",
-          "gpt-4o-mini-search-preview-2025-03-11",
-          "chatgpt-4o-latest",
-          "codex-mini-latest",
-          "gpt-4o-mini",
-          "gpt-4o-mini-2024-07-18",
-          "gpt-4-turbo",
-          "gpt-4-turbo-2024-04-09",
-          "gpt-4-0125-preview",
-          "gpt-4-turbo-preview",
-          "gpt-4-1106-preview",
-          "gpt-4-vision-preview",
-          "gpt-4",
-          "gpt-4-0314",
-          "gpt-4-0613",
-          "gpt-4-32k",
-          "gpt-4-32k-0314",
-          "gpt-4-32k-0613",
-          "gpt-3.5-turbo",
-          "gpt-3.5-turbo-16k",
-          "gpt-3.5-turbo-0301",
-          "gpt-3.5-turbo-0613",
-          "gpt-3.5-turbo-1106",
-          "gpt-3.5-turbo-0125",
-          "gpt-3.5-turbo-16k-0613"
-        ]
-      },
       "OpenAI.ChunkingStrategyRequestParam": {
         "type": "object",
         "required": [
@@ -44874,7 +44821,8 @@
         ],
         "properties": {
           "model": {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsCompaction"
+            "type": "string",
+            "description": "The model deployment to use for the compaction of this response."
           },
           "input": {
             "anyOf": [
@@ -47979,12 +47927,8 @@
             "description": "A list of messages comprising the conversation so far. Depending on the\n  [model](/docs/models) you use, different message types (modalities) are\n  supported, like [text](/docs/guides/text-generation),\n  [images](/docs/guides/vision), and [audio](/docs/guides/audio)."
           },
           "model": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModelIdsShared"
-              }
-            ],
-            "description": "Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI\n  offers a wide range of models with different capabilities, performance\n  characteristics, and price points. Refer to the [model guide](/docs/models)\n  to browse and compare available models."
+            "type": "string",
+            "description": "The model deployment to use for this chat completion."
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -48245,6 +48189,14 @@
             "maxItems": 128,
             "description": "Deprecated in favor of `tools`.\n  A list of functions the model may generate JSON inputs for.",
             "deprecated": true
+          },
+          "user_security_context": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureUserSecurityContext"
+              }
+            ],
+            "description": "User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud."
           }
         }
       },
@@ -48417,7 +48369,7 @@
           },
           "model": {
             "type": "string",
-            "description": "The model used for the chat completion."
+            "description": "The model deployment used for the creation of this chat completion."
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -65873,56 +65825,6 @@
           "name": "The model object",
           "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
-      },
-      "OpenAI.ModelIdsCompaction": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models."
-      },
-      "OpenAI.ModelIdsResponses": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsShared"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "o1-pro",
-              "o1-pro-2025-03-19",
-              "o3-pro",
-              "o3-pro-2025-06-10",
-              "o3-deep-research",
-              "o3-deep-research-2025-06-26",
-              "o4-mini-deep-research",
-              "o4-mini-deep-research-2025-06-26",
-              "computer-use-preview",
-              "computer-use-preview-2025-03-11",
-              "gpt-5-codex",
-              "gpt-5-pro",
-              "gpt-5-pro-2025-10-06",
-              "gpt-5.1-codex-max"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModelIdsShared": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "$ref": "#/components/schemas/OpenAI.ChatModel"
-          }
-        ]
       },
       "OpenAI.Moderation": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -26087,6 +26087,10 @@ paths:
                   type: object
                   unevaluatedProperties: {}
                   description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                user_security_context:
+                  allOf:
+                    - $ref: '#/components/schemas/AzureUserSecurityContext'
+                  description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
       x-oaiMeta:
         name: Create a model response
         group: responses
@@ -41762,6 +41766,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - RedTeams=V1Preview
+    AzureUserSecurityContext:
+      type: object
+      properties:
+        application_name:
+          type: string
+          description: The name of the application. Sensitive personal information should not be included in this field.
+        end_user_id:
+          type: string
+          description: This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field.
+        end_user_tenant_id:
+          type: string
+          description: The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant.
+        source_ip:
+          type: string
+          description: Captures the original client's IP address.
+      description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
     BaseCredentials:
       type: object
       required:
@@ -50412,87 +50432,6 @@ components:
         `required` means the model must call one or more tools.
         Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
         `none` is the default when no tools are present. `auto` is the default if tools are present.
-    OpenAI.ChatModel:
-      type: string
-      enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
-        - gpt-5.2
-        - gpt-5.2-2025-12-11
-        - gpt-5.2-chat-latest
-        - gpt-5.2-pro
-        - gpt-5.2-pro-2025-12-11
-        - gpt-5.1
-        - gpt-5.1-2025-11-13
-        - gpt-5.1-codex
-        - gpt-5.1-mini
-        - gpt-5.1-chat-latest
-        - gpt-5
-        - gpt-5-mini
-        - gpt-5-nano
-        - gpt-5-2025-08-07
-        - gpt-5-mini-2025-08-07
-        - gpt-5-nano-2025-08-07
-        - gpt-5-chat-latest
-        - gpt-4.1
-        - gpt-4.1-mini
-        - gpt-4.1-nano
-        - gpt-4.1-2025-04-14
-        - gpt-4.1-mini-2025-04-14
-        - gpt-4.1-nano-2025-04-14
-        - o4-mini
-        - o4-mini-2025-04-16
-        - o3
-        - o3-2025-04-16
-        - o3-mini
-        - o3-mini-2025-01-31
-        - o1
-        - o1-2024-12-17
-        - o1-preview
-        - o1-preview-2024-09-12
-        - o1-mini
-        - o1-mini-2024-09-12
-        - gpt-4o
-        - gpt-4o-2024-11-20
-        - gpt-4o-2024-08-06
-        - gpt-4o-2024-05-13
-        - gpt-4o-audio-preview
-        - gpt-4o-audio-preview-2024-10-01
-        - gpt-4o-audio-preview-2024-12-17
-        - gpt-4o-audio-preview-2025-06-03
-        - gpt-4o-mini-audio-preview
-        - gpt-4o-mini-audio-preview-2024-12-17
-        - gpt-4o-search-preview
-        - gpt-4o-mini-search-preview
-        - gpt-4o-search-preview-2025-03-11
-        - gpt-4o-mini-search-preview-2025-03-11
-        - chatgpt-4o-latest
-        - codex-mini-latest
-        - gpt-4o-mini
-        - gpt-4o-mini-2024-07-18
-        - gpt-4-turbo
-        - gpt-4-turbo-2024-04-09
-        - gpt-4-0125-preview
-        - gpt-4-turbo-preview
-        - gpt-4-1106-preview
-        - gpt-4-vision-preview
-        - gpt-4
-        - gpt-4-0314
-        - gpt-4-0613
-        - gpt-4-32k
-        - gpt-4-32k-0314
-        - gpt-4-32k-0613
-        - gpt-3.5-turbo
-        - gpt-3.5-turbo-16k
-        - gpt-3.5-turbo-0301
-        - gpt-3.5-turbo-0613
-        - gpt-3.5-turbo-1106
-        - gpt-3.5-turbo-0125
-        - gpt-3.5-turbo-16k-0613
     OpenAI.ChunkingStrategyRequestParam:
       type: object
       required:
@@ -50691,7 +50630,8 @@ components:
         - model
       properties:
         model:
-          $ref: '#/components/schemas/OpenAI.ModelIdsCompaction'
+          type: string
+          description: The model deployment to use for the compaction of this response.
         input:
           anyOf:
             - type: string
@@ -52788,13 +52728,8 @@ components:
               supported, like [text](/docs/guides/text-generation),
               [images](/docs/guides/vision), and [audio](/docs/guides/audio).
         model:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModelIdsShared'
-          description: |-
-            Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI
-              offers a wide range of models with different capabilities, performance
-              characteristics, and price points. Refer to the [model guide](/docs/models)
-              to browse and compare available models.
+          type: string
+          description: The model deployment to use for this chat completion.
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -52993,6 +52928,10 @@ components:
             Deprecated in favor of `tools`.
               A list of functions the model may generate JSON inputs for.
           deprecated: true
+        user_security_context:
+          allOf:
+            - $ref: '#/components/schemas/AzureUserSecurityContext'
+          description: User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
     OpenAI.CreateChatCompletionRequestAudio:
       type: object
       required:
@@ -53119,7 +53058,7 @@ components:
           description: The Unix timestamp (in seconds) of when the chat completion was created.
         model:
           type: string
-          description: The model used for the chat completion.
+          description: The model deployment used for the creation of this chat completion.
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -65273,35 +65212,6 @@ components:
             "created": 1686935002,
             "owned_by": "openai"
           }
-    OpenAI.ModelIdsCompaction:
-      anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
-        - type: string
-        - type: 'null'
-      description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
-    OpenAI.ModelIdsResponses:
-      anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsShared'
-        - type: string
-          enum:
-            - o1-pro
-            - o1-pro-2025-03-19
-            - o3-pro
-            - o3-pro-2025-06-10
-            - o3-deep-research
-            - o3-deep-research-2025-06-26
-            - o4-mini-deep-research
-            - o4-mini-deep-research-2025-06-26
-            - computer-use-preview
-            - computer-use-preview-2025-03-11
-            - gpt-5-codex
-            - gpt-5-pro
-            - gpt-5-pro-2025-10-06
-            - gpt-5.1-codex-max
-    OpenAI.ModelIdsShared:
-      anyOf:
-        - type: string
-        - $ref: '#/components/schemas/OpenAI.ChatModel'
     OpenAI.Moderation:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -17,7 +17,9 @@ using TypeSpec.OpenAPI;
 namespace Azure.AI.Projects;
 
 const AgentOptimizationRequiredPreviews = #{
-  conditional_previews: #[FoundryFeaturesOptInKeys.agents_optimization_v2_preview],
+  conditional_previews: #[
+    FoundryFeaturesOptInKeys.agents_optimization_v2_preview
+  ],
 };
 
 // ---------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -32,7 +32,9 @@ model CreateAgentVersionRequest {
   @doc("(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
+    #{
+      conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview],
+    }
   )
   draft?: boolean = false;
 }
@@ -189,7 +191,9 @@ model AgentVersionObject {
   @doc("Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.")
   @extension(
     "x-ms-foundry-meta",
-    #{ conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview] }
+    #{
+      conditional_previews: #[AgentDefinitionOptInKeys.draft_agents_v1_preview],
+    }
   )
   draft?: boolean = false;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -200,3 +200,20 @@ model DatasetJobSource {
   @doc("The version of the dataset. If not specified, the latest version is used.")
   version?: string;
 }
+
+/**
+ * User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
+ */
+model AzureUserSecurityContext {
+  /** The name of the application. Sensitive personal information should not be included in this field. */
+  application_name?: string;
+
+  /** This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field. */
+  end_user_id?: string;
+
+  /** The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant. */
+  end_user_tenant_id?: string;
+
+  /** Captures the original client's IP address. */
+  source_ip?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -88,8 +88,10 @@ union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
   draft_agents_v1_preview: "DraftAgents=V1Preview",
+
   @removed(Versions.v1)
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
+
   @removed(Versions.v1)
   container_agents_v1_preview: "ContainerAgents=V1Preview",
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -6,7 +6,9 @@ using TypeSpec.OpenAPI;
 namespace Azure.AI.Projects;
 
 const DataGenerationJobsRequiredPreviews = #{
-  conditional_previews: #[FoundryFeaturesOptInKeys.data_generation_jobs_v1_preview],
+  conditional_previews: #[
+    FoundryFeaturesOptInKeys.data_generation_jobs_v1_preview
+  ],
 };
 
 @doc("The supported data generation job types.")

--- a/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
@@ -129,12 +129,14 @@ model ModelVersion {
   ...AssetBase;
 }
 
-@@visibility(ModelVersion.description,
+@@visibility(
+  ModelVersion.description,
   Lifecycle.Create,
   Lifecycle.Update,
   Lifecycle.Read
 );
-@@visibility(ModelVersion.tags,
+@@visibility(
+  ModelVersion.tags,
   Lifecycle.Create,
   Lifecycle.Update,
   Lifecycle.Read

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/chat/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/chat/main.tsp
@@ -1,2 +1,3 @@
+import "./models.tsp";
 import "./routes.generated.tsp";
 import "./routes.meta.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/chat/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/chat/models.tsp
@@ -1,0 +1,30 @@
+import "../../common/models.tsp";
+
+using Azure.Core.Experimental;
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+#suppress "@azure-tools/typespec-azure-core/experimental-feature" "Experimental features applied to augment inherited OpenAI models"
+namespace Azure.AI.Projects {
+  @@changePropertyType(OpenAI.CreateChatCompletionRequest.`model`, string);
+  @@changePropertyType(OpenAI.CreateChatCompletionResponse.`model`, string);
+  @@doc(
+    OpenAI.CreateChatCompletionRequest.`model`,
+    "The model deployment to use for this chat completion."
+  );
+  @@doc(
+    OpenAI.CreateChatCompletionResponse.`model`,
+    "The model deployment used for the creation of this chat completion."
+  );
+  @@changePropertyType(OpenAI.Response.`model`, string);
+
+  @@copyProperties(
+    OpenAI.CreateChatCompletionRequest,
+    {
+      /**
+       * User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
+       */
+      user_security_context?: AzureUserSecurityContext,
+    }
+  );
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/routes.meta.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/routes.meta.tsp
@@ -1923,11 +1923,7 @@ namespace Azure.AI.Projects;
   }
 );
 
-@@extension(
-  Azure.AI.Projects.Evals.getEvalRunOutputItems,
-  "x-ms-list",
-  true
-);
+@@extension(Azure.AI.Projects.Evals.getEvalRunOutputItems, "x-ms-list", true);
 
 @@extension(
   Azure.AI.Projects.Evals.getEvalRunOutputItem,

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/responses/models.tsp
@@ -1,5 +1,6 @@
 import "../conversations/models.tsp";
 import "../../tools/models.tsp";
+import "../../common/models.tsp";
 
 using Azure.Core.Experimental;
 using TypeSpec.Http;
@@ -9,18 +10,26 @@ using TypeSpec.Versioning;
 namespace Azure.AI.Projects {
   @@changePropertyType(OpenAI.CreateResponse.`model`, string);
   @@changePropertyType(OpenAI.Response.`model`, string);
+  @@changePropertyType(OpenAI.CompactResponseMethodPublicBody.`model`, string);
 
   // This is a temporary correction to the OpenAI source spec pending an upstream fix via overlay/origin.
   @@changePropertyType(OpenAI.MCPToolCall.error, Record<unknown>);
 
-  @@doc(OpenAI.CreateResponse.`model`,
+  @@doc(
+    OpenAI.CreateResponse.`model`,
     "The model deployment to use for the creation of this response."
   );
-  @@doc(OpenAI.Response.`model`,
+  @@doc(
+    OpenAI.Response.`model`,
     "The model deployment to use for the creation of this response."
+  );
+  @@doc(
+    OpenAI.CompactResponseMethodPublicBody.`model`,
+    "The model deployment to use for the compaction of this response."
   );
 
-  @@copyProperties(OpenAI.CreateResponse,
+  @@copyProperties(
+    OpenAI.CreateResponse,
     {
       /**
        * (Deprecated) Use agent_reference instead.
@@ -49,9 +58,15 @@ namespace Azure.AI.Projects {
 
     /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
     structured_inputs?: Record<unknown>;
+
+    /**
+     * User security context contains several parameters that describe the application itself, and the end user that interacts with the application. These fields assist your security operations teams to investigate and mitigate security incidents by providing a comprehensive approach to protecting your AI applications. [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using Microsoft Defender for Cloud.
+     */
+    user_security_context?: AzureUserSecurityContext;
   }
 
-  @@copyProperties(OpenAI.Response,
+  @@copyProperties(
+    OpenAI.Response,
     {
       /**
        * (Deprecated) Use agent_reference instead.
@@ -81,7 +96,8 @@ namespace Azure.AI.Projects {
   }
 
   @@withoutOmittedProperties(OpenAI.CodeInterpreterTool, "container");
-  @@copyProperties(OpenAI.CodeInterpreterTool,
+  @@copyProperties(
+    OpenAI.CodeInterpreterTool,
     {
       /** The code interpreter container. Can be a container ID or an object that
        * specifies uploaded file IDs to make available to your code, along with an
@@ -94,7 +110,8 @@ namespace Azure.AI.Projects {
   );
 
   // See GitHub issue https://github.com/microsoft/openai-openapi-pr/issues/644
-  @@summary(OpenAI.AutoCodeInterpreterToolParam,
+  @@summary(
+    OpenAI.AutoCodeInterpreterToolParam,
     "Automatic Code Interpreter Tool Parameters"
   );
 
@@ -178,7 +195,8 @@ namespace Azure.AI.Projects {
   @@copyVariants(OpenAI.OutputItemType, _AgentItemType);
 
   /* created_by conflicts with the property in OpenAI.FunctionShellCall, ApplyPatchToolCall, and ApplyPatchToolCallOutput, to work around it we use a union type here */
-  @@copyProperties(OpenAI.OutputItem,
+  @@copyProperties(
+    OpenAI.OutputItem,
     {
       /** The information about the creator of the item */
       #suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary suppression to allow union type."
@@ -461,7 +479,8 @@ namespace Azure.AI.Projects {
   }
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Experimental features applied to augment inherited OpenAI models"
-  @@copyProperties(OpenAI.Response,
+  @@copyProperties(
+    OpenAI.Response,
     {
       /** The content filter evaluation results. */
       content_filters?: ContentFilterResult[],

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/responses/routes.meta.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/responses/routes.meta.tsp
@@ -2296,11 +2296,7 @@ namespace Azure.AI.Projects;
   }
 );
 
-@@extension(
-  Azure.AI.Projects.Responses.listInputItems,
-  "x-ms-list",
-  true
-);
+@@extension(Azure.AI.Projects.Responses.listInputItems, "x-ms-list", true);
 
 @@extension(
   Azure.AI.Projects.Responses.Compactconversation,

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-common/ops-relocation-agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-common/ops-relocation-agents.tsp
@@ -1,4 +1,4 @@
-// TODO: Rename this file to "relocate-operations.tsp" (or similar), as it now contains both 
+// TODO: Rename this file to "relocate-operations.tsp" (or similar), as it now contains both
 // GA and beta (preview) operations .
 
 // This file moves all beta operations (preview routes) from the Azure.AI.Projects namespace to
@@ -9,51 +9,61 @@
 using Azure.ClientGenerator.Core;
 
 namespace Azure.AI.Projects {
-
-// Relocate these operations from the AgentSessionFiles interface to the Agents interface
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.uploadSessionFile, Agents);
-@@clientLocation(
-  Azure.AI.Projects.AgentSessionFiles.downloadSessionFile,
-  Agents
-);
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.listSessionFiles, Agents);
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.deleteSessionFile, Agents);
-
-};
+  // Relocate these operations from the AgentSessionFiles interface to the Agents interface
+  @@clientLocation(
+    Azure.AI.Projects.AgentSessionFiles.uploadSessionFile,
+    Agents
+  );
+  @@clientLocation(
+    Azure.AI.Projects.AgentSessionFiles.downloadSessionFile,
+    Agents
+  );
+  @@clientLocation(
+    Azure.AI.Projects.AgentSessionFiles.listSessionFiles,
+    Agents
+  );
+  @@clientLocation(
+    Azure.AI.Projects.AgentSessionFiles.deleteSessionFile,
+    Agents
+  );
+}
 
 namespace Azure.AI.Projects.Beta {
+  interface MemoryStores {}
+  @@clientLocation(
+    Azure.AI.Projects.MemoryStores.createMemoryStore,
+    MemoryStores
+  );
+  @@clientLocation(
+    Azure.AI.Projects.MemoryStores.updateMemoryStore,
+    MemoryStores
+  );
+  @@clientLocation(Azure.AI.Projects.MemoryStores.getMemoryStore, MemoryStores);
+  @@clientLocation(
+    Azure.AI.Projects.MemoryStores.listMemoryStores,
+    MemoryStores
+  );
+  @@clientLocation(
+    Azure.AI.Projects.MemoryStores.deleteMemoryStore,
+    MemoryStores
+  );
+  @@clientLocation(Azure.AI.Projects.MemoryStores.searchMemories, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.updateMemories, MemoryStores);
+  @@clientLocation(
+    Azure.AI.Projects.MemoryStores.getUpdateResult,
+    MemoryStores
+  );
+  @@clientLocation(Azure.AI.Projects.MemoryStores.deleteScope, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.createMemory, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.updateMemory, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.getMemory, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.listMemories, MemoryStores);
+  @@clientLocation(Azure.AI.Projects.MemoryStores.deleteMemory, MemoryStores);
 
-interface MemoryStores {}
-@@clientLocation(
-  Azure.AI.Projects.MemoryStores.createMemoryStore,
-  MemoryStores
-);
-@@clientLocation(
-  Azure.AI.Projects.MemoryStores.updateMemoryStore,
-  MemoryStores
-);
-@@clientLocation(Azure.AI.Projects.MemoryStores.getMemoryStore, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.listMemoryStores, MemoryStores);
-@@clientLocation(
-  Azure.AI.Projects.MemoryStores.deleteMemoryStore,
-  MemoryStores
-);
-@@clientLocation(Azure.AI.Projects.MemoryStores.searchMemories, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.updateMemories, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.getUpdateResult, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.deleteScope, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.createMemory, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.updateMemory, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.getMemory, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.listMemories, MemoryStores);
-@@clientLocation(Azure.AI.Projects.MemoryStores.deleteMemory, MemoryStores);
-
-
-interface Agents {}
-@@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.create, Agents);
-@@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.get, Agents);
-@@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.list, Agents);
-@@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.cancel, Agents);
-@@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.delete, Agents);
-
-};
+  interface Agents {}
+  @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.create, Agents);
+  @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.get, Agents);
+  @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.list, Agents);
+  @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.cancel, Agents);
+  @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.delete, Agents);
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-agent-contracts/client.tsp
@@ -264,5 +264,8 @@ namespace Azure.AI.Projects {
 
   @@access(OpenAI.ItemCustomToolCallOutput, Access.public);
   @@usage(OpenAI.ItemCustomToolCallOutput, Usage.input | Usage.output);
-  @@clientName(OpenAI.ItemCustomToolCallOutput, "OutputItemCustomToolCallOutput");
+  @@clientName(
+    OpenAI.ItemCustomToolCallOutput,
+    "OutputItemCustomToolCallOutput"
+  );
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-extensions-openai/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-extensions-openai/client.tsp
@@ -407,7 +407,10 @@ namespace Azure.AI.Projects {
   @@clientName(StructuredOutputDefinition.strict, "IsStrict");
   @@clientName(OpenAI.WebSearchApproximateLocation.type, "Kind");
   @@access(OpenAI.WebSearchApproximateLocation.type, Access.internal);
-  @@clientName(OpenAI.OutputItemMcpApprovalResponseResource.approve, "IsApproved");
+  @@clientName(
+    OpenAI.OutputItemMcpApprovalResponseResource.approve,
+    "IsApproved"
+  );
   @@clientName(A2APreviewTool.base_url, "BaseUri");
   @@clientName(FabricIQPreviewTool.server_url, "ServerUri");
   @@clientName(
@@ -415,7 +418,7 @@ namespace Azure.AI.Projects {
     "OutputDefinition",
     "csharp"
   );
-  
+
   // --------------------------------------------------------------------------------
   // Usage / Public accessibility overrides
   // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/client.tsp
@@ -76,12 +76,14 @@ namespace Azure.AI.Projects;
 @@clientName(Index, "AIProjectIndex", "csharp");
 @@clientName(CosmosDBIndex, "AIProjectCosmosDBIndex", "csharp");
 @@clientName(BaseCredentials, "AIProjectConnectionBaseCredential", "csharp");
-@@clientName(ApiKeyCredentials,
+@@clientName(
+  ApiKeyCredentials,
   "AIProjectConnectionApiKeyCredential",
   "csharp"
 );
 @@clientName(CustomCredential, "AIProjectConnectionCustomCredential", "csharp");
-@@clientName(EntraIDCredentials,
+@@clientName(
+  EntraIDCredentials,
   "AIProjectConnectionEntraIdCredential",
   "csharp"
 );
@@ -102,7 +104,8 @@ namespace Azure.AI.Projects;
 
 // Need to explicitly make all get and list methods include the object name for C#
 @@clientName(Connections.get, "getConnection", "csharp");
-@@clientName(Connections.getWithCredentials,
+@@clientName(
+  Connections.getWithCredentials,
   "getConnectionWithCredentials",
   "csharp"
 );
@@ -122,7 +125,8 @@ namespace Azure.AI.Projects;
 @@access(Connections.getWithCredentials, Access.internal);
 
 // The fix for ambiguous import of OperationState
-@@clientName(Azure.Core.Foundations.OperationState,
+@@clientName(
+  Azure.Core.Foundations.OperationState,
   "operationStatus",
   "csharp"
 );
@@ -131,7 +135,8 @@ namespace Azure.AI.Projects;
 
 @@clientName(AttackStrategy.ROT13, "Rot13", "csharp");
 
-@@alternateType(DayOfWeek,
+@@alternateType(
+  DayOfWeek,
   {
     identity: "System.DayOfWeek",
   },
@@ -141,7 +146,8 @@ namespace Azure.AI.Projects;
 @@access(OpenAI.DetailEnum, Access.internal);
 @@clientName(OpenAI.DetailEnum, "InternalImageDetailLevel");
 @@access(OpenAI.InputImageContentParamAutoParam, Access.internal);
-@@clientName(OpenAI.InputImageContentParamAutoParam,
+@@clientName(
+  OpenAI.InputImageContentParamAutoParam,
   "InternalInputImageContentParamAutoParam"
 );
 // --------------------------------------------------------------------------------
@@ -180,15 +186,18 @@ namespace Azure.AI.Projects;
 @@clientName(DeleteMemoryResponse, "MemoryDeletionResult", "csharp");
 @@clientName(DeleteMemoryStoreResponse.deleted, "IsDeleted", "csharp");
 
-@@clientName(MemoryStoreDefaultOptions.chat_summary_enabled,
+@@clientName(
+  MemoryStoreDefaultOptions.chat_summary_enabled,
   "IsChatSummaryEnabled",
   "csharp"
 );
-@@clientName(MemoryStoreDefaultOptions.user_profile_enabled,
+@@clientName(
+  MemoryStoreDefaultOptions.user_profile_enabled,
   "IsUserProfileEnabled",
   "csharp"
 );
-@@clientName(MemoryStoreDefaultOptions.procedural_memory_enabled,
+@@clientName(
+  MemoryStoreDefaultOptions.procedural_memory_enabled,
   "IsProceduralMemoryEnabled",
   "csharp"
 );
@@ -277,9 +286,21 @@ namespace Azure.AI.Projects;
 @@clientName(Routine.enabled, "IsEnabled");
 @@clientName(DispatchRoutineResponse, "DispatchRoutineResult");
 @@usage(DispatchRoutineResponse, Usage.input | Usage.output);
-@@clientName(InvokeAgentInvocationsApiDispatchPayload, "AgentInvocationsApiDispatchPayload");
-@@clientName(InvokeAgentInvocationsApiRoutineAction, "AgentInvocationsApiRoutineAction");
-@@clientName(InvokeAgentResponsesApiDispatchPayload, "AgentResponsesApiDispatchPayload");
-@@clientName(InvokeAgentResponsesApiRoutineAction, "AgentResponsesApiRoutineAction");
+@@clientName(
+  InvokeAgentInvocationsApiDispatchPayload,
+  "AgentInvocationsApiDispatchPayload"
+);
+@@clientName(
+  InvokeAgentInvocationsApiRoutineAction,
+  "AgentInvocationsApiRoutineAction"
+);
+@@clientName(
+  InvokeAgentResponsesApiDispatchPayload,
+  "AgentResponsesApiDispatchPayload"
+);
+@@clientName(
+  InvokeAgentResponsesApiRoutineAction,
+  "AgentResponsesApiRoutineAction"
+);
 @@clientName(RoutineActionType, "RoutineActionKind");
 @@clientName(RoutineTriggerType, "RoutineTriggerKind");

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/client.tsp
@@ -81,7 +81,10 @@ using Azure.AI.Projects;
 
 @@clientName(OpenAI.DetailEnum, "ImageDetailLevel");
 
-@@clientName(_PreviewAgentToolType.fabric_dataagent_preview, "FABRIC_DATA_AGENT_PREVIEW");
+@@clientName(
+  _PreviewAgentToolType.fabric_dataagent_preview,
+  "FABRIC_DATA_AGENT_PREVIEW"
+);
 
 @@clientName(OpenAI.MCPListToolsToolAnnotations, "McpListToolsToolAnnotations");
 @@clientName(OpenAI.MCPListToolsTool, "McpListToolsTool");
@@ -678,4 +681,3 @@ union WebSearchToolSearchContextSizeExpandable {
 // of our own, to prevent confusion.
 @@clientName(Conversations.listConversations, "listAgentConversations", "java");
 @@clientLocation(Conversations.listConversations, Agents);
-

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/client.tsp
@@ -189,7 +189,6 @@ namespace Azure.AI.Projects;
 @@clientName(AttackStrategy.Base64, "Base_64");
 @@clientName(AttackStrategy.ROT13, "ROT_13");
 
-
 // --------------------------------------------------------------------------------
 // Usage / Public accessibility overrides
 // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -100,8 +100,16 @@ using Azure.AI.Projects;
 @@clientName(OpenAI.ContainerMemoryLimit.`16g`, exact("MEMORY_16GB"), "python");
 @@clientName(OpenAI.ContainerMemoryLimit.`64g`, exact("MEMORY_64GB"), "python");
 
-@@clientName(OpenAI.ToolChoiceParamType.web_search_preview_2025_03_11, exact("WEB_SEARCH_PREVIEW_2025_03_11"), "python");
-@@clientName(OpenAI.RankerVersionType.`default-2024-11-15`, exact("DEFAULT_2024_11_15"), "python");
+@@clientName(
+  OpenAI.ToolChoiceParamType.web_search_preview_2025_03_11,
+  exact("WEB_SEARCH_PREVIEW_2025_03_11"),
+  "python"
+);
+@@clientName(
+  OpenAI.RankerVersionType.`default-2024-11-15`,
+  exact("DEFAULT_2024_11_15"),
+  "python"
+);
 @@clientName(_PreviewAgentToolType.a2a_preview, exact("A2A_PREVIEW"), "python");
 @@clientName(ToolboxToolType.a2a_preview, exact("A2A_PREVIEW"), "python");
 @@clientName(ProtocolConfiguration.a2a, exact("a2a"), "python");
@@ -117,7 +125,11 @@ using Azure.AI.Projects;
 
 // Session operations all use "session_id". Session file operations all use "agent_session_id". Consolidate to use "session_id" everywhere.
 @@clientName(UploadSessionFileParams.agent_session_id, "session_id", "python");
-@@clientName(DownloadSessionFileParams.agent_session_id, "session_id", "python");
+@@clientName(
+  DownloadSessionFileParams.agent_session_id,
+  "session_id",
+  "python"
+);
 @@clientName(ListSessionFilesParams.agent_session_id, "session_id", "python");
 @@clientName(DeleteSessionFileParams.agent_session_id, "session_id", "python");
 
@@ -129,8 +141,16 @@ using Azure.AI.Projects;
 @@clientName(Agents.createAgentVersionFromCode, "createVersionFromCode");
 
 @@access(Agents.createAgentVersionFromCode, Access.internal, "python");
-@@clientName(CreateAgentVersionFromCodeMetadata, "_CreateAgentVersionFromCodeMetadata", "python");
-@@clientName(CreateAgentVersionFromCodeContent, "_CreateAgentVersionFromCodeContent", "python");
+@@clientName(
+  CreateAgentVersionFromCodeMetadata,
+  "_CreateAgentVersionFromCodeMetadata",
+  "python"
+);
+@@clientName(
+  CreateAgentVersionFromCodeContent,
+  "_CreateAgentVersionFromCodeContent",
+  "python"
+);
 
 @@clientName(Agents.downloadAgentCode, "download_code", "python");
 @@clientName(DownloadAgentCodeResponse, "DownloadAgentCodeResult", "python");
@@ -140,7 +160,6 @@ using Azure.AI.Projects;
   "python"
 );
 @@clientName(SessionFileWriteResponse, "SessionFileWriteResult", "python");
-
 
 // --------------------------------------------------------------------------------
 // Datasets sub‐client

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -120,7 +120,6 @@ model ToolboxTool {
  */
 model CodeInterpreterToolboxTool extends ToolboxTool {
   type: ToolboxCodeInterpreterToolType;
-
   ...ToolFields<OpenAI.CodeInterpreterTool>;
 }
 
@@ -129,11 +128,7 @@ model CodeInterpreterToolboxTool extends ToolboxTool {
  */
 model FileSearchToolboxTool extends ToolboxTool {
   type: ToolboxFileSearchToolType;
-
-  ...WithFieldsOptional<
-    ToolFields<OpenAI.FileSearchTool>,
-    "vector_store_ids"
-  >;
+  ...WithFieldsOptional<ToolFields<OpenAI.FileSearchTool>, "vector_store_ids">;
 }
 
 /**
@@ -141,7 +136,6 @@ model FileSearchToolboxTool extends ToolboxTool {
  */
 model WebSearchToolboxTool extends ToolboxTool {
   type: ToolboxWebSearchToolType;
-
   ...ToolFields<OpenAI.WebSearchTool>;
 }
 
@@ -150,7 +144,6 @@ model WebSearchToolboxTool extends ToolboxTool {
  */
 model MCPToolboxTool extends ToolboxTool {
   type: ToolboxMCPToolType;
-
   ...ToolFields<OpenAI.MCPTool>;
 }
 
@@ -159,7 +152,6 @@ model MCPToolboxTool extends ToolboxTool {
  */
 model AzureAISearchToolboxTool extends ToolboxTool {
   type: ToolboxAzureAISearchToolType;
-
   ...ToolFields<AzureAISearchTool>;
 }
 
@@ -168,7 +160,6 @@ model AzureAISearchToolboxTool extends ToolboxTool {
  */
 model OpenApiToolboxTool extends ToolboxTool {
   type: ToolboxOpenApiToolType;
-
   ...ToolFields<OpenApiTool>;
 }
 
@@ -178,7 +169,6 @@ model OpenApiToolboxTool extends ToolboxTool {
 @extension("x-ms-foundry-meta", PreviewTool)
 model A2APreviewToolboxTool extends ToolboxTool {
   type: ToolboxA2APreviewToolType;
-
   ...ToolFields<A2APreviewTool>;
 }
 
@@ -188,7 +178,6 @@ model A2APreviewToolboxTool extends ToolboxTool {
 @extension("x-ms-foundry-meta", PreviewTool)
 model BrowserAutomationPreviewToolboxTool extends ToolboxTool {
   type: ToolboxBrowserAutomationPreviewToolType;
-
   ...ToolFields<BrowserAutomationPreviewTool>;
 }
 
@@ -206,7 +195,6 @@ model ReminderPreviewToolboxTool extends ToolboxTool {
 @extension("x-ms-foundry-meta", PreviewTool)
 model WorkIQPreviewToolboxTool extends ToolboxTool {
   type: ToolboxWorkIQPreviewToolType;
-
   ...ToolFields<WorkIQPreviewTool>;
 }
 
@@ -216,7 +204,6 @@ model WorkIQPreviewToolboxTool extends ToolboxTool {
 @extension("x-ms-foundry-meta", PreviewTool)
 model FabricIQPreviewToolboxTool extends ToolboxTool {
   type: ToolboxFabricIQPreviewToolType;
-
   ...ToolFields<FabricIQPreviewTool>;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -34,10 +34,8 @@ namespace Azure.AI.Projects {
     @removed(Versions.v1)
     memory_search: "memory_search",
   }
-  
-  const PreviewTool = #{
-    required_previews: #["preview_tool"],
-  };
+
+  const PreviewTool = #{ required_previews: #["preview_tool"] };
 
   @@copyVariants(OpenAI.ToolType, Azure.AI.Projects._PreviewAgentToolType);
   @@copyVariants(OpenAI.ToolType, Azure.AI.Projects._AgentToolType);
@@ -828,7 +826,6 @@ namespace Azure.AI.Projects {
      * The ID of the WorkIQ project connection.
      */
     project_connection_id: string;
-
   }
 
   /**
@@ -862,7 +859,6 @@ namespace Azure.AI.Projects {
     #suppress "@azure-tools/typespec-autorest/union-unsupported" "require_approval uses OpenAI union type."
     #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Matching OpenAI MCP tool pattern."
     require_approval?: OpenAI.MCPToolRequireApproval | string | null = "always";
-
   }
 
   /**


### PR DESCRIPTION
- Migrates `user_security_context` from AOAI / account-level OpenAI chat completions into Foundry / project-level chat and responses
- Emplaces `user_security_context` as equivalently optional additions
- Rest of the changes are incidental; `npx tsp format **/*tsp` + extending model/deployment enum correction a bit