### PR TITLE
Fix Java SDK acronym casing for machinelearning via client.tsp

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
@@ -1449,6 +1449,8 @@ using Microsoft.MachineLearningServices;
 @@clientName(NotebookAccessTokenResult.hostName, "hostname", "java");
 @@clientName(UserAccountCredentials.adminUserName, "adminUsername", "java");
 @@clientName(ComputeInstanceSshSettings.adminUserName, "adminUsername", "java");
+@@clientName(DockerCredential.userName, "username", "java");
+@@clientName(ComputeInstanceCreatedBy.userName, "username", "java");
 
 // Java casing fixes for FQDN-related types
 @@clientName(ExternalFQDNResponse, "ExternalFqdnResponse", "java");
@@ -1472,11 +1474,15 @@ using Microsoft.MachineLearningServices;
 );
 
 // Java casing fixes for AKS-related types
-@@clientName(AksNetworkingConfiguration, "AKSNetworkingConfiguration", "java");
-@@clientName(AksComputeSecrets, "AKSComputeSecrets", "java");
+@@clientName(AKS, "Aks", "java");
+@@clientName(AKSSchema, "AksSchema", "java");
+@@clientName(AKSSchemaProperties, "AksSchemaProperties", "java");
+@@clientName(AksNetworkingConfiguration.dnsServiceIP, "dnsServiceIp", "java");
+
+// Java casing fix for PAT-related types
 @@clientName(
-  AksComputeSecretsProperties,
-  "AKSComputeSecretsProperties",
+  PATAuthTypeWorkspaceConnectionProperties,
+  "PatAuthTypeWorkspaceConnectionProperties",
   "java"
 );
 


### PR DESCRIPTION
Fix Java SDK acronym casing for `azure-resourcemanager-machinelearning` via `@@clientName` (`java` scope) in client.tsp, to preserve backward compatibility with the last stable release and follow Java naming conventions (consistent with the existing SAS/FQDN/AAD/CMK casing fixes):

- `AKS` / `AKSSchema` / `AKSSchemaProperties` -> `Aks` / `AksSchema` / `AksSchemaProperties`
- Removed the backwards `Aks*` -> `AKS*` fixes (`AksNetworkingConfiguration`, `AksComputeSecrets`, `AksComputeSecretsProperties`) that were introducing the break
- `PATAuthTypeWorkspaceConnectionProperties` -> `PatAuthTypeWorkspaceConnectionProperties`
- `AksNetworkingConfiguration.dnsServiceIP` -> `dnsServiceIp`
- `DockerCredential.userName` / `ComputeInstanceCreatedBy.userName` -> `username`

Java-emitter-only changes; no effect on other languages. Related SDK AutoPR: Azure/azure-sdk-for-java#49896.