### PR TITLE
Add email service URL env variable in release plan automation pipeline

### DIFF
--- a/eng/pipelines/release-plan.yml
+++ b/eng/pipelines/release-plan.yml
@@ -44,6 +44,7 @@ stages:
             continueOnError: true
             env:
               GH_TOKEN: $(GH_TOKEN)
+              AZSDKTOOLS_NOTIFICATION_SERVICE_URL: $(AzureSDKEmailerSasURL)
               ${{ if eq(parameters['Test-release-Plan'], true) }}:
                 AZSDKTOOLS_AGENT_TESTING: "true"
             inputs:


### PR DESCRIPTION
Set env variable to pass email service URL from variable group to create release plan step.