### PR TITLE
Fix Private Traffic Manager example consistency

### DIFF
--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name",
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint",
     "resource": {
       "properties": {
         "target": "10.0.0.1",
@@ -49,7 +49,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Get_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint"
   },
   "responses": {
     "200": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_ListByParent_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "200": {
@@ -36,7 +36,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/aqavgl"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/endpoints?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Endpoints_Update_MaximumSet_Gen.json
@@ -48,7 +48,7 @@
     },
     "202": {
       "headers": {
-        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_CreateOrUpdate_MaximumSet_Gen.json
@@ -51,7 +51,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "healthPolicyName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "healthPolicyName": "myHealthPolicy"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/HealthPolicies_ListByParent_MaximumSet_Gen.json
@@ -37,7 +37,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/healthPolicies?api-version=2026-02-09-preview&$skipToken=token"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/healthPolicies?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Operations_List_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Operations_List_MaximumSet_Gen.json
@@ -21,7 +21,7 @@
             "actionType": "Internal"
           }
         ],
-        "nextLink": "https://microsoft.com/abzeqnrc"
+        "nextLink": "https://management.azure.com/providers/Microsoft.Network/operations?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway",
     "resource": {
       "properties": {
@@ -16,27 +16,43 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     },
     "201": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Provisioning"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Get_MaximumSet_Gen.json
@@ -5,18 +5,26 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_ListByParent_MaximumSet_Gen.json
@@ -5,22 +5,31 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+            "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
             "name": "myProbingGateway",
             "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
             "properties": {
               "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
               "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-02-18T10:05:58.138Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-02-18T10:05:58.139Z"
             }
           }
-        ]
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/ProfileProbingGateways_Update_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway",
     "properties": {
       "properties": {
@@ -16,18 +16,26 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     },
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
+    "privateTrafficManagerProfileName": "myProfile",
     "resource": {
       "properties": {
         "customTopologyMapMode": "Disabled",
@@ -83,7 +83,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_Delete_MaximumSet_Gen.json
@@ -5,12 +5,12 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_ListByResourceGroup_MaximumSet_Gen.json
@@ -53,7 +53,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/amtg"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_ListBySubscription_MaximumSet_Gen.json
@@ -52,7 +52,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/amtg"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/privateTrafficManagerProfiles?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Profiles_Update_MaximumSet_Gen.json
@@ -82,7 +82,7 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview",
         "Location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile?api-version=2026-02-09-preview",
         "Retry-After": "10"
       }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name",
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite",
     "resource": {
       "properties": {
         "probingGatewayIds": [
@@ -45,7 +45,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name"
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Get_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name"
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite"
   },
   "responses": {
     "200": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_ListByParent_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "200": {
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/abatryei"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps/myTopologyMap/sites?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/Sites_Update_MaximumSet_Gen.json
@@ -47,7 +47,7 @@
     },
     "202": {
       "headers": {
-        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
+    "topologyMapName": "myTopologyMap",
     "resource": {
       "properties": {
         "sites": [
@@ -17,10 +17,11 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            }
+            },
+            "name": "mySite"
           }
         ],
-        "catchAllSiteName": "defaultSite"
+        "catchAllSiteName": "mySite"
       },
       "tags": {
         "environment": "production"
@@ -56,7 +57,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {
@@ -78,7 +79,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {
@@ -106,7 +107,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -17,8 +17,7 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            },
-            "name": "mySite"
+            }
           }
         ],
         "catchAllSiteName": "mySite"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -10,6 +10,7 @@
       "properties": {
         "sites": [
           {
+            "name": "mySite",
             "properties": {
               "probingGatewayIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/probingGateways/myProbingGateway"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Delete_MaximumSet_Gen.json
@@ -5,12 +5,12 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Get_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "200": {
@@ -35,7 +35,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_ListByResourceGroup_MaximumSet_Gen.json
@@ -37,7 +37,7 @@
                 }
               ],
               "provisioningState": "Succeeded",
-              "catchAllSiteName": "defaultSite"
+              "catchAllSiteName": "mySite"
             },
             "tags": {
               "environment": "production"
@@ -56,7 +56,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/a"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_ListBySubscription_MaximumSet_Gen.json
@@ -36,7 +36,7 @@
                 }
               ],
               "provisioningState": "Succeeded",
-              "catchAllSiteName": "defaultSite"
+              "catchAllSiteName": "mySite"
             },
             "tags": {
               "environment": "production"
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/a"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/topologyMaps?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
@@ -17,10 +17,11 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            }
+            },
+            "name": "mySite"
           }
         ],
-        "catchAllSiteName": "updatedDefaultSite"
+        "catchAllSiteName": "mySite"
       },
       "tags": {
         "environment": "staging"
@@ -55,7 +56,7 @@
               }
             }
           ],
