### PR TITLE
[Compute][BulkActions] Disable safe-flatten for ResourcesWithContext (C# SDK CS0102 fix)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -249,6 +249,14 @@ namespace Microsoft.Compute;
 #suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Preserve type for public API surface"
 @@clientOption(ExecutionParameters, "disable-safe-flatten", true, "csharp");
 
+// ResourcesWithContext (added in 2026-07-06-preview) is a single-property model whose inner
+// property would safe-flatten into a "Resources" member, colliding with the existing
+// UserRequestResources "Resources" on the Execute*Content models. Disable safe-flatten to keep
+// it as a distinct type and avoid the duplicate-member (CS0102) build break in the C# SDK.
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve type for public API surface"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Preserve type for public API surface"
+@@clientOption(ResourcesWithContext, "disable-safe-flatten", true, "csharp");
+
 @@clientName(CancelOperationsRequest, "CancelBulkOperationsContent", "csharp");
 @@clientName(
   GetOperationStatusRequest,


### PR DESCRIPTION
## Summary
Adds a C#-only `disable-safe-flatten` client option for the `ResourcesWithContext` model in the BulkActions spec.

## Why
`ResourcesWithContext` was introduced in api-version **2026-07-06-preview** (`@added`) as a single-property model:
```tsp
model ResourcesWithContext {
  resources: Array<ResourceWithContext>;
}
```
For C#, TypeSpec safe-flatten collapses this single-property model into a `Resources` member. That collides with the existing `UserRequestResources Resources` (the `resources` property) on the `Execute*Content` models (`ExecuteStart/Deallocate/Hibernate/...`), producing a duplicate-member **CS0102** build break in the generated .NET SDK.

The 2026-07-06-preview change already added `disable-safe-flatten` for `Resources` and `ExecutionParameters`, but **missed `ResourcesWithContext`** — this PR closes that gap, matching the existing pattern.

## Change
```tsp
@@clientOption(ResourcesWithContext, "disable-safe-flatten", true, "csharp");
```
Single-line client customization; no wire/OpenAPI surface change. C# emitter only.

## Impact
- Unblocks the auto-generated .NET SDK PR (Azure/azure-sdk-for-net#61167, `Azure.ResourceManager.Compute.BulkActions`), whose CI regenerates from this spec and currently fails with CS0102.
- After merge, the SDK PR's `tsp-location.yaml` will be pointed at the new commit.

## Scope
- [x] client.tsp only (customization)
- [x] No `.tsp` model / OpenAPI changes
- [x] Preview api-version `2026-07-06-preview`