### PR TITLE
add registry connection id to hosted agents definition

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29590,7 +29590,7 @@
             "type": "string",
             "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
             "examples": [
-              "jfrog-foundryagents"
+              "my-registry-connection"
             ]
           }
         },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29588,7 +29588,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity.",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity (for example, Azure Container Registry).",
             "examples": [
               "my-registry-connection"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29585,6 +29585,13 @@
             "examples": [
               "my-registry.azurecr.io/my-hosted-agent:latest"
             ]
+          },
+          "registry_connection_id": {
+            "type": "string",
+            "description": "The id (or name) of a Foundry project connection that authorizes pulling `image` from a private\ncontainer registry. Used only for registry authentication and never affects the image name —\n`image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the\nregistry is accessible via the project's managed identity (for example, Azure Container Registry).",
+            "examples": [
+              "jfrog-foundryagents"
+            ]
           }
         },
         "description": "Container-based deployment configuration for a hosted agent."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29588,7 +29588,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of a Foundry project connection that authorizes pulling `image` from a private\ncontainer registry. Used only for registry authentication and never affects the image name —\n`image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the\nregistry is accessible via the project's managed identity (for example, Azure Container Registry).",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
             "examples": [
               "jfrog-foundryagents"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29588,7 +29588,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity.",
             "examples": [
               "my-registry-connection"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40232,9 +40232,8 @@ components:
             The id (or name) of the Foundry project connection that provides the credentials used to
             authenticate to the private container registry hosting `image`. The connection abstracts the
             auth mechanism — for example a managed-identity-federated token exchange, or a username/token
-            secret — so registry credentials are never part of the agent definition. Used only for registry
-            authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
-            literal. Omit for public images or registries already reachable by the platform's default identity.
+            secret — so registry credentials are never part of the agent definition. Omit for public images
+            or registries already reachable by the platform's default identity.
           examples:
             - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40226,6 +40226,15 @@ components:
           description: The container image for the hosted agent.
           examples:
             - my-registry.azurecr.io/my-hosted-agent:latest
+        registry_connection_id:
+          type: string
+          description: |-
+            The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
+            container registry. Used only for registry authentication and never affects the image name —
+            `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
+            registry is accessible via the project's managed identity (for example, Azure Container Registry).
+          examples:
+            - jfrog-foundryagents
       description: Container-based deployment configuration for a hosted agent.
     ContentFilterResult:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40236,7 +40236,7 @@ components:
             authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
             literal. Omit for public images or registries already reachable by the platform's default identity.
           examples:
-            - jfrog-foundryagents
+            - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.
     ContentFilterResult:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40233,7 +40233,7 @@ components:
             authenticate to the private container registry hosting `image`. The connection abstracts the
             auth mechanism — for example a managed-identity-federated token exchange, or a username/token
             secret — so registry credentials are never part of the agent definition. Omit for public images
-            or registries already reachable by the platform's default identity.
+            or registries already reachable by the platform's default identity (for example, Azure Container Registry).
           examples:
             - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40229,10 +40229,12 @@ components:
         registry_connection_id:
           type: string
           description: |-
-            The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
-            container registry. Used only for registry authentication and never affects the image name —
-            `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
-            registry is accessible via the project's managed identity (for example, Azure Container Registry).
+            The id (or name) of the Foundry project connection that provides the credentials used to
+            authenticate to the private container registry hosting `image`. The connection abstracts the
+            auth mechanism — for example a managed-identity-federated token exchange, or a username/token
+            secret — so registry credentials are never part of the agent definition. Used only for registry
+            authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
+            literal. Omit for public images or registries already reachable by the platform's default identity.
           examples:
             - jfrog-foundryagents
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32912,7 +32912,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity.",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity (for example, Azure Container Registry).",
             "examples": [
               "my-registry-connection"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32912,7 +32912,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of a Foundry project connection that authorizes pulling `image` from a private\ncontainer registry. Used only for registry authentication and never affects the image name —\n`image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the\nregistry is accessible via the project's managed identity (for example, Azure Container Registry).",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
             "examples": [
               "jfrog-foundryagents"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32909,6 +32909,13 @@
             "examples": [
               "my-registry.azurecr.io/my-hosted-agent:latest"
             ]
+          },
+          "registry_connection_id": {
+            "type": "string",
+            "description": "The id (or name) of a Foundry project connection that authorizes pulling `image` from a private\ncontainer registry. Used only for registry authentication and never affects the image name —\n`image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the\nregistry is accessible via the project's managed identity (for example, Azure Container Registry).",
+            "examples": [
+              "jfrog-foundryagents"
+            ]
           }
         },
         "description": "Container-based deployment configuration for a hosted agent."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32912,7 +32912,7 @@
           },
           "registry_connection_id": {
             "type": "string",
-            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
+            "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Omit for public images\nor registries already reachable by the platform's default identity.",
             "examples": [
               "my-registry-connection"
             ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32914,7 +32914,7 @@
             "type": "string",
             "description": "The id (or name) of the Foundry project connection that provides the credentials used to\nauthenticate to the private container registry hosting `image`. The connection abstracts the\nauth mechanism — for example a managed-identity-federated token exchange, or a username/token\nsecret — so registry credentials are never part of the agent definition. Used only for registry\nauthentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`\nliteral. Omit for public images or registries already reachable by the platform's default identity.",
             "examples": [
-              "jfrog-foundryagents"
+              "my-registry-connection"
             ]
           }
         },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42458,6 +42458,15 @@ components:
           description: The container image for the hosted agent.
           examples:
             - my-registry.azurecr.io/my-hosted-agent:latest
+        registry_connection_id:
+          type: string
+          description: |-
+            The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
+            container registry. Used only for registry authentication and never affects the image name —
+            `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
+            registry is accessible via the project's managed identity (for example, Azure Container Registry).
+          examples:
+            - jfrog-foundryagents
       description: Container-based deployment configuration for a hosted agent.
     ContainerDetails:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42465,7 +42465,7 @@ components:
             authenticate to the private container registry hosting `image`. The connection abstracts the
             auth mechanism — for example a managed-identity-federated token exchange, or a username/token
             secret — so registry credentials are never part of the agent definition. Omit for public images
-            or registries already reachable by the platform's default identity.
+            or registries already reachable by the platform's default identity (for example, Azure Container Registry).
           examples:
             - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42468,7 +42468,7 @@ components:
             authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
             literal. Omit for public images or registries already reachable by the platform's default identity.
           examples:
-            - jfrog-foundryagents
+            - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.
     ContainerDetails:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42461,10 +42461,12 @@ components:
         registry_connection_id:
           type: string
           description: |-
-            The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
-            container registry. Used only for registry authentication and never affects the image name —
-            `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
-            registry is accessible via the project's managed identity (for example, Azure Container Registry).
+            The id (or name) of the Foundry project connection that provides the credentials used to
+            authenticate to the private container registry hosting `image`. The connection abstracts the
+            auth mechanism — for example a managed-identity-federated token exchange, or a username/token
+            secret — so registry credentials are never part of the agent definition. Used only for registry
+            authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
+            literal. Omit for public images or registries already reachable by the platform's default identity.
           examples:
             - jfrog-foundryagents
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42464,9 +42464,8 @@ components:
             The id (or name) of the Foundry project connection that provides the credentials used to
             authenticate to the private container registry hosting `image`. The connection abstracts the
             auth mechanism — for example a managed-identity-federated token exchange, or a username/token
-            secret — so registry credentials are never part of the agent definition. Used only for registry
-            authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
-            literal. Omit for public images or registries already reachable by the platform's default identity.
+            secret — so registry credentials are never part of the agent definition. Omit for public images
+            or registries already reachable by the platform's default identity.
           examples:
             - my-registry-connection
       description: Container-based deployment configuration for a hosted agent.

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -358,9 +358,8 @@ model ContainerConfiguration {
     The id (or name) of the Foundry project connection that provides the credentials used to
     authenticate to the private container registry hosting `image`. The connection abstracts the
     auth mechanism — for example a managed-identity-federated token exchange, or a username/token
-    secret — so registry credentials are never part of the agent definition. Used only for registry
-    authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
-    literal. Omit for public images or registries already reachable by the platform's default identity.
+    secret — so registry credentials are never part of the agent definition. Omit for public images
+    or registries already reachable by the platform's default identity.
     """)
   @example("my-registry-connection")
   registry_connection_id?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -355,10 +355,12 @@ model ContainerConfiguration {
   image: string;
 
   @doc("""
-    The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
-    container registry. Used only for registry authentication and never affects the image name —
-    `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
-    registry is accessible via the project's managed identity (for example, Azure Container Registry).
+    The id (or name) of the Foundry project connection that provides the credentials used to
+    authenticate to the private container registry hosting `image`. The connection abstracts the
+    auth mechanism — for example a managed-identity-federated token exchange, or a username/token
+    secret — so registry credentials are never part of the agent definition. Used only for registry
+    authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
+    literal. Omit for public images or registries already reachable by the platform's default identity.
     """)
   @example("jfrog-foundryagents")
   registry_connection_id?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -362,7 +362,7 @@ model ContainerConfiguration {
     authentication and never affects the image name; `image` remains a fully-qualified `host/repo:tag`
     literal. Omit for public images or registries already reachable by the platform's default identity.
     """)
-  @example("jfrog-foundryagents")
+  @example("my-registry-connection")
   registry_connection_id?: string;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -353,6 +353,15 @@ model ContainerConfiguration {
   @doc("The container image for the hosted agent.")
   @example("my-registry.azurecr.io/my-hosted-agent:latest")
   image: string;
+
+  @doc("""
+    The id (or name) of a Foundry project connection that authorizes pulling `image` from a private
+    container registry. Used only for registry authentication and never affects the image name —
+    `image` remains a fully-qualified `host/repo:tag` literal. Omit for public images or when the
+    registry is accessible via the project's managed identity (for example, Azure Container Registry).
+    """)
+  @example("jfrog-foundryagents")
+  registry_connection_id?: string;
 }
 
 @doc("Code-based deployment configuration for a hosted agent.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -359,7 +359,7 @@ model ContainerConfiguration {
     authenticate to the private container registry hosting `image`. The connection abstracts the
     auth mechanism — for example a managed-identity-federated token exchange, or a username/token
     secret — so registry credentials are never part of the agent definition. Omit for public images
-    or registries already reachable by the platform's default identity.
+    or registries already reachable by the platform's default identity (for example, Azure Container Registry).
     """)
   @example("my-registry-connection")
   registry_connection_id?: string;


### PR DESCRIPTION
## Summary

Adds an optional `registry_connection_id` field to the hosted-agent `ContainerConfiguration`. It names the Foundry **project connection** that provides the credentials used to authenticate to the **private container registry** hosting `image`. The connection **abstracts the auth mechanism** — managed-identity-federated token exchange, a username/token secret, etc. — so registry credentials are never part of the agent definition. Used **only** for registry authentication; it never affects the image name.

## Changes

- `src/agents/models.tsp` — add `registry_connection_id?: string` to `ContainerConfiguration`.
- Regenerated OpenAPI: `openapi3/v1` and `openapi3/virtual-public-preview` (json + yaml).

## Rationale

Hosted agents today can only pull images that are public or reachable via the platform's default identity (e.g. Azure Container Registry). Customers who host agent images in private third-party registries need a way to tell Foundry which connection authorizes the pull.

`image` stays a fully-qualified `host/repo:tag` literal; `registry_connection_id` names the connection that supplies the registry credentials. How those credentials are obtained (an identity-federated token exchange, a stored username/token secret, etc.) is defined by the connection, not the agent definition. Omit for public images or registries already reachable by the platform's default identity.

## API shape

`ContainerConfiguration`:
- `image: string` — unchanged, required.
- `registry_connection_id?: string` — **new**, optional. The id (or name) of the Foundry project connection.

The field name follows the `*_connection_id` convention already used across the tools surface (e.g. `BingGroundingSearchConfiguration.project_connection_id`, `BingCustomSearchConfiguration.project_connection_id`).

## Design references

- Vienna design — private registry image pull via connection-abstracted auth: [Vienna PR !2207414](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2207414)
