### PR TITLE
Fix alert configuration provisioning state

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
@@ -34,7 +34,7 @@ union AlertConfigurationMode {
  */
 @added(Versions.v2026_05_02_preview)
 union AlertConfigurationProvisioningState {
-  string,
+  ResourceProvisioningState,
 
   /**
    * The alert configuration is being created.
@@ -50,21 +50,6 @@ union AlertConfigurationProvisioningState {
    * The alert configuration is being deleted.
    */
   Deleting: "Deleting",
-
-  /**
-   * The alert configuration has been successfully provisioned.
-   */
-  Succeeded: "Succeeded",
-
-  /**
-   * The alert configuration provisioning failed.
-   */
-  Failed: "Failed",
-
-  /**
-   * The alert configuration provisioning was canceled.
-   */
-  Canceled: "Canceled",
 }
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
@@ -7976,17 +7976,32 @@
       "type": "string",
       "description": "The current provisioning state of the alert configuration.",
       "enum": [
-        "Creating",
-        "Updating",
-        "Deleting",
         "Succeeded",
         "Failed",
-        "Canceled"
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
       ],
       "x-ms-enum": {
         "name": "AlertConfigurationProvisioningState",
         "modelAsString": true,
         "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
           {
             "name": "Creating",
             "value": "Creating",
@@ -8001,21 +8016,6 @@
             "name": "Deleting",
             "value": "Deleting",
             "description": "The alert configuration is being deleted."
-          },
-          {
-            "name": "Succeeded",
-            "value": "Succeeded",
-            "description": "The alert configuration has been successfully provisioned."
-          },
-          {
-            "name": "Failed",
-            "value": "Failed",
-            "description": "The alert configuration provisioning failed."
-          },
-          {
-            "name": "Canceled",
-            "value": "Canceled",
-            "description": "The alert configuration provisioning was canceled."
           }
         ]
       },


### PR DESCRIPTION
## Summary
- compose `AlertConfigurationProvisioningState` with the shared ARM `ResourceProvisioningState` union
- retain the AKS-specific `Creating`, `Updating`, and `Deleting` states
- regenerate the 2026-05-02-preview OpenAPI output

Implements the suggestion in https://github.com/Azure/azure-rest-api-specs/pull/44598#discussion_r3602916478.

## Validation
- `azsdk tsp validate --typespec-project specification/containerservice/resource-manager/Microsoft.ContainerService/aks`
- `npx tsp compile .`