### PR TITLE
[Azure Stack HCI] EdgeMachine reportedProperties parity with EdgeDevice

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_CreateOrUpdate.json
@@ -50,6 +50,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {
@@ -131,6 +202,77 @@
                 {
                   "switchName": "vmanagement",
                   "switchType": "External"
+                }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
                 }
               ]
             },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Get.json
@@ -43,6 +43,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListByResourceGroup.json
@@ -42,6 +42,77 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListBySubscription.json
@@ -41,6 +41,77 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Update.json
@@ -47,6 +47,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_CreateOrUpdate.json
@@ -50,6 +50,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {
@@ -151,6 +231,86 @@
                 {
                   "switchName": "vmanagement",
                   "switchType": "External"
+                }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
                 }
               ]
             },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Get.json
@@ -61,6 +61,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListByResourceGroup.json
@@ -42,6 +42,86 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
+                  ]
+                },
+                "confidentialVmProfile": {
+                  "igvmStatus": "Enabled",
+                  "statusDetails": [
+                    {
+                      "code": "IgvmEnabled",
+                      "message": "Confidential VM capabilities are enabled on the device."
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListBySubscription.json
@@ -41,6 +41,86 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
+                  ]
+                },
+                "confidentialVmProfile": {
+                  "igvmStatus": "Enabled",
+                  "statusDetails": [
+                    {
+                      "code": "IgvmEnabled",
+                      "message": "Confidential VM capabilities are enabled on the device."
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Update.json
@@ -47,6 +47,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7371,7 +7371,7 @@ model EdgeMachineNetworkProfile {
    * HostNetwork configuration reported for the edge machine.
    */
   @visibility(Lifecycle.Read)
-  hostNetwork?: HciEdgeDeviceHostNetwork;
+  hostNetwork?: EdgeMachineHostNetwork;
 
   /**
    * Software Defined Networking (SDN) properties reported for the edge machine.
@@ -7600,7 +7600,281 @@ model StorageProfile {
    */
   @visibility(Lifecycle.Read)
   @Azure.ResourceManager.identifiers(#["id"])
-  disks?: EdgeDeviceDisks[];
+  disks?: EdgeMachineDiskInfo[];
+}
+
+/**
+ * HostNetwork configuration reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineHostNetwork {
+  /**
+   * The network intents assigned to the network reference pattern used for the deployment. Each intent will define its own name, traffic type, adapter names, and overrides as recommended by your OEM.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#["intentName"])
+  intents?: EdgeMachineHostNetworkIntent[];
+
+  /**
+   * List of StorageNetworks config to deploy AzureStackHCI Cluster.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#["networkAdapterName"])
+  storageNetworks?: EdgeMachineStorageNetwork[];
+
+  /**
+   * Defines how the storage adapters between nodes are connected either switch or switch less.
+   */
+  @visibility(Lifecycle.Read)
+  storageConnectivitySwitchless?: boolean;
+
+  /**
+   * Optional parameter required only for 3 Nodes Switchless deployments. This allows users to specify IPs and Mask for Storage NICs when Network ATC is not assigning the IPs for storage automatically.
+   */
+  @visibility(Lifecycle.Read)
+  enableStorageAutoIp?: boolean = false;
+}
+
+/**
+ * The network intent reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineHostNetworkIntent {
+  /**
+   * Scope for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  scope?: int64;
+
+  /**
+   * IntentType for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  intentType?: int64;
+
+  /**
+   * IsComputeIntentSet for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isComputeIntentSet?: boolean;
+
+  /**
+   * IsStorageIntentSet for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isStorageIntentSet?: boolean;
+
+  /**
+   * IntentType for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isOnlyStorage?: boolean;
+
+  /**
+   * IsManagementIntentSet for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isManagementIntentSet?: boolean;
+
+  /**
+   * IsStretchIntentSet for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isStretchIntentSet?: boolean;
+
+  /**
+   * IsOnlyStretch for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isOnlyStretch?: boolean;
+
+  /**
+   * IsNetworkIntentType for host network intent.
+   */
+  @visibility(Lifecycle.Read)
+  isNetworkIntentType?: boolean;
+
+  /**
+   * Name of the network intent you wish to create.
+   */
+  @visibility(Lifecycle.Read)
+  intentName?: string;
+
+  /**
+   * Array of adapters used for the network intent.
+   */
+  @visibility(Lifecycle.Read)
+  intentAdapters?: string[];
+
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.
+   */
+  @visibility(Lifecycle.Read)
+  overrideVirtualSwitchConfiguration?: boolean;
+
+  /**
+   * Set virtualSwitch ConfigurationOverrides for cluster.
+   */
+  @visibility(Lifecycle.Read)
+  virtualSwitchConfigurationOverrides?: EdgeMachineVirtualSwitchConfigurationOverrides;
+
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.
+   */
+  @visibility(Lifecycle.Read)
+  overrideQosPolicy?: boolean;
+
+  /**
+   * Set QoS PolicyOverrides for cluster.
+   */
+  @visibility(Lifecycle.Read)
+  qosPolicyOverrides?: QosPolicyOverrides;
+
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.
+   */
+  @visibility(Lifecycle.Read)
+  overrideAdapterProperty?: boolean;
+
+  /**
+   * Set Adapter PropertyOverrides for cluster.
+   */
+  @visibility(Lifecycle.Read)
+  adapterPropertyOverrides?: EdgeMachineAdapterPropertyOverrides;
+}
+
+/**
+ * The VirtualSwitchConfigurationOverrides reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineVirtualSwitchConfigurationOverrides {
+  /**
+   * Enable IoV for Virtual Switch
+   */
+  @visibility(Lifecycle.Read)
+  enableIov?: string;
+
+  /**
+   * Load Balancing Algorithm for Virtual Switch
+   */
+  @visibility(Lifecycle.Read)
+  loadBalancingAlgorithm?: string;
+}
+
+/**
+ * The AdapterPropertyOverrides reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineAdapterPropertyOverrides {
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.
+   */
+  @visibility(Lifecycle.Read)
+  jumboPacket?: string;
+
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.
+   */
+  @visibility(Lifecycle.Read)
+  networkDirect?: string;
+
+  /**
+   * This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation. Expected values are 'iWARP', 'RoCEv2', 'RoCE'
+   */
+  @visibility(Lifecycle.Read)
+  networkDirectTechnology?: string;
+}
+
+/**
+ * The StorageNetworks reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineStorageNetwork {
+  /**
+   * Name of the storage network.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * Name of the storage network adapter.
+   */
+  @visibility(Lifecycle.Read)
+  networkAdapterName?: string;
+
+  /**
+   * ID specified for the VLAN storage network. This setting is applied to the network interfaces that route the storage and VM migration traffic.
+   */
+  @visibility(Lifecycle.Read)
+  storageVlanId?: string;
+
+  /**
+   * List of Storage adapter physical nodes config to deploy AzureStackHCI Cluster.
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Read)
+  @identifiers(#["physicalNode"])
+  storageAdapterIPInfo?: EdgeMachineStorageAdapterIpInfo[];
+}
+
+/**
+ * The StorageAdapter physical nodes reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineStorageAdapterIpInfo {
+  /**
+   * storage adapter physical node name.
+   */
+  @visibility(Lifecycle.Read)
+  physicalNode?: string;
+
+  /**
+   * The IPv4 address assigned to each storage adapter physical node on your Azure Stack HCI cluster.
+   */
+  @visibility(Lifecycle.Read)
+  ipv4Address?: string;
+
+  /**
+   * The SubnetMask address assigned to each storage adapter physical node on your Azure Stack HCI cluster.
+   */
+  @visibility(Lifecycle.Read)
+  subnetMask?: string;
+}
+
+/**
+ * Represents a storage disk reported for the edge machine.
+ */
+@added(Versions.v2026_10_01)
+model EdgeMachineDiskInfo {
+  /**
+   * The unique identifier of the disk.
+   */
+  @visibility(Lifecycle.Read)
+  id: string;
+
+  /**
+   * The size of the disk in bytes.
+   */
+  @visibility(Lifecycle.Read)
+  sizeInBytes?: string;
+
+  /**
+   * The type of the disk. For example, S2D or SAN.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /** Model number of the hardware. */
+  @visibility(Lifecycle.Read)
+  `model`?: string;
+
+  /** The manufacturer of the disk. */
+  @visibility(Lifecycle.Read)
+  manufacturer?: string;
+
+  /** Indicates whether the manufacturer is supported. */
+  @visibility(Lifecycle.Read)
+  isSupported?: boolean;
 }
 /**
  * details of validation failure

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7280,6 +7280,13 @@ model EdgeMachineReportedProperties {
   extensionProfile?: ExtensionProfile;
 
   /**
+   * CVM (Confidential VM) support details for the edge machine.
+   */
+  @added(Versions.v2026_10_15_preview)
+  @visibility(Lifecycle.Read)
+  confidentialVmProfile?: ConfidentialVmProfile;
+
+  /**
    * Read-only Hyper-V VM inventory reported by the device management extension for VMs visible on this node.
    */
   @visibility(Lifecycle.Read)
