### PR TITLE
ARM API reviewer evals: switch to claude-opus-4.6 and add area tags

### DIFF
--- a/.github/skills/evals/arm-api-reviewer/vally/eval-arm-resource-structure.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-arm-resource-structure.yaml
@@ -3,10 +3,13 @@ description: |
   ARM resource structure & CRUD tests (01xxxx).
   Validates detection of missing lifecycle operations and missing provisioningState.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-breaking-changes.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-breaking-changes.yaml
@@ -4,6 +4,9 @@ description: |
   Validates detection of removed properties, property type changes,
   and enum value narrowing between API versions.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "120s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-check-name-availability.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-check-name-availability.yaml
@@ -4,10 +4,13 @@ description: |
   Validates detection of custom (non-common-types) checkNameAvailability
   request/response models and missing input validation on the name field.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-citation-and-parity.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-citation-and-parity.yaml
@@ -15,10 +15,13 @@ description: |
        (same content, count, severity, rule IDs, links, code blocks,
        fix snippets, and posted-by marker).
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-classification.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-classification.yaml
@@ -4,10 +4,13 @@ description: |
   Validates that the reviewer correctly tags issues as [NEW] (introduced
   in this version) or [EXISTING] (present in the previous version).
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-examples.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-examples.yaml
@@ -4,6 +4,9 @@ description: |
   Validates detection of invalid resource IDs and realistic secrets
   in example JSON files.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "120s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-fast-path-triage.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-fast-path-triage.yaml
@@ -8,6 +8,9 @@ description: |
   touch schema content perform the full review with version comparison.
   The critic gate (Step 7) is never skipped regardless of track.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "240s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-operations.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-operations.yaml
@@ -4,10 +4,13 @@ description: |
   Validates detection of PATCH body violations, PUT response schema mismatches,
   DELETE response issues, and LRO pattern violations.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-pattern-validation.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-pattern-validation.yaml
@@ -6,10 +6,13 @@ description: |
   @pattern decorators. Verifies correct severity assignment: Blocking for
   new properties/parameters, Warning for existing ones (OAPI-PATTERN-ALLOWLIST).
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-property-design.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-property-design.yaml
@@ -4,10 +4,13 @@ description: |
   Validates detection of secret properties, naming violations,
   missing descriptions, and enum issues.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-protocol-safety.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-protocol-safety.yaml
@@ -4,6 +4,9 @@ description: |
   is not exercised by local spec fixtures: subagent auto-unavailable fallback,
   session invalidation, and downstream-CI telemetry markers.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "240s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-report-format.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-report-format.yaml
@@ -4,10 +4,13 @@ description: |
   Validates that the reviewer output includes exact line numbers, rule IDs,
   fix suggestions, and structured sections.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions-yaml.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions-yaml.yaml
@@ -8,6 +8,9 @@ description: |
   field are flagged, and new entries that suppress security-related
   rules with vague or absent justification are treated as Blocking.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "180s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions.yaml
@@ -4,6 +4,9 @@ description: |
   Validates detection of suppressions without justification and
   suppressions of security-related rules with vague reasons.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "120s"

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-true-negatives.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-true-negatives.yaml
@@ -4,10 +4,13 @@ description: |
   Validates that the reviewer does NOT flag blocking violations on clean,
   fully compliant specs and examples.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-typespec-required.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-typespec-required.yaml
@@ -7,10 +7,13 @@ description: |
   as Blocking. Updates to handwritten swagger inside pre-existing API version
   directories MUST NOT be flagged.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-typespec.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-typespec.yaml
@@ -5,10 +5,13 @@ description: |
   PATCH naming, @operationId overrides, enum-vs-union, secret detection,
   type constraints, and common anti-patterns.
 
+tags:
+  area: arm-api-reviewer
+
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6-1m
+  model: claude-opus-4.6
   judge_model: claude-sonnet-4.6
 
 scoring:


### PR DESCRIPTION
### Summary

Fixes the ARM API reviewer eval failures in the specs eval pipeline and adds `area` tags to every ARM eval so CI can shard by tag.

### Changes

- **Model fix (11 files):** Switch `model: claude-opus-4.6-1m` → `claude-opus-4.6`. `claude-opus-4.6-1m` is not supported by copilot-sdk, so those stimuli errored at session creation (`Model "claude-opus-4.6-1m" is not available`) and the whole `area_vally` shard scored 0/11.
- **Tags (all 17 files):** Add a top-level block for CI sharding:

```yaml
tags:
   area: arm-api-reviewer
```
