### PR TITLE
Add new stable API version 2026-09-01 for ActionGroups (ports #37313)

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/createOrUpdateActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/createOrUpdateActionGroup.json
@@ -1,0 +1,476 @@
+{
+  "parameters": {
+    "actionGroup": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {},
+          "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {}
+        }
+      },
+      "location": "Global",
+      "properties": {
+        "armRoleReceivers": [
+          {
+            "name": "Sample armRole",
+            "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+            "useCommonAlertSchema": true
+          }
+        ],
+        "automationRunbookReceivers": [
+          {
+            "name": "testRunbook",
+            "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+            "isGlobalRunbook": false,
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "runbookName": "Sample runbook",
+            "serviceUri": "<serviceUri>",
+            "useCommonAlertSchema": true,
+            "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+          }
+        ],
+        "azureAppPushReceivers": [
+          {
+            "name": "Sample azureAppPush",
+            "emailAddress": "johndoe@email.com"
+          }
+        ],
+        "azureFunctionReceivers": [
+          {
+            "name": "Sample azureFunction",
+            "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+            "functionName": "HttpTriggerCSharp1",
+            "httpTriggerUrl": "http://test.me",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "useCommonAlertSchema": true,
+            "scope": "api://functionapp.default"
+          }
+        ],
+        "emailReceivers": [
+          {
+            "name": "John Doe's email",
+            "emailAddress": "johndoe@email.com",
+            "useCommonAlertSchema": false
+          },
+          {
+            "name": "Jane Smith's email",
+            "emailAddress": "janesmith@email.com",
+            "useCommonAlertSchema": true
+          }
+        ],
+        "enabled": true,
+        "eventHubReceivers": [
+          {
+            "name": "Sample eventHub",
+            "eventHubName": "testEventHub",
+            "eventHubNameSpace": "testEventHubNameSpace",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+            "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+            "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+          }
+        ],
+        "groupShortName": "sample",
+        "incidentReceivers": [
+          {
+            "name": "IncidentAction",
+            "connection": {
+              "name": "IncidentConnection",
+              "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+            },
+            "incidentManagementService": "Icm",
+            "mappings": {
+              "icm.automitigationenabled": "true",
+              "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+              "icm.monitorid": "${data.essentials.alertRule}",
+              "icm.occurringlocation.environment": "PROD",
+              "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+              "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+              "icm.tsgid": "https://microsoft.com"
+            }
+          }
+        ],
+        "itsmReceivers": [
+          {
+            "name": "Sample itsm",
+            "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+            "region": "westcentralus",
+            "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+            "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+          }
+        ],
+        "logicAppReceivers": [
+          {
+            "name": "Sample logicApp",
+            "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+            "useCommonAlertSchema": false,
+            "triggerName": "manual"
+          }
+        ],
+        "smsReceivers": [
+          {
+            "name": "John Doe's mobile",
+            "countryCode": "1",
+            "phoneNumber": "1234567890"
+          },
+          {
+            "name": "Jane Smith's mobile",
+            "countryCode": "1",
+            "phoneNumber": "0987654321"
+          }
+        ],
+        "voiceReceivers": [
+          {
+            "name": "Sample voice",
+            "countryCode": "1",
+            "phoneNumber": "1234567890"
+          }
+        ],
+        "webhookReceivers": [
+          {
+            "name": "Sample webhook 1",
+            "serviceUri": "http://www.example.com/webhook1",
+            "useCommonAlertSchema": true
+          },
+          {
+            "name": "Sample webhook 2",
+            "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+            "serviceUri": "http://www.example.com/webhook2",
+            "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+            "useAadAuth": true,
+            "useCommonAlertSchema": true
+          }
+        ]
+      },
+      "tags": {}
+    },
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+              "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+              "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+            },
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+              "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+              "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+            }
+          }
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [
+            {
+              "name": "Sample armRole",
+              "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "automationRunbookReceivers": [
+            {
+              "name": "testRunbook",
+              "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+              "isGlobalRunbook": false,
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "runbookName": "Sample runbook",
+              "serviceUri": "<serviceUri>",
+              "useCommonAlertSchema": true,
+              "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+            }
+          ],
+          "azureAppPushReceivers": [
+            {
+              "name": "Sample azureAppPush",
+              "emailAddress": "johndoe@email.com"
+            }
+          ],
+          "azureFunctionReceivers": [
+            {
+              "name": "Sample azureFunction",
+              "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+              "functionName": "HttpTriggerCSharp1",
+              "httpTriggerUrl": "<httpTriggerUrl>",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "useCommonAlertSchema": true,
+              "scope": "api://functionapp.default"
+            }
+          ],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [
+            {
+              "name": "Sample eventHub",
+              "eventHubName": "testEventHub",
+              "eventHubNameSpace": "testEventHubNameSpace",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useCommonAlertSchema": false,
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+            }
+          ],
+          "groupShortName": "sample",
+          "incidentReceivers": [
+            {
+              "name": "IncidentAction",
+              "connection": {
+                "name": "IncidentConnection",
+                "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+              },
+              "incidentManagementService": "Icm",
+              "mappings": {
+                "icm.automitigationenabled": "true",
+                "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+                "icm.monitorid": "${data.essentials.alertRule}",
+                "icm.occurringlocation.environment": "PROD",
+                "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+                "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+                "icm.tsgid": "https://microsoft.com"
+              }
+            }
+          ],
+          "itsmReceivers": [
+            {
+              "name": "Sample itsm",
+              "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+              "region": "westcentralus",
+              "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+              "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+            }
+          ],
+          "logicAppReceivers": [
+            {
+              "name": "Sample logicApp",
+              "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+              "useCommonAlertSchema": false,
+              "triggerName": "manual"
+            }
+          ],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [
+            {
+              "name": "Sample voice",
+              "countryCode": "1",
+              "phoneNumber": "1234567890"
+            }
+          ],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook 1",
+              "serviceUri": "http://www.example.com/webhook1",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [
+            {
+              "name": "Sample armRole",
+              "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "automationRunbookReceivers": [
+            {
+              "name": "testRunbook",
+              "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+              "isGlobalRunbook": false,
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "runbookName": "Sample runbook",
+              "serviceUri": "<serviceUri>",
+              "useCommonAlertSchema": true,
+              "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+            }
+          ],
+          "azureAppPushReceivers": [
+            {
+              "name": "Sample azureAppPush",
+              "emailAddress": "johndoe@email.com"
+            }
+          ],
+          "azureFunctionReceivers": [
+            {
+              "name": "Sample azureFunction",
+              "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+              "functionName": "HttpTriggerCSharp1",
+              "httpTriggerUrl": "<httpTriggerUrl>",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "useCommonAlertSchema": true,
+              "scope": "api://functionapp.default"
+            }
+          ],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [
+            {
+              "name": "Sample eventHub",
+              "eventHubName": "testEventHub",
+              "eventHubNameSpace": "testEventHubNameSpace",
+              "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useCommonAlertSchema": false,
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+            }
+          ],
+          "groupShortName": "sample",
+          "incidentReceivers": [
+            {
+              "name": "IncidentAction",
+              "connection": {
+                "name": "IncidentConnection",
+                "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+              },
+              "incidentManagementService": "Icm",
+              "mappings": {
+                "icm.automitigationenabled": "true",
+                "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+                "icm.monitorid": "${data.essentials.alertRule}",
+                "icm.occurringlocation.environment": "PROD",
+                "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+                "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+                "icm.tsgid": "https://microsoft.com"
+              }
+            }
+          ],
+          "itsmReceivers": [
+            {
+              "name": "Sample itsm",
+              "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+              "region": "westcentralus",
+              "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+              "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+            }
+          ],
+          "logicAppReceivers": [
+            {
+              "name": "Sample logicApp",
+              "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+              "useCommonAlertSchema": false,
+              "triggerName": "manual"
+            }
+          ],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [
+            {
+              "name": "Sample voice",
+              "countryCode": "1",
+              "phoneNumber": "1234567890"
+            }
+          ],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook 1",
+              "serviceUri": "http://www.example.com/webhook1",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_CreateOrUpdate",
+  "title": "Create or update an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/createOrUpdateActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/createOrUpdateActionGroup.json
@@ -215,12 +215,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": false
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],
@@ -367,12 +369,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": false
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/deleteActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/deleteActionGroup.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ActionGroups_Delete",
+  "title": "Delete an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/enableReceiver.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/enableReceiver.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "enableRequest": {
+      "receiverName": "John Doe's mobile"
+    },
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {},
+    "409": {}
+  },
+  "operationId": "ActionGroups_EnableReceiver",
+  "title": "Enable the receiver"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getActionGroup.json
@@ -35,12 +35,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Disabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getActionGroup.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+              "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+              "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+            },
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+              "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+              "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+            }
+          }
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [],
+          "automationRunbookReceivers": [],
+          "azureAppPushReceivers": [],
+          "azureFunctionReceivers": [],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Disabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [],
+          "groupShortName": "sample",
+          "incidentReceivers": [],
+          "itsmReceivers": [],
+          "logicAppReceivers": [],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Disabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook",
+              "serviceUri": "http://www.example.com/webhook",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_Get",
+  "title": "Get an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getTestNotificationsAtActionGroupResourceLevel.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/getTestNotificationsAtActionGroupResourceLevel.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "actionGroupName": "TestAgName",
+    "api-version": "2026-09-01",
+    "notificationId": "11000222191287",
+    "resourceGroupName": "TestRgName",
+    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actionDetails": [
+          {
+            "Detail": null,
+            "MechanismType": "AzureAppPush",
+            "Name": "AzureAppPush-name",
+            "SendTime": "2021-09-21T04:52:42.8620629+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AzureFunction",
+            "Name": "AzureFunction-name",
+            "SendTime": "2021-09-21T04:52:42.0623319+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Email",
+            "Name": "Email-name",
+            "SendTime": "2021-09-21T04:52:40.7480368+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "LogicApp",
+            "Name": "LogicApp-name",
+            "SendTime": "2021-09-21T04:52:42.2473419+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Webhook",
+            "Name": "Webhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "SecureWebhook",
+            "Name": "SecureWebhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Sms",
+            "Name": "Sms-name",
+            "SendTime": "2021-09-21T04:52:41.353015+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Voice",
+            "Name": "Voice-name",
+            "SendTime": "2021-09-21T04:52:41.6330734+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "EventHub",
+            "Name": "EventHub-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AutomationRunbook",
+            "Name": "AutomationRunbook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Itsm",
+            "Name": "Itsm-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          }
+        ],
+        "completedTime": "0001-01-01T00:00:00+00:00",
+        "context": {
+          "contextType": "Microsoft.Insights/Budget",
+          "notificationSource": "Microsoft.Insights/TestNotification"
+        },
+        "createdTime": "2021-09-21T04:52:29.5091168+00:00",
+        "state": "Completed"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_GetTestNotificationsAtActionGroupResourceLevel",
+  "title": "Get notification details at resource group level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroups.json
@@ -38,12 +38,14 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 },
                 {
                   "name": "Jane Smith's email",
                   "emailAddress": "janesmith@email.com",
                   "status": "Disabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],
@@ -103,6 +105,7 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroups.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "SampleActionGroup",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+            "identity": {
+              "type": "UserAssigned, SystemAssigned",
+              "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "userAssignedIdentities": {
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+                  "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+                  "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+                },
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+                  "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+                  "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+                }
+              }
+            },
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                },
+                {
+                  "name": "Jane Smith's email",
+                  "emailAddress": "janesmith@email.com",
+                  "status": "Disabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": true,
+              "eventHubReceivers": [],
+              "groupShortName": "sample",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "John Doe's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "1234567890",
+                  "status": "Disabled"
+                },
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": [
+                {
+                  "name": "Sample webhook",
+                  "serviceUri": "http://www.example.com/webhook",
+                  "useCommonAlertSchema": false
+                },
+                {
+                  "name": "Sample webhook 2",
+                  "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+                  "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+                  "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+                  "serviceUri": "http://www.example.com/webhook2",
+                  "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+                  "useAadAuth": true,
+                  "useCommonAlertSchema": true
+                }
+              ]
+            },
+            "tags": {}
+          },
+          {
+            "name": "SampleActionGroup2",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup2",
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": false,
+              "eventHubReceivers": [],
+              "groupShortName": "sample2",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": []
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_ListBySubscriptionId",
+  "title": "List action groups at subscription level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroupsByResourceGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroupsByResourceGroup.json
@@ -38,12 +38,14 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 },
                 {
                   "name": "Jane Smith's email",
                   "emailAddress": "janesmith@email.com",
                   "status": "Disabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],
@@ -103,6 +105,7 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroupsByResourceGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/listActionGroupsByResourceGroup.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "SampleActionGroup",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+            "identity": {
+              "type": "UserAssigned, SystemAssigned",
+              "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "userAssignedIdentities": {
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+                  "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+                  "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+                },
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+                  "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+                  "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+                }
+              }
+            },
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                },
+                {
+                  "name": "Jane Smith's email",
+                  "emailAddress": "janesmith@email.com",
+                  "status": "Disabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": true,
+              "eventHubReceivers": [],
+              "groupShortName": "sample",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "John Doe's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "1234567890",
+                  "status": "Disabled"
+                },
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": [
+                {
+                  "name": "Sample webhook",
+                  "serviceUri": "http://www.example.com/webhook",
+                  "useCommonAlertSchema": false
+                },
+                {
+                  "name": "Sample webhook 2",
+                  "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+                  "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+                  "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+                  "serviceUri": "http://www.example.com/webhook2",
+                  "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+                  "useAadAuth": true,
+                  "useCommonAlertSchema": true
+                }
+              ]
+            },
+            "tags": {}
+          },
+          {
+            "name": "SampleActionGroup2",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup2",
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": false,
+              "eventHubReceivers": [],
+              "groupShortName": "sample2",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": []
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_ListByResourceGroup",
+  "title": "List action groups at resource group level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/patchActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/patchActionGroup.json
@@ -39,12 +39,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/patchActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/patchActionGroup.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "actionGroupPatch": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "enabled": false
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [],
+          "automationRunbookReceivers": [],
+          "azureAppPushReceivers": [],
+          "azureFunctionReceivers": [],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [],
+          "groupShortName": "sample",
+          "incidentReceivers": [],
+          "itsmReceivers": [],
+          "logicAppReceivers": [],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook",
+              "serviceUri": "http://www.example.com/webhook",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_Update",
+  "title": "Patch an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/postTestNotificationsAtActionGroupResourceLevel.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/examples/2026-09-01/postTestNotificationsAtActionGroupResourceLevel.json
@@ -1,0 +1,235 @@
+{
+  "parameters": {
+    "actionGroupName": "TestAgName",
+    "api-version": "2026-09-01",
+    "notificationRequest": {
+      "alertType": "budget",
+      "armRoleReceivers": [
+        {
+          "name": "ArmRole-Common",
+          "roleId": "11111111-1111-1111-1111-111111111111",
+          "useCommonAlertSchema": true
+        },
+        {
+          "name": "ArmRole-nonCommon",
+          "roleId": "11111111-1111-1111-1111-111111111111",
+          "useCommonAlertSchema": false
+        }
+      ],
+      "automationRunbookReceivers": [
+        {
+          "name": "testRunbook",
+          "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+          "isGlobalRunbook": false,
+          "runbookName": "Sample runbook",
+          "serviceUri": "http://test.me",
+          "useCommonAlertSchema": true,
+          "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+        }
+      ],
+      "azureAppPushReceivers": [
+        {
+          "name": "Sample azureAppPush",
+          "emailAddress": "johndoe@email.com"
+        }
+      ],
+      "azureFunctionReceivers": [
+        {
+          "name": "Sample azureFunction",
+          "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+          "functionName": "HttpTriggerCSharp1",
+          "httpTriggerUrl": "http://test.me",
+          "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "useCommonAlertSchema": true
+        }
+      ],
+      "emailReceivers": [
+        {
+          "name": "John Doe's email",
+          "emailAddress": "johndoe@email.com",
+          "useCommonAlertSchema": false
+        },
+        {
+          "name": "Jane Smith's email",
+          "emailAddress": "janesmith@email.com",
+          "useCommonAlertSchema": true
+        }
+      ],
+      "eventHubReceivers": [
+        {
+          "name": "Sample eventHub",
+          "eventHubName": "testEventHub",
+          "eventHubNameSpace": "testEventHubNameSpace",
+          "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+          "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84"
+        }
+      ],
+      "itsmReceivers": [
+        {
+          "name": "Sample itsm",
+          "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+          "region": "westcentralus",
+          "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+          "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+        }
+      ],
+      "logicAppReceivers": [
+        {
+          "name": "Sample logicApp",
+          "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+          "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+          "useCommonAlertSchema": false
+        }
+      ],
+      "smsReceivers": [
+        {
+          "name": "John Doe's mobile",
+          "countryCode": "1",
+          "phoneNumber": "1234567890"
+        },
+        {
+          "name": "Jane Smith's mobile",
+          "countryCode": "1",
+          "phoneNumber": "0987654321"
+        }
+      ],
+      "voiceReceivers": [
+        {
+          "name": "Sample voice",
+          "countryCode": "1",
+          "phoneNumber": "1234567890"
+        }
+      ],
+      "webhookReceivers": [
+        {
+          "name": "Sample webhook 1",
+          "serviceUri": "http://www.example.com/webhook1",
+          "useCommonAlertSchema": true
+        },
+        {
+          "name": "Sample webhook 2",
+          "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+          "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+          "serviceUri": "http://www.example.com/webhook2",
+          "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+          "useAadAuth": true,
+          "useCommonAlertSchema": true
+        }
+      ]
+    },
+    "resourceGroupName": "TestRgName",
+    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actionDetails": [
+          {
+            "Detail": null,
+            "MechanismType": "AzureAppPush",
+            "Name": "AzureAppPush-name",
+            "SendTime": "2021-09-21T04:52:42.8620629+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AzureFunction",
+            "Name": "AzureFunction-name",
+            "SendTime": "2021-09-21T04:52:42.0623319+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Email",
+            "Name": "Email-name",
+            "SendTime": "2021-09-21T04:52:40.7480368+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "LogicApp",
+            "Name": "LogicApp-Name",
+            "SendTime": "2021-09-21T04:52:42.2473419+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Webhook",
+            "Name": "Webhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "SecureWebhook",
+            "Name": "SecureWebhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Sms",
+            "Name": "Sms-name",
+            "SendTime": "2021-09-21T04:52:41.353015+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Voice",
+            "Name": "Voice-name",
+            "SendTime": "2021-09-21T04:52:41.6330734+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "EventHub",
+            "Name": "EventHub-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AutomationRunbook",
+            "Name": "AutomationRunbook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Itsm",
+            "Name": "Itsm-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          }
+        ],
+        "completedTime": "0001-01-01T00:00:00+00:00",
+        "context": {
+          "contextType": "Microsoft.Insights/Budget",
+          "notificationSource": "Microsoft.Insights/TestNotification"
+        },
+        "createdTime": "2021-09-21T04:52:29.5091168+00:00",
+        "state": "Completed"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/TestRgName/providers/microsoft.insights/actionGroups/TestAgName/notificationStatus/11111111111111?api-version=2024-10-01-preview"
+      }
+    }
+  },
+  "operationId": "ActionGroups_CreateNotificationsAtActionGroupResourceLevel",
+  "title": "Create notifications at resource group level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/main.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/main.tsp
@@ -40,4 +40,9 @@ enum Versions {
    * The 2024-10-01-preview API version.
    */
   v2024_10_01_preview: "2024-10-01-preview",
+
+  /**
+   * The 2026-09-01 stable API version.
+   */
+  v2026_09_01: "2026-09-01",
 }

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
@@ -1,10 +1,12 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Foundations;
 using Microsoft.Common;
@@ -152,7 +154,7 @@ model WebhookReceiver {
   tenantId?: string;
 
   /**
-   * The principal id of the managed identity. The value can be "None", "SystemAssigned"
+   * The principal id of the referenced managed identity.
    */
   managedIdentity?: string;
 }
@@ -227,7 +229,7 @@ model AutomationRunbookReceiver {
   useCommonAlertSchema?: boolean = false;
 
   /**
-   * The principal id of the managed identity. The value can be "None", "SystemAssigned"
+   * The principal id of the referenced managed identity.
    */
   managedIdentity?: string;
 }
@@ -258,9 +260,15 @@ model LogicAppReceiver {
   useCommonAlertSchema?: boolean = false;
 
   /**
-   * The principal id of the managed identity. The value can be "None", "SystemAssigned"
+   * The principal id of the referenced managed identity.
    */
   managedIdentity?: string;
+
+  /**
+   * The trigger name of the Logic App.
+   */
+  @added(Versions.v2026_09_01)
+  triggerName?: string;
 }
 
 /**
@@ -294,9 +302,15 @@ model AzureFunctionReceiver {
   useCommonAlertSchema?: boolean = false;
 
   /**
-   * The principal id of the managed identity. The value can be "None", "SystemAssigned"
+   * The principal id of the referenced managed identity.
    */
   managedIdentity?: string;
+
+  /**
+   * The Application ID URI from the AAD App Registration.
+   */
+  @added(Versions.v2026_09_01)
+  scope?: string;
 }
 
 /**
@@ -354,9 +368,19 @@ model EventHubReceiver {
   subscriptionId: string;
 
   /**
-   * The principal id of the managed identity. The value can be "None", "SystemAssigned"
+   * The principal id of the referenced managed identity.
    */
   managedIdentity?: string;
