### PR TITLE
AppConfiguration: rename NSP operations and Location type per SDK review feedback

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -149,6 +149,16 @@ using Azure.ClientGenerator.Core;
   "CheckAppConfigurationRegionalNameAvailability",
   "csharp"
 );
+@@clientName(
+  NetworkSecurityPerimeterConfigurations.get,
+  "GetNetworkSecurityPerimeterConfiguration",
+  "csharp"
+);
+@@clientName(
+  NetworkSecurityPerimeterConfigurations.listByConfigurationStore,
+  "GetNetworkSecurityPerimeterConfigurations",
+  "csharp"
+);
 @@alternateType(
   DeletedConfigurationStoreProperties.configurationStoreId,
   Azure.Core.armResourceIdentifier,
@@ -179,6 +189,11 @@ using Azure.ClientGenerator.Core;
 @@alternateType(
   SnapshotProperties.etag,
   Azure.Core.EtagProperty.etag,
+  "csharp"
+);
+@@alternateType(
+  Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter.location,
+  Azure.Core.azureLocation,
   "csharp"
 );
 @@clientName(

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -206,3 +206,13 @@ using Azure.ClientGenerator.Core;
   "AppConfigurationMoboBrokerResourceInfo",
   "csharp"
 );
+@@clientName(
+  Azure.ResourceManager.CommonTypes.Severity,
+  "AppConfigurationSeverity",
+  "csharp"
+);
+@@clientName(
+  Azure.ResourceManager.CommonTypes.IssueType,
+  "AppConfigurationIssueType",
+  "csharp"
+);


### PR DESCRIPTION
## Summary

Follow-up to release plan 2206 / .NET SDK PR https://github.com/Azure/azure-sdk-for-net/pull/61117 review comments on the Network Security Perimeter (NSP) feature added in #38653.

### Changes
- Rename \NetworkSecurityPerimeterConfigurations.get\ client name to \GetNetworkSecurityPerimeterConfiguration\ (was generating a confusing \Get(string)\ overload on \AppConfigurationStoreResource\)
- Rename \NetworkSecurityPerimeterConfigurations.listByConfigurationStore\ client name to \GetNetworkSecurityPerimeterConfigurations\ (was generating \GetByConfigurationStore()\)
- Add \@@alternateType\ for \NetworkSecurityPerimeter.location\ to use \AzureLocation\ instead of \string\, consistent with other location properties in this spec

All changes are scoped to \client.tsp\ (C# client customization only); no other spec files were modified.