### PR TITLE
Add Microsoft.Network/FirstPartyServiceTags TypeSpec for 2025-09-01 and update Microsoft.Network/PublicIpAddress and Microsoft.Network/PublicIpPrefix TypeSpec for 2025-09-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -99,6 +99,10 @@ enum Features {
   /** Interconnect group resource type for managing interconnect groups. */
   @added(Versions.v2025_07_01)
   interconnectGroup,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required"
+  @added(Versions.v2025_09_01)
+  firstPartyServiceTag,
 }
 
 /**
@@ -1489,6 +1493,16 @@ model IpTag {
    * The value of the IP tag associated with the public IP. Example: SQL.
    */
   tag?: string;
+
+  /**
+   * The resource ID of the first party service tag associated with the IP tag.
+   */
+  @added(Versions.v2025_09_01)
+  firstPartyServiceTagId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/firstPartyServiceTags";
+    }
+  ]>;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
@@ -32,6 +32,18 @@ model FirstPartyServiceTag extends Common.Resource {
   properties?: FirstPartyServiceTagPropertiesFormat;
 
   /**
+   * The unique identifier of the resource.
+   */
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  /**
+   * The type of the resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /**
    * The name of the first party service tag.
    */
   @visibility(Lifecycle.Read)

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
@@ -1,0 +1,208 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "./models.tsp";
+import "../Common/main.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+using Common;
+using Azure.ClientGenerator.Core;
+
+namespace Microsoft.Network;
+
+/**
+ * First party service tag resource.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy.feature decorator is required for swagger file splitting in this converted project"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.firstPartyServiceTag)
+model FirstPartyServiceTag
+  is TrackedResource<FirstPartyServiceTagPropertiesFormat> {
+  /**
+   * The name of the first party service tag.
+   */
+  @visibility(Lifecycle.Read)
+  @path
+  @key("firstPartyServiceTagName")
+  @segment("firstPartyServiceTags")
+  @maxLength(80)
+  @pattern("^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$")
+  name: string;
+
+  /** A unique read-only string that changes whenever the resource is updated. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Etag is a standard read-only envelope property across all Network resources for backward compatibility"
+  @visibility(Lifecycle.Read)
+  etag?: string;
+}
+
+/**
+ * Properties of the first party service tag.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy.feature decorator is required for swagger file splitting in this converted project"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.firstPartyServiceTag)
+model FirstPartyServiceTagPropertiesFormat {
+  /**
+   * The value of the first party service tag.
+   */
+  value: string;
+
+  /**
+   * The reason for failure, if any.
+   */
+  @visibility(Lifecycle.Read)
+  failedReason?: string;
+
+  /**
+   * The resource GUID property of the first party service tag resource.
+   */
+  @visibility(Lifecycle.Read)
+  resourceGuid?: string;
+
+  /**
+   * The provisioning state of the first party service tag resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FirstPartyServiceTags interface uses Azure.ResourceManager.Legacy features for backward compatibility with existing swagger API"
+@added(Versions.v2025_09_01)
+@Azure.ResourceManager.Legacy.feature(Features.firstPartyServiceTag)
+@armResourceOperations
+interface FirstPartyServiceTags {
+  /**
+   * Gets the specified first party service tag.
+   */
+  get is ArmResourceRead<FirstPartyServiceTag, Error = CloudError>;
+
+  /**
+   * Creates or updates a first party service tag.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    FirstPartyServiceTag,
+    Error = CloudError
+  >;
+
+  /**
+   * Updates a first party service tag tags.
+   */
+  @patch(#{ implicitOptionality: false })
+  updateTags is ArmCustomPatchAsync<
+    FirstPartyServiceTag,
+    PatchModel = TagsObject,
+    Error = CloudError
+  >;
+
+  /**
+   * Deletes the specified first party service tag.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-delete-operation-response-codes" "Matching existing Network resource pattern (VirtualNetwork, LoadBalancer, etc.) that supports both sync (200) and async (202) delete"
+  delete is ArmResourceDeleteWithoutOkAsync<
+    FirstPartyServiceTag,
+    Response =
+      | ArmDeletedResponse
+      | ArmDeleteAcceptedLroResponse
+      | ArmDeletedNoContentResponse,
+    Error = CloudError
+  >;
+
+  /**
+   * Gets all the first party service tags in a resource group.
+   */
+  list is ArmResourceListByParent<FirstPartyServiceTag, Error = CloudError>;
+
+  /**
+   * Gets all the first party service tags in a subscription.
+   */
+  listAll is ArmListBySubscription<FirstPartyServiceTag, Error = CloudError>;
+}
+
+@@doc(FirstPartyServiceTag.name, "The name of the first party service tag.");
+@@doc(
+  FirstPartyServiceTag.properties,
+  "Properties of the first party service tag."
+);
+@@doc(
+  FirstPartyServiceTags.createOrUpdate::parameters.resource,
+  "Parameters supplied to the create or update first party service tag operation."
+);
+@@doc(
+  FirstPartyServiceTags.updateTags::parameters.properties,
+  "Parameters supplied to update first party service tag tags."
+);
+@@clientName(
+  FirstPartyServiceTags.createOrUpdate::parameters.resource,
+  "parameters"
+);
+@@clientName(
+  FirstPartyServiceTags.updateTags::parameters.properties,
+  "parameters"
+);
+
+// Link x-ms-examples for swagger validation
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.listAll,
+  "x-ms-examples",
+  #{
+    `List all first party service tags`: #{
+      $ref: "./examples/FirstPartyServiceTagListAll.json",
+    },
+  }
+);
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.list,
+  "x-ms-examples",
+  #{
+    `List first party service tags in resource group`: #{
+      $ref: "./examples/FirstPartyServiceTagList.json",
+    },
+  }
+);
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.get,
+  "x-ms-examples",
+  #{
+    `Get first party service tag`: #{
+      $ref: "./examples/FirstPartyServiceTagGet.json",
+    },
+  }
+);
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.createOrUpdate,
+  "x-ms-examples",
+  #{
+    `Create first party service tag`: #{
+      $ref: "./examples/FirstPartyServiceTagCreate.json",
+    },
+  }
+);
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.updateTags,
+  "x-ms-examples",
+  #{
+    `Update first party service tag tags`: #{
+      $ref: "./examples/FirstPartyServiceTagUpdateTags.json",
+    },
+  }
+);
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-examples extension is required for swagger example validation"
+@@extension(
+  FirstPartyServiceTags.delete,
+  "x-ms-examples",
+  #{
+    `Delete first party service tag`: #{
+      $ref: "./examples/FirstPartyServiceTagDelete.json",
+    },
+  }
+);

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/FirstPartyServiceTag.tsp
@@ -18,11 +18,19 @@ namespace Microsoft.Network;
 /**
  * First party service tag resource.
  */
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Follows the shared Network Common.Resource pattern used by every resource in this converted project"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Network resources extend the shared Common.Resource custom resource for backward compatibility with the existing swagger hierarchy"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Back compatibility with the previous Network AutoRest C# hierarchy"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy.feature decorator is required for swagger file splitting in this converted project"
 @added(Versions.v2025_09_01)
 @Azure.ResourceManager.Legacy.feature(Features.firstPartyServiceTag)
