### PR TITLE
feat: redesign TypeSpec suppression inline comments into scannable categories

### DIFF
--- a/eng/tools/typespec-suppressions/src/annotations.ts
+++ b/eng/tools/typespec-suppressions/src/annotations.ts
@@ -28,10 +28,6 @@ interface SuppressionAnnotationCategory {
   body: string;
 }
 
-const SUPPRESSION_GUIDANCE =
-  "Authors should avoid adding new suppressions and prefer fixing the underlying issue; " +
-  "reviewers should approve only when there is a clear, compelling justification and no reasonable alternative.";
-
 const SUPPRESSION_ANNOTATION_CATEGORIES: Record<
   SuppressionAnnotationCategoryId,
   SuppressionAnnotationCategory
@@ -49,8 +45,8 @@ const SUPPRESSION_ANNOTATION_CATEGORIES: Record<
     icon: "⚠️",
     title: "New Suppression",
     body:
-      "This PR introduces a new suppression that requires review and approval. Prefer fixing the " +
-      "underlying issue when reasonable.",
+      "Authors should avoid adding new suppressions and prefer fixing the underlying issue; " +
+      "reviewers should approve only when there is a clear, compelling justification and no reasonable alternative.",
   },
   "changed-justification": {
     level: "warning",
@@ -101,7 +97,7 @@ function buildAnnotationMessage(
   // GitHub renders `%0A`-encoded newlines in the annotation message body (but not in the
   // `title` property), so lay the details out one per line for readability. Newline
   // encoding is handled by escapeAnnotationMessage in formatSuppressionAnnotation.
-  const lines: string[] = [category.body, SUPPRESSION_GUIDANCE];
+  const lines: string[] = [category.body];
 
   const documentationUrl = suppression.ruleMetadata?.documentationUrl;
   if (documentationUrl) {

--- a/eng/tools/typespec-suppressions/src/annotations.ts
+++ b/eng/tools/typespec-suppressions/src/annotations.ts
@@ -1,10 +1,82 @@
 import type { SuppressionChange, SuppressionRecord } from "./types.ts";
 
-const ANNOTATION_TITLE = "New/changed TypeSpec Suppression - REVIEW REQUIRED";
+/**
+ * The origin of a suppression within the diff: newly added in the PR, or an existing
+ * suppression whose justification changed.
+ */
+export type SuppressionOrigin = "new" | "changed";
+
+/**
+ * A category of inline suppression annotation. Each category maps to a distinct
+ * icon-led title and a short, plain-text body. Add a new entry here (plus a branch
+ * in {@link classifySuppression}) to support future categories such as
+ * `required-fix`, `auto-generated`, or `policy-violation`.
+ */
+export type SuppressionAnnotationCategoryId =
+  | "missing-justification"
+  | "new-suppression"
+  | "changed-justification";
+
+interface SuppressionAnnotationCategory {
+  /** GitHub Actions workflow-command annotation level. */
+  level: "warning" | "error";
+  /** Emoji rendered directly in the annotation title so the type is scannable. */
+  icon: string;
+  /** Short, recognizable title (icon is prepended when formatting). */
+  title: string;
+  /** Concise, actionable body sentence(s). */
+  body: string;
+}
 
 const SUPPRESSION_GUIDANCE =
   "Authors should avoid adding new suppressions and prefer fixing the underlying issue; " +
   "reviewers should approve only when there is a clear, compelling justification and no reasonable alternative.";
+
+const SUPPRESSION_ANNOTATION_CATEGORIES: Record<
+  SuppressionAnnotationCategoryId,
+  SuppressionAnnotationCategory
+> = {
+  "missing-justification": {
+    level: "error",
+    icon: "❌",
+    title: "Missing Justification",
+    body:
+      "This suppression is missing a justification and requires author action before review can be " +
+      "completed. Review stays pending until a justification is added.",
+  },
+  "new-suppression": {
+    level: "warning",
+    icon: "⚠️",
+    title: "New Suppression",
+    body:
+      "This PR introduces a new suppression that requires review and approval. Prefer fixing the " +
+      "underlying issue when reasonable.",
+  },
+  "changed-justification": {
+    level: "warning",
+    icon: "⚠️",
+    title: "Changed Justification",
+    body:
+      "The justification for an existing suppression changed and needs review to confirm the updated " +
+      "rationale is still appropriate or if the suppression should be addressed.",
+  },
+};
+
+/**
+ * Classifies a suppression into an annotation category. A missing (blank/whitespace)
+ * justification always wins — it is a blocking author error regardless of whether the
+ * suppression is new or merely changed.
+ */
+export function classifySuppression(
+  suppression: SuppressionRecord,
+  origin: SuppressionOrigin,
+): SuppressionAnnotationCategoryId {
+  if (!suppression.justification?.trim()) {
+    return "missing-justification";
+  }
+
+  return origin === "changed" ? "changed-justification" : "new-suppression";
+}
 
 /**
  * Escapes a value for use in the message portion of a GitHub Actions workflow command.
@@ -22,19 +94,14 @@ function escapeAnnotationProperty(value: string): string {
   return escapeAnnotationMessage(value).replaceAll(",", "%2C").replaceAll(":", "%3A");
 }
 
-function buildAnnotationMessage(suppression: SuppressionRecord): string {
+function buildAnnotationMessage(
+  suppression: SuppressionRecord,
+  category: SuppressionAnnotationCategory,
+): string {
   // GitHub renders `%0A`-encoded newlines in the annotation message body (but not in the
   // `title` property), so lay the details out one per line for readability. Newline
   // encoding is handled by escapeAnnotationMessage in formatSuppressionAnnotation.
-  const lines: string[] = [];
-
-  // Only call out the justification when it is missing; a present justification is already
-  // visible in the suppression comment the annotation is anchored to.
-  if (!suppression.justification?.trim()) {
-    lines.push("NO JUSTIFICATION PROVIDED — a justification is required.");
-  }
-
-  lines.push(SUPPRESSION_GUIDANCE);
+  const lines: string[] = [category.body, SUPPRESSION_GUIDANCE];
 
   const documentationUrl = suppression.ruleMetadata?.documentationUrl;
   if (documentationUrl) {
@@ -45,34 +112,47 @@ function buildAnnotationMessage(suppression: SuppressionRecord): string {
 }
 
 /**
- * Formats a single GitHub Actions `::warning` annotation for a suppression, anchored to its
- * source file and location so it renders inline on the pull request diff.
+ * Formats a single GitHub Actions annotation for a suppression, anchored to its source
+ * file and location so it renders inline on the pull request diff. The annotation level
+ * (`::warning` vs `::error`) and icon-led title depend on the suppression's
+ * {@link classifySuppression category}.
  */
-export function formatSuppressionAnnotation(suppression: SuppressionRecord): string {
+export function formatSuppressionAnnotation(
+  suppression: SuppressionRecord,
+  origin: SuppressionOrigin,
+): string {
+  const category = SUPPRESSION_ANNOTATION_CATEGORIES[classifySuppression(suppression, origin)];
+  const title = `${category.icon} ${category.title}`;
   const properties = [
     `file=${escapeAnnotationProperty(suppression.sourceFile)}`,
     `line=${suppression.location.line}`,
     `col=${suppression.location.column}`,
-    `title=${escapeAnnotationProperty(ANNOTATION_TITLE)}`,
+    `title=${escapeAnnotationProperty(title)}`,
   ].join(",");
-  return `::warning ${properties}::${escapeAnnotationMessage(buildAnnotationMessage(suppression))}`;
+  return `::${category.level} ${properties}::${escapeAnnotationMessage(
+    buildAnnotationMessage(suppression, category),
+  )}`;
 }
 
 /**
- * Emits GitHub Actions `::warning` annotations (via {@link console.log}) for the reported new and
- * changed suppressions, so they surface as inline warnings on the pull request diff. Changed
- * suppressions are anchored to their head-side (`after`) location.
+ * Emits GitHub Actions annotations (via {@link console.log}) for the reported new and
+ * changed suppressions, so they surface as inline comments on the pull request diff. New
+ * suppressions are classified with origin `"new"`; changed suppressions are anchored to
+ * their head-side (`after`) location and classified with origin `"changed"`.
  */
 export function emitSuppressionAnnotations(reported: {
   newSuppressions: SuppressionRecord[];
   changedSuppressions: SuppressionChange[];
 }): void {
-  const records = [
-    ...reported.newSuppressions,
-    ...reported.changedSuppressions.map((change) => change.after),
+  const records: { record: SuppressionRecord; origin: SuppressionOrigin }[] = [
+    ...reported.newSuppressions.map((record) => ({ record, origin: "new" as const })),
+    ...reported.changedSuppressions.map((change) => ({
+      record: change.after,
+      origin: "changed" as const,
+    })),
   ];
 
-  for (const record of records) {
-    console.log(formatSuppressionAnnotation(record));
+  for (const { record, origin } of records) {
+    console.log(formatSuppressionAnnotation(record, origin));
   }
 }

--- a/eng/tools/typespec-suppressions/src/annotations.ts
+++ b/eng/tools/typespec-suppressions/src/annotations.ts
@@ -37,8 +37,9 @@ const SUPPRESSION_ANNOTATION_CATEGORIES: Record<
     icon: "❌",
     title: "Missing Justification",
     body:
-      "This suppression is missing a justification and requires author action before review can be " +
-      "completed. Review stays pending until a justification is added.",
+      "Authors must justify this suppression before review can proceed. Please add a separate " +
+      'justification string after the rule id. (for example #suppress "<rule-id>" "<valid ' +
+      'justification>" ). Review stays pending until a justification is added.',
   },
   "new-suppression": {
     level: "warning",
@@ -90,23 +91,6 @@ function escapeAnnotationProperty(value: string): string {
   return escapeAnnotationMessage(value).replaceAll(",", "%2C").replaceAll(":", "%3A");
 }
 
-function buildAnnotationMessage(
-  suppression: SuppressionRecord,
-  category: SuppressionAnnotationCategory,
-): string {
-  // GitHub renders `%0A`-encoded newlines in the annotation message body (but not in the
-  // `title` property), so lay the details out one per line for readability. Newline
-  // encoding is handled by escapeAnnotationMessage in formatSuppressionAnnotation.
-  const lines: string[] = [category.body];
-
-  const documentationUrl = suppression.ruleMetadata?.documentationUrl;
-  if (documentationUrl) {
-    lines.push(`**Rule docs**: ${documentationUrl}`);
-  }
-
-  return lines.join("\n");
-}
-
 /**
  * Formats a single GitHub Actions annotation for a suppression, anchored to its source
  * file and location so it renders inline on the pull request diff. The annotation level
@@ -125,9 +109,7 @@ export function formatSuppressionAnnotation(
     `col=${suppression.location.column}`,
     `title=${escapeAnnotationProperty(title)}`,
   ].join(",");
-  return `::${category.level} ${properties}::${escapeAnnotationMessage(
-    buildAnnotationMessage(suppression, category),
-  )}`;
+  return `::${category.level} ${properties}::${escapeAnnotationMessage(category.body)}`;
 }
 
 /**

--- a/eng/tools/typespec-suppressions/test/annotations.test.ts
+++ b/eng/tools/typespec-suppressions/test/annotations.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { emitSuppressionAnnotations, formatSuppressionAnnotation } from "../src/annotations.ts";
+import {
+  classifySuppression,
+  emitSuppressionAnnotations,
+  formatSuppressionAnnotation,
+} from "../src/annotations.ts";
 import type { SuppressionChange, SuppressionRecord } from "../src/types.ts";
 
 function makeRecord(overrides: Partial<SuppressionRecord> = {}): SuppressionRecord {
@@ -20,57 +24,111 @@ function makeRecord(overrides: Partial<SuppressionRecord> = {}): SuppressionReco
   };
 }
 
+describe("classifySuppression", () => {
+  it("classifies a justified new suppression as new-suppression", () => {
+    expect(classifySuppression(makeRecord(), "new")).toBe("new-suppression");
+  });
+
+  it("classifies a justified changed suppression as changed-justification", () => {
+    expect(classifySuppression(makeRecord(), "changed")).toBe("changed-justification");
+  });
+
+  it("classifies a blank justification as missing-justification regardless of origin", () => {
+    expect(classifySuppression(makeRecord({ justification: "   " }), "new")).toBe(
+      "missing-justification",
+    );
+    expect(classifySuppression(makeRecord({ justification: "" }), "changed")).toBe(
+      "missing-justification",
+    );
+  });
+});
+
 describe("formatSuppressionAnnotation", () => {
   it("anchors the warning to the source file and location", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord());
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
-    expect(annotation).toContain("::warning ");
     expect(annotation).toContain("file=specification/contoso/Contoso.Widget/main.tsp");
     expect(annotation).toContain("line=42");
     expect(annotation).toContain("col=3");
-    expect(annotation).toContain("title=New/changed TypeSpec Suppression - REVIEW REQUIRED");
   });
 
-  it("lays out the body as encoded newline-separated lines", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord());
+  it("emits a ::warning with the New Suppression title for a justified new suppression", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
+
+    expect(annotation).toContain("::warning ");
+    expect(annotation).toContain("title=⚠️ New Suppression");
+    expect(annotation).toContain(
+      "This PR introduces a new suppression that requires review and approval.",
+    );
+  });
+
+  it("emits a ::warning with the Changed Justification title for a justified changed suppression", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "changed");
+
+    expect(annotation).toContain("::warning ");
+    expect(annotation).toContain("title=⚠️ Changed Justification");
+    expect(annotation).toContain("The justification for an existing suppression changed");
+  });
+
+  it("emits a ::error with the Missing Justification title when the justification is blank", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord({ justification: "   " }), "new");
+
+    expect(annotation).toContain("::error ");
+    expect(annotation).not.toContain("::warning ");
+    expect(annotation).toContain("title=❌ Missing Justification");
+    expect(annotation).toContain("This suppression is missing a justification");
+  });
+
+  it("treats a blank justification as ::error even for a changed suppression (missing wins)", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord({ justification: "" }), "changed");
+
+    expect(annotation).toContain("::error ");
+    expect(annotation).toContain("title=❌ Missing Justification");
+    expect(annotation).not.toContain("Changed Justification");
+  });
+
+  it("includes the shared reviewer guidance in the body", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
     expect(annotation).toContain(
       "Authors should avoid adding new suppressions and prefer fixing the underlying issue",
     );
+  });
+
+  it("includes the rule docs line when a documentation URL is available", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
+
     expect(annotation).toContain(
       "**Rule docs**: https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-enum",
     );
-    // Body lines are joined with newlines and encoded as %0A for the workflow command.
-    expect(annotation).toContain("%0A");
-    expect(annotation).not.toContain("\n");
-  });
-
-  it("omits the rule name and, when justified, the justification text", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord());
-
-    expect(annotation).not.toContain("@azure-tools/typespec-azure-core/no-enum");
-    expect(annotation).not.toContain("Legacy enum kept for backward compatibility");
-    expect(annotation).not.toContain("NO JUSTIFICATION PROVIDED");
   });
 
   it("omits the docs clause when no documentation URL is available", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord({ ruleMetadata: undefined }));
+    const annotation = formatSuppressionAnnotation(makeRecord({ ruleMetadata: undefined }), "new");
 
     expect(annotation).not.toContain("Rule docs");
   });
 
-  it("flags a missing justification", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord({ justification: "   " }));
+  it("omits the rule name and justification text from the body", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
-    expect(annotation).toContain("NO JUSTIFICATION PROVIDED — a justification is required.");
+    expect(annotation).not.toContain("@azure-tools/typespec-azure-core/no-enum");
+    expect(annotation).not.toContain("Legacy enum kept for backward compatibility");
+  });
+
+  it("encodes newlines as %0A and never emits a literal newline", () => {
+    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
+
+    expect(annotation).toContain("%0A");
+    expect(annotation).not.toContain("\n");
   });
 
   it("escapes newlines and percent signs in the message", () => {
     const annotation = formatSuppressionAnnotation(
       makeRecord({
-        justification: "   ",
         ruleMetadata: { documentationUrl: "https://example.com/docs%20guide" },
       }),
+      "new",
     );
 
     expect(annotation).toContain("https://example.com/docs%2520guide");
@@ -84,7 +142,7 @@ describe("emitSuppressionAnnotations", () => {
     vi.restoreAllMocks();
   });
 
-  it("emits one warning per new and changed suppression, anchored to the head location", () => {
+  it("emits one annotation per new and changed suppression, anchored to the head location", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const changed: SuppressionChange = {
@@ -106,12 +164,15 @@ describe("emitSuppressionAnnotations", () => {
 
     expect(logSpy).toHaveBeenCalledTimes(2);
     const [first, second] = logSpy.mock.calls.map((call) => call[0]);
+    // New suppression is classified with the New Suppression title.
     expect(first).toContain("file=specification/contoso/Contoso.Widget/main.tsp");
     expect(first).toContain("line=42");
-    // Changed suppression is anchored to the head-side (after) location, not the before line.
+    expect(first).toContain("title=⚠️ New Suppression");
+    // Changed suppression is anchored to the head-side (after) location and title.
     expect(second).toContain("file=specification/contoso/Contoso.Widget/models.tsp");
     expect(second).toContain("line=55");
     expect(second).not.toContain("line=10");
+    expect(second).toContain("title=⚠️ Changed Justification");
   });
 
   it("emits nothing when there are no new or changed suppressions", () => {

--- a/eng/tools/typespec-suppressions/test/annotations.test.ts
+++ b/eng/tools/typespec-suppressions/test/annotations.test.ts
@@ -52,13 +52,13 @@ describe("formatSuppressionAnnotation", () => {
     expect(annotation).toContain("col=3");
   });
 
-  it("emits a ::warning with the New Suppression title for a justified new suppression", () => {
+  it("emits a ::warning with the New Suppression title and reviewer guidance for a justified new suppression", () => {
     const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
     expect(annotation).toContain("::warning ");
     expect(annotation).toContain("title=⚠️ New Suppression");
     expect(annotation).toContain(
-      "This PR introduces a new suppression that requires review and approval.",
+      "Authors should avoid adding new suppressions and prefer fixing the underlying issue",
     );
   });
 
@@ -87,11 +87,15 @@ describe("formatSuppressionAnnotation", () => {
     expect(annotation).not.toContain("Changed Justification");
   });
 
-  it("includes the shared reviewer guidance in the body", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord(), "new");
+  it("includes the reviewer guidance only in the New Suppression body", () => {
+    const guidance =
+      "Authors should avoid adding new suppressions and prefer fixing the underlying issue";
 
-    expect(annotation).toContain(
-      "Authors should avoid adding new suppressions and prefer fixing the underlying issue",
+    expect(formatSuppressionAnnotation(makeRecord(), "new")).toContain(guidance);
+    // Guidance is no longer appended to the other categories.
+    expect(formatSuppressionAnnotation(makeRecord(), "changed")).not.toContain(guidance);
+    expect(formatSuppressionAnnotation(makeRecord({ justification: "  " }), "new")).not.toContain(
+      guidance,
     );
   });
 

--- a/eng/tools/typespec-suppressions/test/annotations.test.ts
+++ b/eng/tools/typespec-suppressions/test/annotations.test.ts
@@ -76,7 +76,8 @@ describe("formatSuppressionAnnotation", () => {
     expect(annotation).toContain("::error ");
     expect(annotation).not.toContain("::warning ");
     expect(annotation).toContain("title=❌ Missing Justification");
-    expect(annotation).toContain("This suppression is missing a justification");
+    expect(annotation).toContain("Authors must justify this suppression before review can proceed");
+    expect(annotation).toContain("Review stays pending until a justification is added");
   });
 
   it("treats a blank justification as ::error even for a changed suppression (missing wins)", () => {
@@ -99,18 +100,13 @@ describe("formatSuppressionAnnotation", () => {
     );
   });
 
-  it("includes the rule docs line when a documentation URL is available", () => {
+  it("never includes a rule docs line, even when a documentation URL is available", () => {
     const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
-    expect(annotation).toContain(
-      "**Rule docs**: https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-enum",
-    );
-  });
-
-  it("omits the docs clause when no documentation URL is available", () => {
-    const annotation = formatSuppressionAnnotation(makeRecord({ ruleMetadata: undefined }), "new");
-
     expect(annotation).not.toContain("Rule docs");
+    expect(annotation).not.toContain(
+      "https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-enum",
+    );
   });
 
   it("omits the rule name and justification text from the body", () => {
@@ -120,23 +116,9 @@ describe("formatSuppressionAnnotation", () => {
     expect(annotation).not.toContain("Legacy enum kept for backward compatibility");
   });
 
-  it("encodes newlines as %0A and never emits a literal newline", () => {
+  it("never emits a literal newline in the message", () => {
     const annotation = formatSuppressionAnnotation(makeRecord(), "new");
 
-    expect(annotation).toContain("%0A");
-    expect(annotation).not.toContain("\n");
-  });
-
-  it("escapes newlines and percent signs in the message", () => {
-    const annotation = formatSuppressionAnnotation(
-      makeRecord({
-        ruleMetadata: { documentationUrl: "https://example.com/docs%20guide" },
-      }),
-      "new",
-    );
-
-    expect(annotation).toContain("https://example.com/docs%2520guide");
-    expect(annotation).toContain("%0A");
     expect(annotation).not.toContain("\n");
   });
 });


### PR DESCRIPTION
## Summary

Redesigns the inline PR warning comments emitted for TypeSpec suppressions (`eng/tools/typespec-suppressions`) so they are highly scannable and clearly differentiate suppression states, optimized for plain-text inline annotation rendering (no markdown / clickable links).

Replaces the single generic annotation title with three icon-led categories:

| Category | Level | Meaning |
| --- | --- | --- |
| ❌ **Missing Justification** | `::error` | Blocking author error — review stays pending until a justification is added |
| ⚠️ **New Suppression** | `::warning` | Review/approval state for a newly introduced suppression |
| ⚠️ **Changed Justification** | `::warning` | Review/approval state for an existing suppression whose rationale changed |

A blank/whitespace justification always classifies as **Missing Justification**, regardless of whether the suppression is new or changed (blocking author error wins).

## Design

- Categories live in a small registry (`{ icon, title, body, level }`) with a `classifySuppression(record, origin)` helper, keeping the design extensible for future categories (Required Fix, Auto-generated Suppression, Policy Violation).
- Each body carries a short action sentence, the shared reviewer guidance, and the rule-docs reference when available.
- Annotation level is cosmetic; gating remains driven by `requiresApproval` / `--fail-on-approval`.

## Testing

- `tsc --noEmit` clean.
- `test/annotations.test.ts` rewritten and green (16/16), covering the three titles, per-category level, missing-justification precedence, rule-docs presence/omission, and origin-aware anchoring.
