### PR TITLE
Add soft eviction fields to KubeletConfig in 2026-06-02-preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -556,6 +556,24 @@ model KubeletConfig {
    */
   @added(Versions.v2026_06_02_preview)
   hardEvictionThreshold?: HardEvictionThreshold;
+
+  /**
+   * Soft eviction thresholds for kubelet. Soft evictions trigger graceful pod termination once a signal has been crossed for the corresponding grace period defined in softEvictionGracePeriod. When a threshold is not set, no soft eviction is performed for that signal. Only applicable for Linux nodepools.
+   */
+  @added(Versions.v2026_06_02_preview)
+  softEvictionThreshold?: SoftEvictionThreshold;
+
+  /**
+   * Grace periods for soft eviction thresholds. A soft eviction signal must be crossed for at least the specified duration before pod eviction is triggered. Values are Go-style duration strings (e.g. '1m30s'). Each grace period only applies when the corresponding softEvictionThreshold is set. Only applicable for Linux nodepools.
+   */
+  @added(Versions.v2026_06_02_preview)
+  softEvictionGracePeriod?: SoftEvictionGracePeriod;
+
+  /**
+   * The maximum allowed grace period, in seconds, to use when terminating pods in response to a soft eviction threshold being met. This value effectively caps the pod's terminationGracePeriodSeconds during a soft eviction. Only applicable for Linux nodepools.
+   */
+  @added(Versions.v2026_06_02_preview)
+  evictionMaxPodGracePeriodInSeconds?: int32;
 }
 
 /**
@@ -592,6 +610,48 @@ model HardEvictionThreshold {
 
   /**
    * The threshold for available inodes on the node filesystem below which pod eviction is triggered. Accepts absolute inode counts (e.g. '100000') or percentage values (e.g. '5%'). Percentage values must be greater than or equal to the system default of 5%.
+   */
+  nodeFsInodesFree?: string;
+}
+
+/**
+ * Soft eviction thresholds for kubelet. These thresholds trigger graceful pod eviction when node resources drop below the specified values for at least the corresponding grace period defined in softEvictionGracePeriod. Supported formats are Ki, Mi, Gi, or percentages using %.
+ */
+@added(Versions.v2026_06_02_preview)
+model SoftEvictionThreshold {
+  /**
+   * The threshold for available memory below which soft pod eviction is triggered. Accepts absolute values (e.g. '500Mi') or percentage values (e.g. '5%'). Must be greater than the corresponding hardEvictionThreshold.memoryAvailable when both are set.
+   */
+  memoryAvailable?: string;
+
+  /**
+   * The threshold for available node filesystem space below which soft pod eviction is triggered. Accepts absolute values (e.g. '1Gi') or percentage values (e.g. '10%'). Must be greater than the corresponding hardEvictionThreshold.nodeFsAvailable when both are set.
+   */
+  nodeFsAvailable?: string;
+
+  /**
+   * The threshold for available inodes on the node filesystem below which soft pod eviction is triggered. Accepts absolute inode counts (e.g. '100000') or percentage values (e.g. '5%'). Must be greater than the corresponding hardEvictionThreshold.nodeFsInodesFree when both are set.
+   */
+  nodeFsInodesFree?: string;
+}
+
+/**
+ * Grace periods for kubelet soft eviction thresholds. Each field is a Go-style duration string (e.g. '1m30s') that specifies how long the corresponding soft eviction signal must be crossed before pod eviction is triggered. A grace period only applies when the matching soft eviction threshold is set.
+ */
+@added(Versions.v2026_06_02_preview)
+model SoftEvictionGracePeriod {
+  /**
+   * The grace period for the memoryAvailable soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s').
+   */
+  memoryAvailable?: string;
+
+  /**
+   * The grace period for the nodeFsAvailable soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s').
+   */
+  nodeFsAvailable?: string;
+
+  /**
+   * The grace period for the nodeFsInodesFree soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s').
    */
   nodeFsInodesFree?: string;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsCreate_CustomNodeConfig.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsCreate_CustomNodeConfig.json
@@ -13,6 +13,7 @@
           "cpuCfsQuota": true,
           "cpuCfsQuotaPeriod": "200ms",
           "cpuManagerPolicy": "static",
+          "evictionMaxPodGracePeriodInSeconds": 60,
           "failSwapOn": false,
           "hardEvictionThreshold": {
             "memoryAvailable": "500Mi",
@@ -24,6 +25,16 @@
           "kubeReserved": {
             "cpuMillicores": 200,
             "memoryMB": 1024
+          },
+          "softEvictionGracePeriod": {
+            "memoryAvailable": "1m30s",
+            "nodeFsAvailable": "2m",
+            "nodeFsInodesFree": "2m"
+          },
+          "softEvictionThreshold": {
+            "memoryAvailable": "750Mi",
+            "nodeFsAvailable": "20%",
+            "nodeFsInodesFree": "15%"
           },
           "topologyManagerPolicy": "best-effort"
         },
@@ -64,6 +75,7 @@
             "cpuCfsQuota": true,
             "cpuCfsQuotaPeriod": "200ms",
             "cpuManagerPolicy": "static",
+            "evictionMaxPodGracePeriodInSeconds": 60,
             "failSwapOn": false,
             "hardEvictionThreshold": {
               "memoryAvailable": "500Mi",
@@ -77,6 +89,16 @@
               "memoryMB": 1024
             },
             "seccompDefault": "Unconfined",
+            "softEvictionGracePeriod": {
+              "memoryAvailable": "1m30s",
+              "nodeFsAvailable": "2m",
+              "nodeFsInodesFree": "2m"
+            },
+            "softEvictionThreshold": {
+              "memoryAvailable": "750Mi",
+              "nodeFsAvailable": "20%",
+              "nodeFsInodesFree": "15%"
+            },
             "topologyManagerPolicy": "best-effort"
           },
           "linuxOSConfig": {
@@ -114,6 +136,7 @@
             "cpuCfsQuota": true,
             "cpuCfsQuotaPeriod": "200ms",
             "cpuManagerPolicy": "static",
+            "evictionMaxPodGracePeriodInSeconds": 60,
             "failSwapOn": false,
             "hardEvictionThreshold": {
               "memoryAvailable": "500Mi",
@@ -127,6 +150,16 @@
               "memoryMB": 1024
             },
             "podMaxPids": 100,
+            "softEvictionGracePeriod": {
+              "memoryAvailable": "1m30s",
+              "nodeFsAvailable": "2m",
+              "nodeFsInodesFree": "2m"
+            },
+            "softEvictionThreshold": {
+              "memoryAvailable": "750Mi",
+              "nodeFsAvailable": "20%",
+              "nodeFsInodesFree": "15%"
+            },
             "topologyManagerPolicy": "best-effort"
           },
           "linuxOSConfig": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsCreate_CustomNodeConfig.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsCreate_CustomNodeConfig.json