-          "catchAllSiteName": "updatedDefaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {
@@ -77,7 +78,7 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview",
         "Location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps/myTopologyMap?api-version=2026-02-09-preview",
         "Retry-After": "10"
       }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
@@ -17,8 +17,7 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            },
-            "name": "mySite"
+            }
           }
         ],
         "catchAllSiteName": "mySite"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/examples/2026-02-09-preview/TopologyMaps_Update_MaximumSet_Gen.json
@@ -8,18 +8,6 @@
     "topologyMapName": "myTopologyMap",
     "properties": {
       "properties": {
-        "sites": [
-          {
-            "properties": {
-              "probingGatewayIds": [
-                "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/probingGateways/myProbingGateway"
-              ],
-              "virtualNetworkIds": [
-                "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
-              ]
-            }
-          }
-        ],
         "catchAllSiteName": "mySite"
       },
       "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/Endpoint.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/Endpoint.tsp
@@ -1,10 +1,12 @@
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
+import "@typespec/http";
 import "@typespec/rest";
 import "../models/EndpointModels.tsp";
 
 using Rest;
+using TypeSpec.Http;
 using Azure.ResourceManager;
 
 namespace Microsoft.Network;
@@ -28,7 +30,14 @@ interface Endpoints {
   createOrUpdate is ArmResourceCreateOrReplaceAsync<Endpoint>;
 
   @doc("Updates a Private Traffic Manager endpoint.")
-  update is ArmResourcePatchAsync<Endpoint, EndpointProperties>;
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
+    Endpoint,
+    Azure.ResourceManager.Foundations.ResourceUpdateModel<
+      Endpoint,
+      EndpointProperties
+    >
+  >;
 
   @doc("Deletes a Private Traffic Manager endpoint.")
   delete is ArmResourceDeleteWithoutOkAsync<Endpoint>;

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/ProbingGateway.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/ProbingGateway.tsp
@@ -1,10 +1,12 @@
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/http";
 import "@typespec/rest";
 import "../models/ProbingGatewayModels.tsp";
 import "./Profile.tsp";
 
 using Azure.ResourceManager;
+using TypeSpec.Http;
 using TypeSpec.Rest;
 
 namespace Microsoft.Network;
@@ -36,9 +38,13 @@ interface ProfileProbingGateways {
   createOrUpdate is ArmResourceCreateOrReplaceAsync<ProfileProbingGateway>;
 
   @doc("Updates a probing gateway association with a Private Traffic Manager profile. Only available when the parent profile has `customTopologyMapMode` set to `Disabled`.")
-  update is ArmResourcePatchAsync<
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
     ProfileProbingGateway,
-    ProfileProbingGatewayProperties
+    Azure.ResourceManager.Foundations.ResourceUpdateModel<
+      ProfileProbingGateway,
+      ProfileProbingGatewayProperties
+    >
   >;
 
   @doc("Deletes a probing gateway association from a Private Traffic Manager profile. Only available when the parent profile has `customTopologyMapMode` set to `Disabled`.")

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/Site.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/Site.tsp
@@ -1,10 +1,12 @@
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
+import "@typespec/http";
 import "@typespec/rest";
 import "../models/SiteModels.tsp";
 
 using Rest;
+using TypeSpec.Http;
 using Azure.ResourceManager;
 
 namespace Microsoft.Network;
@@ -26,7 +28,11 @@ interface Sites {
   createOrUpdate is ArmResourceCreateOrReplaceAsync<Site>;
 
   @doc("Updates a Site.")
-  update is ArmResourcePatchAsync<Site, SiteProperties>;
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
+    Site,
+    Azure.ResourceManager.Foundations.ResourceUpdateModel<Site, SiteProperties>
+  >;
 
   @doc("Deletes a Site.")
   delete is ArmResourceDeleteWithoutOkAsync<Site>;

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/TopologyMap.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/interfaces/TopologyMap.tsp
@@ -30,13 +30,7 @@ interface TopologyMaps {
 
   @doc("Updates a Topology Map.")
   @patch(#{ implicitOptionality: false })
-  update is ArmCustomPatchAsync<
-    TopologyMap,
-    Azure.ResourceManager.Foundations.ResourceUpdateModel<
-      TopologyMap,
-      TopologyMapProperties
-    >
-  >;
+  update is ArmCustomPatchAsync<TopologyMap, TopologyMapPatch>;
 
   @doc("Deletes a Topology Map.")
   delete is ArmResourceDeleteWithoutOkAsync<TopologyMap>;

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/models/HealthPolicyModels.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/models/HealthPolicyModels.tsp
@@ -40,7 +40,7 @@ model ProbeConfig {
   @doc("The path relative to the endpoint domain name used to probe for endpoint health.")
   path?: string;
 
-  @doc("The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile. Allowed values: 5, 10, or 30 seconds.")
+  @doc("The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile. Allowed values: 10 or 30 seconds.")
   intervalInSeconds?: int64;
 
   @doc("The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check.")

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/models/TopologyMapModels.tsp
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/models/TopologyMapModels.tsp
@@ -28,7 +28,7 @@ union ProvisioningState {
 @doc("Class representing the Topology Map properties.")
 model TopologyMapProperties {
   @doc("The list of Sites in the Topology Map.")
-  sites?: Site[];
+  sites?: TopologyMapInlineSite[];
 
   @doc("The Name of the CatchAll site. There is only one CatchAll site in a TopologyMap")
   catchAllSiteName?: string;
@@ -36,4 +36,26 @@ model TopologyMapProperties {
   @doc("The provisioning state of the TopologyMap resource.")
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
+}
+
+@doc("A Site embedded in a Topology Map.")
+model TopologyMapInlineSite {
+  ...OmitProperties<Site, "name">;
+
+  @doc("The name of the Site.")
+  name: string;
+}
+
+@doc("The properties of a Topology Map that can be updated.")
+model TopologyMapPatchProperties {
+  @doc("The Name of the CatchAll site. There is only one CatchAll site in a TopologyMap")
+  catchAllSiteName?: string;
+}
+
+@doc("The type used for update operations of the Topology Map.")
+model TopologyMapPatch {
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+
+  @doc("The properties of the Topology Map that can be updated.")
+  properties?: TopologyMapPatchProperties;
 }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name",
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint",
     "resource": {
       "properties": {
         "target": "10.0.0.1",
@@ -49,7 +49,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Get_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "endpointName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "endpointName": "myEndpoint"
   },
   "responses": {
     "200": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_ListByParent_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "200": {
@@ -36,7 +36,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/aqavgl"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/endpoints?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Endpoints_Update_MaximumSet_Gen.json
@@ -48,7 +48,7 @@
     },
     "202": {
       "headers": {
-        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_CreateOrUpdate_MaximumSet_Gen.json
@@ -51,7 +51,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
-    "healthPolicyName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile",
+    "healthPolicyName": "myHealthPolicy"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/HealthPolicies_ListByParent_MaximumSet_Gen.json
@@ -37,7 +37,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/healthPolicies?api-version=2026-02-09-preview&$skipToken=token"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/healthPolicies?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Operations_List_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Operations_List_MaximumSet_Gen.json
@@ -21,7 +21,7 @@
             "actionType": "Internal"
           }
         ],
-        "nextLink": "https://microsoft.com/abzeqnrc"
+        "nextLink": "https://management.azure.com/providers/Microsoft.Network/operations?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway",
     "resource": {
       "properties": {
@@ -16,27 +16,43 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     },
     "201": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Provisioning"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Get_MaximumSet_Gen.json
@@ -5,18 +5,26 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_ListByParent_MaximumSet_Gen.json
@@ -5,22 +5,31 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+            "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
             "name": "myProbingGateway",
             "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
             "properties": {
               "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
               "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-02-18T10:05:58.138Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-02-18T10:05:58.139Z"
             }
           }
-        ]
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/ProfileProbingGateways_Update_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-profile",
+    "privateTrafficManagerProfileName": "myProfile",
     "profileProbingGatewayName": "myProbingGateway",
     "properties": {
       "properties": {
@@ -16,18 +16,26 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/my-profile/probingGateways/myProbingGateway",
+        "id": "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile/probingGateways/myProbingGateway",
         "name": "myProbingGateway",
         "type": "Microsoft.Network/privateTrafficManagerProfiles/probingGateways",
         "properties": {
           "probingGatewayId": "/subscriptions/A1B2C3D4-E5F6-7890-ABCD-1234567890EF/resourceGroups/rgProbingInfra/providers/Microsoft.Network/probingGateways/pgw-westus-001",
           "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-02-18T10:05:58.138Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-02-18T10:05:58.139Z"
         }
       }
     },
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name",
+    "privateTrafficManagerProfileName": "myProfile",
     "resource": {
       "properties": {
         "customTopologyMapMode": "Disabled",
@@ -83,7 +83,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_Delete_MaximumSet_Gen.json
@@ -5,12 +5,12 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "privateTrafficManagerProfileName": "my-resource-name"
+    "privateTrafficManagerProfileName": "myProfile"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_ListByResourceGroup_MaximumSet_Gen.json
@@ -53,7 +53,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/amtg"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_ListBySubscription_MaximumSet_Gen.json
@@ -52,7 +52,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/amtg"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/privateTrafficManagerProfiles?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Profiles_Update_MaximumSet_Gen.json
@@ -82,7 +82,7 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview",
         "Location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/privateTrafficManagerProfiles/myProfile?api-version=2026-02-09-preview",
         "Retry-After": "10"
       }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name",
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite",
     "resource": {
       "properties": {
         "probingGatewayIds": [
@@ -45,7 +45,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Delete_MaximumSet_Gen.json
@@ -5,13 +5,13 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name"
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Get_MaximumSet_Gen.json
@@ -5,8 +5,8 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
-    "siteName": "my-resource-name"
+    "topologyMapName": "myTopologyMap",
+    "siteName": "mySite"
   },
   "responses": {
     "200": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_ListByParent_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_ListByParent_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "200": {
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/abatryei"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps/myTopologyMap/sites?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/Sites_Update_MaximumSet_Gen.json
@@ -47,7 +47,7 @@
     },
     "202": {
       "headers": {
-        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name",
+    "topologyMapName": "myTopologyMap",
     "resource": {
       "properties": {
         "sites": [
@@ -17,10 +17,11 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            }
+            },
+            "name": "mySite"
           }
         ],
-        "catchAllSiteName": "defaultSite"
+        "catchAllSiteName": "mySite"
       },
       "tags": {
         "environment": "production"
@@ -56,7 +57,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {
@@ -78,7 +79,7 @@
     },
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       },
       "body": {
         "properties": {
@@ -106,7 +107,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -17,8 +17,7 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            },
-            "name": "mySite"
+            }
           }
         ],
         "catchAllSiteName": "mySite"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_CreateOrUpdate_MaximumSet_Gen.json
@@ -10,6 +10,7 @@
       "properties": {
         "sites": [
           {
+            "name": "mySite",
             "properties": {
               "probingGatewayIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/probingGateways/myProbingGateway"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Delete_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Delete_MaximumSet_Gen.json
@@ -5,12 +5,12 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "202": {
       "headers": {
-        "location": "https://contoso.com/operationstatus"
+        "location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview"
       }
     },
     "204": {}

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Get_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Get_MaximumSet_Gen.json
@@ -5,7 +5,7 @@
     "api-version": "2026-02-09-preview",
     "subscriptionId": "10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA",
     "resourceGroupName": "rgprivateTrafficManager",
-    "topologyMapName": "my-resource-name"
+    "topologyMapName": "myTopologyMap"
   },
   "responses": {
     "200": {
@@ -35,7 +35,7 @@
               }
             }
           ],
-          "catchAllSiteName": "defaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_ListByResourceGroup_MaximumSet_Gen.json
@@ -37,7 +37,7 @@
                 }
               ],
               "provisioningState": "Succeeded",
-              "catchAllSiteName": "defaultSite"
+              "catchAllSiteName": "mySite"
             },
             "tags": {
               "environment": "production"
@@ -56,7 +56,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/a"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_ListBySubscription_MaximumSet_Gen.json
@@ -36,7 +36,7 @@
                 }
               ],
               "provisioningState": "Succeeded",
-              "catchAllSiteName": "defaultSite"
+              "catchAllSiteName": "mySite"
             },
             "tags": {
               "environment": "production"
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": "https://microsoft.com/a"
+        "nextLink": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/topologyMaps?api-version=2026-02-09-preview&$skipToken=eyJuZXh0UGFnZSI6IjIifQ"
       }
     }
   }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
@@ -17,10 +17,11 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            }
+            },
+            "name": "mySite"
           }
         ],
-        "catchAllSiteName": "updatedDefaultSite"
+        "catchAllSiteName": "mySite"
       },
       "tags": {
         "environment": "staging"
@@ -55,7 +56,7 @@
               }
             }
           ],
