### PR TITLE
Foundry: Add Microsoft 365 publish API reference

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -1,6 +1,7 @@
 import "./src/agents/routes.tsp";
 import "./src/agents-containers/routes.tsp";
 import "./src/agents-session-files/routes.tsp";
+import "./src/agents-microsoft365/routes.tsp";
 import "./src/agents-invocations/routes.tsp";
 import "./src/agents-invocations_ws/routes.tsp";
 import "./src/common/custom-types.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -57,6 +57,10 @@
       "parent": "Agents Root"
     },
     {
+      "name": "Agent Microsoft 365 Publishing",
+      "parent": "Agents Root"
+    },
+    {
       "name": "Platform APIs"
     },
     {
@@ -2637,6 +2641,226 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UpdateAgentFromManifestRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_name}/microsoft365/publish": {
+      "post": {
+        "operationId": "Microsoft365Publishing_publishAgentToMicrosoft365",
+        "summary": "Publish an agent to Microsoft 365",
+        "description": "Publishes a Foundry agent to Microsoft 365 / Microsoft Teams and returns the published title and\nTeams app ids.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to publish.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft365PublishResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft365PublishRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_name}/microsoft365/publishdefaults": {
+      "get": {
+        "operationId": "Microsoft365Publishing_getMicrosoft365PublishDefaults",
+        "summary": "Get Microsoft 365 publish defaults",
+        "description": "Returns default and previously-published values used to pre-populate a Microsoft 365 publish\nrequest for a Foundry agent.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to get publish defaults for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "publishAsDigitalWorker",
+            "in": "query",
+            "required": false,
+            "description": "When true, returns defaults for publishing the agent as an autopilot (digital worker) agent.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft365PublishDefaults"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ]
+      }
+    },
+    "/agents/{agent_name}/microsoft365/zip": {
+      "post": {
+        "operationId": "Microsoft365Publishing_getMicrosoft365AppPackage",
+        "summary": "Generate a Microsoft 365 app package",
+        "description": "Generates the Microsoft Teams app package (zip) for a Foundry agent from the supplied publish\nrequest, without publishing it. Returns the app package as `application/zip`.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to generate the app package for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated Microsoft 365 app package (Microsoft Teams app zip).",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "contentMediaType": "application/zip"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft365PublishRequest"
               }
             }
           }
@@ -26319,6 +26543,194 @@
             "MemoryStores=V1Preview"
           ]
         }