@@ -13,6 +13,7 @@
           "cpuCfsQuota": true,
           "cpuCfsQuotaPeriod": "200ms",
           "cpuManagerPolicy": "static",
+          "evictionMaxPodGracePeriodInSeconds": 60,
           "failSwapOn": false,
           "hardEvictionThreshold": {
             "memoryAvailable": "500Mi",
@@ -24,6 +25,16 @@
           "kubeReserved": {
             "cpuMillicores": 200,
             "memoryMB": 1024
+          },
+          "softEvictionGracePeriod": {
+            "memoryAvailable": "1m30s",
+            "nodeFsAvailable": "2m",
+            "nodeFsInodesFree": "2m"
+          },
+          "softEvictionThreshold": {
+            "memoryAvailable": "750Mi",
+            "nodeFsAvailable": "20%",
+            "nodeFsInodesFree": "15%"
           },
           "topologyManagerPolicy": "best-effort"
         },
@@ -64,6 +75,7 @@
             "cpuCfsQuota": true,
             "cpuCfsQuotaPeriod": "200ms",
             "cpuManagerPolicy": "static",
+            "evictionMaxPodGracePeriodInSeconds": 60,
             "failSwapOn": false,
             "hardEvictionThreshold": {
               "memoryAvailable": "500Mi",
@@ -77,6 +89,16 @@
               "memoryMB": 1024
             },
             "seccompDefault": "Unconfined",
