### PR TITLE
[Datadog] Map ActivateSaaSParameterRequest.saaSResourceId to armResourceIdentifier for C#

### DIFF
--- a/specification/datadog/Datadog.Management/client.tsp
+++ b/specification/datadog/Datadog.Management/client.tsp
@@ -200,6 +200,11 @@ using Microsoft.Datadog;
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
+@@alternateType(
+  ActivateSaaSParameterRequest.saaSResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(PartnerBillingEntity.partnerEntityUri, url, "csharp");
 @@alternateType(DatadogSingleSignOnProperties.singleSignOnUrl, url, "csharp");
 @@alternateType(DatadogOrganizationProperties.redirectUri, url, "csharp");


### PR DESCRIPTION
## Summary
Adds a C#-scoped `@@alternateType` override in `client.tsp` so that `ActivateSaaSParameterRequest.saaSResourceId` generates as `Azure.Core.armResourceIdentifier` (→ `ResourceIdentifier`) in the .NET SDK instead of a plain `string`. Client-config only — no `models.tsp`, no OpenAPI/swagger, no wire change.

## Why
`saaSResourceId` is a full ARM resource ID (`/subscriptions/.../providers/Microsoft.SaaS/resources/{name}`). Its two siblings `SaaSData.saaSResourceId` and `LatestLinkedSaaSResponse.saaSResourceId` already map to `armResourceIdentifier` for C#; this one's override was dropped during the `saaSGuid` → `saaSResourceId` rename (#41946) and never replaced, so .NET fell back to `string`. This inconsistency is flagged by the .NET mgmt-SDK review check (TYPE001) on Azure/azure-sdk-for-net#60649.

## The value really is an ARM resource ID.** The request example for this operation sends a full ARM resource ID:

```json
"saaSResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.SaaS/resources/mySaaSResource"
```

Two sibling properties in this same spec — `SaaSData.saaSResourceId` and `LatestLinkedSaaSResponse.saaSResourceId` — already carry the identical kind of value and are already generated as `ResourceIdentifier` in C#. This change simply makes the third, related property consistent with them.

## Not a breaking change
- **Wire contract unchanged.** `ResourceIdentifier` is just a strongly-typed wrapper over the ID string — it serializes to the same JSON string, and swagger stays `"saaSResourceId": { "type": "string" }`. Requests/responses are byte-for-byte identical.
- **Backend already requires an ARM ID.** The service validates this field as an ARM resource ID (same preview API version) and rejects anything else, so `ResourceIdentifier` just matches the contract already enforced:
  ```csharp
  if (!ResourceId.TryParse(request.SaaSResourceId, out _))
      return BadRequest("SaaSResourceId must be a valid ARM resource ID.");
  ```
- **Nothing released affected.** Preview-only model in the unreleased `Azure.ResourceManager.Datadog 1.1.0-beta.2`; not in the `1.0.0` breaking-change baseline, and beta→beta type refinements are allowed.
- **C#-only.** The override is `"csharp"`-scoped — Python/Java/Go keep modeling it as a string.

## Change
```typespec
@@alternateType(
  ActivateSaaSParameterRequest.saaSResourceId,
  Azure.Core.armResourceIdentifier,
  "csharp"
);
```

## Related
- Blocks: Azure/azure-sdk-for-net#60649 (Datadog `1.1.0-beta.2`)