### PR TITLE
Fix the versioning issue with breakthroughMode

### DIFF
--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Volume.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Volume.tsp
@@ -499,9 +499,9 @@ model VolumeProperties {
   @renamedFrom(Versions.v2026_03_15_preview, "breakthroughMode")
   @added(Versions.v2026_04_01)
   @removed(Versions.v2026_04_15_preview)
-  @added(Versions.v2026_05_01)
-  @removed(Versions.v2026_05_15_preview)
   @renamedFrom(Versions.v2026_04_15_preview, "breakthroughMode")
+  @removed(Versions.v2026_05_15_preview)
+  @renamedFrom(Versions.v2026_05_15_preview, "breakthroughMode")
   breakthroughModeOld?: BreakthroughMode;
 
   /**

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-05-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-05-01/netapp.json
@@ -16526,10 +16526,6 @@
           "x-nullable": true,
           "readOnly": true
         },
-        "breakthroughModeOld": {
-          "$ref": "#/definitions/BreakthroughMode",
-          "description": "Specifies whether the volume operates in Breakthrough Mode."
-        },
         "breakthroughMode": {
           "$ref": "#/definitions/BreakthroughMode",
           "description": "Specifies whether the volume operates in Breakthrough Mode.",


### PR DESCRIPTION
Fixing the versioning issue which we had in 2026-05-01 version, none of the SDKs has been released yet, SDKs will be generated once change made with this PR is merged.