+            "softEvictionGracePeriod": {
+              "memoryAvailable": "1m30s",
+              "nodeFsAvailable": "2m",
+              "nodeFsInodesFree": "2m"
+            },
+            "softEvictionThreshold": {
+              "memoryAvailable": "750Mi",
+              "nodeFsAvailable": "20%",
+              "nodeFsInodesFree": "15%"
+            },
             "topologyManagerPolicy": "best-effort"
           },
           "linuxOSConfig": {
@@ -114,6 +136,7 @@
             "cpuCfsQuota": true,
             "cpuCfsQuotaPeriod": "200ms",
             "cpuManagerPolicy": "static",
+            "evictionMaxPodGracePeriodInSeconds": 60,
             "failSwapOn": false,
             "hardEvictionThreshold": {
               "memoryAvailable": "500Mi",
@@ -127,6 +150,16 @@
               "memoryMB": 1024
             },
             "podMaxPids": 100,
+            "softEvictionGracePeriod": {
+              "memoryAvailable": "1m30s",
+              "nodeFsAvailable": "2m",
+              "nodeFsInodesFree": "2m"
+            },
+            "softEvictionThreshold": {
+              "memoryAvailable": "750Mi",
+              "nodeFsAvailable": "20%",
+              "nodeFsInodesFree": "15%"
+            },
             "topologyManagerPolicy": "best-effort"
           },
           "linuxOSConfig": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -10044,6 +10044,19 @@
         "hardEvictionThreshold": {
           "$ref": "#/definitions/HardEvictionThreshold",
           "description": "Hard eviction thresholds for kubelet. When a threshold is not set, the system default is used. See [AKS node resource reservations](https://aka.ms/aks/nodereservations) for details on computed defaults. Only applicable for Linux nodepools."
+        },
+        "softEvictionThreshold": {
+          "$ref": "#/definitions/SoftEvictionThreshold",
+          "description": "Soft eviction thresholds for kubelet. Soft evictions trigger graceful pod termination once a signal has been crossed for the corresponding grace period defined in softEvictionGracePeriod. When a threshold is not set, no soft eviction is performed for that signal. Only applicable for Linux nodepools."
+        },
+        "softEvictionGracePeriod": {
+          "$ref": "#/definitions/SoftEvictionGracePeriod",
+          "description": "Grace periods for soft eviction thresholds. A soft eviction signal must be crossed for at least the specified duration before pod eviction is triggered. Values are Go-style duration strings (e.g. '1m30s'). Each grace period only applies when the corresponding softEvictionThreshold is set. Only applicable for Linux nodepools."
+        },
+        "evictionMaxPodGracePeriodInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum allowed grace period, in seconds, to use when terminating pods in response to a soft eviction threshold being met. This value effectively caps the pod's terminationGracePeriodSeconds during a soft eviction. Only applicable for Linux nodepools."
         }
       }
     },
@@ -16460,6 +16473,42 @@
           "type": "boolean",
           "description": "Whether to use a FIPS-enabled OS.",
           "readOnly": true
+        }
+      }
+    },
+    "SoftEvictionGracePeriod": {
+      "type": "object",
+      "description": "Grace periods for kubelet soft eviction thresholds. Each field is a Go-style duration string (e.g. '1m30s') that specifies how long the corresponding soft eviction signal must be crossed before pod eviction is triggered. A grace period only applies when the matching soft eviction threshold is set.",
+      "properties": {
+        "memoryAvailable": {
+          "type": "string",
+          "description": "The grace period for the memoryAvailable soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s')."
+        },
+        "nodeFsAvailable": {
+          "type": "string",
+          "description": "The grace period for the nodeFsAvailable soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s')."
+        },
+        "nodeFsInodesFree": {
+          "type": "string",
+          "description": "The grace period for the nodeFsInodesFree soft eviction signal, expressed as a Go-style duration string (e.g. '1m30s')."
+        }
+      }
+    },
+    "SoftEvictionThreshold": {
+      "type": "object",
+      "description": "Soft eviction thresholds for kubelet. These thresholds trigger graceful pod eviction when node resources drop below the specified values for at least the corresponding grace period defined in softEvictionGracePeriod. Supported formats are Ki, Mi, Gi, or percentages using %.",
+      "properties": {
+        "memoryAvailable": {
+          "type": "string",
+          "description": "The threshold for available memory below which soft pod eviction is triggered. Accepts absolute values (e.g. '500Mi') or percentage values (e.g. '5%'). Must be greater than the corresponding hardEvictionThreshold.memoryAvailable when both are set."
+        },
+        "nodeFsAvailable": {
+          "type": "string",
+          "description": "The threshold for available node filesystem space below which soft pod eviction is triggered. Accepts absolute values (e.g. '1Gi') or percentage values (e.g. '10%'). Must be greater than the corresponding hardEvictionThreshold.nodeFsAvailable when both are set."
+        },
+        "nodeFsInodesFree": {
+          "type": "string",
+          "description": "The threshold for available inodes on the node filesystem below which soft pod eviction is triggered. Accepts absolute inode counts (e.g. '100000') or percentage values (e.g. '5%'). Must be greater than the corresponding hardEvictionThreshold.nodeFsInodesFree when both are set."
         }
       }
     },


### PR DESCRIPTION
Adds SoftEvictionThreshold, SoftEvictionGracePeriod, and evictionMaxPodGracePeriodInSeconds to KubeletConfig. TypeSpec source in AgentPoolModels.tsp, example updated in AgentPoolsCreate_CustomNodeConfig.json, and managedClusters.json plus the emitted example regenerated via 'tsp compile .'.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