+      },
+      "Microsoft365AgenticUserTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Identifier of the agentic-user template."
+          },
+          "file": {
+            "type": "string",
+            "description": "Name of the agentic-user template file embedded in the generated app package."
+          },
+          "schemaVersion": {
+            "type": "string",
+            "description": "Schema version of the agentic-user template."
+          },
+          "agentIdentityBlueprintId": {
+            "type": "string",
+            "description": "Blueprint identity client id used for the agentic user."
+          },
+          "communicationProtocol": {
+            "type": "string",
+            "description": "Communication protocol used by the agentic user."
+          }
+        },
+        "description": "An agentic-user template describing how the agent participates as an agentic user in Microsoft 365.\nOnly used when `useAgenticUserTemplate` is true on the publish request."
+      },
+      "Microsoft365PublishDefaults": {
+        "type": "object",
+        "properties": {
+          "appPublishScope": {
+            "$ref": "#/components/schemas/Microsoft365PublishScope",
+            "description": "The publish scope."
+          },
+          "agentName": {
+            "type": "string",
+            "description": "The agent name."
+          },
+          "agentDisplayName": {
+            "type": "string",
+            "description": "The user-facing display name for the agent. Defaults to the agent name if not previously\noverridden."
+          },
+          "appRegistrationClientId": {
+            "type": "string",
+            "description": "The app-registration client id associated with the agent."
+          },
+          "appVersion": {
+            "type": "string",
+            "description": "The most recently published app version."
+          },
+          "recommendedNextAppVersion": {
+            "type": "string",
+            "description": "The recommended next app version (the most recent app version, incremented)."
+          },
+          "titleId": {
+            "type": "string",
+            "description": "The Microsoft 365 title id of the previously-published app, if any."
+          },
+          "teamsAppId": {
+            "type": "string",
+            "description": "The Microsoft Teams app id of the previously-published app, if any."
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short, one-line description shown in the Teams app listing."
+          },
+          "fullDescription": {
+            "type": "string",
+            "description": "Full description shown on the Teams app details page."
+          },
+          "developerName": {
+            "type": "string",
+            "description": "Display name of the developer / publisher."
+          },
+          "developerWebsiteUrl": {
+            "type": "string",
+            "description": "Developer / publisher website URL."
+          },
+          "privacyUrl": {
+            "type": "string",
+            "description": "Privacy policy URL."
+          },
+          "termsOfUseUrl": {
+            "type": "string",
+            "description": "Terms-of-use URL."
+          }
+        },
+        "description": "Default and previously-published values used to pre-populate a Microsoft 365 publish request for a\nFoundry agent."
+      },
+      "Microsoft365PublishRequest": {
+        "type": "object",
+        "required": [
+          "publishScope"
+        ],
+        "properties": {
+          "agentDisplayName": {
+            "type": "string",
+            "description": "Display name used as the published Teams app name. When omitted, the agent name from the route is\nused."
+          },
+          "botServiceArmId": {
+            "type": "string",
+            "description": "ARM resource id of the Azure Bot Service that fronts this agent in Microsoft Teams. Required for\nworkspaces on the default bot-based Teams backend; optional for workspaces on the API-based backend."
+          },
+          "publishAsAutopilot": {
+            "type": "boolean",
+            "description": "When true, the agent is published as an autopilot (digital worker) agent: the bot id is taken from\nthe agent's blueprint identity and the generated Teams manifest is marked as a digital worker."
+          },
+          "useAgenticUserTemplate": {
+            "type": "boolean",
+            "description": "When true, the supplied `agenticUserTemplate` is embedded in the generated Teams app package.",
+            "default": false
+          },
+          "agenticUserTemplate": {
+            "$ref": "#/components/schemas/Microsoft365AgenticUserTemplate",
+            "description": "Optional agentic-user template. Required when `useAgenticUserTemplate` is true."
+          },
+          "publishScope": {
+            "$ref": "#/components/schemas/Microsoft365PublishScope",
+            "description": "Publish scope for the Teams app."
+          },
+          "appVersion": {
+            "type": "string",
+            "description": "App version (for example `1.2.3`) written into the Teams manifest. May contain only digits and\nperiods, must not start with `0`, and must end with a digit. When omitted, a platform default is\nused."
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short, one-line description shown in the Teams app listing."
+          },
+          "fullDescription": {
+            "type": "string",
+            "description": "Full description shown on the Teams app details page."
+          },
+          "developerName": {
+            "type": "string",
+            "description": "Display name of the developer / publisher shown in the Teams app listing."
+          },
+          "developerWebsiteUrl": {
+            "type": "string",
+            "description": "Developer / publisher website URL shown in the Teams app listing. Must be an https URL."
+          },
+          "privacyUrl": {
+            "type": "string",
+            "description": "Privacy policy URL shown in the Teams app listing. Must be an http or https URL."
+          },
+          "termsOfUseUrl": {
+            "type": "string",
+            "description": "Terms-of-use URL shown in the Teams app listing."
+          },
+          "colorIconBase64": {
+            "type": "string",
+            "description": "Optional base64-encoded PNG used as the color (full-bleed) icon in the Teams app package. Must be a\n192x192 PNG (perfect square, no border or rounded corners). Max 1 MB after decode. When omitted, the\nplatform default color icon is used."
+          },
+          "outlineIconBase64": {
+            "type": "string",
+            "description": "Optional base64-encoded PNG used as the outline icon in the Teams app package. Must be a 32x32 PNG.\nMax 1 MB after decode. When omitted, the platform default outline icon is used."
+          }
+        },
+        "description": "Request body for publishing a Foundry agent to Microsoft 365 / Microsoft Teams. The agent is\nidentified by the `agent_name` in the route and resolved server-side, so the agent id, bot id, and\napp-registration id are not supplied in the body."
+      },
+      "Microsoft365PublishResponse": {
+        "type": "object",
+        "properties": {
+          "titleId": {
+            "type": "string",
+            "description": "The Microsoft 365 title id of the published app."
+          },
+          "teamsAppId": {
+            "type": "string",
+            "description": "The Microsoft Teams app id of the published app."
+          }
+        },
+        "description": "Response from publishing an agent to Microsoft 365 / Microsoft Teams."
+      },
+      "Microsoft365PublishScope": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Personal",
+              "Shared",
+              "Tenant"
+            ]
+          }
+        ],
+        "description": "The publish scope for the generated Microsoft Teams app."
       },
       "MicrosoftFabricPreviewTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -30,6 +30,8 @@ tags:
     parent: Agents Root
   - name: Agent Containers
     parent: Agents Root
+  - name: Agent Microsoft 365 Publishing
+    parent: Agents Root
   - name: Platform APIs
   - name: Datasets
     parent: Platform APIs
@@ -1792,6 +1794,152 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateAgentFromManifestRequest'
+  /agents/{agent_name}/microsoft365/publish:
+    post:
+      operationId: Microsoft365Publishing_publishAgentToMicrosoft365
+      summary: Publish an agent to Microsoft 365
+      description: |-
+        Publishes a Foundry agent to Microsoft 365 / Microsoft Teams and returns the published title and
+        Teams app ids.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to publish.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft365PublishResponse'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft365PublishRequest'
+  /agents/{agent_name}/microsoft365/publishdefaults:
+    get:
+      operationId: Microsoft365Publishing_getMicrosoft365PublishDefaults
+      summary: Get Microsoft 365 publish defaults
+      description: |-
+        Returns default and previously-published values used to pre-populate a Microsoft 365 publish
+        request for a Foundry agent.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to get publish defaults for.
+          schema:
+            type: string
+        - name: publishAsDigitalWorker
+          in: query
+          required: false
+          description: When true, returns defaults for publishing the agent as an autopilot (digital worker) agent.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft365PublishDefaults'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+  /agents/{agent_name}/microsoft365/zip:
+    post:
+      operationId: Microsoft365Publishing_getMicrosoft365AppPackage
+      summary: Generate a Microsoft 365 app package
+      description: |-
+        Generates the Microsoft Teams app package (zip) for a Foundry agent from the supplied publish
+        request, without publishing it. Returns the app package as `application/zip`.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to generate the app package for.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The generated Microsoft 365 app package (Microsoft Teams app zip).
+          content:
+            application/zip:
+              schema:
+                contentMediaType: application/zip
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft365PublishRequest'
   /agents/{agent_name}/versions:
     post:
       operationId: Agents_createAgentVersion_Agents_createAgentVersionFromCode