@@ -7359,6 +7366,18 @@ model EdgeMachineNetworkProfile {
   @visibility(Lifecycle.Read)
   @Azure.ResourceManager.identifiers(#["switchName"])
   switchDetails?: SwitchDetail[];
+
+  /**
+   * HostNetwork configuration reported for the edge machine.
+   */
+  @visibility(Lifecycle.Read)
+  hostNetwork?: HciEdgeDeviceHostNetwork;
+
+  /**
+   * Software Defined Networking (SDN) properties reported for the edge machine.
+   */
+  @visibility(Lifecycle.Read)
+  sdnProperties?: SdnProperties;
 }
 
 /**
@@ -7575,6 +7594,13 @@ model StorageProfile {
    */
   @visibility(Lifecycle.Read)
   poolableDisksCount?: int64;
+
+  /**
+   * List of storage disks on the edge machine.
+   */
+  @visibility(Lifecycle.Read)
+  @Azure.ResourceManager.identifiers(#["id"])
+  disks?: EdgeDeviceDisks[];
 }
 /**
  * details of validation failure

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_CreateOrUpdate.json
@@ -50,6 +50,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {
@@ -151,6 +231,86 @@
                 {
                   "switchName": "vmanagement",
                   "switchType": "External"
+                }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
                 }
               ]
             },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Get.json
@@ -61,6 +61,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListByResourceGroup.json
@@ -42,6 +42,86 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
+                  ]
+                },
+                "confidentialVmProfile": {
+                  "igvmStatus": "Enabled",
+                  "statusDetails": [
+                    {
+                      "code": "IgvmEnabled",
+                      "message": "Confidential VM capabilities are enabled on the device."
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListBySubscription.json
@@ -41,6 +41,86 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
+                  ]
+                },
+                "confidentialVmProfile": {
+                  "igvmStatus": "Enabled",
+                  "statusDetails": [
+                    {
+                      "code": "IgvmEnabled",
+                      "message": "Confidential VM capabilities are enabled on the device."
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Update.json
@@ -47,6 +47,86 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
+              ]
+            },
+            "confidentialVmProfile": {
+              "igvmStatus": "Enabled",
+              "statusDetails": [
+                {
+                  "code": "IgvmEnabled",
+                  "message": "Confidential VM capabilities are enabled on the device."
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
@@ -13870,6 +13870,16 @@
           "x-ms-identifiers": [
             "switchName"
           ]
+        },
+        "hostNetwork": {
+          "$ref": "#/definitions/HciEdgeDeviceHostNetwork",
+          "description": "HostNetwork configuration reported for the edge machine.",
+          "readOnly": true
+        },
+        "sdnProperties": {
+          "$ref": "#/definitions/SdnProperties",
+          "description": "Software Defined Networking (SDN) properties reported for the edge machine.",
+          "readOnly": true
         }
       }
     },
@@ -14281,6 +14291,11 @@
         "extensionProfile": {
           "$ref": "#/definitions/ExtensionProfile",
           "description": "Extension details for edge machine.",
+          "readOnly": true
+        },
+        "confidentialVmProfile": {
+          "$ref": "#/definitions/ConfidentialVmProfile",
+          "description": "CVM (Confidential VM) support details for the edge machine.",
           "readOnly": true
         },
         "workloadInventory": {
@@ -21075,6 +21090,17 @@
           "format": "int64",
           "description": "Number of storage disks in the device with $CanPool as true.",
           "readOnly": true
+        },
+        "disks": {
+          "type": "array",
+          "description": "List of storage disks on the edge machine.",
+          "items": {
+            "$ref": "#/definitions/EdgeDeviceDisks"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
         }
       }
     },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
@@ -12799,6 +12799,27 @@
         }
       ]
     },
+    "EdgeMachineAdapterPropertyOverrides": {
+      "type": "object",
+      "description": "The AdapterPropertyOverrides reported for the edge machine.",
+      "properties": {
+        "jumboPacket": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "networkDirect": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "networkDirectTechnology": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation. Expected values are 'iWARP', 'RoCEv2', 'RoCE'",
+          "readOnly": true
+        }
+      }
+    },
     "EdgeMachineCollectLogJobProperties": {
       "type": "object",
       "description": "Properties for pausing a server in the cluster.",
@@ -12912,6 +12933,45 @@
         {
           "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
+      ]
+    },
+    "EdgeMachineDiskInfo": {
+      "type": "object",
+      "description": "Represents a storage disk reported for the edge machine.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the disk.",
+          "readOnly": true
+        },
+        "sizeInBytes": {
+          "type": "string",
+          "description": "The size of the disk in bytes.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the disk. For example, S2D or SAN.",
+          "readOnly": true
+        },
+        "model": {
+          "type": "string",
+          "description": "Model number of the hardware.",
+          "readOnly": true
+        },
+        "manufacturer": {
+          "type": "string",
+          "description": "The manufacturer of the disk.",
+          "readOnly": true
+        },
+        "isSupported": {
+          "type": "boolean",
+          "description": "Indicates whether the manufacturer is supported.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id"
       ]
     },
     "EdgeMachineDiskJob": {
@@ -13429,6 +13489,141 @@
         }
       }
     },
+    "EdgeMachineHostNetwork": {
+      "type": "object",
+      "description": "HostNetwork configuration reported for the edge machine.",
+      "properties": {
+        "intents": {
+          "type": "array",
+          "description": "The network intents assigned to the network reference pattern used for the deployment. Each intent will define its own name, traffic type, adapter names, and overrides as recommended by your OEM.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineHostNetworkIntent"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "intentName"
+          ]
+        },
+        "storageNetworks": {
+          "type": "array",
+          "description": "List of StorageNetworks config to deploy AzureStackHCI Cluster.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineStorageNetwork"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "networkAdapterName"
+          ]
+        },
+        "storageConnectivitySwitchless": {
+          "type": "boolean",
+          "description": "Defines how the storage adapters between nodes are connected either switch or switch less.",
+          "readOnly": true
+        },
+        "enableStorageAutoIp": {
+          "type": "boolean",
+          "description": "Optional parameter required only for 3 Nodes Switchless deployments. This allows users to specify IPs and Mask for Storage NICs when Network ATC is not assigning the IPs for storage automatically.",
+          "default": false,
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineHostNetworkIntent": {
+      "type": "object",
+      "description": "The network intent reported for the edge machine.",
+      "properties": {
+        "scope": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Scope for host network intent.",
+          "readOnly": true
+        },
+        "intentType": {
+          "type": "integer",
+          "format": "int64",
+          "description": "IntentType for host network intent.",
+          "readOnly": true
+        },
+        "isComputeIntentSet": {
+          "type": "boolean",
+          "description": "IsComputeIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isStorageIntentSet": {
+          "type": "boolean",
+          "description": "IsStorageIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isOnlyStorage": {
+          "type": "boolean",
+          "description": "IntentType for host network intent.",
+          "readOnly": true
+        },
+        "isManagementIntentSet": {
+          "type": "boolean",
+          "description": "IsManagementIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isStretchIntentSet": {
+          "type": "boolean",
+          "description": "IsStretchIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isOnlyStretch": {
+          "type": "boolean",
+          "description": "IsOnlyStretch for host network intent.",
+          "readOnly": true
+        },
+        "isNetworkIntentType": {
+          "type": "boolean",
+          "description": "IsNetworkIntentType for host network intent.",
+          "readOnly": true
+        },
+        "intentName": {
+          "type": "string",
+          "description": "Name of the network intent you wish to create.",
+          "readOnly": true
+        },
+        "intentAdapters": {
+          "type": "array",
+          "description": "Array of adapters used for the network intent.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "overrideVirtualSwitchConfiguration": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "virtualSwitchConfigurationOverrides": {
+          "$ref": "#/definitions/EdgeMachineVirtualSwitchConfigurationOverrides",
+          "description": "Set virtualSwitch ConfigurationOverrides for cluster.",
+          "readOnly": true
+        },
+        "overrideQosPolicy": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "qosPolicyOverrides": {
+          "$ref": "#/definitions/QosPolicyOverrides",
+          "description": "Set QoS PolicyOverrides for cluster.",
+          "readOnly": true
+        },
+        "overrideAdapterProperty": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "adapterPropertyOverrides": {
+          "$ref": "#/definitions/EdgeMachineAdapterPropertyOverrides",
+          "description": "Set Adapter PropertyOverrides for cluster.",
+          "readOnly": true
+        }
+      }
+    },
     "EdgeMachineJob": {
       "type": "object",
       "description": "Cluster Jobs resource",
@@ -13872,7 +14067,7 @@
           ]
         },
         "hostNetwork": {
-          "$ref": "#/definitions/HciEdgeDeviceHostNetwork",
+          "$ref": "#/definitions/EdgeMachineHostNetwork",
           "description": "HostNetwork configuration reported for the edge machine.",
           "readOnly": true
         },
@@ -14478,6 +14673,59 @@
         ]
       }
     },
+    "EdgeMachineStorageAdapterIpInfo": {
+      "type": "object",
+      "description": "The StorageAdapter physical nodes reported for the edge machine.",
+      "properties": {
+        "physicalNode": {
+          "type": "string",
+          "description": "storage adapter physical node name.",
+          "readOnly": true
+        },
+        "ipv4Address": {
+          "type": "string",
+          "description": "The IPv4 address assigned to each storage adapter physical node on your Azure Stack HCI cluster.",
+          "readOnly": true
+        },
+        "subnetMask": {
+          "type": "string",
+          "description": "The SubnetMask address assigned to each storage adapter physical node on your Azure Stack HCI cluster.",
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineStorageNetwork": {
+      "type": "object",
+      "description": "The StorageNetworks reported for the edge machine.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the storage network.",
+          "readOnly": true
+        },
+        "networkAdapterName": {
+          "type": "string",
+          "description": "Name of the storage network adapter.",
+          "readOnly": true
+        },
+        "storageVlanId": {
+          "type": "string",
+          "description": "ID specified for the VLAN storage network. This setting is applied to the network interfaces that route the storage and VM migration traffic.",
+          "readOnly": true
+        },
+        "storageAdapterIPInfo": {
+          "type": "array",
+          "description": "List of Storage adapter physical nodes config to deploy AzureStackHCI Cluster.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineStorageAdapterIpInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "physicalNode"
+          ]
+        }
+      }
+    },
     "EdgeMachineUpdate": {
       "type": "object",
       "description": "EdgeMachine Update resource that stores validated update configurations for an edge machine.",
@@ -14619,6 +14867,22 @@
         "status": {
           "type": "string",
           "description": "Edge machine validation status.",
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineVirtualSwitchConfigurationOverrides": {
+      "type": "object",
+      "description": "The VirtualSwitchConfigurationOverrides reported for the edge machine.",
+      "properties": {
+        "enableIov": {
+          "type": "string",
+          "description": "Enable IoV for Virtual Switch",
+          "readOnly": true
+        },
+        "loadBalancingAlgorithm": {
+          "type": "string",
+          "description": "Load Balancing Algorithm for Virtual Switch",
           "readOnly": true
         }
       }
@@ -21095,7 +21359,7 @@
           "type": "array",
           "description": "List of storage disks on the edge machine.",
           "items": {
-            "$ref": "#/definitions/EdgeDeviceDisks"
+            "$ref": "#/definitions/EdgeMachineDiskInfo"
           },
           "readOnly": true,
           "x-ms-identifiers": [

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_CreateOrUpdate.json
@@ -50,6 +50,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {
@@ -131,6 +202,77 @@
                 {
                   "switchName": "vmanagement",
                   "switchType": "External"
+                }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
                 }
               ]
             },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Get.json
@@ -43,6 +43,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListByResourceGroup.json
@@ -42,6 +42,77 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListBySubscription.json
@@ -41,6 +41,77 @@
                       "switchName": "vmanagement",
                       "switchType": "External"
                     }
+                  ],
+                  "hostNetwork": {
+                    "intents": [
+                      {
+                        "scope": 1,
+                        "intentType": 3,
+                        "isComputeIntentSet": true,
+                        "isStorageIntentSet": true,
+                        "isOnlyStorage": false,
+                        "isManagementIntentSet": true,
+                        "isStretchIntentSet": false,
+                        "isOnlyStretch": false,
+                        "isNetworkIntentType": true,
+                        "intentName": "ManagementComputeStorage",
+                        "intentAdapters": [
+                          "port1",
+                          "port2"
+                        ],
+                        "overrideVirtualSwitchConfiguration": false,
+                        "virtualSwitchConfigurationOverrides": {
+                          "enableIov": "true",
+                          "loadBalancingAlgorithm": "Dynamic"
+                        },
+                        "overrideQosPolicy": false,
+                        "qosPolicyOverrides": {
+                          "priorityValue8021Action_Cluster": "7",
+                          "priorityValue8021Action_SMB": "3",
+                          "bandwidthPercentage_SMB": "50"
+                        },
+                        "overrideAdapterProperty": false,
+                        "adapterPropertyOverrides": {
+                          "jumboPacket": "9014",
+                          "networkDirect": "Enabled",
+                          "networkDirectTechnology": "RoCEv2"
+                        }
+                      }
+                    ],
+                    "storageNetworks": [
+                      {
+                        "name": "Storage1Network",
+                        "networkAdapterName": "port3",
+                        "storageVlanId": "711",
+                        "storageAdapterIPInfo": [
+                          {
+                            "physicalNode": "Node-1",
+                            "ipv4Address": "10.0.0.1",
+                            "subnetMask": "255.255.255.0"
+                          }
+                        ]
+                      }
+                    ],
+                    "storageConnectivitySwitchless": true,
+                    "enableStorageAutoIp": true
+                  },
+                  "sdnProperties": {
+                    "sdnStatus": "Enabled",
+                    "sdnDomainName": "sdn-nc.contoso.com",
+                    "sdnApiAddress": "10.0.0.10"
+                  }
+                },
+                "storageProfile": {
+                  "poolableDisksCount": 4,
+                  "disks": [
+                    {
+                      "id": "5000C500A1B2C3D4",
+                      "sizeInBytes": "1920383410176",
+                      "type": "SSD",
+                      "model": "MZ7LH1T9HMLT",
+                      "manufacturer": "Samsung",
+                      "isSupported": true
+                    }
                   ]
                 },
                 "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Update.json
@@ -47,6 +47,77 @@
                   "switchName": "vmanagement",
                   "switchType": "External"
                 }
+              ],
+              "hostNetwork": {
+                "intents": [
+                  {
+                    "scope": 1,
+                    "intentType": 3,
+                    "isComputeIntentSet": true,
+                    "isStorageIntentSet": true,
+                    "isOnlyStorage": false,
+                    "isManagementIntentSet": true,
+                    "isStretchIntentSet": false,
+                    "isOnlyStretch": false,
+                    "isNetworkIntentType": true,
+                    "intentName": "ManagementComputeStorage",
+                    "intentAdapters": [
+                      "port1",
+                      "port2"
+                    ],
+                    "overrideVirtualSwitchConfiguration": false,
+                    "virtualSwitchConfigurationOverrides": {
+                      "enableIov": "true",
+                      "loadBalancingAlgorithm": "Dynamic"
+                    },
+                    "overrideQosPolicy": false,
+                    "qosPolicyOverrides": {
+                      "priorityValue8021Action_Cluster": "7",
+                      "priorityValue8021Action_SMB": "3",
+                      "bandwidthPercentage_SMB": "50"
+                    },
+                    "overrideAdapterProperty": false,
+                    "adapterPropertyOverrides": {
+                      "jumboPacket": "9014",
+                      "networkDirect": "Enabled",
+                      "networkDirectTechnology": "RoCEv2"
+                    }
+                  }
+                ],
+                "storageNetworks": [
+                  {
+                    "name": "Storage1Network",
+                    "networkAdapterName": "port3",
+                    "storageVlanId": "711",
+                    "storageAdapterIPInfo": [
+                      {
+                        "physicalNode": "Node-1",
+                        "ipv4Address": "10.0.0.1",
+                        "subnetMask": "255.255.255.0"
+                      }
+                    ]
+                  }
+                ],
+                "storageConnectivitySwitchless": true,
+                "enableStorageAutoIp": true
+              },
+              "sdnProperties": {
+                "sdnStatus": "Enabled",
+                "sdnDomainName": "sdn-nc.contoso.com",
+                "sdnApiAddress": "10.0.0.10"
+              }
+            },
+            "storageProfile": {
+              "poolableDisksCount": 4,
+              "disks": [
+                {
+                  "id": "5000C500A1B2C3D4",
+                  "sizeInBytes": "1920383410176",
+                  "type": "SSD",
+                  "model": "MZ7LH1T9HMLT",
+                  "manufacturer": "Samsung",
+                  "isSupported": true
+                }
               ]
             },
             "osProfile": {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
@@ -11000,6 +11000,16 @@
           "x-ms-identifiers": [
             "switchName"
           ]
+        },
+        "hostNetwork": {
+          "$ref": "#/definitions/HciEdgeDeviceHostNetwork",
+          "description": "HostNetwork configuration reported for the edge machine.",
+          "readOnly": true
+        },
+        "sdnProperties": {
+          "$ref": "#/definitions/SdnProperties",
+          "description": "Software Defined Networking (SDN) properties reported for the edge machine.",
+          "readOnly": true
         }
       }
     },
@@ -17319,6 +17329,17 @@
           "format": "int64",
           "description": "Number of storage disks in the device with $CanPool as true.",
           "readOnly": true
+        },
+        "disks": {
+          "type": "array",
+          "description": "List of storage disks on the edge machine.",
+          "items": {
+            "$ref": "#/definitions/EdgeDeviceDisks"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
         }
       }
     },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
@@ -10166,6 +10166,27 @@
         }
       ]
     },
+    "EdgeMachineAdapterPropertyOverrides": {
+      "type": "object",
+      "description": "The AdapterPropertyOverrides reported for the edge machine.",
+      "properties": {
+        "jumboPacket": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "networkDirect": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "networkDirectTechnology": {
+          "type": "string",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation. Expected values are 'iWARP', 'RoCEv2', 'RoCE'",
+          "readOnly": true
+        }
+      }
+    },
     "EdgeMachineCollectLogJobProperties": {
       "type": "object",
       "description": "Properties for pausing a server in the cluster.",
@@ -10279,6 +10300,45 @@
         {
           "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
+      ]
+    },
+    "EdgeMachineDiskInfo": {
+      "type": "object",
+      "description": "Represents a storage disk reported for the edge machine.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the disk.",
+          "readOnly": true
+        },
+        "sizeInBytes": {
+          "type": "string",
+          "description": "The size of the disk in bytes.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the disk. For example, S2D or SAN.",
+          "readOnly": true
+        },
+        "model": {
+          "type": "string",
+          "description": "Model number of the hardware.",
+          "readOnly": true
+        },
+        "manufacturer": {
+          "type": "string",
+          "description": "The manufacturer of the disk.",
+          "readOnly": true
+        },
+        "isSupported": {
+          "type": "boolean",
+          "description": "Indicates whether the manufacturer is supported.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id"
       ]
     },
     "EdgeMachineDiskJob": {
@@ -10555,6 +10615,141 @@
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
           "description": "Provisioning state of the disk resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineHostNetwork": {
+      "type": "object",
+      "description": "HostNetwork configuration reported for the edge machine.",
+      "properties": {
+        "intents": {
+          "type": "array",
+          "description": "The network intents assigned to the network reference pattern used for the deployment. Each intent will define its own name, traffic type, adapter names, and overrides as recommended by your OEM.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineHostNetworkIntent"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "intentName"
+          ]
+        },
+        "storageNetworks": {
+          "type": "array",
+          "description": "List of StorageNetworks config to deploy AzureStackHCI Cluster.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineStorageNetwork"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "networkAdapterName"
+          ]
+        },
+        "storageConnectivitySwitchless": {
+          "type": "boolean",
+          "description": "Defines how the storage adapters between nodes are connected either switch or switch less.",
+          "readOnly": true
+        },
+        "enableStorageAutoIp": {
+          "type": "boolean",
+          "description": "Optional parameter required only for 3 Nodes Switchless deployments. This allows users to specify IPs and Mask for Storage NICs when Network ATC is not assigning the IPs for storage automatically.",
+          "default": false,
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineHostNetworkIntent": {
+      "type": "object",
+      "description": "The network intent reported for the edge machine.",
+      "properties": {
+        "scope": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Scope for host network intent.",
+          "readOnly": true
+        },
+        "intentType": {
+          "type": "integer",
+          "format": "int64",
+          "description": "IntentType for host network intent.",
+          "readOnly": true
+        },
+        "isComputeIntentSet": {
+          "type": "boolean",
+          "description": "IsComputeIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isStorageIntentSet": {
+          "type": "boolean",
+          "description": "IsStorageIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isOnlyStorage": {
+          "type": "boolean",
+          "description": "IntentType for host network intent.",
+          "readOnly": true
+        },
+        "isManagementIntentSet": {
+          "type": "boolean",
+          "description": "IsManagementIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isStretchIntentSet": {
+          "type": "boolean",
+          "description": "IsStretchIntentSet for host network intent.",
+          "readOnly": true
+        },
+        "isOnlyStretch": {
+          "type": "boolean",
+          "description": "IsOnlyStretch for host network intent.",
+          "readOnly": true
+        },
+        "isNetworkIntentType": {
+          "type": "boolean",
+          "description": "IsNetworkIntentType for host network intent.",
+          "readOnly": true
+        },
+        "intentName": {
+          "type": "string",
+          "description": "Name of the network intent you wish to create.",
+          "readOnly": true
+        },
+        "intentAdapters": {
+          "type": "array",
+          "description": "Array of adapters used for the network intent.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "overrideVirtualSwitchConfiguration": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "virtualSwitchConfigurationOverrides": {
+          "$ref": "#/definitions/EdgeMachineVirtualSwitchConfigurationOverrides",
+          "description": "Set virtualSwitch ConfigurationOverrides for cluster.",
+          "readOnly": true
+        },
+        "overrideQosPolicy": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "qosPolicyOverrides": {
+          "$ref": "#/definitions/QosPolicyOverrides",
+          "description": "Set QoS PolicyOverrides for cluster.",
+          "readOnly": true
+        },
+        "overrideAdapterProperty": {
+          "type": "boolean",
+          "description": "This parameter should only be modified based on your OEM guidance. Do not modify this parameter without OEM validation.",
+          "readOnly": true
+        },
+        "adapterPropertyOverrides": {
+          "$ref": "#/definitions/EdgeMachineAdapterPropertyOverrides",
+          "description": "Set Adapter PropertyOverrides for cluster.",
           "readOnly": true
         }
       }
@@ -11002,7 +11197,7 @@
           ]
         },
         "hostNetwork": {
-          "$ref": "#/definitions/HciEdgeDeviceHostNetwork",
+          "$ref": "#/definitions/EdgeMachineHostNetwork",
           "description": "HostNetwork configuration reported for the edge machine.",
           "readOnly": true
         },
@@ -11508,6 +11703,59 @@
         ]
       }
     },
+    "EdgeMachineStorageAdapterIpInfo": {
+      "type": "object",
+      "description": "The StorageAdapter physical nodes reported for the edge machine.",
+      "properties": {
+        "physicalNode": {
+          "type": "string",
+          "description": "storage adapter physical node name.",
+          "readOnly": true
+        },
+        "ipv4Address": {
+          "type": "string",
+          "description": "The IPv4 address assigned to each storage adapter physical node on your Azure Stack HCI cluster.",
+          "readOnly": true
+        },
+        "subnetMask": {
+          "type": "string",
+          "description": "The SubnetMask address assigned to each storage adapter physical node on your Azure Stack HCI cluster.",
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineStorageNetwork": {
+      "type": "object",
+      "description": "The StorageNetworks reported for the edge machine.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the storage network.",
+          "readOnly": true
+        },
+        "networkAdapterName": {
+          "type": "string",
+          "description": "Name of the storage network adapter.",
+          "readOnly": true
+        },
+        "storageVlanId": {
+          "type": "string",
+          "description": "ID specified for the VLAN storage network. This setting is applied to the network interfaces that route the storage and VM migration traffic.",
+          "readOnly": true
+        },
+        "storageAdapterIPInfo": {
+          "type": "array",
+          "description": "List of Storage adapter physical nodes config to deploy AzureStackHCI Cluster.",
+          "items": {
+            "$ref": "#/definitions/EdgeMachineStorageAdapterIpInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "physicalNode"
+          ]
+        }
+      }
+    },
     "EdgeMachineValidateRequest": {
       "type": "object",
       "description": "The validate request for Edge Machine.",
@@ -11544,6 +11792,22 @@
         "status": {
           "type": "string",
           "description": "Edge machine validation status.",
+          "readOnly": true
+        }
+      }
+    },
+    "EdgeMachineVirtualSwitchConfigurationOverrides": {
+      "type": "object",
+      "description": "The VirtualSwitchConfigurationOverrides reported for the edge machine.",
+      "properties": {
+        "enableIov": {
+          "type": "string",
+          "description": "Enable IoV for Virtual Switch",
+          "readOnly": true
+        },
+        "loadBalancingAlgorithm": {
+          "type": "string",
+          "description": "Load Balancing Algorithm for Virtual Switch",
           "readOnly": true
         }
       }
@@ -17334,7 +17598,7 @@
           "type": "array",
           "description": "List of storage disks on the edge machine.",
           "items": {
-            "$ref": "#/definitions/EdgeDeviceDisks"
+            "$ref": "#/definitions/EdgeMachineDiskInfo"
           },
           "readOnly": true,
           "x-ms-identifiers": [


### PR DESCRIPTION
## Summary

Adds the remaining EdgeDevice (HCI) reported properties to the EdgeMachine reported surface so that `EdgeMachineReportedProperties` reaches parity with `HciReportedProperties`.

**This PR targets the feature branch of #44812 (`users/abaranwal/hci-2610-apis`), not `main`.**

## Changes (all reuse existing models — no new models defined)

| Property | Model | API version |
|---|---|---|
| `confidentialVmProfile` (`ConfidentialVmProfile`) | `EdgeMachineReportedProperties` | **2026-10-15-preview** (preview only) |
| `hostNetwork` (`HciEdgeDeviceHostNetwork`) | `EdgeMachineNetworkProfile` | 2026-10-01 (GA) |
| `sdnProperties` (`SdnProperties`) | `EdgeMachineNetworkProfile` | 2026-10-01 (GA) |
| `disks` (`EdgeDeviceDisks[]`) | `StorageProfile` | 2026-10-01 (GA) |

All four are optional, read-only reported properties. Per request, CVM goes to the new preview version while the other three go to the GA version.

## Validation

- `tsp compile .` passes with no errors or warnings.
- Generated swagger regenerated: `stable/2026-10-01/hci.json` and `preview/2026-10-15-preview/hci.json`.
- Verified `confidentialVmProfile` appears **only** in `2026-10-15-preview` (not in `2026-10-01` stable); `hostNetwork`/`sdnProperties`/`disks` appear in both.
