### PR TITLE
TypeSpec Suppressions: summarize-checks surface and label gating

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -1017,6 +1017,28 @@ const rulesPri1Suppressions = [
   },
 ];
 
+/** @type {RequiredLabelRule[]} */
+const rulesPri1TypeSpecSuppressions = [
+  // Gates the dedicated TypeSpec suppression category, independent of the
+  // autorest/README `SuppressionReviewRequired` rule above. Mirrors the
+  // Namespace Approval pattern (see `rulesPri1Namespace`): the prerequisite
+  // `TypeSpecSuppressionReviewRequired` label is applied by the TypeSpec
+  // Suppressions workflow when a suppression in scope of the check-rules file is
+  // added or changed, and merge is blocked until a reviewer applies
+  // `Approved-TypeSpecSuppression`. The rule is dormant until that workflow
+  // starts applying the prerequisite label (label gating is rolled out
+  // separately so nothing blocks merges initially).
+  {
+    precedence: 1,
+    anyPrerequisiteLabels: ["TypeSpecSuppressionReviewRequired"],
+    anyRequiredLabels: ["Approved-TypeSpecSuppression"],
+    troubleshootingGuide:
+      `This PR introduced TypeSpec suppressions that require review. Inspect the suppression details in the ` +
+      `<b>TypeSpec Suppressions Review</b> comment on this PR and ask the appropriate reviewer to apply the ` +
+      `<code>Approved-TypeSpecSuppression</code> label. ${diagramTsg(1, true)}.`,
+  },
+];
+
 /**
  * This collection has "SDK breaking changes" labels rules introduced in February 2024.
  * For description of the "SDK breaking changes" labels, see:
@@ -1182,6 +1204,7 @@ export const requiredLabelsRules = rulesPri0dataPlane
   .concat(rulesPri0ArmRev)
   .concat(rulesPri1ArmRev)
   .concat(rulesPri1Suppressions)
+  .concat(rulesPri1TypeSpecSuppressions)
   .concat(rulesPri1Namespace)
   .concat(rulesPri2Sdk)
   .concat(rulesPri2LegacySdk)

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -39,6 +39,7 @@ import {
   reqMetCheckTsg,
   typeSpecRequirementArmTsg,
   typeSpecRequirementDataPlaneTsg,
+  typeSpecSuppressionsTsg,
 } from "./tsgs.js";
 
 import fs from "fs/promises";
@@ -186,6 +187,12 @@ const CHECK_METADATA = [
   },
   {
     precedence: 5,
+    name: "TypeSpec Suppressions",
+    suppressionLabels: ["Approved-TypeSpecSuppression"],
+    troubleshootingGuide: typeSpecSuppressionsTsg,
+  },
+  {
+    precedence: 5,
     name: "Swagger Lint(RPaaS)",
     suppressionLabels: [],
     troubleshootingGuide: defaultTsg,
@@ -234,7 +241,7 @@ const CHECK_METADATA = [
   },
   {
     precedence: 1,
-    name: "Namespace Approval",
+    name: "Package Name Approval",
     suppressionLabels: [],
     troubleshootingGuide: defaultTsg,
   },

--- a/.github/workflows/src/summarize-checks/tsgs.js
+++ b/.github/workflows/src/summarize-checks/tsgs.js
@@ -40,6 +40,12 @@ export const typeSpecRequirementArmTsg =
 
 export const typeSpecRequirementDataPlaneTsg = typeSpecRequirementArmTsg;
 
+export const typeSpecSuppressionsTsg =
+  `This PR adds or updates TypeSpec suppressions, which are strongly discouraged. ` +
+  `See the <strong>TypeSpec Suppressions Review</strong> comment on this PR for the list of ` +
+  `suppressions, their justifications, and source locations. A reviewer must apply the ` +
+  `<code>Approved-TypeSpecSuppression</code> label after confirming every justification is acceptable.`;
+
 export const brchHref = href("aka.ms/brch", "https://aka.ms/brch");
 
 export const brchTsg = `To unblock this PR, follow the process at ${brchHref}.`;

--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -10,6 +10,7 @@ on:
       - "Swagger LintDiff - Set Status"
       - "SDK Validation Status"
       - "TypeSpec Validation"
+      - "TypeSpec Suppressions - Set Status"
       - "Update Labels"
     types:
       - completed


### PR DESCRIPTION
Part 2 of 3 splitting the TypeSpec suppressions workflow PR into smaller, targeted reviews.

Wires TypeSpec suppressions into summarize-checks and the summarize-impact tool:
- Extracts the suppressions section into 	ypespec-suppressions-summary.js
- Updates summarize-checks.js, labelling.js, and test mocks
- Extends the summarize-impact tool (impact.ts, ImpactAssessment.ts) to surface suppression gating via impact assessment
- Adds tests and fixtures

Companion PRs: CI workflow definitions, and check-rules.json + README.