@@ -17971,6 +18119,165 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - MemoryStores=V1Preview
+    Microsoft365AgenticUserTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier of the agentic-user template.
+        file:
+          type: string
+          description: Name of the agentic-user template file embedded in the generated app package.
+        schemaVersion:
+          type: string
+          description: Schema version of the agentic-user template.
+        agentIdentityBlueprintId:
+          type: string
+          description: Blueprint identity client id used for the agentic user.
+        communicationProtocol:
+          type: string
+          description: Communication protocol used by the agentic user.
+      description: |-
+        An agentic-user template describing how the agent participates as an agentic user in Microsoft 365.
+        Only used when `useAgenticUserTemplate` is true on the publish request.
+    Microsoft365PublishDefaults:
+      type: object
+      properties:
+        appPublishScope:
+          $ref: '#/components/schemas/Microsoft365PublishScope'
+          description: The publish scope.
+        agentName:
+          type: string
+          description: The agent name.
+        agentDisplayName:
+          type: string
+          description: |-
+            The user-facing display name for the agent. Defaults to the agent name if not previously
+            overridden.
+        appRegistrationClientId:
+          type: string
+          description: The app-registration client id associated with the agent.
+        appVersion:
+          type: string
+          description: The most recently published app version.
+        recommendedNextAppVersion:
+          type: string
+          description: The recommended next app version (the most recent app version, incremented).
+        titleId:
+          type: string
+          description: The Microsoft 365 title id of the previously-published app, if any.
+        teamsAppId:
+          type: string
+          description: The Microsoft Teams app id of the previously-published app, if any.
+        shortDescription:
+          type: string
+          description: Short, one-line description shown in the Teams app listing.
+        fullDescription:
+          type: string
+          description: Full description shown on the Teams app details page.
+        developerName:
+          type: string
+          description: Display name of the developer / publisher.
+        developerWebsiteUrl:
+          type: string
+          description: Developer / publisher website URL.
+        privacyUrl:
+          type: string
+          description: Privacy policy URL.
+        termsOfUseUrl:
+          type: string
+          description: Terms-of-use URL.
+      description: |-
+        Default and previously-published values used to pre-populate a Microsoft 365 publish request for a
+        Foundry agent.
+    Microsoft365PublishRequest:
+      type: object
+      required:
+        - publishScope
+      properties:
+        agentDisplayName:
+          type: string
+          description: |-
+            Display name used as the published Teams app name. When omitted, the agent name from the route is
+            used.
+        botServiceArmId:
+          type: string
+          description: |-
+            ARM resource id of the Azure Bot Service that fronts this agent in Microsoft Teams. Required for
+            workspaces on the default bot-based Teams backend; optional for workspaces on the API-based backend.
+        publishAsAutopilot:
+          type: boolean
+          description: |-
+            When true, the agent is published as an autopilot (digital worker) agent: the bot id is taken from
+            the agent's blueprint identity and the generated Teams manifest is marked as a digital worker.
+        useAgenticUserTemplate:
+          type: boolean
+          description: When true, the supplied `agenticUserTemplate` is embedded in the generated Teams app package.
+          default: false
+        agenticUserTemplate:
+          $ref: '#/components/schemas/Microsoft365AgenticUserTemplate'
+          description: Optional agentic-user template. Required when `useAgenticUserTemplate` is true.
+        publishScope:
+          $ref: '#/components/schemas/Microsoft365PublishScope'
+          description: Publish scope for the Teams app.
+        appVersion:
+          type: string
+          description: |-
+            App version (for example `1.2.3`) written into the Teams manifest. May contain only digits and
+            periods, must not start with `0`, and must end with a digit. When omitted, a platform default is
+            used.
+        shortDescription:
+          type: string
+          description: Short, one-line description shown in the Teams app listing.
+        fullDescription:
+          type: string
+          description: Full description shown on the Teams app details page.
+        developerName:
+          type: string
+          description: Display name of the developer / publisher shown in the Teams app listing.
+        developerWebsiteUrl:
+          type: string
+          description: Developer / publisher website URL shown in the Teams app listing. Must be an https URL.
+        privacyUrl:
+          type: string
+          description: Privacy policy URL shown in the Teams app listing. Must be an http or https URL.
+        termsOfUseUrl:
+          type: string
+          description: Terms-of-use URL shown in the Teams app listing.
+        colorIconBase64:
+          type: string
+          description: |-
+            Optional base64-encoded PNG used as the color (full-bleed) icon in the Teams app package. Must be a
+            192x192 PNG (perfect square, no border or rounded corners). Max 1 MB after decode. When omitted, the
+            platform default color icon is used.
+        outlineIconBase64:
+          type: string
+          description: |-
+            Optional base64-encoded PNG used as the outline icon in the Teams app package. Must be a 32x32 PNG.
+            Max 1 MB after decode. When omitted, the platform default outline icon is used.
+      description: |-
+        Request body for publishing a Foundry agent to Microsoft 365 / Microsoft Teams. The agent is
+        identified by the `agent_name` in the route and resolved server-side, so the agent id, bot id, and
+        app-registration id are not supplied in the body.
+    Microsoft365PublishResponse:
+      type: object
+      properties:
+        titleId:
+          type: string
+          description: The Microsoft 365 title id of the published app.
+        teamsAppId:
+          type: string
+          description: The Microsoft Teams app id of the published app.
+      description: Response from publishing an agent to Microsoft 365 / Microsoft Teams.
+    Microsoft365PublishScope:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Personal
+            - Shared
+            - Tenant
+      description: The publish scope for the generated Microsoft Teams app.
     MicrosoftFabricPreviewTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -60,6 +60,10 @@
       "parent": "Agents Root"
     },
     {
+      "name": "Agent Microsoft 365 Publishing",
+      "parent": "Agents Root"
+    },
+    {
       "name": "Platform APIs"
     },
     {
@@ -2640,6 +2644,226 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UpdateAgentFromManifestRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_name}/microsoft365/publish": {
+      "post": {
+        "operationId": "Microsoft365Publishing_publishAgentToMicrosoft365",
+        "summary": "Publish an agent to Microsoft 365",
+        "description": "Publishes a Foundry agent to Microsoft 365 / Microsoft Teams and returns the published title and\nTeams app ids.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to publish.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft365PublishResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft365PublishRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_name}/microsoft365/publishdefaults": {
+      "get": {
+        "operationId": "Microsoft365Publishing_getMicrosoft365PublishDefaults",
+        "summary": "Get Microsoft 365 publish defaults",
+        "description": "Returns default and previously-published values used to pre-populate a Microsoft 365 publish\nrequest for a Foundry agent.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to get publish defaults for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "publishAsDigitalWorker",
+            "in": "query",
+            "required": false,
+            "description": "When true, returns defaults for publishing the agent as an autopilot (digital worker) agent.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft365PublishDefaults"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ]
+      }
+    },
+    "/agents/{agent_name}/microsoft365/zip": {
+      "post": {
+        "operationId": "Microsoft365Publishing_getMicrosoft365AppPackage",
+        "summary": "Generate a Microsoft 365 app package",
+        "description": "Generates the Microsoft Teams app package (zip) for a Foundry agent from the supplied publish\nrequest, without publishing it. Returns the app package as `application/zip`.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to generate the app package for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated Microsoft 365 app package (Microsoft Teams app zip).",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "contentMediaType": "application/zip"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Microsoft 365 Publishing"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft365PublishRequest"
               }
             }
           }
