### PR TITLE
fix: gracefully handle missing namespace-results artifact in Set Status workflow

### DIFF
--- a/.github/workflows/namespace-approval-code.yaml
+++ b/.github/workflows/namespace-approval-code.yaml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
       - edited
+    branches:
+      - main
+    paths:
+      - "specification/**/tspconfig.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/src/namespace-approval/post-results.js
+++ b/.github/workflows/src/namespace-approval/post-results.js
@@ -32,7 +32,7 @@ const NamespaceResultsSchema = z.object({
  * @param {string} owner
  * @param {string} repo
  * @param {number} runId
- * @returns {Promise<z.infer<typeof NamespaceResultsSchema>>}
+ * @returns {Promise<z.infer<typeof NamespaceResultsSchema> | null>}
  */
 async function downloadNamespaceResults(github, core, owner, repo, runId) {
   const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
@@ -50,7 +50,10 @@ async function downloadNamespaceResults(github, core, owner, repo, runId) {
   })[0];
 
   if (!artifact) {
-    throw new Error(`No namespace-results artifact found for run ${runId}`);
+    core.info(
+      `No namespace-results artifact found for run ${runId} (PR likely has no tspconfig changes)`,
+    );
+    return null;
   }
 
   const download = await github.rest.actions.downloadArtifact({
@@ -218,6 +221,11 @@ export default async function postResults({ github, context, core }) {
   const { owner, repo, issue_number, run_id } = await extractInputs(github, context, core);
   const approversConfig = await loadApproversConfig();
   const results = await downloadNamespaceResults(github, core, owner, repo, run_id);
+
+  if (!results) {
+    core.info("No namespace results to process (PR has no tspconfig changes), exiting gracefully");
+    return;
+  }
 
   const { data: pr } = await github.rest.pulls.get({
     owner,


### PR DESCRIPTION
## Problem

The **Namespace Approval - Set Status** workflow fails with:
```
Error: No namespace-results artifact found for run <id>
```

This blocks PRs on all branches (main, RPSaaSMaster, release-*) because the failure propagates through `summarize-checks` into "Automated merging requirements met".

**Root causes:**
1. No `paths:` filter - workflow runs on every PR, even those not touching tspconfig.yaml
2. No `branches:` filter - workflow fires on PRs to RPSaaSMaster and release-* branches where namespace approval is unnecessary
3. No graceful handling when the Analyze Code step produces no artifact (PR has no tspconfig changes)

Example: [azure-rest-api-specs-pr#29575](https://github.com/Azure/azure-rest-api-specs-pr/pull/29575)

## Fix

1. **`branches: [main]`** - Namespace approval only enforced on PRs targeting main. RPSaaSMaster specs get re-approved when they move to main (git treats it as new file). release-* branches are mostly existing namespaces and merge to main eventually.

2. **`paths: ['specification/**/tspconfig.yaml']`** - Workflow only runs when tspconfig files change.

3. **Null-guard fallback** in `post-results.js` - if artifact is missing for any edge case, exit gracefully instead of throwing.

## Testing

- Existing tests pass (18/18 in post-results.test.js)
- No behavior change for PRs targeting main that DO have tspconfig changes