### PR TITLE
Add platform service group to Anyscale.Platform ARM lease

### DIFF
--- a/.github/arm-leases/anyscale/Anyscale.Platform/lease.yaml
+++ b/.github/arm-leases/anyscale/Anyscale.Platform/lease.yaml
@@ -1,5 +1,0 @@
-lease:
-  resource-provider: Anyscale.Platform
-  startdate: 2026-07-17
-  duration: P180D
-  reviewer: "@msevanhi"

--- a/.github/arm-leases/anyscale/Anyscale.Platform/platform/lease.yaml
+++ b/.github/arm-leases/anyscale/Anyscale.Platform/platform/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Anyscale.Platform
+  startdate: 2026-07-20
+  duration: P180D
+  reviewer: "@msevanhi"


### PR DESCRIPTION
Adds the **platform** service group under the existing `Anyscale.Platform` ARM lease and removes the root-level lease, so the lease is scoped at the service-group level per the `.github/arm-leases/README.md` folder structure `<orgName>/<rpNamespace>/<serviceName>/lease.yaml`.

Changes:
- Add `.github/arm-leases/anyscale/Anyscale.Platform/platform/lease.yaml`
- Remove `.github/arm-leases/anyscale/Anyscale.Platform/lease.yaml`

Lease:
- Resource provider: `Anyscale.Platform`
- Service group: `platform`
- Start date: 2026-07-20
- Duration: P180D
- Reviewer: @msevanhi

Follow-up to #44774.