@@ -30756,6 +30980,194 @@
           }
         },
         "description": "Abstract base model representing a single message in a conversation."
+      },
+      "Microsoft365AgenticUserTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Identifier of the agentic-user template."
+          },
+          "file": {
+            "type": "string",
+            "description": "Name of the agentic-user template file embedded in the generated app package."
+          },
+          "schemaVersion": {
+            "type": "string",
+            "description": "Schema version of the agentic-user template."
+          },
+          "agentIdentityBlueprintId": {
+            "type": "string",
+            "description": "Blueprint identity client id used for the agentic user."
+          },
+          "communicationProtocol": {
+            "type": "string",
+            "description": "Communication protocol used by the agentic user."
+          }
+        },
+        "description": "An agentic-user template describing how the agent participates as an agentic user in Microsoft 365.\nOnly used when `useAgenticUserTemplate` is true on the publish request."
+      },
+      "Microsoft365PublishDefaults": {
+        "type": "object",
+        "properties": {
+          "appPublishScope": {
+            "$ref": "#/components/schemas/Microsoft365PublishScope",
+            "description": "The publish scope."
+          },
+          "agentName": {
+            "type": "string",
+            "description": "The agent name."
+          },
+          "agentDisplayName": {
+            "type": "string",
+            "description": "The user-facing display name for the agent. Defaults to the agent name if not previously\noverridden."
+          },
+          "appRegistrationClientId": {
+            "type": "string",
+            "description": "The app-registration client id associated with the agent."
+          },
+          "appVersion": {
+            "type": "string",
+            "description": "The most recently published app version."
+          },
+          "recommendedNextAppVersion": {
+            "type": "string",
+            "description": "The recommended next app version (the most recent app version, incremented)."
+          },
+          "titleId": {
+            "type": "string",
+            "description": "The Microsoft 365 title id of the previously-published app, if any."
+          },
+          "teamsAppId": {
+            "type": "string",
+            "description": "The Microsoft Teams app id of the previously-published app, if any."
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short, one-line description shown in the Teams app listing."
+          },
+          "fullDescription": {
+            "type": "string",
+            "description": "Full description shown on the Teams app details page."
+          },
+          "developerName": {
+            "type": "string",
+            "description": "Display name of the developer / publisher."
+          },
+          "developerWebsiteUrl": {
+            "type": "string",
+            "description": "Developer / publisher website URL."
+          },
+          "privacyUrl": {
+            "type": "string",
+            "description": "Privacy policy URL."
+          },
+          "termsOfUseUrl": {
+            "type": "string",
+            "description": "Terms-of-use URL."
+          }
+        },
+        "description": "Default and previously-published values used to pre-populate a Microsoft 365 publish request for a\nFoundry agent."
+      },
+      "Microsoft365PublishRequest": {
+        "type": "object",
+        "required": [
+          "publishScope"
+        ],
+        "properties": {
+          "agentDisplayName": {
+            "type": "string",
+            "description": "Display name used as the published Teams app name. When omitted, the agent name from the route is\nused."
+          },
+          "botServiceArmId": {
+            "type": "string",
+            "description": "ARM resource id of the Azure Bot Service that fronts this agent in Microsoft Teams. Required for\nworkspaces on the default bot-based Teams backend; optional for workspaces on the API-based backend."
+          },
+          "publishAsAutopilot": {
+            "type": "boolean",
+            "description": "When true, the agent is published as an autopilot (digital worker) agent: the bot id is taken from\nthe agent's blueprint identity and the generated Teams manifest is marked as a digital worker."
+          },
+          "useAgenticUserTemplate": {
+            "type": "boolean",
+            "description": "When true, the supplied `agenticUserTemplate` is embedded in the generated Teams app package.",
+            "default": false
+          },
+          "agenticUserTemplate": {
+            "$ref": "#/components/schemas/Microsoft365AgenticUserTemplate",
+            "description": "Optional agentic-user template. Required when `useAgenticUserTemplate` is true."
+          },
+          "publishScope": {
+            "$ref": "#/components/schemas/Microsoft365PublishScope",
+            "description": "Publish scope for the Teams app."
+          },
+          "appVersion": {
+            "type": "string",
+            "description": "App version (for example `1.2.3`) written into the Teams manifest. May contain only digits and\nperiods, must not start with `0`, and must end with a digit. When omitted, a platform default is\nused."
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short, one-line description shown in the Teams app listing."
+          },
+          "fullDescription": {
+            "type": "string",
+            "description": "Full description shown on the Teams app details page."
+          },
+          "developerName": {
+            "type": "string",
+            "description": "Display name of the developer / publisher shown in the Teams app listing."
+          },
+          "developerWebsiteUrl": {
+            "type": "string",
+            "description": "Developer / publisher website URL shown in the Teams app listing. Must be an https URL."
+          },
+          "privacyUrl": {
+            "type": "string",
+            "description": "Privacy policy URL shown in the Teams app listing. Must be an http or https URL."
+          },
+          "termsOfUseUrl": {
+            "type": "string",
+            "description": "Terms-of-use URL shown in the Teams app listing."
+          },
+          "colorIconBase64": {
+            "type": "string",
+            "description": "Optional base64-encoded PNG used as the color (full-bleed) icon in the Teams app package. Must be a\n192x192 PNG (perfect square, no border or rounded corners). Max 1 MB after decode. When omitted, the\nplatform default color icon is used."
+          },
+          "outlineIconBase64": {
+            "type": "string",
+            "description": "Optional base64-encoded PNG used as the outline icon in the Teams app package. Must be a 32x32 PNG.\nMax 1 MB after decode. When omitted, the platform default outline icon is used."
+          }
+        },
+        "description": "Request body for publishing a Foundry agent to Microsoft 365 / Microsoft Teams. The agent is\nidentified by the `agent_name` in the route and resolved server-side, so the agent id, bot id, and\napp-registration id are not supplied in the body."
+      },
+      "Microsoft365PublishResponse": {
+        "type": "object",
+        "properties": {
+          "titleId": {
+            "type": "string",
+            "description": "The Microsoft 365 title id of the published app."
+          },
+          "teamsAppId": {
+            "type": "string",
+            "description": "The Microsoft Teams app id of the published app."
+          }
+        },
+        "description": "Response from publishing an agent to Microsoft 365 / Microsoft Teams."
+      },
+      "Microsoft365PublishScope": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Personal",
+              "Shared",
+              "Tenant"
+            ]
+          }
+        ],
+        "description": "The publish scope for the generated Microsoft Teams app."
       },
       "MicrosoftFabricPreviewTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -31,6 +31,8 @@ tags:
     parent: Agents Root
   - name: Agent Containers
     parent: Agents Root
