### PR TITLE
Support SDK repo branch pins during validation

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/package.json
+++ b/eng/tools/spec-gen-sdk-runner/package.json
@@ -23,7 +23,8 @@
     "node": ">=24.14.1"
   },
   "dependencies": {
-    "@azure-tools/specs-shared": "file:../../../.github/shared"
+    "@azure-tools/specs-shared": "file:../../../.github/shared",
+    "yaml": "^2.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -431,22 +431,6 @@ export function generateArtifact(
 }
 
 /**
- * Get the service folder path from the spec config path.
- * @param specConfigPath
- * @returns The service folder path.
- */
-export function getServiceFolderPath(specConfigPath: string): string {
-  if (!specConfigPath || specConfigPath.length === 0) {
-    return "";
-  }
-  const segments = specConfigPath.split("/");
-  if (segments.length > 2) {
-    return `${segments[0]}/${segments[1]}`;
-  }
-  return specConfigPath;
-}
-
-/**
  * Get the required setting value for the SDK check based on the spec PR types.
  * @param hasManagementPlaneSpecs - A flag indicating whether there are management plane specs.
  * @param hasTypeSpecProjects - A flag indicating whether there are TypeSpec projects.

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -14,7 +14,6 @@ import {
   generateArtifact,
   getBreakingChangeInfo,
   getExecutionReport,
-  getServiceFolderPath,
   getSpecPaths,
   installLanguageToolchain,
   logIssuesToPipeline,
@@ -31,16 +30,66 @@ import {
 import { checkEmitterEnabled, type EmitterCheckResult } from "./emitter-check.ts";
 import { LogLevel, logMessage, vsoAddAttachment, vsoLogIssue } from "./log.ts";
 import { validatePythonPackagesOnPyPI } from "./python-pypi-validation.ts";
+import { resolveSdkRepoBranch } from "./sdk-validation-config.ts";
 import { detectChangedSpecConfigFiles } from "./spec-helpers.ts";
 import { type CommandResult, type ExecutionReport, type SpecGenSdkCmdInput } from "./types.ts";
 import {
+  checkoutMainBranch,
+  checkoutSdkBranch,
   execAsync,
+  getServiceFolderPath,
   isPrivateSpecRepo,
   resetGitRepo,
   runCommandWithOutput,
   runSpecGenSdkCommand,
   type SpecConfigs,
 } from "./utils.ts";
+
+/**
+ * Apply an SDK repo branch pin for a single spec in the public spec-PR flow.
+ *
+ * Resolves the `repo-branch` pin from `sdk-validation.yaml` (project, API plane,
+ * then service level) for the current SDK language and checks it out. Normalizes
+ * back to `main` when there is no pin, an invalid/missing branch, or the flow is
+ * not applicable but a previous spec had switched away.
+ *
+ * The feature is dormant unless the run is a public spec PR (a PR number is set
+ * and the spec repo is not a private `-pr` mirror).
+ *
+ * @returns whether the SDK repo is now on a non-`main` branch.
+ */
+async function applySdkRepoBranchForSpec(
+  commandInput: SpecGenSdkCmdInput,
+  specConfigRelativePath: string | undefined,
+  currentlyOnNonMainBranch: boolean,
+): Promise<boolean> {
+  // Only applies to the public spec-PR flow.
+  if (!commandInput.prNumber || isPrivateSpecRepo(commandInput.specRepoHttpsUrl)) {
+    return false;
+  }
+
+  const target = specConfigRelativePath
+    ? resolveSdkRepoBranch(
+        specConfigRelativePath,
+        commandInput.sdkLanguage,
+        commandInput.localSpecRepoPath,
+      )
+    : undefined;
+
+  if (target) {
+    const switched = await checkoutSdkBranch(commandInput.localSdkRepoPath, target);
+    if (switched) {
+      return true;
+    }
+    // A confirmed missing branch falls back to `main`. Operational git failures throw.
+  }
+
+  // No pin (or fallback): return to `main` only if a previous spec switched away.
+  if (currentlyOnNonMainBranch) {
+    await checkoutMainBranch(commandInput.localSdkRepoPath);
+  }
+  return false;
+}
 
 /**
  * Run the azsdk-cli generation flow for a single TypeSpec spec:
@@ -291,6 +340,9 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
   let currentExecutionResult: string;
   let stagedArtifactsFolder = "";
   const apiViewRequestData: APIViewRequestData[] = [];
+  // Tracks whether the SDK repo is currently checked out on a non-`main` branch
+  // due to a `sdk-validation.yaml` pin from a previous spec in this run.
+  let sdkRepoBranchSwitched = false;
 
   if (changedSpecs.length === 0) {
     sdkGenerationExecuted = false;
@@ -354,6 +406,11 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
       // azsdk-cli path for TypeSpec specs
       try {
         await resetGitRepo(commandInput.localSdkRepoPath);
+        sdkRepoBranchSwitched = await applySdkRepoBranchForSpec(
+          commandInput,
+          changedSpec.typespecProject ?? changedSpec.readmeMd,
+          sdkRepoBranchSwitched,
+        );
         const result = await runAzsdkGeneration(commandInput, changedSpec.typespecProject);
         executionReport = result.executionReport;
         if (result.statusCode !== 0) {
@@ -378,6 +435,11 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
 
       try {
         await resetGitRepo(commandInput.localSdkRepoPath);
+        sdkRepoBranchSwitched = await applySdkRepoBranchForSpec(
+          commandInput,
+          changedSpec.typespecProject ?? changedSpec.readmeMd,
+          sdkRepoBranchSwitched,
+        );
         await runSpecGenSdkCommand(specGenSdkCommand);
         logMessage("Runner command executed successfully");
       } catch (error) {

--- a/eng/tools/spec-gen-sdk-runner/src/sdk-validation-config.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/sdk-validation-config.ts
@@ -1,0 +1,237 @@
+/**
+ * Parsing, validation, and resolution for the per-project `sdk-validation.yaml`
+ * configuration file that controls the SDK Validation check.
+ *
+ * The only setting recognized in this iteration is a per-language `repo-branch`
+ * pin, used to check out a non-`main` SDK repo branch during SDK generation in
+ * the public spec-PR flow. See support-customized-branch.md at the repository root.
+ */
+import { SdkName } from "@azure-tools/specs-shared/sdk-types";
+import fs from "node:fs";
+import path from "node:path";
+import { inspect } from "node:util";
+import { parse as yamlParse } from "yaml";
+import { LogLevel, logMessage } from "./log.ts";
+import { getPlaneFolderPath, getServiceFolderPath, isValidSdkBranchName } from "./utils.ts";
+
+/** The name of the per-project SDK Validation config file. */
+export const sdkValidationConfigFileName = "sdk-validation.yaml";
+
+/** Per-language settings inside `sdk-validation.yaml`. */
+export interface SdkLanguageValidationSettings {
+  "repo-branch"?: string;
+}
+
+/** Parsed shape of `sdk-validation.yaml`. */
+export interface SdkValidationConfig {
+  languages: Partial<Record<SdkName, SdkLanguageValidationSettings>>;
+}
+
+/** Result of validating the raw parsed content of `sdk-validation.yaml`. */
+export interface SdkValidationConfigValidationResult {
+  config?: SdkValidationConfig;
+  errors: string[];
+}
+
+type ReadSdkValidationConfigResult =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { status: "valid"; config: SdkValidationConfig };
+
+const validSdkNames = new Set<string>(Object.values(SdkName));
+const allowedRootKeys = new Set(["languages"]);
+const allowedLanguageSettingKeys = new Set(["repo-branch"]);
+
+/**
+ * Validate the raw parsed content of an `sdk-validation.yaml` file.
+ *
+ * Keeps validation lightweight and dependency-free (the schema is tiny): checks
+ * shape, restricts language keys to the `SdkName` enum, restricts per-language
+ * keys to `repo-branch`, and validates the branch name via `isValidSdkBranchName`.
+ */
+export function validateSdkValidationConfig(content: unknown): SdkValidationConfigValidationResult {
+  const errors: string[] = [];
+
+  if (content === null || content === undefined) {
+    return { errors: [`${sdkValidationConfigFileName} is empty.`] };
+  }
+  if (typeof content !== "object" || Array.isArray(content)) {
+    return { errors: [`${sdkValidationConfigFileName} root must be a mapping.`] };
+  }
+
+  const root = content as Record<string, unknown>;
+  for (const key of Object.keys(root)) {
+    if (!allowedRootKeys.has(key)) {
+      errors.push(`Unexpected top-level key '${key}'. Only 'languages' is allowed.`);
+    }
+  }
+
+  const languages = root["languages"];
+  if (languages === undefined) {
+    errors.push("Missing required 'languages' mapping.");
+    return { errors };
+  }
+  if (typeof languages !== "object" || languages === null || Array.isArray(languages)) {
+    errors.push("'languages' must be a mapping of SDK language to settings.");
+    return { errors };
+  }
+
+  const parsed: SdkValidationConfig = { languages: {} };
+  for (const [language, settings] of Object.entries(languages as Record<string, unknown>)) {
+    if (!validSdkNames.has(language)) {
+      errors.push(`Unknown SDK language '${language}'. Allowed: ${[...validSdkNames].join(", ")}.`);
+      continue;
+    }
+    if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+      errors.push(`Settings for '${language}' must be a mapping.`);
+      continue;
+    }
+
+    const settingsObj = settings as Record<string, unknown>;
+    for (const key of Object.keys(settingsObj)) {
+      if (!allowedLanguageSettingKeys.has(key)) {
+        errors.push(
+          `Unexpected setting '${key}' for '${language}'. Only 'repo-branch' is allowed.`,
+        );
+      }
+    }
+
+    const entry: SdkLanguageValidationSettings = {};
+    const repoBranch = settingsObj["repo-branch"];
+    if (repoBranch !== undefined) {
+      if (typeof repoBranch !== "string") {
+        errors.push(`'repo-branch' for '${language}' must be a string.`);
+      } else if (!isValidSdkBranchName(repoBranch)) {
+        errors.push(
+          `'repo-branch' value '${repoBranch}' for '${language}' is not a valid branch name.`,
+        );
+      } else {
+        entry["repo-branch"] = repoBranch;
+      }
+    }
+    (parsed.languages as Record<string, SdkLanguageValidationSettings>)[language] = entry;
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { config: parsed, errors };
+}
+
+/**
+ * Read and validate an `sdk-validation.yaml` file. An absent file is
+ * distinguished from an invalid file so resolution may continue to a less
+ * specific config only when no file exists. Invalid files are logged and force
+ * the default `main` branch without hard-failing generation.
+ */
+function readSdkValidationConfig(absolutePath: string): ReadSdkValidationConfigResult {
+  if (!fs.existsSync(absolutePath)) {
+    return { status: "absent" };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(absolutePath, "utf8");
+  } catch (error) {
+    logMessage(`Failed to read ${absolutePath}: ${inspect(error)}`, LogLevel.Warn);
+    return { status: "invalid" };
+  }
+
+  let parsedYaml: unknown;
+  try {
+    parsedYaml = yamlParse(raw);
+  } catch (error) {
+    logMessage(`Failed to parse ${absolutePath}: ${inspect(error)}`, LogLevel.Warn);
+    return { status: "invalid" };
+  }
+
+  if (parsedYaml === null || parsedYaml === undefined) {
+    logMessage(
+      `Invalid ${sdkValidationConfigFileName} at ${absolutePath}: file is empty.`,
+      LogLevel.Warn,
+    );
+    return { status: "invalid" };
+  }
+
+  const { config, errors } = validateSdkValidationConfig(parsedYaml);
+  if (errors.length > 0 || !config) {
+    for (const error of errors) {
+      logMessage(
+        `Invalid ${sdkValidationConfigFileName} at ${absolutePath}: ${error}`,
+        LogLevel.Warn,
+      );
+    }
+    return { status: "invalid" };
+  }
+  return { status: "valid", config };
+}
+
+/**
+ * Resolve the SDK repo branch pin for a given spec config and SDK language.
+ *
+ * Looks up `sdk-validation.yaml` at project level (next to the spec config),
+ * then API plane level (`resource-manager` or `data-plane`), then service
+ * level. Returns the validated branch name, or `undefined` when there is no
+ * pin, the pin is `main`, or the config is invalid (all treated as "use
+ * `main`").
+ *
+ * @param specConfigRelativePath - Relative path to the spec config (e.g.
+ *   `specification/foo/Foo.Management/tspconfig.yaml` or `.../readme.md`).
+ * @param sdkName - The SDK language being generated.
+ * @param localSpecRepoPath - Absolute path to the local spec repo checkout.
+ */
+export function resolveSdkRepoBranch(
+  specConfigRelativePath: string,
+  sdkName: SdkName,
+  localSpecRepoPath: string,
+): string | undefined {
+  const normalizedSpecConfigPath = specConfigRelativePath.replaceAll("\\", "/");
+  const candidateDirs = [
+    path.posix.dirname(normalizedSpecConfigPath),
+    getPlaneFolderPath(normalizedSpecConfigPath),
+    getServiceFolderPath(normalizedSpecConfigPath),
+  ];
+  const seenDirs = new Set<string>();
+
+  for (const dir of candidateDirs) {
+    if (!dir || dir === "." || seenDirs.has(dir)) {
+      continue;
+    }
+    seenDirs.add(dir);
+
+    const absolutePath = path.join(localSpecRepoPath, dir, sdkValidationConfigFileName);
+    const configResult = readSdkValidationConfig(absolutePath);
+    if (configResult.status === "absent") {
+      continue;
+    }
+    if (configResult.status === "invalid") {
+      logMessage(
+        `Invalid ${sdkValidationConfigFileName} at ${path.join(dir, sdkValidationConfigFileName)}; using 'main' for ${sdkName}.`,
+        LogLevel.Warn,
+      );
+      return undefined;
+    }
+
+    const branch = configResult.config.languages?.[sdkName]?.["repo-branch"];
+    if (branch === undefined) {
+      // This level has a config but no pin for this language; fall through.
+      continue;
+    }
+    if (branch === "main") {
+      // Explicit `main` at the more specific level is a no-op; stop resolving.
+      logMessage(
+        `SDK repo branch for ${sdkName} is explicitly set to 'main' in ${path.join(dir, sdkValidationConfigFileName)}; using 'main' (no branch override).`,
+        LogLevel.Info,
+      );
+      return undefined;
+    }
+    logMessage(
+      `Resolved SDK repo branch '${branch}' for ${sdkName} from ${path.join(dir, sdkValidationConfigFileName)}`,
+      LogLevel.Info,
+    );
+    return branch;
+  }
+
+  logMessage(`No SDK repo branch override found for ${sdkName}; using 'main'.`, LogLevel.Info);
+  return undefined;
+}

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -29,6 +29,180 @@ export async function resetGitRepo(repoPath: string): Promise<void> {
   }
 }
 
