### PR TITLE
[Authorization] Add AgentUser/AgentServicePrincipal to RBAC roleAssignment principalType on stable 2022-04-01

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -140,6 +140,8 @@ model RoleAssignmentFilter {
   principalId?: string;
 }
 
+// Java and Python retain the existing shared SDK PrincipalType through the
+// combined client's language-scoped alternate-type customization.
 /**
  * The principal type of the assigned principal ID.
  */

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -139,3 +139,45 @@ model RoleAssignmentFilter {
    */
   principalId?: string;
 }
+
+/**
+ * The principal type of the assigned principal ID.
+ */
+union PrincipalType {
+  string,
+
+  /**
+   * User
+   */
+  User: "User",
+
+  /**
+   * Group
+   */
+  Group: "Group",
+
+  /**
+   * ServicePrincipal
+   */
+  ServicePrincipal: "ServicePrincipal",
+
+  /**
+   * ForeignGroup
+   */
+  ForeignGroup: "ForeignGroup",
+
+  /**
+   * Device
+   */
+  Device: "Device",
+
+  /**
+   * AgentUser (agentic identity derived from a User).
+   */
+  AgentUser: "AgentUser",
+
+  /**
+   * AgentServicePrincipal (agentic identity derived from a ServicePrincipal).
+   */
+  AgentServicePrincipal: "AgentServicePrincipal",
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -174,12 +174,12 @@ union PrincipalType {
   Device: "Device",
 
   /**
-   * AgentUser (agentic identity derived from a User).
+   * Agent identity derived from a user.
    */
   AgentUser: "AgentUser",
 
   /**
-   * AgentServicePrincipal (agentic identity derived from a ServicePrincipal).
+   * Agent identity derived from a service principal.
    */
   AgentServicePrincipal: "AgentServicePrincipal",
 }

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
@@ -86,6 +86,14 @@ union RoleManagementScopeType {
   "java"
 );
 
+// Preserve the existing SDK PrincipalType while the REST contract uses the
+// RoleAssignment-scoped union that adds the agent values.
+@@alternateType(
+  Microsoft.RoleAssignment.RoleAssignmentProperties.principalType,
+  Microsoft.Common.PrincipalType,
+  "java,python"
+);
+
 // Restore C# GA resource, model, and extensible-enum names.
 @@clientName(
   Microsoft.ProviderOperations.ProviderOperationsMetadata,

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json
@@ -753,12 +753,12 @@
               {
                 "name": "AgentUser",
                 "value": "AgentUser",
-                "description": "AgentUser (agentic identity derived from a User)."
+                "description": "Agent identity derived from a user."
               },
               {
                 "name": "AgentServicePrincipal",
                 "value": "AgentServicePrincipal",
-                "description": "AgentServicePrincipal (agentic identity derived from a ServicePrincipal)."
+                "description": "Agent identity derived from a service principal."
               }
             ]
           }

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json
@@ -717,7 +717,9 @@
             "Group",
             "ServicePrincipal",
             "ForeignGroup",
-            "Device"
+            "Device",
+            "AgentUser",
+            "AgentServicePrincipal"
           ],
           "x-ms-enum": {
             "name": "PrincipalType",
@@ -747,6 +749,16 @@
                 "name": "Device",
                 "value": "Device",
                 "description": "Device"
+              },
+              {
+                "name": "AgentUser",
+                "value": "AgentUser",
+                "description": "AgentUser (agentic identity derived from a User)."
+              },
+              {
+                "name": "AgentServicePrincipal",
+                "value": "AgentServicePrincipal",
+                "description": "AgentServicePrincipal (agentic identity derived from a ServicePrincipal)."
               }
             ]
           }


### PR DESCRIPTION
## Summary

Adds the two agent identity principal types to `RoleAssignment.principalType` in-place on the existing stable api-version `2022-04-01`:

- `AgentUser` - agent identity derived from a User
- `AgentServicePrincipal` - agent identity derived from a ServicePrincipal

`principalType` is already an extensible enum (`x-ms-enum.modelAsString: true`). This is the selected shipping path instead of publishing a new api-version.

## Breaking-change disposition

Adding enum values in-place is flagged as `AddedEnumValue` (oad rule 1020) on the request and response contract. The Azure Breaking Changes Review Board approved this change on 2026-07-22, and the protected labels `BreakingChange-Approved-BugFix` and `BreakingChange-Approved-Security` are applied.

## Rationale

- Customers assigning Azure RBAC roles to Microsoft Entra Agent identities are failing on the stable `2022-04-01` surface they already use.
- Existing generated SDKs tolerate unknown values on read because the enum is extensible.
- The change unblocks the security-critical Azure AD Graph to Microsoft Graph migration, which surfaces the explicit agent identity types.
- The paired PAS service change is DA PR !16528382.

## Release acknowledgement

This PR intentionally targets `main` and publishes the updated `2022-04-01` contract to customers. The `PublishToCustomers` label acknowledges that the API is considered shipped after merge and that the ARM API best practices apply.

## Remaining

- [x] Breaking-change approval
- [x] Select the in-place shipping path
- [x] Add `PublishToCustomers`
- [ ] Required repository review
