### PR TITLE
iothub: keep Java device-twin free-form maps as Object via alternateType

### DIFF
--- a/specification/iothub/resource-manager/Microsoft.Devices/IoTHub/client.tsp
+++ b/specification/iothub/resource-manager/Microsoft.Devices/IoTHub/client.tsp
@@ -39,6 +39,14 @@ using Http;
   "java"
 );
 
+// Preserve backward-compatible Java surface (free-form Object) for device twin
+// free-form maps. These properties are `Record<unknown>` in the spec, which the
+// Java emitter maps to `Map`; prior releases generated `Object`. Keep `Object`
+// for Java only to avoid a breaking change, while other languages keep `Map`.
+@@alternateType(RoutingTwin.tags, unknown, "java");
+@@alternateType(RoutingTwinProperties.desired, unknown, "java");
+@@alternateType(RoutingTwinProperties.reported, unknown, "java");
+
 @@scope(GroupIdInformations.get, "!csharp");
 @@scope(GroupIdInformations.list, "!csharp");
 @@usage(GroupIdInformation, Usage.output, "csharp");


### PR DESCRIPTION
## Summary
Restores the backward-compatible Java client surface for IoT Hub device-twin free-form maps.

RoutingTwin.tags, RoutingTwinProperties.desired, and RoutingTwinProperties.reported are modeled as `Record<unknown>` in `models.tsp`, which the Java emitter maps to `Map`. Prior releases (api-version `2025-08-01-preview`, `azure-resourcemanager-iothub` 1.4.0-beta.2) generated `Object` for these properties. The current generation therefore introduces a **breaking change** on the Java public API:

- `java.lang.Object reported()` -> `java.util.Map reported()`
- `java.lang.Object desired()` -> `java.util.Map desired()`
- `java.lang.Object tags()` -> `java.util.Map tags()`
- `withReported(Object)` / `withDesired(Object)` / `withTags(Object)` removed

## Change
Add `@@alternateType(..., unknown, "java")` in `client.tsp` for the three properties. TypeSpec `unknown` maps to Java `Object`, so the Java client keeps the original `Object` surface while other languages continue to use the more specific `Map`. No wire/protocol change.

This mitigates the breaking changes observed in azure-sdk-for-java PR [#49868](https://github.com/Azure/azure-sdk-for-java/pull/49868).