+  - name: Agent Microsoft 365 Publishing
+    parent: Agents Root
   - name: Platform APIs
   - name: Datasets
     parent: Platform APIs
@@ -1793,6 +1795,152 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateAgentFromManifestRequest'
+  /agents/{agent_name}/microsoft365/publish:
+    post:
+      operationId: Microsoft365Publishing_publishAgentToMicrosoft365
+      summary: Publish an agent to Microsoft 365
+      description: |-
+        Publishes a Foundry agent to Microsoft 365 / Microsoft Teams and returns the published title and
+        Teams app ids.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to publish.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft365PublishResponse'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft365PublishRequest'
+  /agents/{agent_name}/microsoft365/publishdefaults:
+    get:
+      operationId: Microsoft365Publishing_getMicrosoft365PublishDefaults
+      summary: Get Microsoft 365 publish defaults
+      description: |-
+        Returns default and previously-published values used to pre-populate a Microsoft 365 publish
+        request for a Foundry agent.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to get publish defaults for.
+          schema:
+            type: string
+        - name: publishAsDigitalWorker
+          in: query
+          required: false
+          description: When true, returns defaults for publishing the agent as an autopilot (digital worker) agent.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft365PublishDefaults'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+  /agents/{agent_name}/microsoft365/zip:
+    post:
+      operationId: Microsoft365Publishing_getMicrosoft365AppPackage
+      summary: Generate a Microsoft 365 app package
+      description: |-
+        Generates the Microsoft Teams app package (zip) for a Foundry agent from the supplied publish
+        request, without publishing it. Returns the app package as `application/zip`.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to generate the app package for.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The generated Microsoft 365 app package (Microsoft Teams app zip).
+          content:
+            application/zip:
+              schema:
+                contentMediaType: application/zip
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Microsoft 365 Publishing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft365PublishRequest'
   /agents/{agent_name}/operations:
     get:
       operationId: AgentContainers_listAgentContainerOperations
@@ -21025,6 +21173,165 @@ components:
           user: '#/components/schemas/UserMessage'
           assistant: '#/components/schemas/AssistantMessage'
       description: Abstract base model representing a single message in a conversation.
