### PR TITLE
Add state_source field to AgentObject to denote origin of agent state

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -123,6 +123,17 @@ union AgentState {
   disabled: "disabled",
 }
 
+@doc("Indicates the source of an agent's operational state. Empty when the state is not derived from a specific source.")
+union AgentStateSource {
+  string,
+
+  @doc("The state is derived from the agent's instance identity.")
+  agent_instance_identity: "agent_instance_identity",
+
+  @doc("The state is derived from the agent's blueprint.")
+  agent_blueprint: "agent_blueprint",
+}
+
 model AgentObject {
   @doc("The object type, which is always 'agent'.")
   object: AgentObjectType.agent;
@@ -137,6 +148,10 @@ model AgentObject {
   @doc("The operational state of the agent. Controls whether the agent endpoint accepts or rejects requests.")
   @visibility(Lifecycle.Read)
   state: AgentState;
+
+  @doc("The source of the agent's operational state. When the agent is disabled, indicates where the disabled state originates from. Empty when not derived from a specific source.")
+  @visibility(Lifecycle.Read)
+  state_source?: AgentStateSource;
 
   @doc("The latest version of the agent.")
   versions: {


### PR DESCRIPTION
Reverts the earlier `AgentState` enum additions and instead keeps `AgentState` limited to `enabled` / `disabled`.

Adds a new read-only `state_source` field to `AgentObject` (backed by a new `AgentStateSource` union) to denote where the agent's state — in particular a `disabled` state — originates from:

- `agent_instance_identity` — state derived from the agent's instance identity.
- `agent_blueprint` — state derived from the agent's blueprint.
- empty / absent — state not derived from a specific source (e.g. when enabled).

File: `specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp`