### PR TITLE
Microsoft.Security: add 2026-01-01-preview for DefenderForStorageSettings

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/DefenderForStorageSetting.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/DefenderForStorageSetting.tsp
@@ -2,6 +2,7 @@
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "../Common/main.tsp";
 
@@ -9,6 +10,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 using Common;
 
 namespace DefenderForStorageAPI;
@@ -117,19 +119,6 @@ interface DefenderForStorageSettings {
   >;
 
   /**
-   * Initiate a Defender for Storage malware scan for the specified storage account. Blobs and Files will be scanned for malware.
-   */
-  @tag("DefenderForStorage")
-  @tag("Antimalware")
-  @tag("Scan")
-  startMalwareScan is DefenderForStorageSettingsOps.ActionSync<
-    DefenderForStorageSetting,
-    void,
-    ArmResponse<MalwareScan>,
-    ErrorType = CloudError
-  >;
-
-  /**
    * Cancels a Defender for Storage malware scan for the specified storage account.
    */
   @tag("DefenderForStorage")
@@ -142,6 +131,53 @@ interface DefenderForStorageSettings {
     ArmResponse<MalwareScan>,
     ErrorType = CloudError
   >;
+
+  /**
+   * Initiate a Defender for Storage malware scan for the specified storage account. Blobs and Files will be scanned for malware.
+   */
+  // Hand-written (not built from DefenderForStorageSettingsOps.ActionSync<>) so the request
+  // body can be versioned: only the `body` parameter is @added(v2026), so the operation
+  // exists in all versions but the optional StartMalwareScanRequest body only appears in
+  // 2026-01-01-preview. This keeps 2025-09-01-preview byte-identical to main while adding
+  // the on-demand scan filters in 2026. ActionSync<> can't express a per-version body.
+  //
+  // The path parameters are declared inline (matching the DefenderForStorageSettingsOps
+  // legacy alias) rather than via ResourceInstanceParameters<>, so the URL keeps the
+  // existing `resourceId` scope naming instead of switching to `resourceUri`. Route
+  // assembly is driven by @armResourceAction + the @segment/@key decorators (no explicit
+  // @route), which avoids the path-parameter duplication seen when combining an explicit
+  // @route with @armResourceOperations.
+  @tag("DefenderForStorage")
+  @tag("Antimalware")
+  @tag("Scan")
+  @armResourceAction(DefenderForStorageSetting)
+  @post
+  startMalwareScan(
+    ...ApiVersionParameter,
+
+    /** The fully qualified Azure Resource manager identifier of the resource. */
+    @path(#{ allowReserved: true })
+    @key
+    resourceId: string,
+
+    /** The provider namespace. */
+    @path
+    @segment("providers")
+    @key
+    providerNamespace: "Microsoft.Security",
+
+    /** The defender for storage setting name. */
+    @path
+    @segment("defenderForStorageSettings")
+    @key
+    @pattern("^[a-z][a-z0-9]*$")
+    settingName: SettingName,
+
+    /** Optional request body to filter which blobs and files to scan. */
+    @added(Versions.v2026_01_01_preview)
+    @bodyRoot
+    body?: StartMalwareScanRequest,
+  ): ArmResponse<MalwareScan> | CloudError;
 
   /**
    * Gets the Defender for Storage malware scan for the specified storage resource.

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/CancelMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/CancelMalwareScan_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "3fd3c1be-dbff-4d6e-985f-43f9ec1b1146",
+          "scanStatus": "Canceling",
+          "scanStatusMessage": "The scan request is being canceled upon user request"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_CancelMalwareScan",
+  "title": "Cancel a Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Get",
+  "title": "Gets the Defender for Storage settings for the specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/GetMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/GetMalwareScan_example.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanEndTime": "2025-09-01T12:21:17.5648386Z",
+          "scanId": "0ce362c5-87a5-4030-ba6a-109566cd7b3d",
+          "scanStartTime": "2025-09-01T12:20:14.6364816Z",
+          "scanStatus": "Completed",
+          "scanSummary": {
+            "blobs": {
+              "failedBlobsCount": 0,
+              "maliciousBlobsCount": 10,
+              "scannedBlobsInGB": 0.019550956785678864,
+              "skippedBlobsCount": 0,
+              "totalBlobsScanned": 40
+            },
+            "estimatedScanCostUSD": 0.0029326435178518295,
+            "files": {
+              "failedFilesCount": 0,
+              "maliciousFilesCount": 2,
+              "scannedFilesInGB": 10.5,
+              "skippedFilesCount": 0,
+              "totalFilesScanned": 150
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_GetMalwareScan",
+  "title": "Gets the Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.Security/defenderForStorageSettings",
+            "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+            "properties": {
+              "isEnabled": true,
+              "malwareScanning": {
+                "automatedResponse": "BlobSoftDelete",
+                "blobScanResultsOptions": "BlobIndexTags",
+                "onUpload": {
+                  "capGBPerMonth": 10000,
+                  "filters": {
+                    "excludeBlobsLargerThan": 1024,
+                    "excludeBlobsWithPrefix": [
+                      "sample-container/logs",
+                      "single-excluded-container/",
+                      "excluded-containers"
+                    ],
+                    "excludeBlobsWithSuffix": [
+                      ".log",
+                      ".jpg"
+                    ]
+                  },
+                  "isEnabled": true
+                },
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+              },
+              "overrideSubscriptionLevelSettings": true,
+              "sensitiveDataDiscovery": {
+                "isEnabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_List",
+  "title": "Lists the Defender for Storage settings for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "defenderForStorageSetting": {
+      "properties": {
+        "isEnabled": true,
+        "malwareScanning": {
+          "automatedResponse": "BlobSoftDelete",
+          "blobScanResultsOptions": "BlobIndexTags",
+          "onUpload": {
+            "capGBPerMonth": 10000,
+            "filters": {
+              "excludeBlobsLargerThan": 1024,
+              "excludeBlobsWithPrefix": [
+                "unscanned-container",
+                "sample-container/logs"
+              ],
+              "excludeBlobsWithSuffix": [
+                ".log",
+                ".jpg"
+              ]
+            },
+            "isEnabled": true
+          },
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+        },
+        "overrideSubscriptionLevelSettings": true,
+        "sensitiveDataDiscovery": {
+          "isEnabled": true
+        }
+      }
+    },
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "operationStatus": {
+              "code": "Succeeded"
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true,
+            "operationStatus": {
+              "code": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "None",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": -1,
+              "isEnabled": false
+            },
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": false,
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Create",
+  "title": "Creates or updates the Defender for Storage settings on a specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/StartMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-01-01-preview/DefenderForStorage/StartMalwareScan_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current",
+    "body": {
+      "properties": {
+        "filters": {
+          "blobs": {
+            "container": {
+              "value": "mycontainer",
+              "match": "Exact"
+            },
+            "blob": {
+              "value": "myblob.txt",
+              "match": "Exact"
+            }
+          },
+          "files": {
+            "share": {
+              "value": "myshare",
+              "match": "Exact"
+            },
+            "file": {
+              "value": "dir",
+              "match": "Prefix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "fc831479-412f-4bc2-8333-a8edda751a80",
+          "scanStatus": "Queued",
+          "scanStatusMessage": "The scan request has been queued for scanning"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_StartMalwareScan",
+  "title": "Initiate a Defender for Storage malware scan for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/main.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/main.tsp
@@ -41,4 +41,10 @@ enum Versions {
    * The 2025-09-01-preview API version.
    */
   v2025_09_01_preview: "2025-09-01-preview",
+
+  /**
+   * The 2026-01-01-preview API version.
+   */
+  @previewVersion
+  v2026_01_01_preview: "2026-01-01-preview",
 }

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
@@ -1,11 +1,13 @@
 ﻿import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "../Common/main.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Foundations;
 using Common;
@@ -311,4 +313,108 @@ model FilesScanSummary {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   scannedFilesInGB?: float64;
+}
+
+/**
+ * The matching strategy for the filter.
+ */
+@added(Versions.v2026_01_01_preview)
+union MatchType {
+  string,
+
+  /**
+   * Match resources with values starting with the specified string.
+   */
+  Prefix: "Prefix",
+
+  /**
+   * Match resources with the exact value specified.
+   */
+  Exact: "Exact",
+}
+
+/**
+ * Filter with value and matching strategy.
+ */
+@added(Versions.v2026_01_01_preview)
+model MatchFilter {
+  /**
+   * The value to match against.
+   */
+  value: string;
+
+  /**
+   * The matching strategy for the filter.
+   */
+  match: MatchType;
+}
+
+/**
+ * Filter for blob scanning. At least one of 'container' or 'blob' must be specified; a request with neither is rejected by the service. If only container is provided, all blobs in that container are scanned. If only blob is provided, blobs matching the filter across all containers are scanned.
+ */
+@added(Versions.v2026_01_01_preview)
+model BlobScanFilter {
+  /**
+   * Optional filter for the blob container to scan. If not provided, the blob filter will apply across all containers.
+   */
+  container?: MatchFilter;
+
+  /**
+   * Optional filter for specific blob(s). If container is specified, this filters blobs within that container. If container is not specified, this filters blobs across all containers.
+   */
+  blob?: MatchFilter;
+}
+
+/**
+ * Filter for file scanning. At least one of 'share' or 'file' must be specified; a request with neither is rejected by the service. If only share is provided, all files in that share are scanned. If only file is provided, files matching the filter across all shares are scanned.
+ */
+@added(Versions.v2026_01_01_preview)
+model FileScanFilter {
+  /**
+   * Optional filter for the file share to scan. If not provided, the file filter will apply across all shares.
+   */
+  share?: MatchFilter;
+
+  /**
+   * Optional filter for specific file(s). If share is specified, this filters files within that share. If share is not specified, this filters files across all shares.
+   */
+  file?: MatchFilter;
+}
+
+/**
+ * Filters to scope the malware scan.
+ */
+@added(Versions.v2026_01_01_preview)
+model MalwareScanFilters {
+  /**
+   * Optional filter for blob scanning. Specifies which blobs to scan.
+   */
+  blobs?: BlobScanFilter;
+
+  /**
+   * Optional filter for file scanning. Specifies which files to scan.
+   */
+  files?: FileScanFilter;
+}
+
+/**
+ * Properties for the malware scan request.
+ */
+@added(Versions.v2026_01_01_preview)
+model StartMalwareScanRequestProperties {
+  /**
+   * Optional filters to scope the malware scan to specific blobs or files.
+   */
+  filters?: MalwareScanFilters;
+}
+
+/**
+ * Request body for starting a malware scan with optional filters.
+ */
+@added(Versions.v2026_01_01_preview)
+model StartMalwareScanRequest {
+  /**
+   * Properties for the malware scan request.
+   */
+  properties?: StartMalwareScanRequestProperties;
 }

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/defenderForStorageSettings.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/defenderForStorageSettings.json
@@ -1,0 +1,1092 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Security Center",
+    "version": "2026-01-01-preview",
+    "description": "API spec for Microsoft.Security (Azure Security Center) resource provider",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "DefenderForStorage"
+    },
+    {
+      "name": "Antimalware"
+    },
+    {
+      "name": "Scan"
+    }
+  ],
+  "paths": {
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings": {
+      "get": {
+        "operationId": "DefenderForStorage_List",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Lists the Defender for Storage settings for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSettingList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Lists the Defender for Storage settings for the specified storage account.": {
+            "$ref": "./examples/DefenderForStorage/ListDefenderForStorageSettings_example.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}": {
+      "get": {
+        "operationId": "DefenderForStorage_Get",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Gets the Defender for Storage settings for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets the Defender for Storage settings for the specified resource.": {
+            "$ref": "./examples/DefenderForStorage/GetDefenderForStorageSettings_example.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DefenderForStorage_Create",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Creates or updates the Defender for Storage settings on a specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "defenderForStorageSetting",
+            "in": "body",
+            "description": "Defender for Storage Settings",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DefenderForStorageSetting' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "201": {
+            "description": "Resource 'DefenderForStorageSetting' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Creates or updates the Defender for Storage settings on a specified resource.": {
+            "$ref": "./examples/DefenderForStorage/PutDefenderForStorageSettings_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/malwareScans/{scanId}": {
+      "get": {
+        "operationId": "DefenderForStorage_GetMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Gets the Defender for Storage malware scan for the specified storage resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The identifier of the scan. Can be either 'latest' or a GUID.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(latest|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets the Defender for Storage malware scan for the specified storage resource.": {
+            "$ref": "./examples/DefenderForStorage/GetMalwareScan_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/malwareScans/{scanId}/cancelMalwareScan": {
+      "post": {
+        "operationId": "DefenderForStorage_CancelMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Cancels a Defender for Storage malware scan for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The identifier of the scan. Can be either 'latest' or a GUID.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(latest|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Cancel a Defender for Storage malware scan for the specified storage resource.": {
+            "$ref": "./examples/DefenderForStorage/CancelMalwareScan_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/startMalwareScan": {
+      "post": {
+        "operationId": "DefenderForStorage_StartMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Initiate a Defender for Storage malware scan for the specified storage account. Blobs and Files will be scanned for malware.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Optional request body to filter which blobs and files to scan.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StartMalwareScanRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Initiate a Defender for Storage malware scan for the specified storage account.": {
+            "$ref": "./examples/DefenderForStorage/StartMalwareScan_example.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BlobScanFilter": {
+      "type": "object",
+      "description": "Filter for blob scanning. At least one of 'container' or 'blob' must be specified; a request with neither is rejected by the service. If only container is provided, all blobs in that container are scanned. If only blob is provided, blobs matching the filter across all containers are scanned.",
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for the blob container to scan. If not provided, the blob filter will apply across all containers."
+        },
+        "blob": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for specific blob(s). If container is specified, this filters blobs within that container. If container is not specified, this filters blobs across all containers."
+        }
+      }
+    },
+    "BlobsScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results of the blobs that were scanned.",
+      "properties": {
+        "totalBlobsScanned": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total number of blobs that were scanned."
+        },
+        "maliciousBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of malicious blobs that were detected during the scan."
+        },
+        "skippedBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of blobs that were skipped."
+        },
+        "failedBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of failed blob scans."
+        },
+        "scannedBlobsInGB": {
+          "type": "number",
+          "format": "double",
+          "description": "The number of gigabytes of data that were scanned."
+        }
+      }
+    },
+    "Common.CloudError": {
+      "type": "object",
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Common.CloudErrorBody",
+          "description": "The error object.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "x-ms-external": true
+    },
+    "Common.CloudErrorBody": {
+      "type": "object",
+      "description": "The error detail.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/Common.CloudErrorBody"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorAdditionalInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      },
+      "x-ms-external": true
+    },
+    "Common.OperationStatus": {
+      "type": "object",
+      "description": "A status describing the success/failure of the enablement/disablement operation.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The operation status code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Additional information regarding the success/failure of the operation."
+        }
+      }
+    },
+    "DefenderForStorageSetting": {
+      "type": "object",
+      "description": "The Defender for Storage resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefenderForStorageSettingProperties",
+          "description": "Defender for Storage resource properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DefenderForStorageSettingList": {
+      "type": "object",
+      "description": "List of Defender for Storage settings.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of Defender for Storage settings.",
+          "items": {
+            "$ref": "#/definitions/DefenderForStorageSetting"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page."
+        }
+      }
+    },
+    "DefenderForStorageSettingProperties": {
+      "type": "object",
+      "description": "Defender for Storage resource properties.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether Defender for Storage is enabled on this storage account."
+        },
+        "malwareScanning": {
+          "$ref": "#/definitions/MalwareScanningProperties",
+          "description": "Properties of Malware Scanning."
+        },
+        "sensitiveDataDiscovery": {
+          "$ref": "#/definitions/SensitiveDataDiscoveryProperties",
+          "description": "Properties of Sensitive Data Discovery."
+        },
+        "overrideSubscriptionLevelSettings": {
+          "type": "boolean",
+          "description": "Indicates whether the settings defined for this storage account should override the settings defined for the subscription."
+        }
+      }
+    },
+    "FileScanFilter": {
+      "type": "object",
+      "description": "Filter for file scanning. At least one of 'share' or 'file' must be specified; a request with neither is rejected by the service. If only share is provided, all files in that share are scanned. If only file is provided, files matching the filter across all shares are scanned.",
+      "properties": {
+        "share": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for the file share to scan. If not provided, the file filter will apply across all shares."
+        },
+        "file": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for specific file(s). If share is specified, this filters files within that share. If share is not specified, this filters files across all shares."
+        }
+      }
+    },
+    "FilesScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results of the files that were scanned.",
+      "properties": {
+        "totalFilesScanned": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total number of files that were scanned."
+        },
+        "maliciousFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of malicious files that were detected during the scan."
+        },
+        "skippedFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of files that were skipped."
+        },
+        "failedFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of failed file scans."
+        },
+        "scannedFilesInGB": {
+          "type": "number",
+          "format": "double",
+          "description": "The number of gigabytes of data that were scanned."
+        }
+      }
+    },
+    "MalwareScan": {
+      "type": "object",
+      "description": "Describes the state of a malware scan operation.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MalwareScanProperties"
+        }
+      }
+    },
+    "MalwareScanFilters": {
+      "type": "object",
+      "description": "Filters to scope the malware scan.",
+      "properties": {
+        "blobs": {
+          "$ref": "#/definitions/BlobScanFilter",
+          "description": "Optional filter for blob scanning. Specifies which blobs to scan."
+        },
+        "files": {
+          "$ref": "#/definitions/FileScanFilter",
+          "description": "Optional filter for file scanning. Specifies which files to scan."
+        }
+      }
+    },
+    "MalwareScanProperties": {
+      "type": "object",
+      "properties": {
+        "scanId": {
+          "type": "string",
+          "description": "The identifier of the scan."
+        },
+        "scanStatus": {
+          "type": "string",
+          "description": "A status code of the scan operation."
+        },
+        "scanStatusMessage": {
+          "type": "string",
+          "description": "A description of the status of the scan."
+        },
+        "scanStartTime": {
+          "type": "string",
+          "description": "The time at which the scan had been initiated."
+        },
+        "scanEndTime": {
+          "type": "string",
+          "description": "The time at which the scan has ended. Only available for a scan which has terminated."
+        },
+        "scanSummary": {
+          "$ref": "#/definitions/ScanSummary",
+          "description": "A summary of the scan results."
+        }
+      }
+    },
+    "MalwareScanningProperties": {
+      "type": "object",
+      "description": "Properties of Malware Scanning.",
+      "properties": {
+        "onUpload": {
+          "$ref": "#/definitions/OnUploadProperties",
+          "description": "Properties of On Upload malware scanning."
+        },
+        "scanResultsEventGridTopicResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Resource id of an Event Grid Topic to send scan results to.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.EventGrid/topics"
+              }
+            ]
+          }
+        },
+        "blobScanResultsOptions": {
+          "type": "string",
+          "description": "Optional. Write scan result on BlobIndexTags by default.",
+          "default": "BlobIndexTags",
+          "enum": [
+            "BlobIndexTags",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "BlobScanResultsOptions",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "BlobIndexTags",
+                "value": "BlobIndexTags",
+                "description": "Write scan results on the blobs index tags."
+              },
+              {
+                "name": "None",
+                "value": "None",
+                "description": "Do not write scan results on the blobs index tags."
+              }
+            ]
+          }
+        },
+        "automatedResponse": {
+          "type": "string",
+          "description": "Optional. Specifies the automated response action to take when malware is detected.",
+          "default": "None",
+          "enum": [
+            "None",
+            "BlobSoftDelete"
+          ],
+          "x-ms-enum": {
+            "name": "AutomatedResponseType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No automated response will be taken when malware is detected."
+              },
+              {
+                "name": "BlobSoftDelete",
+                "value": "BlobSoftDelete",
+                "description": "The blob will be soft deleted when malware is detected."
+              }
+            ]
+          }
+        },
+        "operationStatus": {
+          "$ref": "#/definitions/Common.OperationStatus",
+          "description": "Upon failure or partial success. Additional data describing Malware Scanning enable/disable operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "MatchFilter": {
+      "type": "object",
+      "description": "Filter with value and matching strategy.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The value to match against."
+        },
+        "match": {
+          "$ref": "#/definitions/MatchType",
+          "description": "The matching strategy for the filter."
+        }
+      },
+      "required": [
+        "value",
+        "match"
+      ]
+    },
+    "MatchType": {
+      "type": "string",
+      "description": "The matching strategy for the filter.",
+      "enum": [
+        "Prefix",
+        "Exact"
+      ],
+      "x-ms-enum": {
+        "name": "MatchType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Prefix",
+            "value": "Prefix",
+            "description": "Match resources with values starting with the specified string."
+          },
+          {
+            "name": "Exact",
+            "value": "Exact",
+            "description": "Match resources with the exact value specified."
+          }
+        ]
+      }
+    },
+    "OnUploadFilters": {
+      "type": "object",
+      "description": "Optional. Determine which blobs get scanned by On Upload malware scanning. An Or operation is performed between each filter type.",
+      "properties": {
+        "excludeBlobsWithPrefix": {
+          "type": "array",
+          "description": "Optional. A list of prefixes to exclude from on-upload malware scanning.\nFormat: `container-name/blob-name` (start with the container name; do not include the storage account name).\nExclude entire containers: Use prefix of container names you want to exclude without a trailing `/`.\nExclude a single container: Add a trailing slash `/` after the container name to avoid excluding other containers with similar prefixes.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeBlobsWithSuffix": {
+          "type": "array",
+          "description": "Optional. A list of suffixes to exclude from on-upload malware scanning. Suffixes match only the end of blob names, and should be used for file extensions or blob name endings only.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeBlobsLargerThan": {
+          "description": "Optional. Specifies the maximum size in bytes for blobs to be scanned. This parameter accepts a single positive integer value. Blobs larger than this value will be excluded from scanning.",
+          "x-nullable": true
+        }
+      }
+    },
+    "OnUploadProperties": {
+      "type": "object",
+      "description": "Properties of On Upload malware scanning.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether On Upload malware scanning should be enabled."
+        },
+        "capGBPerMonth": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Defines the max GB to be scanned per Month. Set to -1 if no capping is needed. If not specified, the default value is -1."
+        },
+        "filters": {
+          "$ref": "#/definitions/OnUploadFilters",
+          "description": "Optional. Determine which blobs get scanned by On Upload malware scanning. An Or operation is performed between each filter type.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results.",
+      "properties": {
+        "blobs": {
+          "$ref": "#/definitions/BlobsScanSummary",
+          "description": "A summary of the scan results of the blobs that were scanned."
+        },
+        "files": {
+          "$ref": "#/definitions/FilesScanSummary",
+          "description": "A summary of the scan results of the files that were scanned."
+        },
+        "estimatedScanCostUSD": {
+          "type": "number",
+          "format": "double",
+          "description": "The estimated cost of the scan. Only available for a scan which has terminated."
+        }
+      }
+    },
+    "SensitiveDataDiscoveryProperties": {
+      "type": "object",
+      "description": "Properties of Sensitive Data Discovery.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether Sensitive Data Discovery should be enabled."
+        },
+        "operationStatus": {
+          "$ref": "#/definitions/Common.OperationStatus",
+          "description": "Upon failure or partial success. Additional data describing Sensitive Data Discovery enable/disable operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "StartMalwareScanRequest": {
+      "type": "object",
+      "description": "Request body for starting a malware scan with optional filters.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StartMalwareScanRequestProperties",
+          "description": "Properties for the malware scan request."
+        }
+      }
+    },
+    "StartMalwareScanRequestProperties": {
+      "type": "object",
+      "description": "Properties for the malware scan request.",
+      "properties": {
+        "filters": {
+          "$ref": "#/definitions/MalwareScanFilters",
+          "description": "Optional filters to scope the malware scan to specific blobs or files."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/CancelMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/CancelMalwareScan_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "3fd3c1be-dbff-4d6e-985f-43f9ec1b1146",
+          "scanStatus": "Canceling",
+          "scanStatusMessage": "The scan request is being canceled upon user request"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_CancelMalwareScan",
+  "title": "Cancel a Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Get",
+  "title": "Gets the Defender for Storage settings for the specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/GetMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/GetMalwareScan_example.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanEndTime": "2025-09-01T12:21:17.5648386Z",
+          "scanId": "0ce362c5-87a5-4030-ba6a-109566cd7b3d",
+          "scanStartTime": "2025-09-01T12:20:14.6364816Z",
+          "scanStatus": "Completed",
+          "scanSummary": {
+            "blobs": {
+              "failedBlobsCount": 0,
+              "maliciousBlobsCount": 10,
+              "scannedBlobsInGB": 0.019550956785678864,
+              "skippedBlobsCount": 0,
+              "totalBlobsScanned": 40
+            },
+            "estimatedScanCostUSD": 0.0029326435178518295,
+            "files": {
+              "failedFilesCount": 0,
+              "maliciousFilesCount": 2,
+              "scannedFilesInGB": 10.5,
+              "skippedFilesCount": 0,
+              "totalFilesScanned": 150
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_GetMalwareScan",
+  "title": "Gets the Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.Security/defenderForStorageSettings",
+            "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+            "properties": {
+              "isEnabled": true,
+              "malwareScanning": {
+                "automatedResponse": "BlobSoftDelete",
+                "blobScanResultsOptions": "BlobIndexTags",
+                "onUpload": {
+                  "capGBPerMonth": 10000,
+                  "filters": {
+                    "excludeBlobsLargerThan": 1024,
+                    "excludeBlobsWithPrefix": [
+                      "sample-container/logs",
+                      "single-excluded-container/",
+                      "excluded-containers"
+                    ],
+                    "excludeBlobsWithSuffix": [
+                      ".log",
+                      ".jpg"
+                    ]
+                  },
+                  "isEnabled": true
+                },
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+              },
+              "overrideSubscriptionLevelSettings": true,
+              "sensitiveDataDiscovery": {
+                "isEnabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_List",
+  "title": "Lists the Defender for Storage settings for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "defenderForStorageSetting": {
+      "properties": {
+        "isEnabled": true,
+        "malwareScanning": {
+          "automatedResponse": "BlobSoftDelete",
+          "blobScanResultsOptions": "BlobIndexTags",
+          "onUpload": {
+            "capGBPerMonth": 10000,
+            "filters": {
+              "excludeBlobsLargerThan": 1024,
+              "excludeBlobsWithPrefix": [
+                "unscanned-container",
+                "sample-container/logs"
+              ],
+              "excludeBlobsWithSuffix": [
+                ".log",
+                ".jpg"
+              ]
+            },
+            "isEnabled": true
+          },
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+        },
+        "overrideSubscriptionLevelSettings": true,
+        "sensitiveDataDiscovery": {
+          "isEnabled": true
+        }
+      }
+    },
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "operationStatus": {
+              "code": "Succeeded"
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true,
+            "operationStatus": {
+              "code": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "None",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": -1,
+              "isEnabled": false
+            },
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": false,
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Create",
+  "title": "Creates or updates the Defender for Storage settings on a specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/StartMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-01-01-preview/examples/DefenderForStorage/StartMalwareScan_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current",
+    "body": {
+      "properties": {
+        "filters": {
+          "blobs": {
+            "container": {
+              "value": "mycontainer",
+              "match": "Exact"
+            },
+            "blob": {
+              "value": "myblob.txt",
+              "match": "Exact"
+            }
+          },
+          "files": {
+            "share": {
+              "value": "myshare",
+              "match": "Exact"
+            },
+            "file": {
+              "value": "dir",
+              "match": "Prefix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "fc831479-412f-4bc2-8333-a8edda751a80",
+          "scanStatus": "Queued",
+          "scanStatusMessage": "The scan request has been queued for scanning"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_StartMalwareScan",
+  "title": "Initiate a Defender for Storage malware scan for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/readme.md
+++ b/specification/security/resource-manager/Microsoft.Security/Security/readme.md
@@ -210,6 +210,15 @@ input-file:
   - preview/2025-10-01-preview/pricings.json
 ```
 
+### Tag: package-preview-2026-01-01-preview
+
+These settings apply only when `--tag=package-preview-2026-01-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-01-01-preview'
+input-file:
+  - preview/2026-01-01-preview/defenderForStorageSettings.json
+```
+
 ### Tag: package-preview-2025-09-01-preview
 
 These settings apply only when `--tag=package-preview-2025-09-01-preview` is specified on the command line.
@@ -705,7 +714,7 @@ input-file:
 - preview/2023-12-01-preview/security-Automations.json
 - preview/2024-08-01-preview/securityConnectors.json
 - stable/2025-05-04/security-Assessment.json
-- preview/2025-09-01-preview/defenderForStorageSettings.json
+- preview/2026-01-01-preview/defenderForStorageSettings.json
 - preview/2025-11-01-preview/securityConnectorsDevOps.json
 - preview/2025-10-01-preview/security-Operations.json
 - stable/2017-08-01/complianceResults.json


### PR DESCRIPTION
Adds new API version **`2026-01-01-preview`** for the Microsoft.Security **DefenderForStorageSettings** APIs, introducing **on-demand malware scan filtering**: the `startMalwareScan` operation gains an optional request body (`StartMalwareScanRequest`) that lets callers scope a scan to specific blobs and files via `BlobScanFilter` / `FileScanFilter`, each supporting `Prefix` or `Exact` matching (`MatchType`).

Based on `2025-09-01-preview`. All other DefenderForStorage operations (get, create, list, getMalwareScan, cancelMalwareScan) are carried over unchanged.

Release plan: [#2226 — Microsoft Defender for Cloud (Public Preview)](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=2226).

## What's new in 2026-01-01-preview

- New optional request body on `POST .../defenderForStorageSettings/{settingName}/startMalwareScan`:
  - `StartMalwareScanRequest` → `properties.filters` (`MalwareScanFilters`)
  - `MalwareScanFilters` → `blobs` (`BlobScanFilter`), `files` (`FileScanFilter`)
  - `BlobScanFilter` → `container`, `blob`; `FileScanFilter` → `share`, `file` (all `MatchFilter`)
  - `MatchFilter` → `value` (string) + `match` (`MatchType`: `Prefix` | `Exact`)
- Authored in TypeSpec (`DefenderForStorageAPI`); swagger is TypeSpec-generated.

## Backward compatibility

- **`2025-09-01-preview/defenderForStorageSettings.json` is byte-identical to `main`.** The new request body is versioned at the parameter level (`@added(2026-01-01-preview)` on the body parameter only), so the previously shipped version is unchanged. Confirmed via diff against `main`.
- The new body parameter is optional; existing `startMalwareScan` callers that send no body are unaffected.

…ings (#43845)

* Microsoft.Security: add 2026-01-01-preview for DefenderForStorageSettings

Adds new API version 2026-01-01-preview for the DefenderForStorageSettings swagger, based on 2025-09-01-preview, introducing on-demand malware scan filtering (BlobScanFilter / FileScanFilter with container, blob, share, file match filters supporting Prefix or Exact matching).

Ports the changes from Azure/azure-rest-api-specs-pr#26426. Only the DefenderForStorageSettings surface is included in this version (privateLinks.json is intentionally excluded).

* Microsoft.Security: regenerate 2026-01-01-preview DefenderForStorageSettings from TypeSpec

Replaces the handwritten preview/2026-01-01-preview/defenderForStorageSettings.json with a TypeSpec-generated swagger, addressing the TypeSpec Requirement gate.

TypeSpec changes (DefenderForStorageAPI):
- Add v2026_01_01_preview to the Versions enum (decorated @previewVersion).
- Add new models for the malware scan filter feature (all @added on v2026_01_01_preview): MatchType, MatchFilter, ContainerFilter, BlobFilter, ShareFilter, FileFilter, BlobScanFilter, FileScanFilter, MalwareScanFilters, StartMalwareScanRequestProperties.
- Add StartMalwareScanRequest as the request body for startMalwareScan. The model itself exists in all versions, but its properties field is @added on v2026_01_01_preview, so the v2025 body schema is empty ({}) while v2026 carries the filter properties.
- Update startMalwareScan to use OptionalRequestBody = true and reference StartMalwareScanRequest, keeping a single source operation (and a single SDK method) across versions.
- Copy 2025-09-01-preview examples into the new version's examples folder; use the rich StartMalwareScan example for the v2026 filters.

Other:
- Delete preview/2026-01-01-preview/operations.json and Operations example (recent preview versions omit per-version operations.json; default tag in readme.md already references the latest operations swagger).
- Remove operations.json from the package-preview-2026-01-01-preview tag block in readme.md.

Notes:
- preview/2025-09-01-preview/defenderForStorageSettings.json is regenerated to add an optional empty body parameter to startMalwareScan and an empty StartMalwareScanRequest definition (additions only; no shape changes to existing parameters or schemas). Wire-compatible with existing clients that send no body. To be reviewed with the ARM team via the breaking- change review label flow.



* Microsoft.Security: keep 2025-09-01-preview unchanged; version startMalwareScan body

Per ARM API review feedback, 2025-09-01-preview/defenderForStorageSettings.json must remain byte-identical to main. Reworks the startMalwareScan operation so the new optional request body only appears in 2026-01-01-preview.

- Move startMalwareScan out of the DefenderForStorageSettings @armResourceOperations interface into a standalone hand-written operation (interface DefenderForStorageMalwareScan). ActionSync<> cannot version its body parameter, so the operation is hand-authored with an explicit @route.
- Mark only the `body` parameter @added(v2026_01_01_preview); the operation itself exists in all versions. Result: 2025-09-01-preview has no body (byte-identical to main); 2026-01-01-preview has the optional StartMalwareScanRequest body.
- Restore @added(v2026_01_01_preview) on the StartMalwareScanRequest model.
- @@clientLocation folds the operation into the DefenderForStorage SDK client, so there is a single startMalwareScan SDK method per version.

Verified: 2025-09-01-preview is byte-identical to main.



* Microsoft.Security: move startMalwareScan into DefenderForStorageSettings interface

Simplifies the previous standalone-interface workaround. The hand-written startMalwareScan operation now lives inside the DefenderForStorageSettings @armResourceOperations interface alongside its sibling operations, instead of a separate DefenderForStorageMalwareScan interface.

Key: the path parameters are declared inline with the same @segment/@key decorators as the DefenderForStorageSettingsOps legacy alias, and route assembly is driven by @armResourceAction (no explicit @route). This keeps the existing resourceId scope naming and avoids the path-parameter duplication that occurs when combining an explicit @route with @armResourceOperations, while still allowing @added(v2026) on the body parameter only.

Emitted swagger is unchanged from the previous commit:
- 2025-09-01-preview remains byte-identical to main (no request body).
- 2026-01-01-preview keeps the optional StartMalwareScanRequest body.

Removes the standalone interface, its explicit @route, the @operationId override, and the arm-resource-interface-requires-decorator suppression.



* Microsoft.Security: drop nullable unions on new DefenderForStorage filter props

Addresses ARM API review finding (typespec-review section 5): the seven net-new @added(v2026_01_01_preview) filter properties used T | null with a circular no-nullable suppression ("Property is x-nullable in swagger" — the swagger is generated from this TypeSpec). The service treats an explicit null identically to an omitted value, so the optional ? marker is sufficient.

Removes | null and the accompanying #suppress no-nullable on: BlobScanFilter.container/.blob, FileScanFilter.share/.file, MalwareScanFilters.blobs/.files, StartMalwareScanRequestProperties.filters. This also removes the non-standard x-nullable: true from the generated 2026-01-01-preview swagger for these properties, simplifying SDK codegen.

2025-09-01-preview remains byte-identical to main.



* Microsoft.Security: drop empty DefenderForStorage filter wrapper models

Addresses ARM API review finding (typespec-review section 4.1): the four @added(v2026_01_01_preview) wrapper models ContainerFilter, BlobFilter, ShareFilter and FileFilter were empty xtends MatchFilter {} subtypes, each suppressing composition-over-inheritance and no-empty-model with the inaccurate reason "Wrapper subtype matches existing swagger allOf pattern" (these models are new in this PR, so there is no existing swagger pattern to match).

Removes the four empty models and points the container/blob/share/file properties on BlobScanFilter and FileScanFilter directly at MatchFilter. Property names are unchanged; only the referenced type is now the shared MatchFilter. The service applies no type-specific filter behavior, so a single shared type is sufficient, and an optional type-specific field can still be introduced later in a future version without a breaking change.

2025-09-01-preview remains byte-identical to main.



* Microsoft.Security: clarify DefenderForStorage scan filter empty-request behavior

Addresses ARM API review suggestion (typespec-review section 5): the BlobScanFilter and FileScanFilter docs stated "at least one of ... must be specified", but that constraint is not expressible in the OpenAPI schema (both members are optional). Adds a one-line note to each model that a request with neither member specified is rejected by the service, so SDK/API consumers are not surprised by a 400.

2025-09-01-preview remains byte-identical to main.



* Microsoft.Security: fix StartMalwareScan example body parameter key

The StartMalwareScan example keyed the request body as "startMalwareScanRequest", but the operation's body parameter is named "body". Since x-ms-examples bind by the swagger parameter name and the body is optional, the mismatch caused the filter payload to be silently ignored by model validation, so the new 2026-01-01-preview scan-filter feature was never actually exercised.

Renames the example key to "body" so ModelValidation validates the filter payload. Found by a local ARM API Reviewer pass.

2025-09-01-preview remains byte-identical to main.



---------

# ARM (Control Plane) API Specification Update Pull Request 

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## Purpose of this PR

What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

  - [ ] New resource provider.
  - [x] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
  - [ ] Other, please clarify:
    - _edit this with your clarification_

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://aka.ms/azurerpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## Additional information

<details>
<summary> Viewing API changes</summary>

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

</details>
<details>
<summary>Suppressing failures</summary>

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[suppressions guide](https://aka.ms/azsdk/pr-suppressions) to get approval.

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom. Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- For help with ARM review (PR workflow diagram Step 2), see https://aka.ms/azsdk/pr-arm-review.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
- For guidance on SDK breaking change review, refer to https://aka.ms/ci-fix.