+    Microsoft365AgenticUserTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier of the agentic-user template.
+        file:
+          type: string
+          description: Name of the agentic-user template file embedded in the generated app package.
+        schemaVersion:
+          type: string
+          description: Schema version of the agentic-user template.
+        agentIdentityBlueprintId:
+          type: string
+          description: Blueprint identity client id used for the agentic user.
+        communicationProtocol:
+          type: string
+          description: Communication protocol used by the agentic user.
+      description: |-
+        An agentic-user template describing how the agent participates as an agentic user in Microsoft 365.
+        Only used when `useAgenticUserTemplate` is true on the publish request.
+    Microsoft365PublishDefaults:
+      type: object
+      properties:
+        appPublishScope:
+          $ref: '#/components/schemas/Microsoft365PublishScope'
+          description: The publish scope.
+        agentName:
+          type: string
+          description: The agent name.
+        agentDisplayName:
+          type: string
+          description: |-
+            The user-facing display name for the agent. Defaults to the agent name if not previously
+            overridden.
+        appRegistrationClientId:
+          type: string
+          description: The app-registration client id associated with the agent.
+        appVersion:
+          type: string
+          description: The most recently published app version.
+        recommendedNextAppVersion:
+          type: string
+          description: The recommended next app version (the most recent app version, incremented).
+        titleId:
+          type: string
+          description: The Microsoft 365 title id of the previously-published app, if any.
+        teamsAppId:
+          type: string
+          description: The Microsoft Teams app id of the previously-published app, if any.
+        shortDescription:
+          type: string
+          description: Short, one-line description shown in the Teams app listing.
+        fullDescription:
+          type: string
+          description: Full description shown on the Teams app details page.
+        developerName:
+          type: string
+          description: Display name of the developer / publisher.
+        developerWebsiteUrl:
+          type: string
+          description: Developer / publisher website URL.
+        privacyUrl:
+          type: string
+          description: Privacy policy URL.
+        termsOfUseUrl:
+          type: string
+          description: Terms-of-use URL.
+      description: |-
+        Default and previously-published values used to pre-populate a Microsoft 365 publish request for a
+        Foundry agent.
+    Microsoft365PublishRequest:
+      type: object
+      required:
+        - publishScope
+      properties:
+        agentDisplayName:
+          type: string
+          description: |-
+            Display name used as the published Teams app name. When omitted, the agent name from the route is
+            used.
+        botServiceArmId:
+          type: string
+          description: |-
+            ARM resource id of the Azure Bot Service that fronts this agent in Microsoft Teams. Required for
+            workspaces on the default bot-based Teams backend; optional for workspaces on the API-based backend.
+        publishAsAutopilot:
+          type: boolean
+          description: |-
+            When true, the agent is published as an autopilot (digital worker) agent: the bot id is taken from
+            the agent's blueprint identity and the generated Teams manifest is marked as a digital worker.
+        useAgenticUserTemplate:
+          type: boolean
+          description: When true, the supplied `agenticUserTemplate` is embedded in the generated Teams app package.
+          default: false
+        agenticUserTemplate:
+          $ref: '#/components/schemas/Microsoft365AgenticUserTemplate'
+          description: Optional agentic-user template. Required when `useAgenticUserTemplate` is true.
+        publishScope:
+          $ref: '#/components/schemas/Microsoft365PublishScope'
+          description: Publish scope for the Teams app.
+        appVersion:
+          type: string
+          description: |-
+            App version (for example `1.2.3`) written into the Teams manifest. May contain only digits and
+            periods, must not start with `0`, and must end with a digit. When omitted, a platform default is
+            used.
+        shortDescription:
+          type: string
+          description: Short, one-line description shown in the Teams app listing.
+        fullDescription:
+          type: string
+          description: Full description shown on the Teams app details page.
+        developerName:
+          type: string
+          description: Display name of the developer / publisher shown in the Teams app listing.
+        developerWebsiteUrl:
+          type: string
+          description: Developer / publisher website URL shown in the Teams app listing. Must be an https URL.
+        privacyUrl:
+          type: string
+          description: Privacy policy URL shown in the Teams app listing. Must be an http or https URL.
+        termsOfUseUrl:
+          type: string
+          description: Terms-of-use URL shown in the Teams app listing.
+        colorIconBase64:
+          type: string
+          description: |-
+            Optional base64-encoded PNG used as the color (full-bleed) icon in the Teams app package. Must be a
+            192x192 PNG (perfect square, no border or rounded corners). Max 1 MB after decode. When omitted, the
+            platform default color icon is used.
+        outlineIconBase64:
+          type: string
+          description: |-
+            Optional base64-encoded PNG used as the outline icon in the Teams app package. Must be a 32x32 PNG.
+            Max 1 MB after decode. When omitted, the platform default outline icon is used.
+      description: |-
+        Request body for publishing a Foundry agent to Microsoft 365 / Microsoft Teams. The agent is
+        identified by the `agent_name` in the route and resolved server-side, so the agent id, bot id, and
+        app-registration id are not supplied in the body.
+    Microsoft365PublishResponse:
+      type: object
+      properties:
+        titleId:
+          type: string
+          description: The Microsoft 365 title id of the published app.
+        teamsAppId:
+          type: string
+          description: The Microsoft Teams app id of the published app.
+      description: Response from publishing an agent to Microsoft 365 / Microsoft Teams.
+    Microsoft365PublishScope:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Personal
+            - Shared
+            - Tenant
+      description: The publish scope for the generated Microsoft Teams app.
     MicrosoftFabricPreviewTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-microsoft365/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-microsoft365/models.tsp
