### PR TITLE
Set default tag for VoiceLive readme (unblocks LintDiff for new API versions)

### DIFF
--- a/specification/ai/data-plane/VoiceLive/readme.md
+++ b/specification/ai/data-plane/VoiceLive/readme.md
@@ -15,6 +15,7 @@ API version is controlled by the `@azure-tools/typespec-autorest` emitter in tsp
 
 ```yaml
 openapi-type: data-plane
+tag: package-2026-07-15
 ```
 
 ### Tag: package-2026-07-15


### PR DESCRIPTION
## Summary

Declares a global default `tag: package-2026-07-15` in the VoiceLive readme's `### Basic Information` block. The readme previously set only `openapi-type: data-plane` with no default tag.

## Why

Swagger **LintDiff** reads the default tag from the **target branch (`main`)** to establish a correlation baseline whenever a PR adds a *new* API-version tag. With no default tag, `getDefaultTag` returns `""` and lint-diff throws:

```
No default tag found for readme .../VoiceLive/readme.md in before state
```

before it can evaluate any rule. This blocks any PR that introduces a new tag (e.g. #44930, which adds `package-2026-07-31-preview`).

Setting the default to the latest existing tag — the GA `package-2026-07-15` — provides that baseline and matches the convention used by the majority of `data-plane` readmes (e.g. `HealthInsights`, `ImageAnalysis`).

## Scope / safety

- **Readme-only, single line.** No swagger, TypeSpec, or example files change.
- Affects only doc / apiview generation — **not** SDK code gen, which uses the TypeSpec emitter configured in `tspconfig.yaml`.
- LintDiff on this PR early-exits with *"No applicable files found in after"* because it builds its tag map only from changed `.json` swaggers, so a readme-only change is a no-op for it.

## Unblocks

#44930 — once this merges, that PR's LintDiff `before` baseline resolves and the check runs normally instead of crashing.