### PR TITLE
add `no-unnamed-types` suppressions

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -227,7 +227,7 @@ model PromptAgentDefinition extends AgentDefinition {
     """)
   tools?: OpenAI.Tool[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @doc("""
     How the model should select which tool (or tools) to use when generating a response.
     See the `tools` parameter to see how to specify which tools the model can call.

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
@@ -169,7 +169,7 @@ model AgentEvaluation {
 @discriminator("role")
 @removed(Versions.v1)
 model Message {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   @doc("The role of the message author. Known values: 'system', 'assistant', 'developer', 'user'.")
   role: "system" | "assistant" | "developer" | "user" | string;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
@@ -7,7 +7,7 @@ namespace Azure.AI.Projects;
 alias EvaluatorsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.evaluations_v1_preview>;
 
 alias ListEvaluatorVersionsParameters = {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   @doc("Filter evaluators by type. Possible values: 'all', 'custom', 'builtin'.")
   @Http.query
   type?: EvaluatorType | "all";

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
@@ -102,7 +102,7 @@ interface Conversations {
       @query include?: string[];
 
       /** The items to add to the conversation. You may add up to 20 items at a time. */
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
       @maxItems(20)
       items: OpenAI.Item[];
     },

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -75,7 +75,7 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
   type: "azure_ai_source";
 
   /** Data schema scenario. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   scenario:
     | "red_team"
     | "responses"
@@ -102,7 +102,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
 /** Adding Azure AI Source type to data source for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 #suppress "deprecated" "Deprecated status inherited from source OpenAI specification"
 @@changePropertyType(
   OpenAI.Eval.data_source_config,
@@ -117,7 +117,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
 /** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.Eval.testing_criteria,
   (
@@ -150,7 +150,7 @@ model Eval is OpenAI.Eval {
 /** Adding Azure AI Source type to data source for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 #suppress "deprecated" "Deprecated status inherited from source OpenAI specification"
 @@changePropertyType(
   OpenAI.CreateEvalRequest.data_source_config,
@@ -165,7 +165,7 @@ model Eval is OpenAI.Eval {
 /** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.CreateEvalRequest.testing_criteria,
   (
@@ -273,7 +273,7 @@ model ResponseRetrievalItemGenerationParams extends ItemGenerationParams {
 
   /** The source from which JSONL content is read. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: OpenAI.EvalJsonlFileContentSource | OpenAI.EvalJsonlFileIdSource;
 }
 
@@ -441,7 +441,7 @@ model TargetCompletionEvalRunDataSource extends EvalRunDataSource {
 
   /** The source configuration for inline or file data. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: OpenAI.EvalJsonlFileContentSource | OpenAI.EvalJsonlFileIdSource;
 
   /** The target configuration for the evaluation. */
@@ -464,7 +464,7 @@ model EvalCsvRunDataSource extends EvalRunDataSource {
 
   /** The source of the CSV data, either inline content or a file reference. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   source: EvalCsvFileIdSource;
 }
 
@@ -493,13 +493,13 @@ model AzureAIBenchmarkPreviewEvalRunDataSource extends EvalRunDataSource {
    * inference parameters are auto-filled from the benchmark specification stored in eval group properties.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
   target: AzureAIModelTarget | AzureAIAgentTarget;
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.EvalRun.data_source,
 
@@ -529,7 +529,7 @@ model EvalRun is OpenAI.EvalRun {
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "Imported from OpenAI spec."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
 @@changePropertyType(
   OpenAI.CreateEvalRunRequest.data_source,
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
@@ -13,7 +13,7 @@ alias EvalQueryParameters = {
   @doc("Number of runs to retrieve.")
   limit?: integer = 20;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query
   @doc("Sort order for runs by timestamp. Use `asc` for ascending order or `desc` for descending order. Defaults to `asc`.")
   order?: "asc" | "desc" = "asc";
@@ -22,7 +22,7 @@ alias EvalQueryParameters = {
 alias RunListQueryParameters = {
   ...EvalQueryParameters;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query
   @doc("Filter runs by status. One of `queued` | `in_progress` | `failed` | `completed` | `canceled`.")
   status?: "queued" | "in_progress" | "completed" | "canceled" | "failed";
@@ -35,7 +35,7 @@ alias EvalListQueryParameters = {
    * Evals can be ordered by creation time or last updated time.
    * Use `created_at` for creation time or `updated_at` for last updated time.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query(#{ explode: true })
   order_by?: "created_at" | "updated_at" = "created_at";
 };
@@ -47,7 +47,7 @@ alias EvalRunOutputItemsQueryParameters = {
    * Filter output items by status. Use `failed` to filter by failed output
    * items or `pass` to filter by passed output items.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" ""
   @query(#{ explode: true })
   status?: "fail" | "pass";
 };

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -93,7 +93,7 @@ namespace Azure.AI.Projects {
        * optional `memory_limit` setting.
        * If not provided, the service assumes auto.
        */
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Copying existing union type."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Copying existing union type."
       container?: string | OpenAI.AutoCodeInterpreterToolParam,
     }
   );
@@ -187,7 +187,7 @@ namespace Azure.AI.Projects {
     {
       /** The information about the creator of the item */
       #suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary suppression to allow union type."
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "This is required due to a conflict with the service."
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "This is required due to a conflict with the service."
       @removed(Versions.v1)
       created_by?: CreatedBy | string,
 
@@ -230,7 +230,7 @@ namespace Azure.AI.Projects {
     @doc("ID of the previous action if this action follows another.")
     previous_action_id?: string;
 
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     @doc("Status of the action (e.g., 'in_progress', 'completed', 'failed', 'cancelled').")
     status: "completed" | "failed" | "in_progress" | "cancelled";
   }

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/client.tsp
@@ -73,7 +73,7 @@ namespace Azure.AI.Projects {
     /**The status of the item. One of `in_progress`, `completed`, or
   `incomplete`. Populated when items are returned via API.*/
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Auto-suppressed warnings non-applicable rules during import."
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     status: "in_progress" | "completed" | "incomplete";
   }
 
@@ -95,7 +95,7 @@ namespace Azure.AI.Projects {
     /**The status of the item. One of `in_progress`, `completed`, or
   `incomplete`. Populated when items are returned via API.*/
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Auto-suppressed warnings non-applicable rules during import."
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     status: "in_progress" | "completed" | "incomplete";
   }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -775,7 +775,7 @@ namespace Azure.AI.Projects {
   model MemorySearchToolCallItemResource extends OpenAI.OutputItem {
     type: "memory_search_call";
 
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Auto-suppressed warnings non-applicable rules during import."
     @doc("""
       The status of the memory search tool call. One of `in_progress`,
       `searching`, `completed`, `incomplete` or `failed`,
@@ -801,7 +801,7 @@ namespace Azure.AI.Projects {
   // Tool Call Output Content Type
   // ==============================================================================
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Output can be multiple types"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Output can be multiple types"
   @doc("The output content from a tool call, which can be a dictionary, string, or array.")
   union ToolCallOutputContent {
     @doc("A dictionary/object output.")

--- a/specification/ai/DocumentIntelligence/routes.tsp
+++ b/specification/ai/DocumentIntelligence/routes.tsp
@@ -114,7 +114,7 @@ model DocumentClassifierAnalyzeRequestParams {
 @doc("Analyze from stream request parameters.")
 model AnalyzeFromStreamRequestParams {
   #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "This union cannot be open"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing clients"
   @doc("Input content type.")
   @header
   contentType:

--- a/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
@@ -19,6 +19,7 @@ alias HealthInsightsRetryAfterTrait = ResponseHeadersTrait<
 @trait("RequestIdResponseHeader")
 model RequestIdResponseHeaderTrait {
   @doc("An opaque, globally-unique, server-generated string identifier for the request.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   requestId: {
     @traitLocation(TraitLocation.Response)
     response: RequestIdResponseHeader;

--- a/specification/ai/ModelInference/models/chat_completions.tsp
+++ b/specification/ai/ModelInference/models/chat_completions.tsp
@@ -434,7 +434,7 @@ model ChatRequestUserMessage extends ChatRequestMessage {
   role: ChatRole.user;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @doc("The contents of the user message, with available input types varying by selected model.")
   content: string | ChatMessageContentItem[];
 }
@@ -529,7 +529,7 @@ model ChatResponseMessage {
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
 alias ChatCompletionsToolChoice =
   | ChatCompletionsToolChoicePreset
   | ChatCompletionsNamedToolChoice;

--- a/specification/ai/OpenAI.Assistants/common/models.tsp
+++ b/specification/ai/OpenAI.Assistants/common/models.tsp
@@ -171,7 +171,7 @@ model AssistantsApiResponseFormatJsonSchema
   type: ApiResponseFormat.jsonSchema;
 
   /** The JSON schema that the model must output. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @encodedName("application/json", "json_schema")
   jsonSchema: {
     /** A description of what the response format is for, used by the model to determine how to respond in the format. */

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -79,7 +79,7 @@ model RequestSession {
 
   /** Maximum number of tokens to generate in the response. Default is unlimited. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_response_output_tokens?: int32 | "inf";
 
   /**
@@ -673,7 +673,7 @@ model AudioInputTranscriptionOptions {
    * 'whisper-1', 'gpt-4o-transcribe', 'gpt-4o-mini-transcribe',
    * 'mai-transcribe-1', 'azure-speech'.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   @typeChangedFrom(
     Versions.v2026_04_10,
 
@@ -723,7 +723,7 @@ union Modality {
 @discriminator("model")
 @usage(RequestUsage)
 model EouDetection {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   @typeChangedFrom(
     Versions.v2026_06_01_preview,
 
@@ -989,7 +989,7 @@ model AzureSemanticVadMultilingual extends TurnDetection {
 @usage(RequestUsage)
 model AudioNoiseReduction {
   /** The type of noise reduction model. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   type: "azure_deep_noise_suppression" | "near_field" | "far_field" | string;
 }
 

--- a/specification/ai/data-plane/VoiceLive/items.tsp
+++ b/specification/ai/data-plane/VoiceLive/items.tsp
@@ -262,7 +262,7 @@ model ResponseCancelledDetails extends ResponseStatusDetails {
   // Narrow the discriminator to a literal in each child:
   type: "cancelled";
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   reason: "turn_detected" | "client_cancelled" | string;
 }
 
@@ -270,7 +270,7 @@ model ResponseCancelledDetails extends ResponseStatusDetails {
 @usage(ResponseUsage)
 model ResponseIncompleteDetails extends ResponseStatusDetails {
   type: "incomplete";
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   reason: "max_output_tokens" | "content_filter" | string;
 }
 
@@ -531,7 +531,7 @@ model ResponseWebSearchCallItem extends ResponseItem {
   type: ItemType.web_search_call;
 
   /** The status of the web search tool call. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to match source."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to match source."
   status: "in_progress" | "searching" | "completed" | "failed" | string;
 }
 
@@ -568,7 +568,7 @@ model ResponseFileSearchCallItem extends ResponseItem {
   queries?: string[];
 
   /** The status of the file search tool call. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to match source."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to match source."
   status:
     | "in_progress"
     | "searching"

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -267,7 +267,7 @@ model Response {
    * inclusive of tool calls, that was used in this response.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_output_tokens?: int32 | "inf";
 
   /**
@@ -1123,7 +1123,7 @@ model ServerEventResponseAnimationBlendshapeDelta extends ServerEvent {
   output_index: int32;
   content_index: int32;
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   frames: float32[][] | string;
   frame_index: int32;
 }
@@ -1258,7 +1258,7 @@ model ResponseCreateParams {
    * given model. Defaults to `inf`.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "This is how it's represented OpenAI Style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   max_output_tokens?: int32 | "inf";
 
   /** Create the response with pre-generated assistant message. The message item would be

--- a/specification/ai/data-plane/VoiceLive/tools.tsp
+++ b/specification/ai/data-plane/VoiceLive/tools.tsp
@@ -96,7 +96,7 @@ model MCPServer extends Tool {
   headers?: Record<string>;
   allowed_tools?: string[];
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "require_approval is represented this way in OpenAI style."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Keeping inline union to avoid breaking changes."
   require_approval?: MCPApprovalType | Record<string[]>;
 }
 

--- a/specification/apicenter/ApiCenter.DataApi/models/api.tsp
+++ b/specification/apicenter/ApiCenter.DataApi/models/api.tsp
@@ -50,7 +50,7 @@ model Api {
   @doc("Points of contact for the API.")
   contacts?: Contact[];
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
   @doc("The custom metadata defined for API entities.")
   customProperties?: {};
 

--- a/specification/apicenter/ApiCenter.DataApi/models/environment.tsp
+++ b/specification/apicenter/ApiCenter.DataApi/models/environment.tsp
@@ -36,7 +36,7 @@ model Environment {
   @doc("Onboarding information for this environment.")
   onboarding?: EnvironmentOnboardingModel;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with existing swagger."
   @doc("The custom metadata defined for environment entities.")
   customProperties?: {};
 }

--- a/specification/app/data-plane/DynamicSessions/routes.tsp
+++ b/specification/app/data-plane/DynamicSessions/routes.tsp
@@ -86,7 +86,6 @@ interface SessionResourceFiles {
       contentType: "multipart/form-data";
 
       /** Multipart body */
-      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       @multipartBody body: {
         /** The file to upload. */
         file: HttpPart<bytes>;

--- a/specification/app/data-plane/DynamicSessions/routes.tsp
+++ b/specification/app/data-plane/DynamicSessions/routes.tsp
@@ -86,6 +86,7 @@ interface SessionResourceFiles {
       contentType: "multipart/form-data";
 
       /** Multipart body */
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       @multipartBody body: {
         /** The file to upload. */
         file: HttpPart<bytes>;

--- a/specification/appconfiguration/data-plane/AppConfiguration/models.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/models.tsp
@@ -351,14 +351,14 @@ alias SyncTokenHeader = {
 
 #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
 alias ContentTypeHeader<T extends string> = {
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Avoiding creating a bunch of types for each content type."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Avoiding creating a bunch of types for each content type."
   @doc("Content-Type header")
   @header("Content-Type")
   contentType?: T | "application/problem+json";
 };
 
 alias PutKeyValueRequestContentType = {
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
   @doc("Content-Type header")
   @header("Content-Type")

--- a/specification/appconfiguration/data-plane/AppConfiguration/routes.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/routes.tsp
@@ -268,7 +268,7 @@ op getSnapshot is StandardOps.ResourceRead<
 @put
 op createSnapshot is Foundations.LongRunningOperation<
   {
-    #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
     @doc("Content-Type header")
     @header("Content-Type")
@@ -300,7 +300,7 @@ op createSnapshot is Foundations.LongRunningOperation<
 op updateSnapshot is AppConfigOperation<
   {
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Needs fix: https://github.com/microsoft/typespec/issues/2853"
-    #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
     @doc("Content-Type header")
     @header("Content-Type")
     contentType: "application/merge-patch+json" | "application/json";

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
@@ -540,7 +540,7 @@ model DrillStartRequest {
   @doc("Mode of starting the Drill")
   mode: DrillMode;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Maintaining compatibility with current SDKs."
   @doc("Inputs needed for the Recovery Orchestration Plan")
   @removed(Versions.v2026_04_01_preview)
   recoveryPlanInputs: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
@@ -225,6 +225,7 @@ model BatchRequestOutput {
   @encodedName("application/json", "custom_id")
   customId?: string;
 
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   /** The http response */
   response?: {
     /** The HTTP status code of the response */
@@ -239,6 +240,7 @@ model BatchRequestOutput {
     body?: Record<string>;
   };
 
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   /** For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure. */
   error?: {
     /** A machine-readable error code. */

--- a/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
@@ -180,7 +180,7 @@ model Batch {
   cancelledAt?: utcDateTime;
 
   /** The request counts for different statuses within the batch. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @encodedName("application/json", "request_counts")
   requestCounts?: {
     /** Total number of requests in the batch. */

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -60,7 +60,7 @@ model ChatCompletionsJsonSchemaResponseFormat
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "this represents the case-sensitive wire format"
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicitly required, nullable types"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   json_schema: {
     /** A description of what the response format is for, used by the model to determine how to respond in the format. */
     description?: string;
@@ -395,7 +395,7 @@ model PredictionContent {
    * can be returned much more quickly.
    */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   content: string | ChatMessageTextContentItem[];
 }
 

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
@@ -151,7 +151,7 @@ model ChatRequestSystemMessage extends ChatRequestMessage {
   role: ChatRole.system;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The contents of the system message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string)
   content: string | ChatMessageTextContentItem[];
@@ -171,7 +171,7 @@ model ChatRequestDeveloperMessage extends ChatRequestMessage {
 
   /** An array of content parts with a defined type. For developer messages, only type `text` is supported. */
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   content: string | ChatMessageTextContentItem[];
 
   /** An optional name for the participant. Provides the model information to differentiate between participants of the same role. */
@@ -185,7 +185,7 @@ model ChatRequestUserMessage extends ChatRequestMessage {
   role: ChatRole.user;
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The contents of the user message, with available input types varying by selected model.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, ChatMessageContent)
   @typeChangedFrom(
@@ -211,7 +211,7 @@ model ChatRequestAssistantMessage extends ChatRequestMessage {
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "explicitly nullable in mirrored API"
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The content of the message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string | null)
   content:
@@ -255,7 +255,7 @@ model ChatRequestToolMessage extends ChatRequestMessage {
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "explicitly nullable in mirrored API"
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The content of the message.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, string | null)
   content: string | ChatMessageTextContentItem[] | null;

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/common.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/common.tsp
@@ -25,7 +25,7 @@ model CompletionsUsage {
   @encodedName("application/json", "total_tokens")
   totalTokens: int32;
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("Details of the prompt tokens.")
   @added(ServiceApiVersions.v2024_10_01_Preview)
   @encodedName("application/json", "prompt_tokens_details")
@@ -41,7 +41,7 @@ model CompletionsUsage {
   };
 
   /** Breakdown of tokens used in a completion. */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @added(ServiceApiVersions.v2024_09_01_Preview)
   @encodedName("application/json", "completion_tokens_details")
   completionTokensDetails?: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/mongodb_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/mongodb_options.tsp
@@ -60,7 +60,7 @@ model MongoDBChatExtensionParameters {
    * Note that content and vector field mappings are required for MongoDB.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "this represents the case-sensitive wire format"
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   fields_mapping: {
     content_fields: string[];
     vector_fields: string[];
@@ -71,7 +71,7 @@ model MongoDBChatExtensionParameters {
   };
 
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("""
     The vectorization source to use with the MongoDB chat extension.
     """)

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/functions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/functions.tsp
@@ -36,7 +36,7 @@ union FunctionCallPreset {
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
 alias FunctionCallConfig = FunctionCallPreset | FunctionName;
 
 @doc("""

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/tools.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/tools.tsp
@@ -8,7 +8,7 @@ using TypeSpec.Versioning;
 // tool_choice: "auto" | "none" | { "type": "function", "name": string }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "External API shape is defined in OpenAPI 3.0 as oneOf."
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
 alias ChatCompletionsToolSelection =
   | ChatCompletionsToolSelectionPreset
   | ChatCompletionsNamedToolSelection;
@@ -83,7 +83,7 @@ model ChatCompletionsFunctionToolDefinition
   @doc("The object name, which is always 'function'.")
   type: "function";
 
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @doc("The function definition details for the function tool.")
   @typeChangedFrom(ServiceApiVersions.v2024_08_01_Preview, FunctionDefinition)
   function: {

--- a/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
@@ -18,7 +18,7 @@ model CreateUploadRequest {
    *
    * Use 'assistants' for Assistants and Message files, 'vision' for Assistants image file inputs, 'batch' for Batch API, and 'fine-tune' for Fine-tuning.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   purpose: string | "assistants" | "batch" | "fine-tune" | "vision";
 
   /** The number of bytes in the file you are uploading. */
@@ -71,7 +71,7 @@ model Upload {
 
   // Reference: https://platform.openai.com/docs/api-reference/files/object#files/object-purpose
   /** The intended purpose of the file. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   purpose:
     | string
     | "batch"
@@ -83,7 +83,7 @@ model Upload {
     | "vision";
 
   /** The status of the Upload. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   status: string | "pending" | "completed" | "cancelled" | "expired";
 
   // Tool customization: 'created' and fields ending in '_at' are Unix encoded utcDateTime

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -2761,6 +2761,7 @@ model ManagedClusterNATGatewayProfile {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_04_02_preview)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   outboundIPPrefixes?: {
     /**
      * A list of public IP prefix resources.
@@ -2778,6 +2779,7 @@ model ManagedClusterNATGatewayProfile {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_04_02_preview)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   outboundIPs?: {
     /**
      * A list of public IP resources.

--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/HostPool.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/HostPool.tsp
@@ -37,7 +37,7 @@ interface AppAttachPackageInfo {
   /**
    * Gets information from a package given the path to the package.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("importAppAttachPackageInfo")
   @list
   `import` is ArmResourceActionSync<
@@ -54,7 +54,7 @@ interface MSIXImages {
    * Expands and Lists MSIX packages in an Image, given the Image Path.
    * This action uses incorrect Msix casing intentionally to match the previous APIs.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("expandMsixImage")
   @list
   expand is ArmResourceActionSync<

--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/SessionHostManagement.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/SessionHostManagement.tsp
@@ -41,7 +41,7 @@ interface InitiateSessionHostUpdate {
   /**
    * Initiates a hostpool update or schedule an update for the future.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backwards compatibility with existing clients."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility with existing clients."
   @action("initiateSessionHostUpdate")
   post is ArmResourceActionSync<
     SessionHostManagement,

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
@@ -43,6 +43,7 @@ model Operation {
   /**
    * The display information for the operation.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   display?: {
     /**
      * Service provider: Microsoft Devices.

--- a/specification/discovery/Discovery.Workspace/_tool.tsp
+++ b/specification/discovery/Discovery.Workspace/_tool.tsp
@@ -319,6 +319,7 @@ model RunResult {
   createdBy?: string;
 
   @doc("Details provided by the tool (rather than the platform).")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   toolReport?: {
     /** Percentage compete */
     percentageComplete: int32;

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
@@ -16,6 +16,7 @@ namespace Microsoft.GuestConfiguration;
 @error
 model ErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   error?: {
     /**
      * Error code.

--- a/specification/keyvault/data-plane/Administration/common/common.tsp
+++ b/specification/keyvault/data-plane/Administration/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Certificates/common/common.tsp
+++ b/specification/keyvault/data-plane/Certificates/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Keys/common/common.tsp
+++ b/specification/keyvault/data-plane/Keys/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/Secrets/common/common.tsp
+++ b/specification/keyvault/data-plane/Secrets/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/keyvault/data-plane/SecurityDomain/common/common.tsp
+++ b/specification/keyvault/data-plane/SecurityDomain/common/common.tsp
@@ -13,10 +13,10 @@ alias KeyVaultOperation<
  * The key vault server error.
  */
 #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
-#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
 union Error {
   null,
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   {
     /**
      * The error code.

--- a/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
+++ b/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
@@ -687,6 +687,7 @@ model ProtectionGroupResources {
 
   @doc("Rules to match resources")
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   matchRules?: {
     @doc("rules to match")
     @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/community/community.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/community/community.tsp
@@ -210,7 +210,7 @@ model CommunityBaseModel {
   @identifiers(#[])
   governedServiceList?: GovernedServiceItem[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @added(Microsoft.Mission.Versions.v2025_05_01_preview)
   @doc("Policy override setting for the community. Specifies whether to apply enclave-specific policies or disable policy enforcement.")
   policyOverride?: "Enclave" | "None" | string;

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/postActions/approvalspostactions.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/postActions/approvalspostactions.tsp
@@ -15,11 +15,11 @@ model ApprovalCallbackRequest {
   @doc("Resource Id of the item being approved or rejected")
   resourceId: armResourceIdentifier;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Resource request action indicating action which needed to be performed upon calling approval-callback post action")
   resourceRequestAction: "Create" | "Delete" | "Update" | "Reset" | string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Approval status indicating 'Approved' or 'Rejected'")
   approvalStatus: "Approved" | "Rejected" | string;
 
@@ -31,7 +31,7 @@ model ApprovalCallbackRequest {
 // Define a model for the approval initator callback request
 @doc("Request body for calling post-action")
 model ApprovalActionRequest {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Approval status indicating 'Approved' or 'Rejected'")
   approvalStatus: "Approved" | "Rejected" | string;
 }
@@ -45,7 +45,7 @@ model ApprovalActionResponse {
 
 @doc("Request body for calling post-action")
 model ApprovalDeletionCallbackRequest {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Resource request action indicating action which needed to be performed upon calling approval-deletion-callback post action")
   resourceRequestAction: "Create" | "Delete" | "Update" | string;
 }

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/governedserviceitem.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/governedserviceitem.tsp
@@ -70,11 +70,11 @@ model GovernedServiceItem {
   @visibility(Lifecycle.Read)
   serviceName?: string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Governance option for this service (Allow, Deny, ExceptionOnly, or NotApplicable).")
   option?: "Allow" | "Deny" | "ExceptionOnly" | "NotApplicable" | string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Initiative enforcement (Enabled or Disabled).")
   enforcement?: "Enabled" | "Disabled" | string;
 
@@ -82,7 +82,7 @@ model GovernedServiceItem {
   @doc("Policies set to auditOnly (True or False).")
   auditOnly?: boolean;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @added(Microsoft.Mission.Versions.v2025_05_01_preview)
   @doc("Enforcement mode for policy. AuditOnly, Enforce, or None.")
   policyAction?: "AuditOnly" | "Enforce" | "None" | string;

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/maintenancemodeconfiguration.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/maintenancemodeconfiguration.tsp
@@ -5,14 +5,14 @@ namespace Microsoft.Mission;
 
 @doc("Maintenance Mode")
 model MaintenanceModeConfigurationModel {
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Current mode of Maintenance Mode Configuration")
   mode: "On" | "CanNotDelete" | "Off" | "General" | "Advanced" | string = "Off";
 
   @doc("The user, group or service principal object affected by Maintenance Mode")
   principals?: Principal[] = #[];
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("Justification for entering or exiting Maintenance Mode")
   justification?: "Networking" | "Governance" | "Off" | string = "Off";
 }

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/principal.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/shared/principal.tsp
@@ -6,7 +6,7 @@ model Principal {
   @doc("The object id associated with the principal")
   id: string;
 
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backwards compatibility - Existing union"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backwards compatibility - Existing union"
   @doc("The type of the object id. We currently allow users, groups, and service principals")
   type: "User" | "Group" | "ServicePrincipal" | string;
 }

--- a/specification/onlineexperimentation/OnlineExperimentation.Management/OnlineExperimentationWorkspace.tsp
+++ b/specification/onlineexperimentation/OnlineExperimentation.Management/OnlineExperimentationWorkspace.tsp
@@ -47,7 +47,7 @@ model OnlineExperimentationWorkspacePatch {
   /**
    * Updatable properties of the online experimentation workspace resource.
    */
-  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   properties?: {
     /**
      * The resource identifier of the Log Analytics workspace which online experimentation workspace uses for generating experiment analysis results.

--- a/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
@@ -445,7 +445,7 @@ interface StacItems {
      * This union allows the request body to accept either a single Item or a collection of Items.
      */
     #suppress "@azure-tools/typespec-autorest/union-unsupported" ""
-    #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backcompatibility with existing clients"
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
     @body
     body: StacItemOrStacItemCollection,
   ):

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.stac.spec.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.stac.spec.tsp
@@ -910,7 +910,7 @@ model StacLink {
    * Specifies the HTTP method that the resource expects.
    * Default: GET.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Backcompatibility with existing clients"
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "Backcompatibility with existing clients"
   method?: "GET" | "POST" | string = "GET";
 
   /**

--- a/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
+++ b/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
@@ -215,6 +215,7 @@ model ErrorResponse {
   /**
    * The error object.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   error?: {
     /**
      * Error code
@@ -570,6 +571,7 @@ model Operation {
   /**
    * The object that represents the operation.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   display?: {
     /**
      * Service provider: Microsoft.PowerBIDedicated.

--- a/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
+++ b/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
@@ -1185,6 +1185,7 @@ model ScheduleEntity {
   @doc("Trigger configuration for execution timing and scheduling")
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   trigger?: {
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     /**
      * Trigger type classification (Manual, TimeBased, EventDriven)
      */
@@ -1214,7 +1215,7 @@ model ScheduleEntity {
        */
       @doc("Next scheduled execution time (UTC)")
       triggerTime?: utcDateTime;
-    };
+  };
   };
 
   /**
@@ -1259,6 +1260,7 @@ model ScheduleEntity {
         @doc("Data asset unique identifier")
         referenceId: string;
 
+        #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
         /**
          * Reference type classification for data asset
          */
@@ -1365,6 +1367,7 @@ model ScheduleEntityRequestResponse {
        */
       @doc("Flag for automatic execution activation")
       isScheduled?: boolean;
+ #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
 
       /**
        * Next scheduled execution time in UTC format
@@ -1410,6 +1413,7 @@ model ScheduleEntityRequestResponse {
       @doc("Data asset reference within scope")
       #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataAsset: {
+        #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
         /**
          * Unique identifier of the referenced data asset
          */
@@ -2423,6 +2427,7 @@ model DataSourceEntity {
   @doc("Human-readable display name identifying the data source connection.")
   name?: string;
 
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   /**
    * Indicates whether the data source is configured for Virtual Network connectivity.
    */
@@ -2473,6 +2478,7 @@ model DataSourceEntity {
   @doc("ISO 8601 timestamp representing the creation time.")
   createdAt?: string;
 
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Already existing body parameter"
   @doc("Entity tag for concurrency control and change detection.")
   ETag?: string;
@@ -2495,6 +2501,7 @@ model DataSourceEntity {
   @doc("Authentication credential configuration for data source access.")
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   credential?: {
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     /**
      * Type of credential (e.g., ServicePrincipal, ManagedIdentity, UsernamePassword).
      */
@@ -2703,6 +2710,7 @@ model DataSourceEntityResponse {
   @doc("Display name of the data source connection.")
   name: string;
 
+   #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   /**
    * Unique system identifier for the data source entity.
    */
@@ -2856,6 +2864,7 @@ model ScheduleScanMonitoringResponse {
   @doc("HTTP status code for successful retrieval")
   @statusCode
   statusCode: 200;
+ #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
 
   /**
    * Collection of monitoring entities with execution metrics, timing, and status details
@@ -2864,6 +2873,7 @@ model ScheduleScanMonitoringResponse {
   value: ScheduleScanMonitoringEntity[];
 }
 
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
 /**
  * Profile entity configuration for data profiling and analysis operations.
  * Defines data source locations, key columns, and profiling parameters for quality assessment.
@@ -2968,6 +2978,7 @@ model ProfileEntityResponse {
  */
 @doc("Latest data quality snapshot report with comprehensive metrics and observer details.")
 model DataQualitySnapshotResponse {
+   #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   /**
    * Identifier of the business domain associated with this snapshot.
    */
@@ -3082,6 +3093,7 @@ model DataQualitySnapshotResponse {
                */
               @doc("Sample of columns with their names and types.")
               sampleColumns: Array<{
+                 #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
                 /**
                  * Name of the column.
                  */

--- a/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
+++ b/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
@@ -1215,7 +1215,7 @@ model ScheduleEntity {
        */
       @doc("Next scheduled execution time (UTC)")
       triggerTime?: utcDateTime;
-  };
+    };
   };
 
   /**

--- a/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
+++ b/specification/purviewdatagovernace/Azure.Analaytics.Purview.DataQuality/models.tsp
@@ -1089,12 +1089,15 @@ model ScheduleEntityResponse {
    * Execution scope defining which data products and assets are included in scheduled runs
    */
   @doc("Execution scope for data products and assets")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   scope?: {
     items: Array<{
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataProduct: {
         referenceId: string;
         type: string;
       };
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataAsset: {
         referenceId: string;
         type: string;
@@ -1106,8 +1109,10 @@ model ScheduleEntityResponse {
    * Trigger configuration defining when and how often the schedule executes
    */
   @doc("Trigger configuration for schedule timing")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   trigger?: {
     type: string;
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     typeProperties: {
       timezone?: string;
       isScheduled?: boolean;
@@ -1178,6 +1183,7 @@ model ScheduleEntity {
    * Trigger configuration defining execution timing and scheduling behavior
    */
   @doc("Trigger configuration for execution timing and scheduling")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   trigger?: {
     /**
      * Trigger type classification (Manual, TimeBased, EventDriven)
@@ -1189,6 +1195,7 @@ model ScheduleEntity {
      * Type-specific configuration properties for trigger behavior
      */
     @doc("Type-specific trigger configuration properties")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     typeProperties: {
       /**
        * Time zone identifier for schedule evaluation (e.g., 'UTC', 'America/New_York')
@@ -1214,6 +1221,7 @@ model ScheduleEntity {
    * Execution scope defining the data products and assets targeted for quality scanning
    */
   @doc("Execution scope for data quality scanning")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   scope?: {
     /**
      * Collection of data product and asset pairs that define the scanning boundary
@@ -1224,6 +1232,7 @@ model ScheduleEntity {
        * Reference to the data product containing the target assets
        */
       @doc("Data product reference within scope")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataProduct: {
         /**
          * Unique identifier of the referenced data product
@@ -1242,6 +1251,7 @@ model ScheduleEntity {
        * Reference to the specific data asset to be scanned
        */
       @doc("Data asset reference within scope")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataAsset: {
         /**
          * Unique identifier of the referenced data asset
@@ -1262,6 +1272,7 @@ model ScheduleEntity {
    * Reference to the parent business domain that governs this schedule
    */
   @doc("Reference to the governing business domain")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   businessDomain?: {
     /**
      * Reference type classification for business domain
@@ -1329,6 +1340,7 @@ model ScheduleEntityRequestResponse {
    * Trigger configuration defining execution timing and scheduling behavior
    */
   @doc("Trigger configuration for execution timing and scheduling")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   trigger?: {
     /**
      * Trigger type classification (Manual, TimeBased, EventDriven)
@@ -1340,6 +1352,7 @@ model ScheduleEntityRequestResponse {
      * Type-specific configuration properties for trigger behavior
      */
     @doc("Type-specific trigger configuration properties")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     typeProperties: {
       /**
        * Time zone identifier for schedule evaluation (e.g., 'UTC', 'America/New_York')
@@ -1365,6 +1378,7 @@ model ScheduleEntityRequestResponse {
    * Execution scope defining the data products and assets targeted for quality scanning
    */
   @doc("Execution scope for data quality scanning")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   scope?: {
     /**
      * Collection of data product and asset pairs that define the scanning boundary
@@ -1375,6 +1389,7 @@ model ScheduleEntityRequestResponse {
        * Reference to the data product containing the target assets
        */
       @doc("Data product reference within scope")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataProduct: {
         /**
          * Unique identifier of the referenced data product
@@ -1393,6 +1408,7 @@ model ScheduleEntityRequestResponse {
        * Reference to the specific data asset to be scanned
        */
       @doc("Data asset reference within scope")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataAsset: {
         /**
          * Unique identifier of the referenced data asset
@@ -1413,6 +1429,7 @@ model ScheduleEntityRequestResponse {
    * Reference to the parent business domain that governs this schedule
    */
   @doc("Reference to the governing business domain")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   businessDomain?: {
     /**
      * Reference type classification for business domain
@@ -2423,6 +2440,7 @@ model DataSourceEntity {
    * Reference to the business domain that governs this data source.
    */
   @doc("Business domain governance reference for this data source.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   businessDomain?: {
     /**
      * Type classification for the business domain reference.
@@ -2475,6 +2493,7 @@ model DataSourceEntity {
    * Authentication credential information for accessing the data source.
    */
   @doc("Authentication credential configuration for data source access.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   credential?: {
     /**
      * Type of credential (e.g., ServicePrincipal, ManagedIdentity, UsernamePassword).
@@ -2499,6 +2518,7 @@ model DataSourceEntity {
    * Consolidated configuration properties covering all supported data source types.
    */
   @doc("Combined configuration properties for all supported data source platforms.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   typeProperties?: {
     // ---------- Azure SQL ----------
     @doc("Azure SQL server name (for AzureSqlDatabase).")
@@ -2620,6 +2640,7 @@ model DataSourceEntity {
      * Scope configuration defining access boundaries and included objects.
      */
     @doc("Scope configuration defining inclusion and exclusion boundaries.")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     scope: {
       /**
        * Type classification for the scope (e.g., SQL, NoSQL, File, etc.).
@@ -2705,6 +2726,7 @@ model DataSourceEntityResponse {
    * Reference to the business domain that governs this data source.
    */
   @doc("Business domain governance reference for this data source.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   businessDomain?: {
     /**
      * Reference type classification for the business domain relationship.
@@ -2752,6 +2774,7 @@ model DataSourceEntityResponse {
      * Scope configuration defining access boundaries and included objects.
      */
     @doc("Scope configuration defining inclusion and exclusion boundaries.")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     scope: {
       /**
        * Scope type classification (SQL, NoSQL, File, etc.)
@@ -2776,6 +2799,7 @@ model DataSourceEntityResponse {
      * Authentication credential information for accessing the data source.
      */
     @doc("Authentication credential configuration for data source access.")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     credential?: {
       /**
        * Type of credential (e.g., ServicePrincipal, ManagedIdentity, UsernamePassword).
@@ -2856,6 +2880,7 @@ model ProfileEntity {
    * Type-specific configuration properties including location definitions and access parameters
    */
   @doc("Type-specific profiling configuration properties")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   typeProperties: {
     /**
      * Collection of data location definitions specifying where profiling should be performed
@@ -2869,6 +2894,7 @@ model ProfileEntity {
       /**
        * Location-specific properties defining file system and path details
        */
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       typeProperties: {
         /**
          * File system or container name where data resides
@@ -2893,6 +2919,7 @@ model ProfileEntity {
    * Profiling configuration including key column definitions and analysis parameters
    */
   @doc("Profiling configuration with key columns and parameters")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   configuration: {
     /**
      * Collection of key columns that serve as primary identifiers for profiling analysis
@@ -2969,6 +2996,7 @@ model DataQualitySnapshotResponse {
    * Detailed snapshot data containing observer and rule information.
    */
   @doc("Detailed snapshot data containing observer and rule information.")
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   snapshot: {
     /**
      * Array of observers monitoring this data asset.
@@ -2991,6 +3019,7 @@ model DataQualitySnapshotResponse {
        * Reference to the data asset being observed.
        */
       @doc("Reference to the data asset being observed.")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       dataAsset: {
         /**
          * Reference identifier for the data asset.
@@ -3003,6 +3032,7 @@ model DataQualitySnapshotResponse {
        * Observer-specific configuration properties.
        */
       @doc("Observer-specific configuration properties.")
+      #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
       typeProperties: {
         /**
          * Array of input datasets for this observer.
@@ -3026,6 +3056,7 @@ model DataQualitySnapshotResponse {
            * Dataset configuration and metadata.
            */
           @doc("Dataset configuration and metadata.")
+          #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
           dataset: {
             /**
              * Fully qualified name of the data source.
@@ -3038,6 +3069,7 @@ model DataQualitySnapshotResponse {
              * Schema summary information for the dataset.
              */
             @doc("Schema summary information for the dataset.")
+            #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
             schemaSummary: {
               /**
                * Total number of columns in the dataset.
@@ -3084,6 +3116,7 @@ model DataQualitySnapshotResponse {
      * Summary of data quality rules associated with this snapshot.
      */
     @doc("Summary of data quality rules associated with this snapshot.")
+    #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
     rulesSummary: {
       /**
        * Total number of rules configured.

--- a/specification/storage/data-plane/BlobStorage/Common/models.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/models.tsp
@@ -2738,7 +2738,6 @@ alias BodyParameter = {
 /** The multipart body parameter. */
 alias MultipartBodyParameter = {
   /** The body of the request. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   @multipartBody body: {
     body: HttpPart<bytes>;
   };

--- a/specification/storage/data-plane/BlobStorage/Common/models.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/models.tsp
@@ -2738,6 +2738,7 @@ alias BodyParameter = {
 /** The multipart body parameter. */
 alias MultipartBodyParameter = {
   /** The body of the request. */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   @multipartBody body: {
     body: HttpPart<bytes>;
   };

--- a/specification/storagemover/StorageMover.Management/models.tsp
+++ b/specification/storagemover/StorageMover.Management/models.tsp
@@ -775,6 +775,7 @@ model JobDefinitionProperties {
    * The list of cloud endpoints to migrate.
    */
   @added(Versions.v2025_07_01)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-types" "inline anonymous model"
   sourceTargetMap?: {
     @visibility(Lifecycle.Read)
     @added(Versions.v2025_07_01)


### PR DESCRIPTION
## Summary

Updates all linter suppressions for the `no-unnamed-union` to `no-unnamed-types` rule rename, and adds new suppressions for anonymous model violations newly caught by the broadened rule.

## Context

The `no-unnamed-union` rule in `@azure-tools/typespec-azure-core` has been replaced with a broader `no-unnamed-types` rule that covers both anonymous unions and anonymous models used as property types. The `@azure-tools/typespec-client-generator-core/no-unnamed-types` rule has been removed; its functionality is now part of the azure-core rule.

Companion PR: https://github.com/Azure/typespec-azure/pull/4880

## Changes

**Rule renames (47 files):**
- `@azure-tools/typespec-azure-core/no-unnamed-union` -> `@azure-tools/typespec-azure-core/no-unnamed-types`
- `@azure-tools/typespec-client-generator-core/no-unnamed-types` -> `@azure-tools/typespec-azure-core/no-unnamed-types`
- Removed 5 duplicate suppressions (same property suppressed by both old rules)

**New suppressions (11 files, 45 additions):**
Anonymous inline models used as property types that are now caught by the broadened rule.

Validated locally using `tsp-integration azure-specs --stage validate` with locally-built packages - all specs pass (except 2 pre-existing `search` failures due to compiler-version-mismatch).