@@ -1,0 +1,199 @@
+using TypeSpec.Http;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/** The publish scope for the generated Microsoft Teams app. */
+union Microsoft365PublishScope {
+  string,
+
+  /** Publish the app for the acting user only. */
+  personal: "Personal",
+
+  /** Publish the app to a shared scope within the organization. */
+  shared: "Shared",
+
+  /** Publish the app tenant-wide. */
+  tenant: "Tenant",
+}
+
+// ---------------------------------------------------------------------------
+// Request models
+// ---------------------------------------------------------------------------
+
+/**
+ * An agentic-user template describing how the agent participates as an agentic user in Microsoft 365.
+ * Only used when `useAgenticUserTemplate` is true on the publish request.
+ */
+model Microsoft365AgenticUserTemplate {
+  /** Identifier of the agentic-user template. */
+  id?: string;
+
+  /** Name of the agentic-user template file embedded in the generated app package. */
+  file?: string;
+
+  /** Schema version of the agentic-user template. */
+  schemaVersion?: string;
+
+  /** Blueprint identity client id used for the agentic user. */
+  agentIdentityBlueprintId?: string;
+
+  /** Communication protocol used by the agentic user. */
+  communicationProtocol?: string;
+}
+
+/**
+ * Request body for publishing a Foundry agent to Microsoft 365 / Microsoft Teams. The agent is
+ * identified by the `agent_name` in the route and resolved server-side, so the agent id, bot id, and
+ * app-registration id are not supplied in the body.
+ */
+model Microsoft365PublishRequest {
+  /**
+   * Display name used as the published Teams app name. When omitted, the agent name from the route is
+   * used.
+   */
+  agentDisplayName?: string;
+
+  /**
+   * ARM resource id of the Azure Bot Service that fronts this agent in Microsoft Teams. Required for
+   * workspaces on the default bot-based Teams backend; optional for workspaces on the API-based backend.
+   */
+  botServiceArmId?: string;
+
+  /**
+   * When true, the agent is published as an autopilot (digital worker) agent: the bot id is taken from
+   * the agent's blueprint identity and the generated Teams manifest is marked as a digital worker.
+   */
+  publishAsAutopilot?: boolean;
+
+  /** When true, the supplied `agenticUserTemplate` is embedded in the generated Teams app package. */
+  useAgenticUserTemplate?: boolean = false;
+
+  /** Optional agentic-user template. Required when `useAgenticUserTemplate` is true. */
+  agenticUserTemplate?: Microsoft365AgenticUserTemplate;
+
+  /** Publish scope for the Teams app. */
+  publishScope: Microsoft365PublishScope;
+
+  /**
+   * App version (for example `1.2.3`) written into the Teams manifest. May contain only digits and
+   * periods, must not start with `0`, and must end with a digit. When omitted, a platform default is
+   * used.
+   */
+  appVersion?: string;
+
+  /** Short, one-line description shown in the Teams app listing. */
+  shortDescription?: string;
+
+  /** Full description shown on the Teams app details page. */
+  fullDescription?: string;
+
+  /** Display name of the developer / publisher shown in the Teams app listing. */
+  developerName?: string;
+
+  /** Developer / publisher website URL shown in the Teams app listing. Must be an https URL. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  developerWebsiteUrl?: string;
+
+  /** Privacy policy URL shown in the Teams app listing. Must be an http or https URL. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  privacyUrl?: string;
+
+  /** Terms-of-use URL shown in the Teams app listing. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  termsOfUseUrl?: string;
+
+  /**
+   * Optional base64-encoded PNG used as the color (full-bleed) icon in the Teams app package. Must be a
+   * 192x192 PNG (perfect square, no border or rounded corners). Max 1 MB after decode. When omitted, the
+   * platform default color icon is used.
+   */
+  colorIconBase64?: string;
+
+  /**
+   * Optional base64-encoded PNG used as the outline icon in the Teams app package. Must be a 32x32 PNG.
+   * Max 1 MB after decode. When omitted, the platform default outline icon is used.
+   */
+  outlineIconBase64?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Response models
+// ---------------------------------------------------------------------------
+
+/** Response from publishing an agent to Microsoft 365 / Microsoft Teams. */
+model Microsoft365PublishResponse {
+  /** The Microsoft 365 title id of the published app. */
+  titleId?: string;
+
+  /** The Microsoft Teams app id of the published app. */
+  teamsAppId?: string;
+}
+
+/** The generated Microsoft 365 app package (Microsoft Teams app zip). */
+model Microsoft365AppPackageResponse {
+  /** The media type of the returned package content. */
+  @header("Content-Type")
+  content_type: "application/zip";
+
+  /** The Microsoft Teams app package zip content. */
+  @body
+  content: bytes;
+}
+
+/**
+ * Default and previously-published values used to pre-populate a Microsoft 365 publish request for a
+ * Foundry agent.
+ */
+model Microsoft365PublishDefaults {
+  /** The publish scope. */
+  appPublishScope?: Microsoft365PublishScope;
+
+  /** The agent name. */
+  agentName?: string;
+
+  /**
+   * The user-facing display name for the agent. Defaults to the agent name if not previously
+   * overridden.
+   */
+  agentDisplayName?: string;
+
+  /** The app-registration client id associated with the agent. */
+  appRegistrationClientId?: string;
+
+  /** The most recently published app version. */
+  appVersion?: string;
+
+  /** The recommended next app version (the most recent app version, incremented). */
+  recommendedNextAppVersion?: string;
+
+  /** The Microsoft 365 title id of the previously-published app, if any. */
+  titleId?: string;
+
+  /** The Microsoft Teams app id of the previously-published app, if any. */
+  teamsAppId?: string;
+
+  /** Short, one-line description shown in the Teams app listing. */
+  shortDescription?: string;
+
+  /** Full description shown on the Teams app details page. */
+  fullDescription?: string;
+
+  /** Display name of the developer / publisher. */
+  developerName?: string;
+
+  /** Developer / publisher website URL. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  developerWebsiteUrl?: string;
+
+  /** Privacy policy URL. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  privacyUrl?: string;
+
+  /** Terms-of-use URL. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Wire field name uses the 'Url' suffix; renaming would break the documented contract."
+  termsOfUseUrl?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-microsoft365/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-microsoft365/routes.tsp
@@ -1,0 +1,73 @@
+import "../common/models.tsp";
+import "../common/servicepatterns.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+
+namespace Azure.AI.Projects;
+
+/**
+ * Operations for publishing a Foundry agent to Microsoft 365 / Microsoft Teams.
+ *
+ * These operations generate and publish a Microsoft Teams app for an existing Foundry agent. The
+ * agent is identified by `agent_name` in the route and resolved server-side; the caller must have
+ * write access to the agent's workspace.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+@tag("Agent Microsoft 365 Publishing")
+interface Microsoft365Publishing {
+  /**
+   * Publishes a Foundry agent to Microsoft 365 / Microsoft Teams and returns the published title and
+   * Teams app ids.
+   */
+  @summary("Publish an agent to Microsoft 365")
+  @post
+  @route("/agents/{agent_name}/microsoft365/publish")
+  publishAgentToMicrosoft365 is FoundryDataPlaneOperation<
+    {
+      /** The name of the agent to publish. */
+      @path agent_name: string;
+
+      ...Microsoft365PublishRequest;
+    },
+    Microsoft365PublishResponse
+  >;
+
+  /**
+   * Generates the Microsoft Teams app package (zip) for a Foundry agent from the supplied publish
+   * request, without publishing it. Returns the app package as `application/zip`.
+   */
+  #suppress "@azure-tools/typespec-azure-core/byos" "The app package is generated and returned inline, not stored."
+  @summary("Generate a Microsoft 365 app package")
+  @post
+  @route("/agents/{agent_name}/microsoft365/zip")
+  getMicrosoft365AppPackage is FoundryDataPlaneOperation<
+    {
+      /** The name of the agent to generate the app package for. */
+      @path agent_name: string;
+
+      ...Microsoft365PublishRequest;
+    },
+    Microsoft365AppPackageResponse
+  >;
+
+  /**
+   * Returns default and previously-published values used to pre-populate a Microsoft 365 publish
+   * request for a Foundry agent.
+   */
+  @summary("Get Microsoft 365 publish defaults")
+  @get
+  @route("/agents/{agent_name}/microsoft365/publishdefaults")
+  getMicrosoft365PublishDefaults is FoundryDataPlaneOperation<
+    {
+      /** The name of the agent to get publish defaults for. */
+      @path agent_name: string;
+
+      /**
+       * When true, returns defaults for publishing the agent as an autopilot (digital worker) agent.
+       */
+      @query publishAsDigitalWorker?: boolean = false;
+    },
+    Microsoft365PublishDefaults
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/tag-definitions.tsp
@@ -24,6 +24,7 @@ using OpenAPI;
   #{ name: "Agent Session Files", parent: "Agents Root" },
   #{ name: "Agent Versions", parent: "Agents Root" },
   #{ name: "Agent Containers", parent: "Agents Root" },
+  #{ name: "Agent Microsoft 365 Publishing", parent: "Agents Root" },
   #{ name: "Platform APIs" },
   #{ name: "Datasets", parent: "Platform APIs" },
   #{ name: "Indexes", parent: "Platform APIs" },


### PR DESCRIPTION
## Summary

Documents the agent Microsoft 365 / Microsoft Teams publish API in the Foundry data-plane
API reference. This surface is exposed publicly through APIM passthrough, so it belongs in
the signed-out Foundry reference.

Adds a new `agents-microsoft365` TypeSpec project describing three operations:

| Verb | Route | Description |
| ---- | ----- | ----------- |
| POST | `/agents/{agent_name}/microsoft365/publish` | Publish an agent to Microsoft 365 and return the title id and Teams app id. |
| POST | `/agents/{agent_name}/microsoft365/zip` | Generate the Microsoft Teams app package (`application/zip`) without publishing. |
| GET  | `/agents/{agent_name}/microsoft365/publishdefaults` | Return default and previously-published values to pre-populate a publish request. |

## Changes

- New `src/agents-microsoft365/models.tsp` and `src/agents-microsoft365/routes.tsp`
  describing the request/response models and the three operations. Field names use the
  camelCase wire contract the service actually serializes.
- Registered the `Agent Microsoft 365 Publishing` tag under `Agents Root` in
  `tag-definitions.tsp` and imported the new routes in `main.tsp`.
- Regenerated the OpenAPI descriptions (`openapi3/v1` and
  `openapi3/virtual-public-preview`) via `tsp compile .`. The change is purely additive.

## Validation

- `tsp compile .` completes successfully with no new warnings from the added project.
- Generated OpenAPI diff is additive only (new paths, schemas, and tag).