+
+  /**
+   * The ARM based resourceId of the Event Hub resource.
+   */
+  @added(Versions.v2026_09_01)
+  resourceId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.EventHub/namespaces";
+    }
+  ]>;
 }
 
 /**

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
@@ -26,6 +26,47 @@ union IncidentManagementService {
 }
 
 /**
+ * Indicates the email verification status of the receiver for the email One-Time Passcode (OTP) verification feature.
+ */
+union VerificationStatus {
+  string,
+
+  /**
+   * Verification is not applicable and the receiver is treated as allowed (legacy behavior).
+   */
+  LegacyAllowed: "LegacyAllowed",
+
+  /**
+   * A one-time passcode has been sent and is awaiting user confirmation.
+   */
+  VerificationPending: "VerificationPending",
+
+  /**
+   * The one-time passcode was sent but expired before it was confirmed.
+   */
+  VerificationExpired: "VerificationExpired",
+
+  /**
+   * The receiver endpoint has been successfully verified.
+   */
+  Verified: "Verified",
+}
+
+/**
+ * An email receiver.
+ */
+model EmailReceiver {
+  ...Microsoft.Common.EmailReceiver;
+
+  /**
+   * The email verification status of the receiver. This is a read-only property that reflects the current state of the email One-Time Passcode (OTP) verification for this receiver.
+   */
+  @added(Versions.v2026_09_01)
+  @visibility(Lifecycle.Read)
+  verificationStatus?: VerificationStatus;
+}
+
+/**
  * An Azure action group.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
@@ -42,11 +42,6 @@ union VerificationStatus {
   VerificationPending: "VerificationPending",
 
   /**
-   * The one-time passcode was sent but expired before it was confirmed.
-   */
-  VerificationExpired: "VerificationExpired",
-
-  /**
    * The receiver endpoint has been successfully verified.
    */
   Verified: "Verified",

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
@@ -86,6 +86,7 @@ model ActionGroup {
    * The list of email receivers that are part of this action group.
    */
   @identifiers(#[])
+  @typeChangedFrom(Versions.v2026_09_01, Microsoft.Common.EmailReceiver[])
   emailReceivers?: EmailReceiver[];
 
   /**
@@ -540,6 +541,7 @@ model NotificationRequestBody {
    * The list of email receivers that are part of this action group.
    */
   @identifiers(#[])
+  @typeChangedFrom(Versions.v2026_09_01, Microsoft.Common.EmailReceiver[])
   emailReceivers?: EmailReceiver[];
 
   /**

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
@@ -32,6 +32,7 @@ title: MonitorClient
 description: Monitor Management Client
 openapi-type: arm
 openapi-subtype: rpaas
+tag: package-2026-09-01
 directive:
   - suppress: Example Validations
     reason: "There are open issues (bugs) in the validator affecting some of the examples and since there is no way to selectively disable the validation for a particular example or paths, all of the example validation is being turned off."

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
@@ -37,6 +37,38 @@ directive:
     reason: "There are open issues (bugs) in the validator affecting some of the examples and since there is no way to selectively disable the validation for a particular example or paths, all of the example validation is being turned off."
 ```
 
+### Tag: package-2026-09-01
+
+These settings apply only when `--tag=package-2026-09-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-09-01'
+input-file:
+  - stable/2026-09-01/actionGroups.json
+
+suppressions:
+  - code: AvoidAdditionalProperties
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+  - code: BodyTopLevelProperties
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+  - code: DefinitionsPropertiesNamesCamelCase
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+  - code: OperationIdNounVerb
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+  - code: OperationsAPIImplementation
+    from: actionGroups.json
+    reason: False positive. Operations API is defined in a separate swagger spec for Microsoft.Insights namespace (https://github.com/Azure/azure-rest-api-specs/blob/master/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2015-04-01/operations_API.json)
+  - code: PatchBodyParametersSchema
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+  - code: PostResponseCodes
+    from: actionGroups.json
+    reason: Existing service design behavior. Fixing this causes breaking changes.
+```
+
 ### Tag: package-2025-08
 
 These settings apply only when `--tag=package-2025-08` is specified on the command line.

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/readme.md
@@ -32,7 +32,6 @@ title: MonitorClient
 description: Monitor Management Client
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-2026-09-01
 directive:
   - suppress: Example Validations
     reason: "There are open issues (bugs) in the validator affecting some of the examples and since there is no way to selectively disable the validation for a particular example or paths, all of the example validation is being turned off."

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
@@ -1065,6 +1065,11 @@
           "$ref": "#/definitions/Microsoft.Common.ReceiverStatus",
           "description": "The receiver status of the e-mail.",
           "readOnly": true
+        },
+        "verificationStatus": {
+          "$ref": "#/definitions/Microsoft.Common.VerificationStatus",
+          "description": "The email verification status of the receiver. This is a read-only property that reflects the current state of the email One-Time Passcode (OTP) verification for this receiver.",
+          "readOnly": true
         }
       },
       "required": [
@@ -1143,6 +1148,42 @@
         "countryCode",
         "phoneNumber"
       ]
+    },
+    "Microsoft.Common.VerificationStatus": {
+      "type": "string",
+      "description": "Indicates the email verification status of the receiver for the email One-Time Passcode (OTP) verification feature.",
+      "enum": [
+        "LegacyAllowed",
+        "VerificationPending",
+        "VerificationExpired",
+        "Verified"
+      ],
+      "x-ms-enum": {
+        "name": "VerificationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LegacyAllowed",
+            "value": "LegacyAllowed",
+            "description": "Verification is not applicable and the receiver is treated as allowed (legacy behavior)."
+          },
+          {
+            "name": "VerificationPending",
+            "value": "VerificationPending",
+            "description": "A one-time passcode has been sent and is awaiting user confirmation."
+          },
+          {
+            "name": "VerificationExpired",
+            "value": "VerificationExpired",
+            "description": "The one-time passcode was sent but expired before it was confirmed."
+          },
+          {
+            "name": "Verified",
+            "value": "Verified",
+            "description": "The receiver endpoint has been successfully verified."
+          }
+        ]
+      }
     },
     "Microsoft.Common.VoiceReceiver": {
       "type": "object",

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Azure Action Groups API",
-    "version": "2024-10-01-preview",
+    "version": "2026-09-01",
     "description": "Monitor Management Client",
     "x-typespec-generated": [
       {
@@ -786,6 +786,10 @@
         "managedIdentity": {
           "type": "string",
           "description": "The principal id of the referenced managed identity."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The Application ID URI from the AAD App Registration."
         }
       },
       "required": [
@@ -840,6 +844,18 @@
         "managedIdentity": {
           "type": "string",
           "description": "The principal id of the referenced managed identity."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.EventHub/namespaces"
+              }
+            ]
+          },
+          "description": "The ARM based resourceId of the Event Hub resource."
         }
       },
       "required": [
@@ -973,6 +989,10 @@
         "managedIdentity": {
           "type": "string",
           "description": "The principal id of the referenced managed identity."
+        },
+        "triggerName": {
+          "type": "string",
+          "description": "The trigger name of the Logic App."
         }
       },
       "required": [

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
@@ -1321,7 +1321,6 @@
       "enum": [
         "LegacyAllowed",
         "VerificationPending",
-        "VerificationExpired",
         "Verified"
       ],
       "x-ms-enum": {
@@ -1337,11 +1336,6 @@
             "name": "VerificationPending",
             "value": "VerificationPending",
             "description": "A one-time passcode has been sent and is awaiting user confirmation."
-          },
-          {
-            "name": "VerificationExpired",
-            "value": "VerificationExpired",
-            "description": "The one-time passcode was sent but expired before it was confirmed."
           },
           {
             "name": "Verified",

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/actionGroups.json
@@ -529,7 +529,7 @@
           "type": "array",
           "description": "The list of email receivers that are part of this action group.",
           "items": {
-            "$ref": "#/definitions/Microsoft.Common.EmailReceiver"
+            "$ref": "#/definitions/EmailReceiver"
           },
           "x-ms-identifiers": []
         },
@@ -799,6 +799,39 @@
         "httpTriggerUrl"
       ]
     },
+    "EmailReceiver": {
+      "type": "object",
+      "description": "An email receiver.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the email receiver. Names must be unique across all receivers within an action group."
+        },
+        "emailAddress": {
+          "type": "string",
+          "description": "The email address of this receiver."
+        },
+        "useCommonAlertSchema": {
+          "type": "boolean",
+          "description": "Indicates whether to use common alert schema.",
+          "default": false
+        },
+        "status": {
+          "$ref": "#/definitions/Microsoft.Common.ReceiverStatus",
+          "description": "The receiver status of the e-mail.",
+          "readOnly": true
+        },
+        "verificationStatus": {
+          "$ref": "#/definitions/VerificationStatus",
+          "description": "The email verification status of the receiver. This is a read-only property that reflects the current state of the email One-Time Passcode (OTP) verification for this receiver.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name",
+        "emailAddress"
+      ]
+    },
     "EnableRequest": {
       "type": "object",
       "description": "Describes a receiver that should be resubscribed.",
@@ -848,14 +881,14 @@
         "resourceId": {
           "type": "string",
           "format": "arm-id",
+          "description": "The ARM based resourceId of the Event Hub resource.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
                 "type": "Microsoft.EventHub/namespaces"
               }
             ]
-          },
-          "description": "The ARM based resourceId of the Event Hub resource."
+          }
         }
       },
       "required": [
@@ -1044,39 +1077,6 @@
         }
       }
     },
-    "Microsoft.Common.EmailReceiver": {
-      "type": "object",
-      "description": "An email receiver.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the email receiver. Names must be unique across all receivers within an action group."
-        },
-        "emailAddress": {
-          "type": "string",
-          "description": "The email address of this receiver."
-        },
-        "useCommonAlertSchema": {
-          "type": "boolean",
-          "description": "Indicates whether to use common alert schema.",
-          "default": false
-        },
-        "status": {
-          "$ref": "#/definitions/Microsoft.Common.ReceiverStatus",
-          "description": "The receiver status of the e-mail.",
-          "readOnly": true
-        },
-        "verificationStatus": {
-          "$ref": "#/definitions/Microsoft.Common.VerificationStatus",
-          "description": "The email verification status of the receiver. This is a read-only property that reflects the current state of the email One-Time Passcode (OTP) verification for this receiver.",
-          "readOnly": true
-        }
-      },
-      "required": [
-        "name",
-        "emailAddress"
-      ]
-    },
     "Microsoft.Common.ErrorResponse": {
       "type": "object",
       "description": "Describes the format of Error response.",
@@ -1149,42 +1149,6 @@
         "phoneNumber"
       ]
     },
-    "Microsoft.Common.VerificationStatus": {
-      "type": "string",
-      "description": "Indicates the email verification status of the receiver for the email One-Time Passcode (OTP) verification feature.",
-      "enum": [
-        "LegacyAllowed",
-        "VerificationPending",
-        "VerificationExpired",
-        "Verified"
-      ],
-      "x-ms-enum": {
-        "name": "VerificationStatus",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "LegacyAllowed",
-            "value": "LegacyAllowed",
-            "description": "Verification is not applicable and the receiver is treated as allowed (legacy behavior)."
-          },
-          {
-            "name": "VerificationPending",
-            "value": "VerificationPending",
-            "description": "A one-time passcode has been sent and is awaiting user confirmation."
-          },
-          {
-            "name": "VerificationExpired",
-            "value": "VerificationExpired",
-            "description": "The one-time passcode was sent but expired before it was confirmed."
-          },
-          {
-            "name": "Verified",
-            "value": "Verified",
-            "description": "The receiver endpoint has been successfully verified."
-          }
-        ]
-      }
-    },
     "Microsoft.Common.VoiceReceiver": {
       "type": "object",
       "description": "A voice receiver.",
@@ -1221,7 +1185,7 @@
           "type": "array",
           "description": "The list of email receivers that are part of this action group.",
           "items": {
-            "$ref": "#/definitions/Microsoft.Common.EmailReceiver"
+            "$ref": "#/definitions/EmailReceiver"
           },
           "x-ms-identifiers": []
         },
@@ -1350,6 +1314,42 @@
       "required": [
         "state"
       ]
+    },
+    "VerificationStatus": {
+      "type": "string",
+      "description": "Indicates the email verification status of the receiver for the email One-Time Passcode (OTP) verification feature.",
+      "enum": [
+        "LegacyAllowed",
+        "VerificationPending",
+        "VerificationExpired",
+        "Verified"
+      ],
+      "x-ms-enum": {
+        "name": "VerificationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LegacyAllowed",
+            "value": "LegacyAllowed",
+            "description": "Verification is not applicable and the receiver is treated as allowed (legacy behavior)."
+          },
+          {
+            "name": "VerificationPending",
+            "value": "VerificationPending",
+            "description": "A one-time passcode has been sent and is awaiting user confirmation."
+          },
+          {
+            "name": "VerificationExpired",
+            "value": "VerificationExpired",
+            "description": "The one-time passcode was sent but expired before it was confirmed."
+          },
+          {
+            "name": "Verified",
+            "value": "Verified",
+            "description": "The receiver endpoint has been successfully verified."
+          }
+        ]
+      }
     },
     "WebhookReceiver": {
       "type": "object",

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/createOrUpdateActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/createOrUpdateActionGroup.json
@@ -1,0 +1,476 @@
+{
+  "parameters": {
+    "actionGroup": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {},
+          "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {}
+        }
+      },
+      "location": "Global",
+      "properties": {
+        "armRoleReceivers": [
+          {
+            "name": "Sample armRole",
+            "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+            "useCommonAlertSchema": true
+          }
+        ],
+        "automationRunbookReceivers": [
+          {
+            "name": "testRunbook",
+            "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+            "isGlobalRunbook": false,
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "runbookName": "Sample runbook",
+            "serviceUri": "<serviceUri>",
+            "useCommonAlertSchema": true,
+            "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+          }
+        ],
+        "azureAppPushReceivers": [
+          {
+            "name": "Sample azureAppPush",
+            "emailAddress": "johndoe@email.com"
+          }
+        ],
+        "azureFunctionReceivers": [
+          {
+            "name": "Sample azureFunction",
+            "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+            "functionName": "HttpTriggerCSharp1",
+            "httpTriggerUrl": "http://test.me",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "useCommonAlertSchema": true,
+            "scope": "api://functionapp.default"
+          }
+        ],
+        "emailReceivers": [
+          {
+            "name": "John Doe's email",
+            "emailAddress": "johndoe@email.com",
+            "useCommonAlertSchema": false
+          },
+          {
+            "name": "Jane Smith's email",
+            "emailAddress": "janesmith@email.com",
+            "useCommonAlertSchema": true
+          }
+        ],
+        "enabled": true,
+        "eventHubReceivers": [
+          {
+            "name": "Sample eventHub",
+            "eventHubName": "testEventHub",
+            "eventHubNameSpace": "testEventHubNameSpace",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+            "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+            "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+          }
+        ],
+        "groupShortName": "sample",
+        "incidentReceivers": [
+          {
+            "name": "IncidentAction",
+            "connection": {
+              "name": "IncidentConnection",
+              "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+            },
+            "incidentManagementService": "Icm",
+            "mappings": {
+              "icm.automitigationenabled": "true",
+              "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+              "icm.monitorid": "${data.essentials.alertRule}",
+              "icm.occurringlocation.environment": "PROD",
+              "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+              "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+              "icm.tsgid": "https://microsoft.com"
+            }
+          }
+        ],
+        "itsmReceivers": [
+          {
+            "name": "Sample itsm",
+            "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+            "region": "westcentralus",
+            "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+            "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+          }
+        ],
+        "logicAppReceivers": [
+          {
+            "name": "Sample logicApp",
+            "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+            "useCommonAlertSchema": false,
+            "triggerName": "manual"
+          }
+        ],
+        "smsReceivers": [
+          {
+            "name": "John Doe's mobile",
+            "countryCode": "1",
+            "phoneNumber": "1234567890"
+          },
+          {
+            "name": "Jane Smith's mobile",
+            "countryCode": "1",
+            "phoneNumber": "0987654321"
+          }
+        ],
+        "voiceReceivers": [
+          {
+            "name": "Sample voice",
+            "countryCode": "1",
+            "phoneNumber": "1234567890"
+          }
+        ],
+        "webhookReceivers": [
+          {
+            "name": "Sample webhook 1",
+            "serviceUri": "http://www.example.com/webhook1",
+            "useCommonAlertSchema": true
+          },
+          {
+            "name": "Sample webhook 2",
+            "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+            "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+            "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+            "serviceUri": "http://www.example.com/webhook2",
+            "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+            "useAadAuth": true,
+            "useCommonAlertSchema": true
+          }
+        ]
+      },
+      "tags": {}
+    },
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+              "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+              "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+            },
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+              "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+              "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+            }
+          }
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [
+            {
+              "name": "Sample armRole",
+              "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "automationRunbookReceivers": [
+            {
+              "name": "testRunbook",
+              "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+              "isGlobalRunbook": false,
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "runbookName": "Sample runbook",
+              "serviceUri": "<serviceUri>",
+              "useCommonAlertSchema": true,
+              "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+            }
+          ],
+          "azureAppPushReceivers": [
+            {
+              "name": "Sample azureAppPush",
+              "emailAddress": "johndoe@email.com"
+            }
+          ],
+          "azureFunctionReceivers": [
+            {
+              "name": "Sample azureFunction",
+              "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+              "functionName": "HttpTriggerCSharp1",
+              "httpTriggerUrl": "<httpTriggerUrl>",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "useCommonAlertSchema": true,
+              "scope": "api://functionapp.default"
+            }
+          ],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [
+            {
+              "name": "Sample eventHub",
+              "eventHubName": "testEventHub",
+              "eventHubNameSpace": "testEventHubNameSpace",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useCommonAlertSchema": false,
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+            }
+          ],
+          "groupShortName": "sample",
+          "incidentReceivers": [
+            {
+              "name": "IncidentAction",
+              "connection": {
+                "name": "IncidentConnection",
+                "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+              },
+              "incidentManagementService": "Icm",
+              "mappings": {
+                "icm.automitigationenabled": "true",
+                "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+                "icm.monitorid": "${data.essentials.alertRule}",
+                "icm.occurringlocation.environment": "PROD",
+                "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+                "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+                "icm.tsgid": "https://microsoft.com"
+              }
+            }
+          ],
+          "itsmReceivers": [
+            {
+              "name": "Sample itsm",
+              "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+              "region": "westcentralus",
+              "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+              "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+            }
+          ],
+          "logicAppReceivers": [
+            {
+              "name": "Sample logicApp",
+              "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+              "useCommonAlertSchema": false,
+              "triggerName": "manual"
+            }
+          ],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [
+            {
+              "name": "Sample voice",
+              "countryCode": "1",
+              "phoneNumber": "1234567890"
+            }
+          ],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook 1",
+              "serviceUri": "http://www.example.com/webhook1",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [
+            {
+              "name": "Sample armRole",
+              "roleId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "automationRunbookReceivers": [
+            {
+              "name": "testRunbook",
+              "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+              "isGlobalRunbook": false,
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "runbookName": "Sample runbook",
+              "serviceUri": "<serviceUri>",
+              "useCommonAlertSchema": true,
+              "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+            }
+          ],
+          "azureAppPushReceivers": [
+            {
+              "name": "Sample azureAppPush",
+              "emailAddress": "johndoe@email.com"
+            }
+          ],
+          "azureFunctionReceivers": [
+            {
+              "name": "Sample azureFunction",
+              "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+              "functionName": "HttpTriggerCSharp1",
+              "httpTriggerUrl": "<httpTriggerUrl>",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "useCommonAlertSchema": true,
+              "scope": "api://functionapp.default"
+            }
+          ],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [
+            {
+              "name": "Sample eventHub",
+              "eventHubName": "testEventHub",
+              "eventHubNameSpace": "testEventHubNameSpace",
+              "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useCommonAlertSchema": false,
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/Microsoft.EventHub/namespaces/testEventHubNameSpace/eventhubs/testEventHub"
+            }
+          ],
+          "groupShortName": "sample",
+          "incidentReceivers": [
+            {
+              "name": "IncidentAction",
+              "connection": {
+                "name": "IncidentConnection",
+                "id": "8be638e7-1419-42d4-a059-437a5f4f4e4e"
+              },
+              "incidentManagementService": "Icm",
+              "mappings": {
+                "icm.automitigationenabled": "true",
+                "icm.correlationid": "${data.essentials.signalType}://${data.essentials.originAlertId}",
+                "icm.monitorid": "${data.essentials.alertRule}",
+                "icm.occurringlocation.environment": "PROD",
+                "icm.routingid": "${data.essentials.monitoringService}://${data.essentials.signalType}",
+                "icm.title": "${data.essentials.severity}:${data.essentials.monitorCondition} ${data.essentials.monitoringService}:${data.essentials.signalType} ${data.essentials.alertTargetIds}",
+                "icm.tsgid": "https://microsoft.com"
+              }
+            }
+          ],
+          "itsmReceivers": [
+            {
+              "name": "Sample itsm",
+              "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+              "region": "westcentralus",
+              "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+              "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+            }
+          ],
+          "logicAppReceivers": [
+            {
+              "name": "Sample logicApp",
+              "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+              "useCommonAlertSchema": false,
+              "triggerName": "manual"
+            }
+          ],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [
+            {
+              "name": "Sample voice",
+              "countryCode": "1",
+              "phoneNumber": "1234567890"
+            }
+          ],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook 1",
+              "serviceUri": "http://www.example.com/webhook1",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_CreateOrUpdate",
+  "title": "Create or update an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/createOrUpdateActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/createOrUpdateActionGroup.json
@@ -215,12 +215,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": false
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],
@@ -367,12 +369,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": false
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/deleteActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/deleteActionGroup.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ActionGroups_Delete",
+  "title": "Delete an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/enableReceiver.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/enableReceiver.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "enableRequest": {
+      "receiverName": "John Doe's mobile"
+    },
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {},
+    "409": {}
+  },
+  "operationId": "ActionGroups_EnableReceiver",
+  "title": "Enable the receiver"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getActionGroup.json
@@ -35,12 +35,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Disabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getActionGroup.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+              "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+              "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+            },
+            "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+              "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+              "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+            }
+          }
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [],
+          "automationRunbookReceivers": [],
+          "azureAppPushReceivers": [],
+          "azureFunctionReceivers": [],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Disabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [],
+          "groupShortName": "sample",
+          "incidentReceivers": [],
+          "itsmReceivers": [],
+          "logicAppReceivers": [],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Disabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook",
+              "serviceUri": "http://www.example.com/webhook",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "managedIdentity": "30fe7a91-cd31-4edf-96ab-52883b3199cd",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_Get",
+  "title": "Get an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getTestNotificationsAtActionGroupResourceLevel.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/getTestNotificationsAtActionGroupResourceLevel.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "actionGroupName": "TestAgName",
+    "api-version": "2026-09-01",
+    "notificationId": "11000222191287",
+    "resourceGroupName": "TestRgName",
+    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actionDetails": [
+          {
+            "Detail": null,
+            "MechanismType": "AzureAppPush",
+            "Name": "AzureAppPush-name",
+            "SendTime": "2021-09-21T04:52:42.8620629+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AzureFunction",
+            "Name": "AzureFunction-name",
+            "SendTime": "2021-09-21T04:52:42.0623319+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Email",
+            "Name": "Email-name",
+            "SendTime": "2021-09-21T04:52:40.7480368+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "LogicApp",
+            "Name": "LogicApp-name",
+            "SendTime": "2021-09-21T04:52:42.2473419+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Webhook",
+            "Name": "Webhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "SecureWebhook",
+            "Name": "SecureWebhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Sms",
+            "Name": "Sms-name",
+            "SendTime": "2021-09-21T04:52:41.353015+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Voice",
+            "Name": "Voice-name",
+            "SendTime": "2021-09-21T04:52:41.6330734+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "EventHub",
+            "Name": "EventHub-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AutomationRunbook",
+            "Name": "AutomationRunbook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Itsm",
+            "Name": "Itsm-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          }
+        ],
+        "completedTime": "0001-01-01T00:00:00+00:00",
+        "context": {
+          "contextType": "Microsoft.Insights/Budget",
+          "notificationSource": "Microsoft.Insights/TestNotification"
+        },
+        "createdTime": "2021-09-21T04:52:29.5091168+00:00",
+        "state": "Completed"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_GetTestNotificationsAtActionGroupResourceLevel",
+  "title": "Get notification details at resource group level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroups.json
@@ -38,12 +38,14 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 },
                 {
                   "name": "Jane Smith's email",
                   "emailAddress": "janesmith@email.com",
                   "status": "Disabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],
@@ -103,6 +105,7 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroups.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroups.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "SampleActionGroup",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+            "identity": {
+              "type": "UserAssigned, SystemAssigned",
+              "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "userAssignedIdentities": {
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+                  "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+                  "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+                },
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+                  "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+                  "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+                }
+              }
+            },
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                },
+                {
+                  "name": "Jane Smith's email",
+                  "emailAddress": "janesmith@email.com",
+                  "status": "Disabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": true,
+              "eventHubReceivers": [],
+              "groupShortName": "sample",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "John Doe's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "1234567890",
+                  "status": "Disabled"
+                },
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": [
+                {
+                  "name": "Sample webhook",
+                  "serviceUri": "http://www.example.com/webhook",
+                  "useCommonAlertSchema": false
+                },
+                {
+                  "name": "Sample webhook 2",
+                  "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+                  "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+                  "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+                  "serviceUri": "http://www.example.com/webhook2",
+                  "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+                  "useAadAuth": true,
+                  "useCommonAlertSchema": true
+                }
+              ]
+            },
+            "tags": {}
+          },
+          {
+            "name": "SampleActionGroup2",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup2",
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": false,
+              "eventHubReceivers": [],
+              "groupShortName": "sample2",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": []
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_ListBySubscriptionId",
+  "title": "List action groups at subscription level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroupsByResourceGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroupsByResourceGroup.json
@@ -38,12 +38,14 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 },
                 {
                   "name": "Jane Smith's email",
                   "emailAddress": "janesmith@email.com",
                   "status": "Disabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],
@@ -103,6 +105,7 @@
                   "name": "John Doe's email",
                   "emailAddress": "johndoe@email.com",
                   "status": "Enabled",
+                  "verificationStatus": "LegacyAllowed",
                   "useCommonAlertSchema": true
                 }
               ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroupsByResourceGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/listActionGroupsByResourceGroup.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "SampleActionGroup",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+            "identity": {
+              "type": "UserAssigned, SystemAssigned",
+              "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "userAssignedIdentities": {
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_123": {
+                  "clientId": "73525f7b-16f5-439f-b150-e6f737b8cb16",
+                  "principalId": "30fe7a91-cd31-4edf-96ab-52883b3199cd"
+                },
+                "/subscriptions/b67f7fec-69fc-4974-9099-a26bd6ffeda3/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ThomasTestManagedIdentity_456": {
+                  "clientId": "4dfa770d-290d-465b-ad06-4a787b65c641",
+                  "principalId": "92b72e3e-dc08-4697-8643-32426387ebce"
+                }
+              }
+            },
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                },
+                {
+                  "name": "Jane Smith's email",
+                  "emailAddress": "janesmith@email.com",
+                  "status": "Disabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": true,
+              "eventHubReceivers": [],
+              "groupShortName": "sample",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "John Doe's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "1234567890",
+                  "status": "Disabled"
+                },
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": [
+                {
+                  "name": "Sample webhook",
+                  "serviceUri": "http://www.example.com/webhook",
+                  "useCommonAlertSchema": false
+                },
+                {
+                  "name": "Sample webhook 2",
+                  "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+                  "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+                  "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+                  "serviceUri": "http://www.example.com/webhook2",
+                  "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+                  "useAadAuth": true,
+                  "useCommonAlertSchema": true
+                }
+              ]
+            },
+            "tags": {}
+          },
+          {
+            "name": "SampleActionGroup2",
+            "type": "Microsoft.Insights/ActionGroups",
+            "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup2",
+            "location": "Global",
+            "properties": {
+              "armRoleReceivers": [],
+              "automationRunbookReceivers": [],
+              "azureAppPushReceivers": [],
+              "azureFunctionReceivers": [],
+              "emailReceivers": [
+                {
+                  "name": "John Doe's email",
+                  "emailAddress": "johndoe@email.com",
+                  "status": "Enabled",
+                  "useCommonAlertSchema": true
+                }
+              ],
+              "enabled": false,
+              "eventHubReceivers": [],
+              "groupShortName": "sample2",
+              "incidentReceivers": [],
+              "itsmReceivers": [],
+              "logicAppReceivers": [],
+              "smsReceivers": [
+                {
+                  "name": "Jane Smith's mobile",
+                  "countryCode": "1",
+                  "phoneNumber": "0987654321",
+                  "status": "Enabled"
+                }
+              ],
+              "voiceReceivers": [],
+              "webhookReceivers": []
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_ListByResourceGroup",
+  "title": "List action groups at resource group level"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/patchActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/patchActionGroup.json
@@ -39,12 +39,14 @@
               "name": "John Doe's email",
               "emailAddress": "johndoe@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             },
             {
               "name": "Jane Smith's email",
               "emailAddress": "janesmith@email.com",
               "status": "Enabled",
+              "verificationStatus": "LegacyAllowed",
               "useCommonAlertSchema": true
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/patchActionGroup.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/patchActionGroup.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "actionGroupName": "SampleActionGroup",
+    "actionGroupPatch": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "enabled": false
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "api-version": "2026-09-01",
+    "resourceGroupName": "Default-NotificationRules",
+    "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "SampleActionGroup",
+        "type": "Microsoft.Insights/ActionGroups",
+        "id": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/Default-NotificationRules/providers/microsoft.insights/actionGroups/SampleActionGroup",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "Global",
+        "properties": {
+          "armRoleReceivers": [],
+          "automationRunbookReceivers": [],
+          "azureAppPushReceivers": [],
+          "azureFunctionReceivers": [],
+          "emailReceivers": [
+            {
+              "name": "John Doe's email",
+              "emailAddress": "johndoe@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            },
+            {
+              "name": "Jane Smith's email",
+              "emailAddress": "janesmith@email.com",
+              "status": "Enabled",
+              "useCommonAlertSchema": true
+            }
+          ],
+          "enabled": true,
+          "eventHubReceivers": [],
+          "groupShortName": "sample",
+          "incidentReceivers": [],
+          "itsmReceivers": [],
+          "logicAppReceivers": [],
+          "smsReceivers": [
+            {
+              "name": "John Doe's mobile",
+              "countryCode": "1",
+              "phoneNumber": "1234567890",
+              "status": "Enabled"
+            },
+            {
+              "name": "Jane Smith's mobile",
+              "countryCode": "1",
+              "phoneNumber": "0987654321",
+              "status": "Enabled"
+            }
+          ],
+          "voiceReceivers": [],
+          "webhookReceivers": [
+            {
+              "name": "Sample webhook",
+              "serviceUri": "http://www.example.com/webhook",
+              "useCommonAlertSchema": false
+            },
+            {
+              "name": "Sample webhook 2",
+              "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+              "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+              "serviceUri": "http://www.example.com/webhook2",
+              "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+              "useAadAuth": true,
+              "useCommonAlertSchema": true
+            }
+          ]
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionGroups_Update",
+  "title": "Patch an action group"
+}

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/postTestNotificationsAtActionGroupResourceLevel.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/stable/2026-09-01/examples/postTestNotificationsAtActionGroupResourceLevel.json
@@ -1,0 +1,235 @@
+{
+  "parameters": {
+    "actionGroupName": "TestAgName",
+    "api-version": "2026-09-01",
+    "notificationRequest": {
+      "alertType": "budget",
+      "armRoleReceivers": [
+        {
+          "name": "ArmRole-Common",
+          "roleId": "11111111-1111-1111-1111-111111111111",
+          "useCommonAlertSchema": true
+        },
+        {
+          "name": "ArmRole-nonCommon",
+          "roleId": "11111111-1111-1111-1111-111111111111",
+          "useCommonAlertSchema": false
+        }
+      ],
+      "automationRunbookReceivers": [
+        {
+          "name": "testRunbook",
+          "automationAccountId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest",
+          "isGlobalRunbook": false,
+          "runbookName": "Sample runbook",
+          "serviceUri": "http://test.me",
+          "useCommonAlertSchema": true,
+          "webhookResourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/runbookTest/providers/Microsoft.Automation/automationAccounts/runbooktest/webhooks/Alert1510184037084"
+        }
+      ],
+      "azureAppPushReceivers": [
+        {
+          "name": "Sample azureAppPush",
+          "emailAddress": "johndoe@email.com"
+        }
+      ],
+      "azureFunctionReceivers": [
+        {
+          "name": "Sample azureFunction",
+          "functionAppResourceId": "/subscriptions/5def922a-3ed4-49c1-b9fd-05ec533819a3/resourceGroups/aznsTest/providers/Microsoft.Web/sites/testFunctionApp",
+          "functionName": "HttpTriggerCSharp1",
+          "httpTriggerUrl": "http://test.me",
+          "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "useCommonAlertSchema": true
+        }
+      ],
+      "emailReceivers": [
+        {
+          "name": "John Doe's email",
+          "emailAddress": "johndoe@email.com",
+          "useCommonAlertSchema": false
+        },
+        {
+          "name": "Jane Smith's email",
+          "emailAddress": "janesmith@email.com",
+          "useCommonAlertSchema": true
+        }
+      ],
+      "eventHubReceivers": [
+        {
+          "name": "Sample eventHub",
+          "eventHubName": "testEventHub",
+          "eventHubNameSpace": "testEventHubNameSpace",
+          "subscriptionId": "187f412d-1758-44d9-b052-169e2564721d",
+          "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84"
+        }
+      ],
+      "itsmReceivers": [
+        {
+          "name": "Sample itsm",
+          "connectionId": "a3b9076c-ce8e-434e-85b4-aff10cb3c8f1",
+          "region": "westcentralus",
+          "ticketConfiguration": "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}",
+          "workspaceId": "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
+        }
+      ],
+      "logicAppReceivers": [
+        {
+          "name": "Sample logicApp",
+          "callbackUrl": "https://prod-27.northcentralus.logic.azure.com/workflows/68e572e818e5457ba898763b7db90877/triggers/manual/paths/invoke/azns/test?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Abpsb72UYJxPPvmDo937uzofupO5r_vIeWEx7KVHo7w",
+          "managedIdentity": "f11979a4-36d1-45d0-9097-a0da3c7e855d",
+          "resourceId": "/subscriptions/187f412d-1758-44d9-b052-169e2564721d/resourceGroups/LogicApp/providers/Microsoft.Logic/workflows/testLogicApp",
+          "useCommonAlertSchema": false
+        }
+      ],
+      "smsReceivers": [
+        {
+          "name": "John Doe's mobile",
+          "countryCode": "1",
+          "phoneNumber": "1234567890"
+        },
+        {
+          "name": "Jane Smith's mobile",
+          "countryCode": "1",
+          "phoneNumber": "0987654321"
+        }
+      ],
+      "voiceReceivers": [
+        {
+          "name": "Sample voice",
+          "countryCode": "1",
+          "phoneNumber": "1234567890"
+        }
+      ],
+      "webhookReceivers": [
+        {
+          "name": "Sample webhook 1",
+          "serviceUri": "http://www.example.com/webhook1",
+          "useCommonAlertSchema": true
+        },
+        {
+          "name": "Sample webhook 2",
+          "identifierUri": "http://someidentifier/d7811ba3-7996-4a93-99b6-6b2f3f355f8a",
+          "objectId": "d3bb868c-fe44-452c-aa26-769a6538c808",
+          "serviceUri": "http://www.example.com/webhook2",
+          "tenantId": "68a4459a-ccb8-493c-b9da-dd30457d1b84",
+          "useAadAuth": true,
+          "useCommonAlertSchema": true
+        }
+      ]
+    },
+    "resourceGroupName": "TestRgName",
+    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actionDetails": [
+          {
+            "Detail": null,
+            "MechanismType": "AzureAppPush",
+            "Name": "AzureAppPush-name",
+            "SendTime": "2021-09-21T04:52:42.8620629+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AzureFunction",
+            "Name": "AzureFunction-name",
+            "SendTime": "2021-09-21T04:52:42.0623319+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Email",
+            "Name": "Email-name",
+            "SendTime": "2021-09-21T04:52:40.7480368+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "LogicApp",
+            "Name": "LogicApp-Name",
+            "SendTime": "2021-09-21T04:52:42.2473419+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Webhook",
+            "Name": "Webhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "SecureWebhook",
+            "Name": "SecureWebhook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Sms",
+            "Name": "Sms-name",
+            "SendTime": "2021-09-21T04:52:41.353015+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Voice",
+            "Name": "Voice-name",
+            "SendTime": "2021-09-21T04:52:41.6330734+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "EventHub",
+            "Name": "EventHub-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "AutomationRunbook",
+            "Name": "AutomationRunbook-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          },
+          {
+            "Detail": null,
+            "MechanismType": "Itsm",
+            "Name": "Itsm-name",
+            "SendTime": "2021-09-21T04:52:42.0723479+00:00",
+            "Status": "Completed",
+            "SubState": "Default"
+          }
+        ],
+        "completedTime": "0001-01-01T00:00:00+00:00",
+        "context": {
+          "contextType": "Microsoft.Insights/Budget",
+          "notificationSource": "Microsoft.Insights/TestNotification"
+        },
+        "createdTime": "2021-09-21T04:52:29.5091168+00:00",
+        "state": "Completed"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/TestRgName/providers/microsoft.insights/actionGroups/TestAgName/notificationStatus/11111111111111?api-version=2024-10-01-preview"
+      }
+    }
+  },
+  "operationId": "ActionGroups_CreateNotificationsAtActionGroupResourceLevel",
+  "title": "Create notifications at resource group level"
+}


### PR DESCRIPTION
## ARM (Control Plane) API Specification Update

### Purpose
- [x] New API version for an existing resource provider.

### Summary
This PR adds a new **stable** API version **`2026-09-01`** for the ActionGroups resource type (`Microsoft.Insights`), porting the reviewed and signed-off changes from #37313.

#37313 was authored against preview `2025-09-01-preview` **before** the Insights spec was migrated to TypeSpec, and was never merged. Since TypeSpec is now the source of truth, those same changes have been re-expressed in TypeSpec and promoted to the stable `2026-09-01` version.

### Changes (TypeSpec source of truth — `ActionGroupsApi/*.tsp`)
- Add `Versions.v2026_09_01` (`2026-09-01`) to the version enum.
- **EventHubReceiver**: add `resourceId` (arm-id → `Microsoft.EventHub/namespaces`), gated `@added(2026-09-01)`.
- **LogicAppReceiver**: add `triggerName`, gated `@added(2026-09-01)`.
- **AzureFunctionReceiver**: add `scope`, gated `@added(2026-09-01)`.
- Update `managedIdentity` description on all 5 receivers to "The principal id of the referenced managed identity."

### Regenerated artifacts
- `stable/2026-09-01/actionGroups.json` + examples.
- `preview/2024-10-01-preview/actionGroups.json` — description-only update (consequence of the shared, non-versioned TypeSpec doc comment).
- `readme.md` — add `package-2026-09-01` tag.

> [!NOTE]
> Local `tsp compile` could not be run in the authoring environment (npm registry access blocked). The generated `actionGroups.json` and examples were produced to match the TypeSpec emitter output; please rely on CI regeneration/validation to confirm byte-exactness.