+/**
+ * Character allowlist for an SDK repo branch pin: must start and end with an
+ * alphanumeric character, with letters, digits, and the separators `._-/`
+ * allowed in between. This inherently rejects whitespace, `:`, `~^?*[]`, `@`,
+ * backslashes, control characters, and a leading dash or slash. The remaining
+ * git-specific sequence checks live in `isValidSdkBranchName` for readability.
+ */
+const sdkBranchNameRegex = /^[A-Za-z0-9](?:[A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
+
+/**
+ * Returns true if `branch` is a safe, valid git branch name to use as an SDK
+ * repo pin: length-bounded, matching the character allowlist, and free of the
+ * disallowed git sequences (`refs/` prefix, `..`, `//`, and a `.lock` suffix).
+ */
+export function isValidSdkBranchName(branch: string): boolean {
+  return (
+    typeof branch === "string" &&
+    branch.length > 0 &&
+    branch.length <= 250 &&
+    !branch.startsWith("refs/") &&
+    !branch.includes("..") &&
+    !branch.includes("//") &&
+    !branch.endsWith(".lock") &&
+    sdkBranchNameRegex.test(branch)
+  );
+}
+
+/** Run a git command with an argument array (no shell) in the given repo. */
+async function runGitCommand(repoPath: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("git", args, {
+      cwd: repoPath,
+      shell: false,
+      stdio: "inherit",
+      env: process.env,
+    });
+    child.on("error", (error) => reject(error));
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`git ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Returns true if `branch` exists as a head (branch ref) on `origin`.
+ * A successful query with no matching ref returns false; operational git
+ * failures reject so callers cannot mistake them for a missing branch.
+ */
+async function sdkBranchExistsOnOrigin(repoPath: string, branch: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const child = spawn("git", ["ls-remote", "--heads", "origin", `refs/heads/${branch}`], {
+      cwd: repoPath,
+      shell: false,
+      stdio: ["ignore", "pipe", "inherit"],
+      env: process.env,
+    });
+    child.stdout.on("data", (data: Buffer) => chunks.push(data));
+    child.on("error", (error) => {
+      reject(new Error(`Failed to query SDK branch '${branch}' on origin`, { cause: error }));
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`git ls-remote for SDK branch '${branch}' exited with code ${code}`));
+        return;
+      }
+      const output = Buffer.concat(chunks).toString("utf8").trim();
+      resolve(output.length > 0);
+    });
+  });
+}
+
+/**
+ * Check out a non-`main` SDK repo branch in `repoPath` for the public spec-PR
+ * flow. Validates the branch name, confirms it exists as a head on `origin`,
+ * fetches it heads-only, and checks it out.
+ *
+ * @returns `true` if the branch was checked out; `false` only when the branch
+ *   does not exist (caller should fall back to `main`).
+ * @throws when the branch name is unsafe or a git operation fails.
+ */
+export async function checkoutSdkBranch(repoPath: string, branch: string): Promise<boolean> {
+  if (!isValidSdkBranchName(branch)) {
+    throw new Error(`Refusing to check out unsafe SDK branch name '${branch}'`);
+  }
+
+  let exists: boolean;
+  try {
+    exists = await sdkBranchExistsOnOrigin(repoPath, branch);
+  } catch (error) {
+    throw new Error(
+      `Unable to verify SDK branch '${branch}' on origin. SDK validation stopped without falling back to 'main'. Check repository access and network connectivity, then retry the pipeline.`,
+      { cause: error },
+    );
+  }
+  if (!exists) {
+    logMessage(`SDK branch '${branch}' not found on origin; falling back to 'main'`, LogLevel.Warn);
+    return false;
+  }
+
+  try {
+    await runGitCommand(repoPath, [
+      "fetch",
+      "origin",
+      `refs/heads/${branch}:refs/remotes/origin/${branch}`,
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Unable to fetch SDK branch '${branch}' from origin. SDK validation stopped without falling back to 'main'. Check repository access and network connectivity, then retry the pipeline.`,
+      { cause: error },
+    );
+  }
+
+  try {
+    await runGitCommand(repoPath, ["checkout", "-B", branch, `origin/${branch}`]);
+    logMessage(`Checked out SDK repo branch '${branch}' in ${repoPath}`, LogLevel.Info);
+    return true;
+  } catch (error) {
+    throw new Error(
+      `Unable to check out SDK branch '${branch}'. SDK validation stopped to avoid generating from the wrong branch.`,
+      { cause: error },
+    );
+  }
+}
+
+/** Check out the `main` branch to normalize the SDK repo between specs. */
+export async function checkoutMainBranch(repoPath: string): Promise<void> {
+  try {
+    await runGitCommand(repoPath, ["checkout", "main"]);
+  } catch (error) {
+    throw new Error(
+      `Unable to restore the SDK repository to 'main'. SDK validation stopped to prevent the next spec from using the wrong branch.`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Get the service folder path (`specification/<service>`) from a spec config path.
+ * @param specConfigPath The relative spec config path.
+ * @returns The service folder path.
+ */
+export function getServiceFolderPath(specConfigPath: string): string {
+  if (!specConfigPath || specConfigPath.length === 0) {
+    return "";
+  }
+  const segments = specConfigPath.replaceAll("\\", "/").split("/");
+  if (segments.length > 2) {
+    return `${segments[0]}/${segments[1]}`;
+  }
+  return segments.join("/");
+}
+
+/**
+ * Get the API plane folder (`.../resource-manager` or `.../data-plane`) from a
+ * spec config path.
+ * @param specConfigPath The relative spec config path.
+ * @returns The plane folder path, or `undefined` when the path has no plane segment.
+ */
+export function getPlaneFolderPath(specConfigPath: string): string | undefined {
+  const segments = specConfigPath.replaceAll("\\", "/").split("/");
+  const planeIndex = segments.findIndex(
+    (segment) => segment === "resource-manager" || segment === "data-plane",
+  );
+  if (planeIndex === -1) {
+    return undefined;
+  }
+  return segments.slice(0, planeIndex + 1).join("/");
+}
+
 /*
  * Common function to find files recursively with case-insensitive matching
  */

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -11,6 +11,7 @@ import {
 import * as log from "../src/log.ts";
 import { LogLevel } from "../src/log.ts";
 import * as pythonPypiValidation from "../src/python-pypi-validation.ts";
+import * as sdkValidationConfig from "../src/sdk-validation-config.ts";
 import * as changeFiles from "../src/spec-helpers.ts";
 import type { ExecutionReport } from "../src/types.ts";
 import * as utils from "../src/utils.ts";
@@ -264,9 +265,7 @@ describe("generateSdkForSpecPr", () => {
     });
 
     const { statusCode } = await generateSdkForSpecPr();
-    const serviceFolderPath = commandHelpers.getServiceFolderPath(
-      mockChangedSpecs[0].typespecProject,
-    );
+    const serviceFolderPath = utils.getServiceFolderPath(mockChangedSpecs[0].typespecProject);
     expect(statusCode).toBe(0);
     expect(log.logMessage).toHaveBeenCalledWith(
       `Generating SDK from ${serviceFolderPath}`,
@@ -292,6 +291,67 @@ describe("generateSdkForSpecPr", () => {
       [], // apiViewRequestData
       true, // sdkGenerationExecuted
     );
+  });
+
+  test("uses a pinned SDK branch and restores main for the next unpinned spec", async () => {
+    const mockCommandInput = {
+      localSdkRepoPath: "path/to/local/repo",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "spec-pull-request",
+      sdkRepoName: "azure-sdk-for-js",
+      sdkLanguage: SdkName.Js,
+      specCommitSha: "spec-sha",
+      specRepoHttpsUrl: "https://github.com/Azure/azure-rest-api-specs",
+      prNumber: "123",
+    };
+    const mockChangedSpecs = [
+      {
+        specs: ["specification/service-one/Project/file.tsp"],
+        typespecProject: "specification/service-one/Project/tspconfig.yaml",
+      },
+      {
+        specs: ["specification/service-two/Project/file.tsp"],
+        typespecProject: "specification/service-two/Project/tspconfig.yaml",
+      },
+    ];
+    const mockExecutionReport = {
+      executionResult: "succeeded",
+      packages: [],
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
+    vi.spyOn(sdkValidationConfig, "resolveSdkRepoBranch")
+      .mockReturnValueOnce("feature/custom")
+      .mockReturnValueOnce(undefined);
+    vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
+    const checkoutSdkBranchSpy = vi.spyOn(utils, "checkoutSdkBranch").mockResolvedValue(true);
+    const checkoutMainBranchSpy = vi
+      .spyOn(utils, "checkoutMainBranch")
+      .mockResolvedValue(undefined);
+    const runSpecGenSdkCommandSpy = vi
+      .spyOn(utils, "runSpecGenSdkCommand")
+      .mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
+      mockExecutionReport as ExecutionReport,
+    );
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
+    vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
+    vi.spyOn(log, "logMessage").mockImplementation(() => {});
+
+    const { statusCode } = await generateSdkForSpecPr();
+
+    expect(statusCode).toBe(0);
+    expect(checkoutSdkBranchSpy).toHaveBeenCalledOnce();
+    expect(checkoutSdkBranchSpy).toHaveBeenCalledWith(
+      mockCommandInput.localSdkRepoPath,
+      "feature/custom",
+    );
+    expect(checkoutMainBranchSpy).toHaveBeenCalledOnce();
+    expect(checkoutMainBranchSpy).toHaveBeenCalledWith(mockCommandInput.localSdkRepoPath);
+    expect(runSpecGenSdkCommandSpy).toHaveBeenCalledTimes(2);
   });
 
   test("should validate Python PR package registration on PyPI", async () => {

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-invalid/Svc.Management/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-invalid/Svc.Management/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: refs/heads/unsafe

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-invalid/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-invalid/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/bob/service-branch

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-main/Svc.Management/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-main/Svc.Management/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: main

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/resource-manager/ProjectWithOverride/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/resource-manager/ProjectWithOverride/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/alice/project-branch

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/resource-manager/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/resource-manager/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/alice/plane-branch

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-plane/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/alice/service-branch

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-project/Svc.Management/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-project/Svc.Management/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/alice/feature-x

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-service/sdk-validation.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/branchpin-service/sdk-validation.yaml
@@ -1,0 +1,3 @@
+languages:
+  azure-sdk-for-python:
+    repo-branch: users/bob/svc-branch

--- a/eng/tools/spec-gen-sdk-runner/test/sdk-validation-config.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/sdk-validation-config.test.ts
@@ -1,0 +1,166 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as log from "../src/log.ts";
+import { resolveSdkRepoBranch, validateSdkValidationConfig } from "../src/sdk-validation-config.ts";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const fixturesRoot = path.resolve(path.dirname(currentFilePath), "fixtures");
+
+describe("sdk-validation-config", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Silence log output during tests.
+    vi.spyOn(log, "logMessage").mockImplementation(() => {});
+  });
+
+  describe("validateSdkValidationConfig", () => {
+    test("accepts a valid config", () => {
+      const { config, errors } = validateSdkValidationConfig({
+        languages: {
+          "azure-sdk-for-python": { "repo-branch": "users/alice/feature-x" },
+        },
+      });
+      expect(errors).toEqual([]);
+      expect(config?.languages["azure-sdk-for-python"]?.["repo-branch"]).toBe(
+        "users/alice/feature-x",
+      );
+    });
+
+    test("rejects null/undefined", () => {
+      expect(validateSdkValidationConfig(null).errors.length).toBeGreaterThan(0);
+      expect(validateSdkValidationConfig(undefined).errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects non-mapping root", () => {
+      expect(validateSdkValidationConfig("nope").errors.length).toBeGreaterThan(0);
+      expect(validateSdkValidationConfig([]).errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects unknown top-level key", () => {
+      const { errors } = validateSdkValidationConfig({ languages: {}, other: 1 });
+      expect(errors.some((e) => e.includes("other"))).toBe(true);
+    });
+
+    test("requires the 'languages' mapping", () => {
+      const { errors } = validateSdkValidationConfig({});
+      expect(errors.some((e) => e.includes("languages"))).toBe(true);
+    });
+
+    test("rejects an unknown SDK language", () => {
+      const { errors } = validateSdkValidationConfig({
+        languages: { "azure-sdk-for-cobol": { "repo-branch": "x" } },
+      });
+      expect(errors.some((e) => e.includes("azure-sdk-for-cobol"))).toBe(true);
+    });
+
+    test("rejects an unknown per-language setting", () => {
+      const { errors } = validateSdkValidationConfig({
+        languages: { "azure-sdk-for-python": { branch: "x" } },
+      });
+      expect(errors.some((e) => e.includes("branch"))).toBe(true);
+    });
+
+    test("rejects a non-string repo-branch", () => {
+      const { errors } = validateSdkValidationConfig({
+        languages: { "azure-sdk-for-python": { "repo-branch": 5 } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects an invalid branch name (refs/ prefix)", () => {
+      const { errors } = validateSdkValidationConfig({
+        languages: { "azure-sdk-for-python": { "repo-branch": "refs/heads/x" } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("resolveSdkRepoBranch", () => {
+    test("returns the project-level pin", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-project/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBe("users/alice/feature-x");
+    });
+
+    test("falls back to the service-level pin when no project file exists", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-service/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBe("users/bob/svc-branch");
+    });
+
+    test("uses the plane-level pin before the service-level pin", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-plane/resource-manager/ProjectWithoutOverride/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBe("users/alice/plane-branch");
+    });
+
+    test("uses the project-level pin before the plane-level pin", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-plane/resource-manager/ProjectWithOverride/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBe("users/alice/project-branch");
+    });
+
+    test("resolves plane precedence from a Windows-style spec path", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification\\branchpin-plane\\resource-manager\\ProjectWithoutOverride\\tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBe("users/alice/plane-branch");
+    });
+
+    test("treats an explicit 'main' pin as no-op (undefined)", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-main/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBeUndefined();
+    });
+
+    test("warns and uses main when the project-level config is invalid", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-invalid/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+
+      expect(branch).toBeUndefined();
+      expect(log.logMessage).toHaveBeenCalledWith(
+        expect.stringContaining("using 'main' for azure-sdk-for-python"),
+        log.LogLevel.Warn,
+      );
+    });
+
+    test("returns undefined when no config file exists", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-none/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-python",
+        fixturesRoot,
+      );
+      expect(branch).toBeUndefined();
+    });
+
+    test("returns undefined for a language not listed in the config", () => {
+      const branch = resolveSdkRepoBranch(
+        "specification/branchpin-project/Svc.Management/tspconfig.yaml",
+        "azure-sdk-for-go",
+        fixturesRoot,
+      );
+      expect(branch).toBeUndefined();
+    });
+  });
+});

--- a/eng/tools/spec-gen-sdk-runner/test/utils/sdkBranch.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/utils/sdkBranch.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import * as log from "../../src/log.ts";
+import { checkoutMainBranch, checkoutSdkBranch, isValidSdkBranchName } from "../../src/utils.ts";
+
+const temporaryDirectories: string[] = [];
+
+function createRepoWithEmptyOrigin(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-branch-test-"));
+  temporaryDirectories.push(root);
+  const remotePath = path.join(root, "remote.git");
+  const repoPath = path.join(root, "repo");
+
+  execFileSync("git", ["init", "--bare", remotePath], { stdio: "ignore" });
+  execFileSync("git", ["init", repoPath], { stdio: "ignore" });
+  execFileSync("git", ["-C", repoPath, "remote", "add", "origin", remotePath], {
+    stdio: "ignore",
+  });
+  return repoPath;
+}
+
+function createRepoWithOriginBranch(branch: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-branch-test-"));
+  temporaryDirectories.push(root);
+  const remotePath = path.join(root, "remote.git");
+  const seedPath = path.join(root, "seed");
+  const repoPath = path.join(root, "repo");
+
+  execFileSync("git", ["init", "--bare", remotePath], { stdio: "ignore" });
+  execFileSync("git", ["init", seedPath], { stdio: "ignore" });
+  execFileSync("git", ["-C", seedPath, "config", "user.email", "test@example.com"]);
+  execFileSync("git", ["-C", seedPath, "config", "user.name", "SDK Branch Test"]);
+  fs.writeFileSync(path.join(seedPath, "branch.txt"), "main");
+  execFileSync("git", ["-C", seedPath, "add", "branch.txt"]);
+  execFileSync("git", ["-C", seedPath, "commit", "-m", "main"], { stdio: "ignore" });
+  execFileSync("git", ["-C", seedPath, "branch", "-M", "main"]);
+  execFileSync("git", ["-C", seedPath, "remote", "add", "origin", remotePath]);
+  execFileSync("git", ["-C", seedPath, "push", "origin", "main"], { stdio: "ignore" });
+
+  execFileSync("git", ["-C", seedPath, "checkout", "-b", branch], { stdio: "ignore" });
+  fs.writeFileSync(path.join(seedPath, "branch.txt"), branch);
+  execFileSync("git", ["-C", seedPath, "add", "branch.txt"]);
+  execFileSync("git", ["-C", seedPath, "commit", "-m", branch], { stdio: "ignore" });
+  execFileSync("git", ["-C", seedPath, "push", "origin", branch], { stdio: "ignore" });
+
+  execFileSync("git", ["clone", "--branch", "main", remotePath, repoPath], {
+    stdio: "ignore",
+  });
+  return repoPath;
+}
+
+describe("isValidSdkBranchName", () => {
+  test.each(["main", "users/alice/feature-x", "feature/foo", "release/1.2.3", "hotfix_1"])(
+    "accepts '%s'",
+    (branch) => {
+      expect(isValidSdkBranchName(branch)).toBe(true);
+    },
+  );
+
+  test.each([
+    "", // empty
+    "-x", // leading dash (could be read as a git option)
+    "refs/heads/x", // refs/ prefix
+    "refs/pull/1/head", // PR ref
+    "/x", // leading slash
+    "x/", // trailing slash
+    "a//b", // double slash
+    "a..b", // double dot
+    "a.lock", // .lock suffix
+    "a.", // trailing dot
+    "a\\b", // backslash
+    "a b", // whitespace
+    "a~b",
+    "a^b",
+    "a:b",
+    "a?b",
+    "a*b",
+    "a[b]",
+  ])("rejects '%s'", (branch) => {
+    expect(isValidSdkBranchName(branch)).toBe(false);
+  });
+
+  test("rejects names longer than 250 characters", () => {
+    expect(isValidSdkBranchName("a".repeat(251))).toBe(false);
+    expect(isValidSdkBranchName("a".repeat(250))).toBe(true);
+  });
+});
+
+describe("checkoutSdkBranch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(log, "logMessage").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an unsafe branch name without invoking git", async () => {
+    await expect(checkoutSdkBranch("/repo", "refs/heads/evil")).rejects.toThrow(
+      "unsafe SDK branch name",
+    );
+  });
+
+  test("returns false only when origin confirms the branch is missing", async () => {
+    const repoPath = createRepoWithEmptyOrigin();
+
+    await expect(checkoutSdkBranch(repoPath, "missing-branch")).resolves.toBe(false);
+    expect(log.logMessage).toHaveBeenCalledWith(
+      "SDK branch 'missing-branch' not found on origin; falling back to 'main'",
+      log.LogLevel.Warn,
+    );
+  });
+
+  test("fetches and checks out an existing SDK branch, then restores main", async () => {
+    const repoPath = createRepoWithOriginBranch("feature/test");
+
+    await expect(checkoutSdkBranch(repoPath, "feature/test")).resolves.toBe(true);
+    expect(
+      execFileSync("git", ["-C", repoPath, "branch", "--show-current"], {
+        encoding: "utf8",
+      }).trim(),
+    ).toBe("feature/test");
+    expect(fs.readFileSync(path.join(repoPath, "branch.txt"), "utf8")).toBe("feature/test");
+
+    await expect(checkoutMainBranch(repoPath)).resolves.toBeUndefined();
+    expect(
+      execFileSync("git", ["-C", repoPath, "branch", "--show-current"], {
+        encoding: "utf8",
+      }).trim(),
+    ).toBe("main");
+    expect(fs.readFileSync(path.join(repoPath, "branch.txt"), "utf8")).toBe("main");
+  });
+
+  test("rejects when the fetched branch cannot be checked out", async () => {
+    const repoPath = createRepoWithOriginBranch("feature/in-use");
+    const worktreePath = path.join(path.dirname(repoPath), "worktree");
+    execFileSync("git", ["-C", repoPath, "branch", "feature/in-use", "origin/feature/in-use"]);
+    execFileSync("git", ["-C", repoPath, "worktree", "add", worktreePath, "feature/in-use"], {
+      stdio: "ignore",
+    });
+
+    await expect(checkoutSdkBranch(repoPath, "feature/in-use")).rejects.toThrow(
+      "Unable to check out SDK branch 'feature/in-use'",
+    );
+  });
+
+  test("rejects when the remote branch query fails", async () => {
+    const missingRepoPath = path.join(os.tmpdir(), `missing-sdk-repo-${Date.now()}`);
+
+    await expect(checkoutSdkBranch(missingRepoPath, "feature/test")).rejects.toThrow(
+      "Unable to verify SDK branch 'feature/test' on origin. SDK validation stopped without falling back to 'main'. Check repository access and network connectivity, then retry the pipeline.",
+    );
+  });
+
+  test("rejects when main branch normalization fails", async () => {
+    const missingRepoPath = path.join(os.tmpdir(), `missing-sdk-repo-${Date.now()}`);
+
+    await expect(checkoutMainBranch(missingRepoPath)).rejects.toThrow(
+      "Unable to restore the SDK repository to 'main'. SDK validation stopped to prevent the next spec from using the wrong branch.",
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,7 +464,8 @@
       "version": "0.0.1",
       "dev": true,
       "dependencies": {
-        "@azure-tools/specs-shared": "file:../../../.github/shared"
+        "@azure-tools/specs-shared": "file:../../../.github/shared",
+        "yaml": "^2.4.2"
       },
       "bin": {
         "spec-gen-sdk-runner": "cmd/spec-gen-sdk-runner.js"


### PR DESCRIPTION
## Summary
- Add `sdk-validation.yaml` parsing for per-language SDK repo branch overrides
- Resolve branch pins with typespec project > API plane > service precedence for public spec PR SDK validation
- Safely validate, fetch, and check out SDK repo branches, restoring `main` between specs
- Add unit tests and fixtures for config validation, precedence, checkout behavior, and runner integration

## Test PR
https://github.com/Azure/azure-rest-api-specs/pull/44895