### PR TITLE
[SQL MI] Add principalType to ManagedInstanceAdministrator (2025-08-01-preview)

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/ManagedInstanceAdministrators.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/ManagedInstanceAdministrators.json
@@ -325,6 +325,19 @@
           "format": "uuid",
           "description": "Tenant ID of the managed instance administrator.",
           "type": "string"
+        },
+        "principalType": {
+          "description": "Principal type of the managed instance administrator.",
+          "enum": [
+            "User",
+            "Group",
+            "Application"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ManagedInstanceAdministratorPrincipalType",
+            "modelAsString": false
+          }
         }
       }
     }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorCreate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorCreate.json
@@ -10,7 +10,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     }
   },
@@ -23,7 +24,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         },
         "type": "Microsoft.Sql/managedInstances/administrators"
       }
@@ -36,7 +38,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         },
         "type": "Microsoft.Sql/managedInstances/administrators"
       }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorGet.json
@@ -15,7 +15,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         },
         "type": "Microsoft.Sql/managedInstances/administrators"
       }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorListByInstance.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorListByInstance.json
@@ -16,7 +16,8 @@
               "administratorType": "ActiveDirectory",
               "login": "bob@contoso.com",
               "sid": "44444444-3333-2222-1111-000000000000",
-              "tenantId": "55555555-4444-3333-2222-111111111111"
+              "tenantId": "55555555-4444-3333-2222-111111111111",
+              "principalType": "User"
             },
             "type": "Microsoft.Sql/managedInstances/administrators"
           }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorUpdate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorUpdate.json
@@ -10,7 +10,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     }
   },
@@ -23,7 +24,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         },
         "type": "Microsoft.Sql/managedInstances/administrators"
       }
@@ -36,7 +38,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         },
         "type": "Microsoft.Sql/managedInstances/administrators"
       }


### PR DESCRIPTION
Adds the optional principalType property (enum: User/Group/Application, modelAsString: false) to ManagedInstanceAdministratorProperties for the Microsoft.Sql **2025-08-01-preview** API version, and updates the Get/Create/Update/ListByInstance examples to include it.

This mirrors the corresponding SQL MI Administrators change (Entra ID principal type support) and is the azure-rest-api-specs counterpart to the internal DsMainDev spec change.

- Swagger: principalType added to ManagedInstanceAdministratorProperties (optional, not in equired).
- Examples: principalType added alongside 	enantId in response/request bodies.

Targeting the current release branch elease-sql-Microsoft.Sql-2025-08-01-preview.