### PR TITLE
feat(chaos/2026-08-01-preview): surface resolved/excluded resources on validation and run results

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_Get.json
@@ -27,6 +27,11 @@
               "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
             }
           ],
+          "excludedResources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+            }
+          ],
           "scenarioRunJson": "{\"experiment\":{\"steps\":[{\"name\":\"step1\",\"branches\":[{\"name\":\"branch1\",\"actions\":[{\"name\":\"urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0\",\"type\":\"continuous\",\"duration\":\"PT10M\",\"selectorId\":\"selector1\"}]}]}]}}",
           "scenarioRunSummary": [
             {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/ScenarioRuns_ListAll.json
@@ -25,6 +25,11 @@
                   "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
                 }
               ],
+              "excludedResources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+                }
+              ],
               "startTime": "2025-01-20T14:30:00.000Z",
               "endTime": "2025-01-20T14:40:00.000Z"
             },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_Get.json
@@ -27,6 +27,11 @@
               "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
             }
           ],
+          "excludedResources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+            }
+          ],
           "scenarioRunJson": "{\"experiment\":{\"steps\":[{\"name\":\"step1\",\"branches\":[{\"name\":\"branch1\",\"actions\":[{\"name\":\"urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0\",\"type\":\"continuous\",\"duration\":\"PT10M\",\"selectorId\":\"selector1\"}]}]}]}}",
           "scenarioRunSummary": [
             {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/ScenarioRuns_ListAll.json
@@ -25,6 +25,11 @@
                   "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
                 }
               ],
+              "excludedResources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+                }
+              ],
               "startTime": "2025-01-20T14:30:00.000Z",
               "endTime": "2025-01-20T14:40:00.000Z"
             },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
@@ -7118,6 +7118,17 @@
             "id"
           ]
         },
+        "excludedResources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types but were excluded\nfrom fault injection by the configuration's resource-targeting filters\n(for example zone, location, or explicit exclusions). These resources will not be impacted by the run.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
         "errors": {
           "type": "array",
           "description": "System or infrastructure errors encountered during the scenario run.",
@@ -7731,6 +7742,28 @@
           "format": "date-time",
           "description": "The scenario validation UTC end time.",
           "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types and will be impacted\nby the run, resolved after applying the configuration's resource-targeting filters.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "excludedResources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types but were excluded\nfrom fault injection by the configuration's resource-targeting filters\n(for example zone, location, or explicit exclusions). These resources will not be impacted.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
         },
         "errors": {
           "type": "array",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
@@ -245,6 +245,25 @@ model ValidationProperties {
   endTime?: utcDateTime;
 
   /**
+   * Resources that matched the scenario's target resource types and will be impacted
+   * by the run, resolved after applying the configuration's resource-targeting filters.
+   */
+  @added(Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read)
+  @identifiers(#["id"])
+  resources?: ScenarioRunResource[];
+
+  /**
+   * Resources that matched the scenario's target resource types but were excluded
+   * from fault injection by the configuration's resource-targeting filters
+   * (for example zone, location, or explicit exclusions). These resources will not be impacted.
+   */
+  @added(Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read)
+  @identifiers(#["id"])
+  excludedResources?: ScenarioRunResource[];
+
+  /**
    * System or infrastructure errors encountered during validation.
    */
   @visibility(Lifecycle.Read)

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -109,6 +109,16 @@ model ScenarioRunProperties {
   resources: ScenarioRunResource[];
 
   /**
+   * Resources that matched the scenario's target resource types but were excluded
+   * from fault injection by the configuration's resource-targeting filters
+   * (for example zone, location, or explicit exclusions). These resources will not be impacted by the run.
+   */
+  @added(Microsoft.Chaos.Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read)
+  @identifiers(#["id"])
+  excludedResources?: ScenarioRunResource[];
+
+  /**
    * System or infrastructure errors encountered during the scenario run.
    */
   @visibility(Lifecycle.Read)


### PR DESCRIPTION
## What

Surface the resolved (impacted) and excluded (not-impacted) resource lists on the customer-facing ARM surface so scenario validation produces actionable results:

- `ValidationProperties`: add `resources` + `excludedResources` (optional, read-only)
- `ScenarioRunProperties`: add `excludedResources` (optional, read-only)

All gated to `2026-08-01-preview` via `@added` (2026-05 / 2026-02 unchanged). Additive, read-only, backward compatible.

## Why

The backend already computes and returns these lists; this surfaces them through ARM. Backs ADO Feature 36089285 / User Story 36686743.

## Notes

- Targets `user/renzopretto/chaos-2026-08-01-preview` (where `2026-08-01-preview` is staged), not `main`.
- Regenerated `openapi.json`; updated `ScenarioRuns_Get` / `ScenarioRuns_ListAll` + validation examples.
- Paired ARM Gateway change lands in the Chaos ADO repo.