-model FirstPartyServiceTag
-  is TrackedResource<FirstPartyServiceTagPropertiesFormat> {
+@Http.Private.includeInapplicableMetadataInPayload(false)
+model FirstPartyServiceTag extends Common.Resource {
+  /**
+   * Properties of the first party service tag.
+   */
+  properties?: FirstPartyServiceTagPropertiesFormat;
+
   /**
    * The name of the first party service tag.
    */

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagCreate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "parameters": {
+      "location": "eastus",
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "value": "myServiceTagValue"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_CreateOrUpdate",
+  "title": "Create first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-09-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FirstPartyServiceTags_Delete",
+  "title": "Delete first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_Get",
+  "title": "Get first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagList.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myServiceTag",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "name": "myServiceTag2",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag2",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue2",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "11111111-1111-1111-1111-111111111111"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_List",
+  "title": "List first party service tags in resource group"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagListAll.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myServiceTag",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "name": "myServiceTag2",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag2",
+            "location": "westus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue2",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "11111111-1111-1111-1111-111111111111"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_ListAll",
+  "title": "List all first party service tags"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/FirstPartyServiceTagUpdateTags.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-09-01"
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_UpdateTags",
+  "title": "Update first party service tag tags"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/PublicIpAddressCreateWithFirstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/PublicIpAddressCreateWithFirstPartyServiceTag.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "idleTimeoutInMinutes": 10,
+        "ipTags": [
+          {
+            "ipTagType": "FirstPartyUsage",
+            "tag": "SQL",
+            "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+          }
+        ],
+        "publicIPAddressVersion": "IPv4",
+        "publicIPAllocationMethod": "Static"
+      },
+      "sku": {
+        "name": "Standard",
+        "tier": "Global"
+      }
+    },
+    "publicIpAddressName": "test-ip",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ip",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location": "eastus",
+        "properties": {
+          "ddosSettings": {
+            "protectionMode": "VirtualNetworkInherited"
+          },
+          "idleTimeoutInMinutes": 10,
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "publicIPAllocationMethod": "Static"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Global"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ip",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location": "eastus",
+        "properties": {
+          "ddosSettings": {
+            "protectionMode": "VirtualNetworkInherited"
+          },
+          "idleTimeoutInMinutes": 10,
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "publicIPAllocationMethod": "Static"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Global"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_CreateOrUpdate",
+  "title": "Create public IP address with first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/PublicIpPrefixCreateWithFirstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/PublicIpPrefixCreateWithFirstPartyServiceTag.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "parameters": {
+      "location": "westus",
+      "properties": {
+        "ipTags": [
+          {
+            "ipTagType": "FirstPartyUsage",
+            "tag": "SQL",
+            "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+          }
+        ],
+        "prefixLength": 30,
+        "publicIPAddressVersion": "IPv4"
+      },
+      "sku": {
+        "name": "Standard",
+        "tier": "Regional"
+      }
+    },
+    "publicIpPrefixName": "test-ipprefix",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ipprefix",
+        "type": "Microsoft.Network/publicIPPrefixes",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "location": "westus",
+        "properties": {
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "prefixLength": 30,
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "resourceGuid": "00000000-0000-0000-0000-00000000"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Regional"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ipprefix",
+        "type": "Microsoft.Network/publicIPPrefixes",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "location": "westus",
+        "properties": {
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "prefixLength": 30,
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "resourceGuid": "00000000-0000-0000-0000-00000000"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Regional"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPPrefixes_CreateOrUpdate",
+  "title": "Create public IP prefix with first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -136,6 +136,7 @@ import "./routes.tsp";
 import "./VirtualNetworkAppliance.tsp";
 import "./ServiceGateway.tsp";
 import "./InterconnectGroup.tsp";
+import "./FirstPartyServiceTag.tsp";
 import "../Common/main.tsp";
 
 using TypeSpec.Rest;
@@ -146,11 +147,11 @@ using Azure.ResourceManager;
 using TypeSpec.Versioning;
 using Common;
 /**
- * APIs to manage web application firewall rules.
+ * APIs to manage Microsoft Azure network resources.
  */
 @Azure.ResourceManager.Legacy.features(Features)
 @armProviderNamespace
-@service(#{ title: "WebApplicationFirewallManagement" })
+@service(#{ title: "NetworkManagementClient" })
 @versioned(Versions)
 @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
 namespace Microsoft.Network;

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -151,7 +151,7 @@ using Common;
  */
 @Azure.ResourceManager.Legacy.features(Features)
 @armProviderNamespace
-@service(#{ title: "NetworkManagementClient" })
+@service(#{ title: "WebApplicationFirewallManagement" })
 @versioned(Versions)
 @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
 namespace Microsoft.Network;

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -15,7 +15,7 @@ using Common;
 
 // This empty namespace is the merged SDK client target used by later client
 // customizations such as @@clientName and @@clientLocation.
-#suppress "@azure-tools/typespec-client-generator-core/inconsistent-multiple-service-dependency" "temporarily suppressing"
+#suppress "@azure-tools/typespec-client-generator-core/inconsistent-multiple-service-dependency" "CombineClient intentionally merges the Microsoft.Network and Microsoft.Compute (VMSS) services into a single SDK client surface via autoMergeService; the resulting multiple-service dependency is by design for this combined client target."
 @client({
   name: "CombineClient",
   service: [Microsoft.Network, Microsoft.Compute],

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -6,6 +6,19 @@ This is the AutoRest configuration file for Network.
 
 ---
 
+## Note: VMSS `2018-10-01` captured-schema exception
+
+The `stable/2018-10-01/vmssNetwork.json` spec is an **intentional, long-standing exception** to the "same-version stable API surface must not change" (captured-schema) rule. These VMSS network APIs have always pinned the `2018-10-01` api-version while returning the **latest** `NetworkInterface` and `PublicIPAddress` types. Consequently, additive changes to the shared `Common` types (e.g., new properties such as `firstPartyServiceTagId`) ripple into `2018-10-01` **by design**, and BreakingChange/versioning tooling may flag them (e.g., OAD rule [`1041 AddedPropertyInResponse`](https://github.com/Azure/openapi-diff/blob/main/docs/rules/1041.md)). This is expected and has already been signed off for SDKs, PowerShell, CLI, and Terraform. Do not "fix" this by scoping the property out of `2018-10-01`.
+
+Precedent (the latest network types have long been captured under `2018-10-01`):
+
+- [`stable/2025-01-01/vmssNetworkInterface.json` (L6)](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-01-01/vmssNetworkInterface.json#L6)
+- [`stable/2024-10-01/vmssNetworkInterface.json` (L6)](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/Network/stable/2024-10-01/vmssNetworkInterface.json#L6)
+- The same `2018-10-01` spec was similarly updated during the `2025-07-01` TypeSpec network version update in [PR #42717](https://github.com/Azure/azure-rest-api-specs/pull/42717).
+- Full history of previously checked-in changes to these types: [VMSS network schema changes 2019-07-01 to 2025-01-01](https://github.com/markcowl/azure-rest-api-specs/blob/markcowl/vmss-network-schema-change-report/specification/network/resource-manager/Microsoft.Network/Network/Vmss/vmss-network-api-schema-changes-2019-07-01-to-2025-01-01.md).
+
+---
+
 ## Getting Started
 
 To build the SDK for Network, simply [Install AutoRest](https://aka.ms/autorest/install) and in this folder, run:

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -43,6 +43,7 @@ input-file:
   - stable/2025-09-01/expressRoute.json
   - stable/2025-09-01/firewall.json
   - stable/2025-09-01/firewallPolicy.json
+  - stable/2025-09-01/firstPartyServiceTag.json
   - stable/2025-09-01/interconnectGroup.json
   - stable/2025-09-01/loadBalancer.json
   - stable/2025-09-01/networkGateway.json
@@ -79,6 +80,7 @@ suppressions:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkReferences/{linkReferenceName}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}"].delete
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firstPartyServiceTags/{firstPartyServiceTagName}"].delete
   - code: ProvisioningStateMustBeReadOnly
     from: interconnectGroup.json
     reason: provisioningState is correctly marked readOnly in the referenced schema. The linter does not follow $ref chains to verify readOnly.
@@ -123,6 +125,14 @@ suppressions:
     reason: Not a standard azure resource.
     where:
       - $.definitions.GetServiceGatewayServicesResult
+  - code: ProvisioningStateMustBeReadOnly
+    from: firstPartyServiceTag.json
+    reason: >-
+      The TypeSpec emitter correctly places readOnly: true as a sibling of $ref, which AutoRest
+      supports (along with description, title, nullable, and x-* extensions). The TypeSpec source
+      correctly marks provisioningState with @visibility(Lifecycle.Read). The lintdiff rule does
+      not recognize readOnly next to $ref, so this suppression is needed.
+      See: https://github.com/Azure/typespec-azure/issues/4611
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -1677,6 +1677,18 @@
         "tag": {
           "type": "string",
           "description": "The value of the IP tag associated with the public IP. Example: SQL."
+        },
+        "firstPartyServiceTagId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the first party service tag associated with the IP tag.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/firstPartyServiceTags"
+              }
+            ]
+          }
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/applicationGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/applicationGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/azureWebCategory.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/azureWebCategory.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/common.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/common.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/expressRoute.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/expressRoute.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewall.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewall.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewallPolicy.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/firewallPolicy.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/loadBalancer.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/loadBalancer.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkManager.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkManager.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkSecurityPerimeter.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkSecurityPerimeter.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkWatcher.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkWatcher.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkingOperations.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/networkingOperations.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/serviceGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/serviceGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetwork.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetwork.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetworkAppliance.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualNetworkAppliance.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-05-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-05-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/azureWebCategory.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/azureWebCategory.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewall.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewall.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewallPolicy.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/firewallPolicy.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/loadBalancer.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/loadBalancer.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkManager.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkManager.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkSecurityPerimeter.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkSecurityPerimeter.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkWatcher.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkWatcher.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkingOperations.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/networkingOperations.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/serviceGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/serviceGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetworkAppliance.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetworkAppliance.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-07-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-07-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/azureWebCategory.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/azureWebCategory.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagCreate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "parameters": {
+      "location": "eastus",
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "value": "myServiceTagValue"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_CreateOrUpdate",
+  "title": "Create first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-09-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FirstPartyServiceTags_Delete",
+  "title": "Delete first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_Get",
+  "title": "Get first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagList.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myServiceTag",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "name": "myServiceTag2",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag2",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue2",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "11111111-1111-1111-1111-111111111111"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_List",
+  "title": "List first party service tags in resource group"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagListAll.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myServiceTag",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "name": "myServiceTag2",
+            "type": "Microsoft.Network/firstPartyServiceTags",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag2",
+            "location": "westus",
+            "tags": {
+              "key1": "value1"
+            },
+            "properties": {
+              "value": "myServiceTagValue2",
+              "failedReason": "",
+              "provisioningState": "Succeeded",
+              "resourceGuid": "11111111-1111-1111-1111-111111111111"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_ListAll",
+  "title": "List all first party service tags"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/FirstPartyServiceTagUpdateTags.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "resourceGroupName": "rg1",
+    "firstPartyServiceTagName": "myServiceTag",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myServiceTag",
+        "type": "Microsoft.Network/firstPartyServiceTags",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag",
+        "location": "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "value": "myServiceTagValue",
+          "failedReason": "",
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-09-01"
+      }
+    }
+  },
+  "operationId": "FirstPartyServiceTags_UpdateTags",
+  "title": "Update first party service tag tags"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/PublicIpAddressCreateWithFirstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/PublicIpAddressCreateWithFirstPartyServiceTag.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "idleTimeoutInMinutes": 10,
+        "ipTags": [
+          {
+            "ipTagType": "FirstPartyUsage",
+            "tag": "SQL",
+            "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+          }
+        ],
+        "publicIPAddressVersion": "IPv4",
+        "publicIPAllocationMethod": "Static"
+      },
+      "sku": {
+        "name": "Standard",
+        "tier": "Global"
+      }
+    },
+    "publicIpAddressName": "test-ip",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ip",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location": "eastus",
+        "properties": {
+          "ddosSettings": {
+            "protectionMode": "VirtualNetworkInherited"
+          },
+          "idleTimeoutInMinutes": 10,
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "publicIPAllocationMethod": "Static"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Global"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ip",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location": "eastus",
+        "properties": {
+          "ddosSettings": {
+            "protectionMode": "VirtualNetworkInherited"
+          },
+          "idleTimeoutInMinutes": 10,
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "publicIPAllocationMethod": "Static"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Global"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_CreateOrUpdate",
+  "title": "Create public IP address with first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/PublicIpPrefixCreateWithFirstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/PublicIpPrefixCreateWithFirstPartyServiceTag.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01",
+    "parameters": {
+      "location": "westus",
+      "properties": {
+        "ipTags": [
+          {
+            "ipTagType": "FirstPartyUsage",
+            "tag": "SQL",
+            "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+          }
+        ],
+        "prefixLength": 30,
+        "publicIPAddressVersion": "IPv4"
+      },
+      "sku": {
+        "name": "Standard",
+        "tier": "Regional"
+      }
+    },
+    "publicIpPrefixName": "test-ipprefix",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ipprefix",
+        "type": "Microsoft.Network/publicIPPrefixes",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "location": "westus",
+        "properties": {
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "prefixLength": 30,
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "resourceGuid": "00000000-0000-0000-0000-00000000"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Regional"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ipprefix",
+        "type": "Microsoft.Network/publicIPPrefixes",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "location": "westus",
+        "properties": {
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": [
+            {
+              "ipTagType": "FirstPartyUsage",
+              "tag": "SQL",
+              "firstPartyServiceTagId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/firstPartyServiceTags/myServiceTag"
+            }
+          ],
+          "prefixLength": 30,
+          "provisioningState": "Succeeded",
+          "publicIPAddressVersion": "IPv4",
+          "resourceGuid": "00000000-0000-0000-0000-00000000"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Regional"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPPrefixes_CreateOrUpdate",
+  "title": "Create public IP prefix with first party service tag"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/expressRoute.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/expressRoute.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewall.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewall.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewallPolicy.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firewallPolicy.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
@@ -398,6 +398,16 @@
           "$ref": "#/definitions/FirstPartyServiceTagPropertiesFormat",
           "description": "Properties of the first party service tag."
         },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
         "etag": {
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
@@ -406,7 +406,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "./common.json#/definitions/Common.Resource"
         }
       ]
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
@@ -40,17 +40,17 @@
   },
   "tags": [
     {
-      "name": "VirtualNetworkAppliances"
+      "name": "FirstPartyServiceTags"
     }
   ],
   "paths": {
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkAppliances": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firstPartyServiceTags": {
       "get": {
-        "operationId": "VirtualNetworkAppliances_ListAll",
+        "operationId": "FirstPartyServiceTags_ListAll",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Gets all virtual network appliances in a subscription.",
+        "description": "Gets all the first party service tags in a subscription.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -63,7 +63,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkApplianceListResult"
+              "$ref": "#/definitions/FirstPartyServiceTagListResult"
             }
           },
           "default": {
@@ -74,8 +74,8 @@
           }
         },
         "x-ms-examples": {
-          "List all virtual network appliances": {
-            "$ref": "./examples/VirtualNetworkAppliances_ListBySubscription.json"
+          "List all first party service tags": {
+            "$ref": "./examples/FirstPartyServiceTagListAll.json"
           }
         },
         "x-ms-pageable": {
@@ -83,13 +83,13 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firstPartyServiceTags": {
       "get": {
-        "operationId": "VirtualNetworkAppliances_List",
+        "operationId": "FirstPartyServiceTags_List",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Gets all virtual network appliances in a resource group.",
+        "description": "Gets all the first party service tags in a resource group.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -105,7 +105,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkApplianceListResult"
+              "$ref": "#/definitions/FirstPartyServiceTagListResult"
             }
           },
           "default": {
@@ -116,8 +116,8 @@
           }
         },
         "x-ms-examples": {
-          "List virtual network appliances in resource group": {
-            "$ref": "./examples/VirtualNetworkAppliances_List.json"
+          "List first party service tags in resource group": {
+            "$ref": "./examples/FirstPartyServiceTagList.json"
           }
         },
         "x-ms-pageable": {
@@ -125,13 +125,13 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances/{virtualNetworkApplianceName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firstPartyServiceTags/{firstPartyServiceTagName}": {
       "get": {
-        "operationId": "VirtualNetworkAppliances_Get",
+        "operationId": "FirstPartyServiceTags_Get",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Gets information about the specified virtual network appliance.",
+        "description": "Gets the specified first party service tag.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -143,19 +143,20 @@
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "virtualNetworkApplianceName",
+            "name": "firstPartyServiceTagName",
             "in": "path",
-            "description": "The name of the virtual network appliance.",
+            "description": "The name of the first party service tag.",
             "required": true,
             "type": "string",
-            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
           }
         ],
         "responses": {
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkAppliance"
+              "$ref": "#/definitions/FirstPartyServiceTag"
             }
           },
           "default": {
@@ -166,17 +167,17 @@
           }
         },
         "x-ms-examples": {
-          "Get virtual network appliance": {
-            "$ref": "./examples/VirtualNetworkAppliances_Get.json"
+          "Get first party service tag": {
+            "$ref": "./examples/FirstPartyServiceTagGet.json"
           }
         }
       },
       "put": {
-        "operationId": "VirtualNetworkAppliances_CreateOrUpdate",
+        "operationId": "FirstPartyServiceTags_CreateOrUpdate",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Creates or updates a virtual network appliance.",
+        "description": "Creates or updates a first party service tag.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -188,34 +189,35 @@
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "virtualNetworkApplianceName",
+            "name": "firstPartyServiceTagName",
             "in": "path",
-            "description": "The name of the virtual network appliance.",
+            "description": "The name of the first party service tag.",
             "required": true,
             "type": "string",
-            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
           },
           {
             "name": "parameters",
             "in": "body",
-            "description": "Parameters supplied to the create or update virtual network appliance operation.",
+            "description": "Parameters supplied to the create or update first party service tag operation.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkAppliance"
+              "$ref": "#/definitions/FirstPartyServiceTag"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Resource 'VirtualNetworkAppliance' update operation succeeded",
+            "description": "Resource 'FirstPartyServiceTag' update operation succeeded",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkAppliance"
+              "$ref": "#/definitions/FirstPartyServiceTag"
             }
           },
           "201": {
-            "description": "Resource 'VirtualNetworkAppliance' create operation succeeded",
+            "description": "Resource 'FirstPartyServiceTag' create operation succeeded",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkAppliance"
+              "$ref": "#/definitions/FirstPartyServiceTag"
             },
             "headers": {
               "Azure-AsyncOperation": {
@@ -237,22 +239,22 @@
           }
         },
         "x-ms-examples": {
-          "Create virtual network appliance": {
-            "$ref": "./examples/VirtualNetworkAppliances_CreateOrUpdate.json"
+          "Create first party service tag": {
+            "$ref": "./examples/FirstPartyServiceTagCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/VirtualNetworkAppliance"
+          "final-state-schema": "#/definitions/FirstPartyServiceTag"
         },
         "x-ms-long-running-operation": true
       },
       "patch": {
-        "operationId": "VirtualNetworkAppliances_UpdateTags",
+        "operationId": "FirstPartyServiceTags_UpdateTags",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Updates a virtual network appliance tags.",
+        "description": "Updates a first party service tag tags.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -264,17 +266,18 @@
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "virtualNetworkApplianceName",
+            "name": "firstPartyServiceTagName",
             "in": "path",
-            "description": "The name of the virtual network appliance.",
+            "description": "The name of the first party service tag.",
             "required": true,
             "type": "string",
-            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
           },
           {
             "name": "parameters",
             "in": "body",
-            "description": "Parameters supplied to update virtual network appliance tags.",
+            "description": "Parameters supplied to update first party service tag tags.",
             "required": true,
             "schema": {
               "$ref": "./common.json#/definitions/TagsObject"
@@ -285,7 +288,21 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "#/definitions/VirtualNetworkAppliance"
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
             }
           },
           "default": {
@@ -296,17 +313,22 @@
           }
         },
         "x-ms-examples": {
-          "Update virtual network appliance tags": {
-            "$ref": "./examples/VirtualNetworkAppliances_UpdateTags.json"
+          "Update first party service tag tags": {
+            "$ref": "./examples/FirstPartyServiceTagUpdateTags.json"
           }
-        }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/FirstPartyServiceTag"
+        },
+        "x-ms-long-running-operation": true
       },
       "delete": {
-        "operationId": "VirtualNetworkAppliances_Delete",
+        "operationId": "FirstPartyServiceTags_Delete",
         "tags": [
-          "VirtualNetworkAppliances"
+          "FirstPartyServiceTags"
         ],
-        "description": "Deletes the specified virtual network appliance.",
+        "description": "Deletes the specified first party service tag.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -318,15 +340,19 @@
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "virtualNetworkApplianceName",
+            "name": "firstPartyServiceTagName",
             "in": "path",
-            "description": "The name of the virtual network appliance.",
+            "description": "The name of the first party service tag.",
             "required": true,
             "type": "string",
-            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "202": {
             "description": "Resource deletion accepted.",
             "headers": {
@@ -352,8 +378,8 @@
           }
         },
         "x-ms-examples": {
-          "Delete virtual network appliance": {
-            "$ref": "./examples/VirtualNetworkAppliances_Delete.json"
+          "Delete first party service tag": {
+            "$ref": "./examples/FirstPartyServiceTagDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -364,14 +390,13 @@
     }
   },
   "definitions": {
-    "VirtualNetworkAppliance": {
+    "FirstPartyServiceTag": {
       "type": "object",
-      "description": "A virtual network appliance in a resource group.",
+      "description": "First party service tag resource.",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/VirtualNetworkAppliancePropertiesFormat",
-          "description": "Properties of the virtual network appliance.",
-          "x-ms-client-flatten": true
+          "$ref": "#/definitions/FirstPartyServiceTagPropertiesFormat",
+          "description": "Properties of the first party service tag."
         },
         "etag": {
           "type": "string",
@@ -381,76 +406,19 @@
       },
       "allOf": [
         {
-          "$ref": "./common.json#/definitions/Common.Resource"
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
         }
       ]
     },
-    "VirtualNetworkApplianceIpConfiguration": {
+    "FirstPartyServiceTagListResult": {
       "type": "object",
-      "description": "The virtual network appliance ip configuration.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/VirtualNetworkApplianceIpConfigurationProperties",
-          "description": "Properties of the virtual network appliance ip configuration.",
-          "x-ms-client-flatten": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of virtual network appliance ip configuration."
-        },
-        "etag": {
-          "type": "string",
-          "description": "A unique read-only string that changes whenever the resource is updated.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The resource type.",
-          "readOnly": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "./common.json#/definitions/Common.SubResource"
-        }
-      ]
-    },
-    "VirtualNetworkApplianceIpConfigurationProperties": {
-      "type": "object",
-      "description": "Properties of virtual network appliance IP configuration.",
-      "properties": {
-        "privateIPAddress": {
-          "type": "string",
-          "description": "The private IP address of the IP configuration."
-        },
-        "privateIPAllocationMethod": {
-          "$ref": "./common.json#/definitions/Common.IPAllocationMethod",
-          "description": "The private IP address allocation method."
-        },
-        "primary": {
-          "type": "boolean",
-          "description": "Whether the ip configuration is primary or not."
-        },
-        "provisioningState": {
-          "$ref": "./common.json#/definitions/Common.ProvisioningState",
-          "description": "The provisioning state of the private link service IP configuration resource.",
-          "readOnly": true
-        },
-        "privateIPAddressVersion": {
-          "$ref": "./common.json#/definitions/Common.IPVersion",
-          "description": "Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4."
-        }
-      }
-    },
-    "VirtualNetworkApplianceListResult": {
-      "type": "object",
-      "description": "The response of a VirtualNetworkAppliance list operation.",
+      "description": "The response of a FirstPartyServiceTag list operation.",
       "properties": {
         "value": {
           "type": "array",
-          "description": "The VirtualNetworkAppliance items on this page",
+          "description": "The FirstPartyServiceTag items on this page",
           "items": {
-            "$ref": "#/definitions/VirtualNetworkAppliance"
+            "$ref": "#/definitions/FirstPartyServiceTag"
           }
         },
         "nextLink": {
@@ -463,42 +431,33 @@
         "value"
       ]
     },
-    "VirtualNetworkAppliancePropertiesFormat": {
+    "FirstPartyServiceTagPropertiesFormat": {
       "type": "object",
-      "description": "VirtualNetworkAppliance properties.",
+      "description": "Properties of the first party service tag.",
       "properties": {
-        "bandwidthInGbps": {
-          "type": "number",
-          "format": "double",
-          "description": "Bandwidth of the VirtualNetworkAppliance resource in Gbps."
+        "value": {
+          "type": "string",
+          "description": "The value of the first party service tag."
         },
-        "ipConfigurations": {
-          "type": "array",
-          "description": "A list of IPConfigurations of the virtual network appliance.",
-          "items": {
-            "$ref": "#/definitions/VirtualNetworkApplianceIpConfiguration"
-          },
-          "readOnly": true
-        },
-        "privateIPAddressVersion": {
-          "$ref": "./common.json#/definitions/VirtualNetworkApplianceIpVersionType",
-          "description": "Whether the specific virtual network appliance is IPv4 or Dual Stack. Default is IPv4."
-        },
-        "provisioningState": {
-          "$ref": "./common.json#/definitions/Common.ProvisioningState",
-          "description": "The provisioning state of the virtual network appliance resource.",
+        "failedReason": {
+          "type": "string",
+          "description": "The reason for failure, if any.",
           "readOnly": true
         },
         "resourceGuid": {
           "type": "string",
-          "description": "The resource GUID property of the virtual network appliance resource.",
+          "description": "The resource GUID property of the first party service tag resource.",
           "readOnly": true
         },
-        "subnet": {
-          "$ref": "./virtualNetwork.json#/definitions/Common.Subnet",
-          "description": "The reference to the subnet resource."
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/Common.ProvisioningState",
+          "description": "The provisioning state of the first party service tag resource.",
+          "readOnly": true
         }
-      }
+      },
+      "required": [
+        "value"
+      ]
     }
   },
   "parameters": {}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/firstPartyServiceTag.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/interconnectGroup.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/interconnectGroup.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/loadBalancer.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/loadBalancer.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkManager.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkManager.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkSecurityPerimeter.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkSecurityPerimeter.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkWatcher.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkWatcher.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkingOperations.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/networkingOperations.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/serviceGateway.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/serviceGateway.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"
@@ -10301,6 +10301,9 @@
           },
           "Create public IP address defaults with StandardV2 Sku": {
             "$ref": "./examples/PublicIpAddressCreateDefaultsStandardV2Sku.json"
+          },
+          "Create public IP address with first party service tag": {
+            "$ref": "./examples/PublicIpAddressCreateWithFirstPartyServiceTag.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -10818,6 +10821,9 @@
           },
           "Create public IP prefix defaults with StandardV2 Sku": {
             "$ref": "./examples/PublicIpPrefixCreateDefaultsStandardV2Sku.json"
+          },
+          "Create public IP prefix with first party service tag": {
+            "$ref": "./examples/PublicIpPrefixCreateWithFirstPartyServiceTag.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14999,6 +15005,18 @@
         "tag": {
           "type": "string",
           "description": "The value of the IP tag associated with the public IP. Example: SQL."
+        },
+        "firstPartyServiceTagId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the first party service tag associated with the IP tag.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/firstPartyServiceTags"
+              }
+            ]
+          }
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetworkAppliance.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "NetworkManagementClient",
+    "title": "WebApplicationFirewallManagement",
     "version": "2025-09-01",
     "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "WebApplicationFirewallManagement",
+    "title": "NetworkManagementClient",
     "version": "2025-09-01",
-    "description": "APIs to manage web application firewall rules.",
+    "description": "APIs to manage Microsoft Azure network resources.",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"


### PR DESCRIPTION
Add Microsoft.Network/FirstPartyServiceTags TypeSpec for 2025-09-01 and update Microsoft.Network/PublicIpAddress and Microsoft.Network/PublicIpPrefix TypeSpec for 2025-09-01 to consume the reference to the FirstPartyServiceTags resource

Copilot-Session: 021fef56-c735-4428-b5bf-4171afabb106

**This change had already been reviewed on private branch, this PR is only to bring it into public release branch, as suggested by Release Manager -** 

https://github.com/Azure/azure-rest-api-specs-pr/pull/28751

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