-          "catchAllSiteName": "updatedDefaultSite",
+          "catchAllSiteName": "mySite",
           "provisioningState": "Succeeded"
         },
         "tags": {
@@ -77,7 +78,7 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/operationId?api-version=2026-02-09-preview",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/providers/Microsoft.Network/locations/eastus/operationStatuses/6d3e9f5a-1234-4a2b-9cde-0123456789ab?api-version=2026-02-09-preview",
         "Location": "https://management.azure.com/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/topologyMaps/myTopologyMap?api-version=2026-02-09-preview",
         "Retry-After": "10"
       }

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
@@ -17,8 +17,7 @@
               "virtualNetworkIds": [
                 "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
               ]
-            },
-            "name": "mySite"
+            }
           }
         ],
         "catchAllSiteName": "mySite"

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/examples/TopologyMaps_Update_MaximumSet_Gen.json
@@ -8,18 +8,6 @@
     "topologyMapName": "myTopologyMap",
     "properties": {
       "properties": {
-        "sites": [
-          {
-            "properties": {
-              "probingGatewayIds": [
-                "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/probingGateways/myProbingGateway"
-              ],
-              "virtualNetworkIds": [
-                "/subscriptions/10B6D88D-ADF4-4281-B3D0-B5A6702DEEDA/resourceGroups/rgprivateTrafficManager/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork"
-              ]
-            }
-          }
-        ],
         "catchAllSiteName": "mySite"
       },
       "tags": {

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/privateTrafficManager.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/privateTrafficManager.json
@@ -2232,9 +2232,19 @@
         "target"
       ]
     },
