### PR TITLE
Virtual Hub IPv6 and enableOnlyIPv6Peering changes

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionGet.json
@@ -11,9 +11,10 @@
       "body": {
         "name": "connection1",
         "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionList.json
@@ -13,9 +13,10 @@
           {
             "name": "connection1",
             "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
+              "enableOnlyIpv6Peering": "Disabled",
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -76,9 +77,10 @@
           {
             "name": "connection2",
             "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
+              "enableOnlyIpv6Peering": "Disabled",
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionPut.json
@@ -5,6 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
+        "enableOnlyIpv6Peering": "Disabled",
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -67,6 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -132,6 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubGet.json
@@ -15,6 +15,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.10.1.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -29,6 +30,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubList.json
@@ -15,6 +15,7 @@
             "location": "West US",
             "properties": {
               "addressPrefix": "10.10.1.0/24",
+              "addressPrefixV6": "2001:db8::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -65,6 +66,10 @@
                 "10.10.1.12",
                 "10.10.1.13"
               ],
+              "virtualRouterIpsV6": [
+                "2001:db8:0:1::5",
+                "2001:db8:0:1::4"
+              ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
               }
@@ -78,6 +83,7 @@
             "location": "East US",
             "properties": {
               "addressPrefix": "210.10.1.0/24",
+              "addressPrefixV6": "2001:db8:1::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -127,6 +133,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:1:1::5",
+                "2001:db8:1:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubListByResourceGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubListByResourceGroup.json
@@ -16,6 +16,7 @@
             "location": "West US",
             "properties": {
               "addressPrefix": "10.10.1.0/24",
+              "addressPrefixV6": "2001:db8::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -65,6 +66,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:0:1::5",
+                "2001:db8:0:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -79,6 +84,7 @@
             "location": "East US",
             "properties": {
               "addressPrefix": "210.10.1.0/24",
+              "addressPrefixV6": "2001:db8:1::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -128,6 +134,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:1:1::5",
+                "2001:db8:1:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubPut.json
@@ -8,6 +8,7 @@
       "location": "West US",
       "properties": {
         "addressPrefix": "10.168.0.0/24",
+        "addressPrefixV6": "2001:db8::/56",
         "sku": "Basic",
         "virtualWan": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -28,6 +29,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -42,6 +44,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -58,6 +64,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -72,6 +79,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/VirtualHubUpdateTags.json
@@ -21,6 +21,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "provisioningState": "Succeeded",
@@ -33,6 +34,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -23669,6 +23669,18 @@ model VirtualHubProperties {
   virtualRouterIps?: string[];
 
   /**
+   * IPv6 Address-prefix for this VirtualHub.
+   */
+  @added(Versions.v2025_09_01)
+  addressPrefixV6?: string;
+
+  /**
+   * VirtualRouter IPv6 IPs.
+   */
+  @added(Versions.v2025_09_01)
+  virtualRouterIpsV6?: string[];
+
+  /**
    * Flag to control transit for VirtualRouter hub.
    */
   allowBranchToBranchTraffic?: boolean;
@@ -24008,10 +24020,34 @@ model HubVirtualNetworkConnectionProperties {
   routingConfiguration?: RoutingConfiguration;
 
   /**
+   * Enable Only IPv6 Peering for this connection.
+   */
+  @added(Versions.v2025_09_01)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  enableOnlyIpv6Peering?: EnableOnlyIpv6PeeringState;
+
+  /**
    * The provisioning state of the hub virtual network connection resource.
    */
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
+}
+
+/**
+ * The state of IPv6 peering.
+ */
+union EnableOnlyIpv6PeeringState {
+  string,
+
+  /**
+   * IPv6 peering is enabled.
+   */
+  Enabled: "Enabled",
+
+  /**
+   * IPv6 peering is disabled.
+   */
+  Disabled: "Disabled",
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -4321,6 +4321,30 @@
         ]
       }
     },
+    "EnableOnlyIpv6PeeringState": {
+      "type": "string",
+      "description": "The state of IPv6 peering.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EnableOnlyIpv6PeeringState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "IPv6 peering is enabled."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "IPv6 peering is disabled."
+          }
+        ]
+      }
+    },
     "EndpointType": {
       "type": "string",
       "description": "The endpoint type.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionGet.json
@@ -11,9 +11,10 @@
       "body": {
         "name": "connection1",
         "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionList.json
@@ -13,9 +13,10 @@
           {
             "name": "connection1",
             "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
+              "enableOnlyIpv6Peering": "Disabled",
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -76,9 +77,10 @@
           {
             "name": "connection2",
             "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/virtualHubVnetConnections/connection2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
+              "enableOnlyIpv6Peering": "Disabled",
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionPut.json
@@ -5,6 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
+        "enableOnlyIpv6Peering": "Disabled",
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -67,6 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -132,6 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
+          "enableOnlyIpv6Peering": "Disabled",
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubGet.json
@@ -15,6 +15,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.10.1.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -29,6 +30,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubList.json
@@ -15,6 +15,7 @@
             "location": "West US",
             "properties": {
               "addressPrefix": "10.10.1.0/24",
+              "addressPrefixV6": "2001:db8::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -65,6 +66,10 @@
                 "10.10.1.12",
                 "10.10.1.13"
               ],
+              "virtualRouterIpsV6": [
+                "2001:db8:0:1::5",
+                "2001:db8:0:1::4"
+              ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
               }
@@ -78,6 +83,7 @@
             "location": "East US",
             "properties": {
               "addressPrefix": "210.10.1.0/24",
+              "addressPrefixV6": "2001:db8:1::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -127,6 +133,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:1:1::5",
+                "2001:db8:1:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubListByResourceGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubListByResourceGroup.json
@@ -16,6 +16,7 @@
             "location": "West US",
             "properties": {
               "addressPrefix": "10.10.1.0/24",
+              "addressPrefixV6": "2001:db8::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -65,6 +66,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:0:1::5",
+                "2001:db8:0:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -79,6 +84,7 @@
             "location": "East US",
             "properties": {
               "addressPrefix": "210.10.1.0/24",
+              "addressPrefixV6": "2001:db8:1::/56",
               "allowBranchToBranchTraffic": false,
               "hubRoutingPreference": "ExpressRoute",
               "preferredRoutingGateway": "ExpressRoute",
@@ -128,6 +134,10 @@
               "virtualRouterIps": [
                 "10.10.1.12",
                 "10.10.1.13"
+              ],
+              "virtualRouterIpsV6": [
+                "2001:db8:1:1::5",
+                "2001:db8:1:1::4"
               ],
               "virtualWan": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubPut.json
@@ -8,6 +8,7 @@
       "location": "West US",
       "properties": {
         "addressPrefix": "10.168.0.0/24",
+        "addressPrefixV6": "2001:db8::/56",
         "sku": "Basic",
         "virtualWan": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -28,6 +29,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -42,6 +44,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"
@@ -58,6 +64,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "preferredRoutingGateway": "ExpressRoute",
@@ -72,6 +79,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VirtualHubUpdateTags.json
@@ -21,6 +21,7 @@
         "location": "West US",
         "properties": {
           "addressPrefix": "10.168.0.0/24",
+          "addressPrefixV6": "2001:db8::/56",
           "allowBranchToBranchTraffic": false,
           "hubRoutingPreference": "ExpressRoute",
           "provisioningState": "Succeeded",
@@ -33,6 +34,10 @@
           "virtualRouterIps": [
             "10.10.1.12",
             "10.10.1.13"
+          ],
+          "virtualRouterIpsV6": [
+            "2001:db8:0:1::5",
+            "2001:db8:0:1::4"
           ],
           "virtualWan": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualWans/virtualWan1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
@@ -8540,6 +8540,14 @@
           "$ref": "#/definitions/RoutingConfiguration",
           "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
         },
+        "enableOnlyIpv6Peering": {
+          "$ref": "./common.json#/definitions/EnableOnlyIpv6PeeringState",
+          "description": "Enable Only IPv6 Peering for this connection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
         "provisioningState": {
           "$ref": "./common.json#/definitions/Common.ProvisioningState",
           "description": "The provisioning state of the hub virtual network connection resource.",
@@ -9748,6 +9756,17 @@
         "virtualRouterIps": {
           "type": "array",
           "description": "VirtualRouter IPs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "addressPrefixV6": {
+          "type": "string",
+          "description": "IPv6 Address-prefix for this VirtualHub."
+        },
+        "virtualRouterIpsV6": {
+          "type": "array",
+          "description": "VirtualRouter IPv6 IPs.",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
## Description
- Added IPv6 support fields for Virtual Hub in 2025-09-01:
  - addressPrefixV6
  - virtualRouterIpsV6
- Added enableOnlyIPv6Peering to HubVirtualNetworkConnection in 2025-09-01.
- Updated CRUD operations for VirtualHub and HubVirtualNetworkConnection to include IPv6 fields

### Updated example files
- `VirtualHubGet.json`
- `VirtualHubPut.json`
- `VirtualHubList.json`
- `VirtualHubListByResourceGroup.json`
- `VirtualHubUpdateTags.json`
- `HubVirtualNetworkConnectionGet.json`
- `HubVirtualNetworkConnectionPut.json`
- `HubVirtualNetworkConnectionList.json`

## Validation
- Prettier
- TypeSpec