### PR TITLE
[Monitor] Add workspace search data-plane operations

### DIFF
--- a/specification/monitor/data-plane/OperationalInsights/client.tsp
+++ b/specification/monitor/data-plane/OperationalInsights/client.tsp
@@ -35,6 +35,9 @@ interface MonitorQueryLogsClient {
   executeWithResourceId is MonitorQueryLogs.Query.executeWithResourceId;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  search is MonitorQueryLogs.Search.execute;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   batch is MonitorQueryLogs.Query.batch;
 }
 
@@ -52,6 +55,9 @@ interface Client {
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   queryResource is MonitorQueryLogs.Query.executeWithResourceId;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  searchWorkspace is MonitorQueryLogs.Search.execute;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   queryBatch is MonitorQueryLogs.Query.batch;

--- a/specification/monitor/data-plane/OperationalInsights/examples/v1/search-get-example.json
+++ b/specification/monitor/data-plane/OperationalInsights/examples/v1/search-get-example.json
@@ -1,0 +1,37 @@
+{
+  "description": "A search query that returns workspace data.",
+  "parameters": {
+    "query": "Usage | take 1",
+    "timespan": "PT12H",
+    "workspaceId": "63613592-b6f7-4c3d-a390-22ba13102111"
+  },
+  "title": "A simple GET search query on a workspace",
+  "responses": {
+    "200": {
+      "body": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "2026-03-01T00:00:00Z",
+                "Usage"
+              ]
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Search_Get"
+}

--- a/specification/monitor/data-plane/OperationalInsights/examples/v1/search-post-example.json
+++ b/specification/monitor/data-plane/OperationalInsights/examples/v1/search-post-example.json
@@ -1,0 +1,39 @@
+{
+  "description": "A search query that returns workspace data.",
+  "parameters": {
+    "body": {
+      "query": "Usage | take 1",
+      "timespan": "PT12H"
+    },
+    "workspaceId": "63613592-b6f7-4c3d-a390-22ba13102111"
+  },
+  "title": "A simple POST search query on a workspace",
+  "responses": {
+    "200": {
+      "body": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "2026-03-01T00:00:00Z",
+                "Usage"
+              ]
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Search_Execute"
+}

--- a/specification/monitor/data-plane/OperationalInsights/routes.tsp
+++ b/specification/monitor/data-plane/OperationalInsights/routes.tsp
@@ -160,6 +160,72 @@ interface Query {
   ): BatchResponse | MonitorQueryLogs.ErrorResponse;
 }
 
+interface Search {
+  /** Executes a search query for data in a workspace. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "This service uses path param to specify API version"
+  @summary("Execute a search query")
+  @route("/workspaces/{workspaceId}/search")
+  @get
+  get(
+    /**
+     * Primary Workspace ID of the query. This is the Workspace ID from the Properties
+     * blade in the Azure portal.
+     */
+    @path
+    workspaceId: string,
+
+    /** The search query to execute. */
+    @query("query")
+    query: string,
+
+    /**
+     * The timespan over which to query data. This is an ISO8601 time period value.
+     * This timespan is applied in addition to any that are specified in the query expression.
+     */
+    @query("timespan")
+    timespan: duration,
+  ): QueryResults | MonitorQueryLogs.ErrorResponse;
+
+  /** Executes a search query for data in a workspace. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "This service uses path param to specify API version"
+  @summary("Execute a search query")
+  @route("/workspaces/{workspaceId}/search")
+  @post
+  execute(
+    /**
+     * Primary Workspace ID of the query. This is the Workspace ID from the Properties
+     * blade in the Azure portal.
+     */
+    @path
+    workspaceId: string,
+
+    /**
+     * Optional. The timespan over which to query data. A timespan must be supplied either
+     * here or in the request body. If both are supplied, the service uses their intersection.
+     */
+    @query("timespan")
+    timespan?: duration,
+
+    /** Optional. The prefer header to set server timeout, query statistics and visualization information. */
+    @header("Prefer")
+    @clientName("options", "go")
+    prefer?: string,
+
+    /** Body Parameter content-type */
+    @header("content-type")
+    contentType: "application/json",
+
+    /**
+     * The search query to execute. A timespan must be supplied either in this body or as
+     * a query parameter. If both are supplied, the service uses their intersection.
+     */
+    @bodyRoot
+    body: QueryBody,
+  ): QueryResults | MonitorQueryLogs.ErrorResponse;
+}
+
 interface Metadata {
   /**
    * Retrieve the metadata information for the workspace, including its schema,

--- a/specification/monitor/data-plane/OperationalInsights/stable/v1/OperationalInsights.json
+++ b/specification/monitor/data-plane/OperationalInsights/stable/v1/OperationalInsights.json
@@ -386,6 +386,114 @@
           }
         }
       }
+    },
+    "/workspaces/{workspaceId}/search": {
+      "get": {
+        "operationId": "Search_Get",
+        "summary": "Execute a search query",
+        "description": "Executes a search query for data in a workspace.",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "Primary Workspace ID of the query. This is the Workspace ID from the Properties\nblade in the Azure portal.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The search query to execute.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "timespan",
+            "in": "query",
+            "description": "The timespan over which to query data. This is an ISO8601 time period value.\nThis timespan is applied in addition to any that are specified in the query expression.",
+            "required": true,
+            "type": "string",
+            "format": "duration"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/QueryResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "A simple GET search query on a workspace": {
+            "$ref": "./examples/search-get-example.json"
+          }
+        }
+      },
+      "post": {
+        "operationId": "Search_Execute",
+        "summary": "Execute a search query",
+        "description": "Executes a search query for data in a workspace.",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "Primary Workspace ID of the query. This is the Workspace ID from the Properties\nblade in the Azure portal.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "timespan",
+            "in": "query",
+            "description": "Optional. The timespan over which to query data. A timespan must be supplied either\nhere or in the request body. If both are supplied, the service uses their intersection.",
+            "required": false,
+            "type": "string",
+            "format": "duration"
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "description": "Optional. The prefer header to set server timeout, query statistics and visualization information.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "prefer"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The search query to execute. A timespan must be supplied either in this body or as\na query parameter. If both are supplied, the service uses their intersection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/QueryResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "A simple POST search query on a workspace": {
+            "$ref": "./examples/search-post-example.json"
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/specification/monitor/data-plane/OperationalInsights/stable/v1/examples/search-get-example.json
+++ b/specification/monitor/data-plane/OperationalInsights/stable/v1/examples/search-get-example.json
@@ -1,0 +1,37 @@
+{
+  "description": "A search query that returns workspace data.",
+  "parameters": {
+    "query": "Usage | take 1",
+    "timespan": "PT12H",
+    "workspaceId": "63613592-b6f7-4c3d-a390-22ba13102111"
+  },
+  "title": "A simple GET search query on a workspace",
+  "responses": {
+    "200": {
+      "body": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "2026-03-01T00:00:00Z",
+                "Usage"
+              ]
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Search_Get"
+}

--- a/specification/monitor/data-plane/OperationalInsights/stable/v1/examples/search-post-example.json
+++ b/specification/monitor/data-plane/OperationalInsights/stable/v1/examples/search-post-example.json
@@ -1,0 +1,39 @@
+{
+  "description": "A search query that returns workspace data.",
+  "parameters": {
+    "body": {
+      "query": "Usage | take 1",
+      "timespan": "PT12H"
+    },
+    "workspaceId": "63613592-b6f7-4c3d-a390-22ba13102111"
+  },
+  "title": "A simple POST search query on a workspace",
+  "responses": {
+    "200": {
+      "body": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "2026-03-01T00:00:00Z",
+                "Usage"
+              ]
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Search_Execute"
+}


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Adds GET and POST workspace search operations to the Azure Monitor Logs data-plane V1 API at `api.loganalytics.io`.

The operations reuse the existing query request, result, table, column, and error models. This change does not add an ARM endpoint and does not require an ARM Manifest registration.

## API Info: The Basics

* Link to API Spec engagement record issue:

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [ ] GA release

### Change Scope

* Design Document:
* Previous API Spec Doc: `specification/monitor/data-plane/OperationalInsights/stable/v1/OperationalInsights.json`
* Updated paths:
  * `GET /v1/workspaces/{workspaceId}/search`
  * `POST /v1/workspaces/{workspaceId}/search`

### Validation

- TypeSpec editor diagnostics pass.
- Generated Swagger and examples parse as valid JSON.
- GET and POST operation IDs and schema references were verified.
- Source and stable examples are identical.
- `git diff --check` passes.

A full TypeSpec compile was not run locally because the pinned compiler toolchain is unavailable in this sparse checkout; repository CI should regenerate and validate the checked-in Swagger.
### Same-version review rationale

`GET /v1/workspaces/{workspaceId}/search` and `POST /v1/workspaces/{workspaceId}/search` are already implemented and deployed by the Log Analytics Query Service. This PR documents the existing V1 wire contract; it does not introduce a new runtime route or change existing request/response behavior.

The service currently recognizes only `beta` and `v1`, so publishing these operations under a speculative `v2` would not match the deployed service. `VersioningReviewRequired` is therefore expected, and this PR requests approval for adding the existing operations to the published V1 specification.