-    "EndpointPropertiesUpdate": {
+    "EndpointUpdate": {
       "type": "object",
-      "description": "Class representing a Traffic Manager endpoint properties.",
+      "description": "The type used for update operations of the Endpoint.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EndpointUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "EndpointUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the Endpoint.",
       "properties": {
         "target": {
           "type": "string",
@@ -2271,21 +2281,6 @@
           "description": "The health policy associated with this endpoint."
         }
       }
-    },
-    "EndpointUpdate": {
-      "type": "object",
-      "description": "Class representing a Private Traffic Manager endpoint.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/EndpointPropertiesUpdate",
-          "description": "The properties of the Private Traffic Manager endpoint."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
     },
     "EndpointsKind": {
       "type": "string",
@@ -2524,7 +2519,7 @@
         "intervalInSeconds": {
           "type": "integer",
           "format": "int64",
-          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile. Allowed values: 5, 10, or 30 seconds."
+          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile. Allowed values: 10 or 30 seconds."
         },
         "timeoutInSeconds": {
           "type": "integer",
@@ -2694,30 +2689,25 @@
         "probingGatewayId"
       ]
     },
-    "ProfileProbingGatewayPropertiesUpdate": {
+    "ProfileProbingGatewayUpdate": {
       "type": "object",
-      "description": "Properties of a probing gateway association with a Private Traffic Manager profile.",
+      "description": "The type used for update operations of the ProfileProbingGateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProfileProbingGatewayUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "ProfileProbingGatewayUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the ProfileProbingGateway.",
       "properties": {
         "probingGatewayId": {
           "$ref": "#/definitions/ProbingGatewayId",
           "description": "The ARM resource ID of the probing gateway."
         }
       }
-    },
-    "ProfileProbingGatewayUpdate": {
-      "type": "object",
-      "description": "Class representing a probing gateway associated with a Private Traffic Manager profile. This resource is only available when the parent profile has `customTopologyMapMode` set to `Disabled` (Basic experience).",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ProfileProbingGatewayPropertiesUpdate",
-          "description": "The properties of the probing gateway association."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
     },
     "ProfileProperties": {
       "type": "object",
@@ -2962,18 +2952,33 @@
     },
     "SiteUpdate": {
       "type": "object",
-      "description": "Class representing a Site.",
+      "description": "The type used for update operations of the Site.",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/SiteProperties",
-          "description": "The properties of the Site."
+          "$ref": "#/definitions/SiteUpdateProperties",
+          "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+      }
+    },
+    "SiteUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the Site.",
+      "properties": {
+        "probingGatewayIds": {
+          "type": "array",
+          "description": "The ARM resource ID of the probing gateway that can be used to monitor health as surrogate to the networks in the Site.",
+          "items": {
+            "$ref": "#/definitions/ProbingGatewayId"
+          }
+        },
+        "virtualNetworkIds": {
+          "type": "array",
+          "description": "The list of Network IDs that forms the Site.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkId"
+          }
         }
-      ]
+      }
     },
     "TopologyMap": {
       "type": "object",

--- a/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/privateTrafficManager.json
+++ b/specification/privatetrafficmanager/resource-manager/Microsoft.Network/PrivateTrafficManager/preview/2026-02-09-preview/privateTrafficManager.json
@@ -1596,7 +1596,7 @@
             "description": "The resource properties to be updated.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/TopologyMapUpdate"
+              "$ref": "#/definitions/TopologyMapPatch"
             }
           }
         ],
