### PR TITLE
[SQL MI] Add principalType to ManagedInstanceAdministrator (2025-08-01-preview TypeSpec)

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorCreate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorCreate.json
@@ -8,7 +8,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     },
     "resourceGroupName": "Default-SQL-SouthEastAsia",
@@ -24,7 +25,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },
@@ -37,7 +39,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorGet.json
@@ -16,7 +16,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorListByInstance.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorListByInstance.json
@@ -17,7 +17,8 @@
               "administratorType": "ActiveDirectory",
               "login": "bob@contoso.com",
               "sid": "44444444-3333-2222-1111-000000000000",
-              "tenantId": "55555555-4444-3333-2222-111111111111"
+              "tenantId": "55555555-4444-3333-2222-111111111111",
+              "principalType": "User"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorUpdate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2025-08-01-preview/ManagedInstanceAdministratorUpdate.json
@@ -8,7 +8,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     },
     "resourceGroupName": "Default-SQL-SouthEastAsia",
@@ -24,7 +25,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },
@@ -37,7 +39,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -2280,17 +2280,17 @@ union ManagedInstanceAdministratorType {
 @added(Versions.v2025_08_01_preview)
 enum ManagedInstanceAdministratorPrincipalType {
   /**
-   * User
+   * Indicates that the principal is a user.
    */
   User,
 
   /**
-   * Group
+   * Indicates that the principal is a group.
    */
   Group,
 
   /**
-   * Application
+   * Indicates that the principal is an application.
    */
   Application,
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -2273,6 +2273,28 @@ union ManagedInstanceAdministratorType {
   ActiveDirectory: "ActiveDirectory",
 }
 
+/**
+ * Principal type of the managed instance administrator.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-enum" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_08_01_preview)
+enum ManagedInstanceAdministratorPrincipalType {
+  /**
+   * User
+   */
+  User,
+
+  /**
+   * Group
+   */
+  Group,
+
+  /**
+   * Application
+   */
+  Application,
+}
+
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 union AdministratorName {
   string,
@@ -11768,6 +11790,12 @@ model ManagedInstanceAdministratorProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/no-format" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   tenantId?: Azure.Core.uuid;
+
+  /**
+   * Principal type of the managed instance administrator.
+   */
+  @added(Versions.v2025_08_01_preview)
+  principalType?: ManagedInstanceAdministratorPrincipalType;
 }
 
 /**

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorCreate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorCreate.json
@@ -8,7 +8,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     },
     "resourceGroupName": "Default-SQL-SouthEastAsia",
@@ -24,7 +25,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },
@@ -37,7 +39,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorGet.json
@@ -16,7 +16,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorListByInstance.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorListByInstance.json
@@ -17,7 +17,8 @@
               "administratorType": "ActiveDirectory",
               "login": "bob@contoso.com",
               "sid": "44444444-3333-2222-1111-000000000000",
-              "tenantId": "55555555-4444-3333-2222-111111111111"
+              "tenantId": "55555555-4444-3333-2222-111111111111",
+              "principalType": "User"
             }
           }
         ]

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorUpdate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/examples/ManagedInstanceAdministratorUpdate.json
@@ -8,7 +8,8 @@
         "administratorType": "ActiveDirectory",
         "login": "bob@contoso.com",
         "sid": "44444444-3333-2222-1111-000000000000",
-        "tenantId": "55555555-4444-3333-2222-111111111111"
+        "tenantId": "55555555-4444-3333-2222-111111111111",
+        "principalType": "User"
       }
     },
     "resourceGroupName": "Default-SQL-SouthEastAsia",
@@ -24,7 +25,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },
@@ -37,7 +39,8 @@
           "administratorType": "ActiveDirectory",
           "login": "bob@contoso.com",
           "sid": "44444444-3333-2222-1111-000000000000",
-          "tenantId": "55555555-4444-3333-2222-111111111111"
+          "tenantId": "55555555-4444-3333-2222-111111111111",
+          "principalType": "User"
         }
       }
     },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
@@ -50946,6 +50946,36 @@
         "value"
       ]
     },
+    "ManagedInstanceAdministratorPrincipalType": {
+      "type": "string",
+      "description": "Principal type of the managed instance administrator.",
+      "enum": [
+        "User",
+        "Group",
+        "Application"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedInstanceAdministratorPrincipalType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "User",
+            "value": "User",
+            "description": "User"
+          },
+          {
+            "name": "Group",
+            "value": "Group",
+            "description": "Group"
+          },
+          {
+            "name": "Application",
+            "value": "Application",
+            "description": "Application"
+          }
+        ]
+      }
+    },
     "ManagedInstanceAdministratorProperties": {
       "type": "object",
       "description": "The properties of a managed instance administrator.",
@@ -50965,6 +50995,10 @@
         "tenantId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "Tenant ID of the managed instance administrator."
+        },
+        "principalType": {
+          "$ref": "#/definitions/ManagedInstanceAdministratorPrincipalType",
+          "description": "Principal type of the managed instance administrator."
         }
       },
       "required": [

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2025-08-01-preview/openapi.json
@@ -50961,17 +50961,17 @@
           {
             "name": "User",
             "value": "User",
-            "description": "User"
+            "description": "Indicates that the principal is a user."
           },
           {
             "name": "Group",
             "value": "Group",
-            "description": "Group"
+            "description": "Indicates that the principal is a group."
           },
           {
             "name": "Application",
             "value": "Application",
-            "description": "Application"
+            "description": "Indicates that the principal is an application."
           }
         ]
       }


### PR DESCRIPTION
Adds the optional `principalType` enum (`User`/`Group`/`Application`, `modelAsString: false`) to `ManagedInstanceAdministratorProperties` for the Microsoft.Sql **2025-08-01-preview** API version.

- `models.tsp`: new closed enum `ManagedInstanceAdministratorPrincipalType` and `principalType?` property, gated with `@added(Versions.v2025_08_01_preview)` so it only appears in 2025-08-01-preview.
- Regenerated `preview/2025-08-01-preview/openapi.json`.
- Updated Get/Create/Update/ListByInstance examples (both TypeSpec source under `examples/` and generated copies under `preview/.../examples/`).

Targets the TypeSpec release branch `release-sql-Microsoft.Sql-2025-08-01-preview-typespec`.

This supersedes the earlier swagger-only PR (#44923), which targeted the non-TypeSpec branch.