### PR TITLE
[ContainerServiceSafeguards] change DeploymentSafeguard.eTag C# type to Azure.Core.eTag

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/deploymentsafeguards/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/deploymentsafeguards/client.tsp
@@ -4,6 +4,7 @@ import "@typespec/versioning";
 
 using Azure.ClientGenerator.Core;
 using TypeSpec.Versioning;
+using Microsoft.ContainerService;
 
 @@clientName(
   Microsoft.ContainerService,
@@ -41,3 +42,5 @@ namespace Microsoft.ContainerService {
   Microsoft.ContainerService.DeploymentSafeguardCreate,
   "javascript"
 );
+
+@@alternateType(DeploymentSafeguard.eTag, Azure.Core.eTag, "csharp");


### PR DESCRIPTION
Adds a C#-scoped `@@alternateType` decorator in `client.tsp` to change the generated .NET type of `DeploymentSafeguard.eTag` from `string` to `Azure.Core.eTag` (`Azure.ETag` in the SDK).

This aligns the ETag property with the standard Azure SDK for .NET convention for entity tags. No wire/serialization changes; C#-only client customization.