@@ -2084,6 +2084,10 @@
           }
         ]
       }
+    },
+    "Azure.Core.armResourceType": {
+      "type": "string",
+      "description": "Represents an Azure Resource Type."
     },
     "CustomHeader": {
       "type": "object",
@@ -3007,6 +3011,39 @@
         ]
       }
     },
+    "TopologyMapInlineSite": {
+      "type": "object",
+      "description": "A Site embedded in a Topology Map.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SiteProperties",
+          "description": "The properties of the Site."
+        },
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/Azure.Core.armResourceType",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\"",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/systemData",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Site."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "TopologyMapListResult": {
       "type": "object",
       "description": "The response of a TopologyMap list operation.",
@@ -3028,6 +3065,33 @@
         "value"
       ]
     },
+    "TopologyMapPatch": {
+      "type": "object",
+      "description": "The type used for update operations of the Topology Map.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/TopologyMapPatchProperties",
+          "description": "The properties of the Topology Map that can be updated."
+        }
+      }
+    },
+    "TopologyMapPatchProperties": {
+      "type": "object",
+      "description": "The properties of a Topology Map that can be updated.",
+      "properties": {
+        "catchAllSiteName": {
+          "type": "string",
+          "description": "The Name of the CatchAll site. There is only one CatchAll site in a TopologyMap"
+        }
+      }
+    },
     "TopologyMapProperties": {
       "type": "object",
       "description": "Class representing the Topology Map properties.",
@@ -3036,7 +3100,7 @@
           "type": "array",
           "description": "The list of Sites in the Topology Map.",
           "items": {
-            "$ref": "#/definitions/Site"
+            "$ref": "#/definitions/TopologyMapInlineSite"
           }
         },
         "catchAllSiteName": {
@@ -3047,40 +3111,6 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The provisioning state of the TopologyMap resource.",
           "readOnly": true
-        }
-      }
-    },
-    "TopologyMapUpdate": {
-      "type": "object",
-      "description": "The type used for update operations of the TopologyMap.",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "properties": {
-          "$ref": "#/definitions/TopologyMapUpdateProperties",
-          "description": "The resource-specific properties for this resource."
-        }
-      }
-    },
-    "TopologyMapUpdateProperties": {
-      "type": "object",
-      "description": "The updatable properties of the TopologyMap.",
-      "properties": {
-        "sites": {
-          "type": "array",
-          "description": "The list of Sites in the Topology Map.",
-          "items": {
-            "$ref": "#/definitions/Site"
-          }
-        },
-        "catchAllSiteName": {
-          "type": "string",
-          "description": "The Name of the CatchAll site. There is only one CatchAll site in a TopologyMap"
         }
       }
     },


### PR DESCRIPTION

Updates the Private Traffic Manager examples to:

- Use consistent `systemData` across resource responses.
- Use realistic paging and long-running operation URLs.
- Add missing `nextLink` values to paginated examples.
- Align parameter values with resource names and IDs.
- Fix topology map site and `catchAllSiteName` references.
- Use consistent PATCH operation definitions.
- Limit documented probing intervals to 10 and 30 seconds.
