### PR TITLE
CognitiveServices: add modelProviderData to deployment properties

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/PutDeploymentWithModelProviderData.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/PutDeploymentWithModelProviderData.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "Deployments_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-05-15-preview",
+    "deployment": {
+      "properties": {
+        "model": {
+          "name": "claude-sonnet-5",
+          "format": "Anthropic"
+        },
+        "modelProviderData": {
+          "organizationName": "Contoso, Ltd.",
+          "countryCode": "US",
+          "industry": "technology"
+        }
+      },
+      "sku": {
+        "name": "GlobalStandard",
+        "capacity": 25
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutDeploymentWithModelProviderData",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "model": {
+            "name": "claude-sonnet-5",
+            "format": "Anthropic"
+          },
+          "modelProviderData": {
+            "organizationName": "Contoso, Ltd.",
+            "countryCode": "US",
+            "industry": "technology"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "GlobalStandard",
+          "capacity": 25
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "model": {
+            "name": "claude-sonnet-5",
+            "format": "Anthropic"
+          },
+          "modelProviderData": {
+            "organizationName": "Contoso, Ltd.",
+            "countryCode": "US",
+            "industry": "technology"
+          },
+          "provisioningState": "Accepted"
+        },
+        "sku": {
+          "name": "GlobalStandard",
+          "capacity": 25
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -3166,6 +3166,88 @@ model DeploymentProperties {
    * Routing configuration for the model-router deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, quality, cost) for routing across all supported models or the model subset.
    */
   routing?: DeploymentRouting;
+
+  /**
+   * Attestation data about the organization deploying the model, forwarded to the model provider. This property is required when deploying partner models whose 'model.format' is 'Anthropic', and is ignored for all other model formats. Omitting it for an Anthropic deployment causes the deployment to fail during provisioning with an 'AnthropicOrganizationCreationFailed' error.
+   */
+  @added(Versions.v2026_05_15_preview)
+  modelProviderData?: ModelProviderData;
+}
+
+/**
+ * Industry of the organization deploying a partner model. Values are lowercase.
+ */
+@added(Versions.v2026_05_15_preview)
+union ModelProviderIndustry {
+  string,
+
+  /**
+   * Technology sector organization.
+   */
+  Technology: "technology",
+
+  /**
+   * Financial services sector organization.
+   */
+  Finance: "finance",
+
+  /**
+   * Healthcare sector organization.
+   */
+  Healthcare: "healthcare",
+
+  /**
+   * Education sector organization.
+   */
+  Education: "education",
+
+  /**
+   * Retail sector organization.
+   */
+  Retail: "retail",
+
+  /**
+   * Manufacturing sector organization.
+   */
+  Manufacturing: "manufacturing",
+
+  /**
+   * Government sector organization.
+   */
+  Government: "government",
+
+  /**
+   * Media sector organization.
+   */
+  Media: "media",
+
+  /**
+   * An industry not covered by the other values.
+   */
+  Other: "other",
+}
+
+/**
+ * Attestation data about the organization deploying a partner model, forwarded to the model provider when the deployment is created.
+ */
+@added(Versions.v2026_05_15_preview)
+model ModelProviderData {
+  /**
+   * Legal entity name of the organization deploying the model.
+   */
+  organizationName: string;
+
+  /**
+   * Country of the organization deploying the model, as a two-letter ISO 3166-1 alpha-2 code.
+   */
+  @minLength(2)
+  @maxLength(2)
+  countryCode: string;
+
+  /**
+   * Industry of the organization deploying the model.
+   */
+  industry: ModelProviderIndustry;
 }
 
 /**

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -3855,6 +3855,9 @@
           "PutDeployment": {
             "$ref": "./examples/PutDeployment.json"
           },
+          "PutDeploymentWithModelProviderData": {
+            "$ref": "./examples/PutDeploymentWithModelProviderData.json"
+          },
           "PutDeploymentWithSpeculativeDecoding": {
             "$ref": "./examples/PutDeploymentWithSpeculativeDecoding.json"
           }
@@ -15069,6 +15072,10 @@
         "routing": {
           "$ref": "#/definitions/DeploymentRouting",
           "description": "Routing configuration for the model-router deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, quality, cost) for routing across all supported models or the model subset."
+        },
+        "modelProviderData": {
+          "$ref": "#/definitions/ModelProviderData",
+          "description": "Attestation data about the organization deploying the model, forwarded to the model provider. This property is required when deploying partner models whose 'model.format' is 'Anthropic', and is ignored for all other model formats. Omitting it for an Anthropic deployment causes the deployment to fail during provisioning with an 'AnthropicOrganizationCreationFailed' error."
         }
       }
     },
@@ -16795,6 +16802,97 @@
             "/model/version"
           ]
         }
+      }
+    },
+    "ModelProviderData": {
+      "type": "object",
+      "description": "Attestation data about the organization deploying a partner model, forwarded to the model provider when the deployment is created.",
+      "properties": {
+        "organizationName": {
+          "type": "string",
+          "description": "Legal entity name of the organization deploying the model."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "Country of the organization deploying the model, as a two-letter ISO 3166-1 alpha-2 code.",
+          "minLength": 2,
+          "maxLength": 2
+        },
+        "industry": {
+          "$ref": "#/definitions/ModelProviderIndustry",
+          "description": "Industry of the organization deploying the model."
+        }
+      },
+      "required": [
+        "organizationName",
+        "countryCode",
+        "industry"
+      ]
+    },
+    "ModelProviderIndustry": {
+      "type": "string",
+      "description": "Industry of the organization deploying a partner model. Values are lowercase.",
+      "enum": [
+        "technology",
+        "finance",
+        "healthcare",
+        "education",
+        "retail",
+        "manufacturing",
+        "government",
+        "media",
+        "other"
+      ],
+      "x-ms-enum": {
+        "name": "ModelProviderIndustry",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Technology",
+            "value": "technology",
+            "description": "Technology sector organization."
+          },
+          {
+            "name": "Finance",
+            "value": "finance",
+            "description": "Financial services sector organization."
+          },
+          {
+            "name": "Healthcare",
+            "value": "healthcare",
+            "description": "Healthcare sector organization."
+          },
+          {
+            "name": "Education",
+            "value": "education",
+            "description": "Education sector organization."
+          },
+          {
+            "name": "Retail",
+            "value": "retail",
+            "description": "Retail sector organization."
+          },
+          {
+            "name": "Manufacturing",
+            "value": "manufacturing",
+            "description": "Manufacturing sector organization."
+          },
+          {
+            "name": "Government",
+            "value": "government",
+            "description": "Government sector organization."
+          },
+          {
+            "name": "Media",
+            "value": "media",
+            "description": "Media sector organization."
+          },
+          {
+            "name": "Other",
+            "value": "other",
+            "description": "An industry not covered by the other values."
+          }
+        ]
       }
     },
     "ModelSku": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/PutDeploymentWithModelProviderData.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/PutDeploymentWithModelProviderData.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "Deployments_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-05-15-preview",
+    "deployment": {
+      "properties": {
+        "model": {
+          "name": "claude-sonnet-5",
+          "format": "Anthropic"
+        },
+        "modelProviderData": {
+          "organizationName": "Contoso, Ltd.",
+          "countryCode": "US",
+          "industry": "technology"
+        }
+      },
+      "sku": {
+        "name": "GlobalStandard",
+        "capacity": 25
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutDeploymentWithModelProviderData",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "model": {
+            "name": "claude-sonnet-5",
+            "format": "Anthropic"
+          },
+          "modelProviderData": {
+            "organizationName": "Contoso, Ltd.",
+            "countryCode": "US",
+            "industry": "technology"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "GlobalStandard",
+          "capacity": 25
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "model": {
+            "name": "claude-sonnet-5",
+            "format": "Anthropic"
+          },
+          "modelProviderData": {
+            "organizationName": "Contoso, Ltd.",
+            "countryCode": "US",
+            "industry": "technology"
+          },
+          "provisioningState": "Accepted"
+        },
+        "sku": {
+          "name": "GlobalStandard",
+          "capacity": 25
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Deploying an Anthropic-format model requires a modelProviderData attestation (organizationName, countryCode, industry) that the RP uses to accept the Marketplace offer on the caller's behalf. The spec never described it, so deployments fail with AnthropicOrganizationCreationFailed and no generated client can express the property.

Shape and the nine lowercase industry values come from the Claude on Foundry documentation and the Azure-Samples/claude starter kit: https://learn.microsoft.com/azure/foundry/foundry-models/concepts/claude-models

The enum is extensible so later provider-side additions do not break existing clients.

Added to 2026-05-15-preview only. Consumers pin earlier versions, so a follow-up should backfill the rest; that touches GA and needs breaking-change review.

Unverified: whether the RP returns modelProviderData on GET. The example shows it echoed on 200/201. If it does not, this needs @visibility(Lifecycle.Create).

Addresses #43610 