### PR TITLE
[Microsoft.Security] Add DefenderForStorageSettings 2026-03-01-preview (per-extension scanners)

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/CancelMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/CancelMalwareScan_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "3fd3c1be-dbff-4d6e-985f-43f9ec1b1146",
+          "scanStatus": "Canceling",
+          "scanStatusMessage": "The scan request is being canceled upon user request"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_CancelMalwareScan",
+  "title": "Cancel a Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Get",
+  "title": "Gets the Defender for Storage settings for the specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -31,11 +31,14 @@
               },
               "isEnabled": true
             },
-            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
-            "isEnabled": true
+            "isEnabled": true,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
           }
         }
       }

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/GetMalwareScan_example.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanEndTime": "2025-09-01T12:21:17.5648386Z",
+          "scanId": "0ce362c5-87a5-4030-ba6a-109566cd7b3d",
+          "scanStartTime": "2025-09-01T12:20:14.6364816Z",
+          "scanStatus": "Completed",
+          "scanSummary": {
+            "blobs": {
+              "failedBlobsCount": 0,
+              "maliciousBlobsCount": 10,
+              "scannedBlobsInGB": 0.019550956785678864,
+              "skippedBlobsCount": 0,
+              "totalBlobsScanned": 40
+            },
+            "estimatedScanCostUSD": 0.0029326435178518295,
+            "files": {
+              "failedFilesCount": 0,
+              "maliciousFilesCount": 2,
+              "scannedFilesInGB": 10.5,
+              "skippedFilesCount": 0,
+              "totalFilesScanned": 150
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_GetMalwareScan",
+  "title": "Gets the Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.Security/defenderForStorageSettings",
+            "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+            "properties": {
+              "isEnabled": true,
+              "malwareScanning": {
+                "automatedResponse": "BlobSoftDelete",
+                "blobScanResultsOptions": "BlobIndexTags",
+                "onUpload": {
+                  "capGBPerMonth": 10000,
+                  "filters": {
+                    "excludeBlobsLargerThan": 1024,
+                    "excludeBlobsWithPrefix": [
+                      "sample-container/logs",
+                      "single-excluded-container/",
+                      "excluded-containers"
+                    ],
+                    "excludeBlobsWithSuffix": [
+                      ".log",
+                      ".jpg"
+                    ]
+                  },
+                  "isEnabled": true
+                },
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+              },
+              "overrideSubscriptionLevelSettings": true,
+              "sensitiveDataDiscovery": {
+                "isEnabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_List",
+  "title": "Lists the Defender for Storage settings for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -32,11 +32,14 @@
                   },
                   "isEnabled": true
                 },
-                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+                "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
               },
+              "managedBy": "None",
               "overrideSubscriptionLevelSettings": true,
               "sensitiveDataDiscovery": {
-                "isEnabled": true
+                "isEnabled": true,
+                "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
               }
             }
           }

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -22,11 +22,13 @@
             },
             "isEnabled": true
           },
-          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+          "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
         },
         "overrideSubscriptionLevelSettings": true,
         "sensitiveDataDiscovery": {
-          "isEnabled": true
+          "isEnabled": true,
+          "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
         }
       }
     },
@@ -63,11 +65,14 @@
             "operationStatus": {
               "code": "Succeeded"
             },
-            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
             "isEnabled": true,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator",
             "operationStatus": {
               "code": "Succeeded"
             }
@@ -89,14 +94,17 @@
               "capGBPerMonth": -1,
               "isEnabled": false
             },
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator",
             "operationStatus": {
               "code": "PartialSuccess",
               "message": "Failed to setup data scanner."
             }
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
             "isEnabled": false,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator",
             "operationStatus": {
               "code": "PartialSuccess",
               "message": "Failed to setup data scanner."

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "defenderForStorageSetting": {
+      "properties": {
+        "isEnabled": true,
+        "malwareScanning": {
+          "automatedResponse": "BlobSoftDelete",
+          "blobScanResultsOptions": "BlobIndexTags",
+          "onUpload": {
+            "capGBPerMonth": 10000,
+            "filters": {
+              "excludeBlobsLargerThan": 1024,
+              "excludeBlobsWithPrefix": [
+                "unscanned-container",
+                "sample-container/logs"
+              ],
+              "excludeBlobsWithSuffix": [
+                ".log",
+                ".jpg"
+              ]
+            },
+            "isEnabled": true
+          },
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+        },
+        "overrideSubscriptionLevelSettings": true,
+        "sensitiveDataDiscovery": {
+          "isEnabled": true
+        }
+      }
+    },
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "operationStatus": {
+              "code": "Succeeded"
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true,
+            "operationStatus": {
+              "code": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "None",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": -1,
+              "isEnabled": false
+            },
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": false,
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Create",
+  "title": "Creates or updates the Defender for Storage settings on a specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/StartMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/examples/2026-03-01-preview/DefenderForStorage/StartMalwareScan_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current",
+    "body": {
+      "properties": {
+        "filters": {
+          "blobs": {
+            "container": {
+              "value": "mycontainer",
+              "match": "Exact"
+            },
+            "blob": {
+              "value": "myblob.txt",
+              "match": "Exact"
+            }
+          },
+          "files": {
+            "share": {
+              "value": "myshare",
+              "match": "Exact"
+            },
+            "file": {
+              "value": "dir",
+              "match": "Prefix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "fc831479-412f-4bc2-8333-a8edda751a80",
+          "scanStatus": "Queued",
+          "scanStatusMessage": "The scan request has been queued for scanning"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_StartMalwareScan",
+  "title": "Initiate a Defender for Storage malware scan for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/main.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/main.tsp
@@ -45,6 +45,11 @@ enum Versions {
   /**
    * The 2026-01-01-preview API version.
    */
-  @previewVersion
   v2026_01_01_preview: "2026-01-01-preview",
+
+  /**
+   * The 2026-03-01-preview API version.
+   */
+  @previewVersion
+  v2026_03_01_preview: "2026-03-01-preview",
 }

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
@@ -49,6 +49,29 @@ union AutomatedResponseType {
 }
 
 /**
+ * Indicates whether this resource's Defender for Storage settings are managed by a higher MDC enforcement scope and which component is managing them.
+ */
+@added(Versions.v2026_03_01_preview)
+union ManagedByType {
+  string,
+
+  /**
+   * The resource's Defender for Storage settings are not managed by a higher enforcement scope.
+   */
+  None: "None",
+
+  /**
+   * The resource's Defender for Storage settings are managed by Microsoft Defender XDR.
+   */
+  MicrosoftDefenderXDR: "MicrosoftDefenderXDR",
+
+  /**
+   * The resource's Defender for Storage settings are managed by the subscription-level settings enforcer.
+   */
+  SubscriptionSettingsEnforcer: "SubscriptionSettingsEnforcer",
+}
+
+/**
  * List of Defender for Storage settings.
  */
 model DefenderForStorageSettingList {
@@ -90,6 +113,13 @@ model DefenderForStorageSettingProperties {
    * Indicates whether the settings defined for this storage account should override the settings defined for the subscription.
    */
   overrideSubscriptionLevelSettings?: boolean;
+
+  /**
+   * Indicates whether this resource's Defender for Storage settings are managed by a higher MDC enforcement scope and which component is managing them. When set to a value other than 'None', the resource-level settings become read-only and can only be modified by the managing component. Possible values: 'None' (not managed), 'MicrosoftDefenderXDR' (managed by Microsoft Defender XDR), 'SubscriptionSettingsEnforcer' (managed by subscription-level settings enforcer).
+   */
+  @added(Versions.v2026_03_01_preview)
+  @visibility(Lifecycle.Read)
+  managedBy?: ManagedByType;
 }
 
 /**
@@ -119,6 +149,22 @@ model MalwareScanningProperties {
    * Optional. Specifies the automated response action to take when malware is detected.
    */
   automatedResponse?: AutomatedResponseType = AutomatedResponseType.None;
+
+  /**
+   * Optional. Resource id of the scanner resource (e.g., securityOperator or dataScanner) whose identity will be used for malware scanning.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "The scanner resource id is nullable in the API contract to allow explicitly clearing a previously configured scanner."
+  @added(Versions.v2026_03_01_preview)
+  scannerResourceId?:
+    | Azure.Core.armResourceIdentifier<[
+        {
+          type: "Microsoft.Security/securityOperators";
+        },
+        {
+          type: "Microsoft.Security/dataScanners";
+        }
+      ]>
+    | null;
 
   /**
    * Upon failure or partial success. Additional data describing Malware Scanning enable/disable operation.
@@ -183,6 +229,22 @@ model SensitiveDataDiscoveryProperties {
    * Indicates whether Sensitive Data Discovery should be enabled.
    */
   isEnabled?: boolean;
+
+  /**
+   * Optional. Resource id of the scanner resource (e.g., securityOperator or dataScanner) whose identity will be used for sensitive data discovery.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "The scanner resource id is nullable in the API contract to allow explicitly clearing a previously configured scanner."
+  @added(Versions.v2026_03_01_preview)
+  scannerResourceId?:
+    | Azure.Core.armResourceIdentifier<[
+        {
+          type: "Microsoft.Security/securityOperators";
+        },
+        {
+          type: "Microsoft.Security/dataScanners";
+        }
+      ]>
+    | null;
 
   /**
    * Upon failure or partial success. Additional data describing Sensitive Data Discovery enable/disable operation.

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/defenderForStorageSettings.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/defenderForStorageSettings.json
@@ -1,0 +1,1092 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Security Center",
+    "version": "2026-03-01-preview",
+    "description": "API spec for Microsoft.Security (Azure Security Center) resource provider",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "DefenderForStorage"
+    },
+    {
+      "name": "Antimalware"
+    },
+    {
+      "name": "Scan"
+    }
+  ],
+  "paths": {
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings": {
+      "get": {
+        "operationId": "DefenderForStorage_List",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Lists the Defender for Storage settings for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSettingList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Lists the Defender for Storage settings for the specified storage account.": {
+            "$ref": "./examples/DefenderForStorage/ListDefenderForStorageSettings_example.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}": {
+      "get": {
+        "operationId": "DefenderForStorage_Get",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Gets the Defender for Storage settings for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets the Defender for Storage settings for the specified resource.": {
+            "$ref": "./examples/DefenderForStorage/GetDefenderForStorageSettings_example.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DefenderForStorage_Create",
+        "tags": [
+          "DefenderForStorage"
+        ],
+        "description": "Creates or updates the Defender for Storage settings on a specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "defenderForStorageSetting",
+            "in": "body",
+            "description": "Defender for Storage Settings",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DefenderForStorageSetting' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "201": {
+            "description": "Resource 'DefenderForStorageSetting' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForStorageSetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Creates or updates the Defender for Storage settings on a specified resource.": {
+            "$ref": "./examples/DefenderForStorage/PutDefenderForStorageSettings_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/malwareScans/{scanId}": {
+      "get": {
+        "operationId": "DefenderForStorage_GetMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Gets the Defender for Storage malware scan for the specified storage resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The identifier of the scan. Can be either 'latest' or a GUID.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(latest|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets the Defender for Storage malware scan for the specified storage resource.": {
+            "$ref": "./examples/DefenderForStorage/GetMalwareScan_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/malwareScans/{scanId}/cancelMalwareScan": {
+      "post": {
+        "operationId": "DefenderForStorage_CancelMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Cancels a Defender for Storage malware scan for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The identifier of the scan. Can be either 'latest' or a GUID.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(latest|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Cancel a Defender for Storage malware scan for the specified storage resource.": {
+            "$ref": "./examples/DefenderForStorage/CancelMalwareScan_example.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.Security/defenderForStorageSettings/{settingName}/startMalwareScan": {
+      "post": {
+        "operationId": "DefenderForStorage_StartMalwareScan",
+        "tags": [
+          "DefenderForStorage",
+          "Antimalware",
+          "Scan"
+        ],
+        "description": "Initiate a Defender for Storage malware scan for the specified storage account. Blobs and Files will be scanned for malware.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "settingName",
+            "in": "path",
+            "description": "The defender for storage setting name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$",
+            "enum": [
+              "MCAS",
+              "WDATP",
+              "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+              "WDATP_UNIFIED_SOLUTION",
+              "Sentinel",
+              "current"
+            ],
+            "x-ms-enum": {
+              "name": "SettingName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "MCAS",
+                  "value": "MCAS",
+                  "description": "MCAS"
+                },
+                {
+                  "name": "WDATP",
+                  "value": "WDATP",
+                  "description": "WDATP"
+                },
+                {
+                  "name": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "value": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+                  "description": "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+                },
+                {
+                  "name": "WDATP_UNIFIED_SOLUTION",
+                  "value": "WDATP_UNIFIED_SOLUTION",
+                  "description": "WDATP_UNIFIED_SOLUTION"
+                },
+                {
+                  "name": "Sentinel",
+                  "value": "Sentinel",
+                  "description": "Sentinel"
+                },
+                {
+                  "name": "current",
+                  "value": "current",
+                  "description": "Name of the Defender for Storage Settings name."
+                }
+              ]
+            }
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Optional request body to filter which blobs and files to scan.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StartMalwareScanRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MalwareScan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Initiate a Defender for Storage malware scan for the specified storage account.": {
+            "$ref": "./examples/DefenderForStorage/StartMalwareScan_example.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BlobScanFilter": {
+      "type": "object",
+      "description": "Filter for blob scanning. At least one of 'container' or 'blob' must be specified; a request with neither is rejected by the service. If only container is provided, all blobs in that container are scanned. If only blob is provided, blobs matching the filter across all containers are scanned.",
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for the blob container to scan. If not provided, the blob filter will apply across all containers."
+        },
+        "blob": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for specific blob(s). If container is specified, this filters blobs within that container. If container is not specified, this filters blobs across all containers."
+        }
+      }
+    },
+    "BlobsScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results of the blobs that were scanned.",
+      "properties": {
+        "totalBlobsScanned": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total number of blobs that were scanned."
+        },
+        "maliciousBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of malicious blobs that were detected during the scan."
+        },
+        "skippedBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of blobs that were skipped."
+        },
+        "failedBlobsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of failed blob scans."
+        },
+        "scannedBlobsInGB": {
+          "type": "number",
+          "format": "double",
+          "description": "The number of gigabytes of data that were scanned."
+        }
+      }
+    },
+    "Common.CloudError": {
+      "type": "object",
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Common.CloudErrorBody",
+          "description": "The error object.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "x-ms-external": true
+    },
+    "Common.CloudErrorBody": {
+      "type": "object",
+      "description": "The error detail.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/Common.CloudErrorBody"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorAdditionalInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      },
+      "x-ms-external": true
+    },
+    "Common.OperationStatus": {
+      "type": "object",
+      "description": "A status describing the success/failure of the enablement/disablement operation.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The operation status code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Additional information regarding the success/failure of the operation."
+        }
+      }
+    },
+    "DefenderForStorageSetting": {
+      "type": "object",
+      "description": "The Defender for Storage resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefenderForStorageSettingProperties",
+          "description": "Defender for Storage resource properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DefenderForStorageSettingList": {
+      "type": "object",
+      "description": "List of Defender for Storage settings.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of Defender for Storage settings.",
+          "items": {
+            "$ref": "#/definitions/DefenderForStorageSetting"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page."
+        }
+      }
+    },
+    "DefenderForStorageSettingProperties": {
+      "type": "object",
+      "description": "Defender for Storage resource properties.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether Defender for Storage is enabled on this storage account."
+        },
+        "malwareScanning": {
+          "$ref": "#/definitions/MalwareScanningProperties",
+          "description": "Properties of Malware Scanning."
+        },
+        "sensitiveDataDiscovery": {
+          "$ref": "#/definitions/SensitiveDataDiscoveryProperties",
+          "description": "Properties of Sensitive Data Discovery."
+        },
+        "overrideSubscriptionLevelSettings": {
+          "type": "boolean",
+          "description": "Indicates whether the settings defined for this storage account should override the settings defined for the subscription."
+        }
+      }
+    },
+    "FileScanFilter": {
+      "type": "object",
+      "description": "Filter for file scanning. At least one of 'share' or 'file' must be specified; a request with neither is rejected by the service. If only share is provided, all files in that share are scanned. If only file is provided, files matching the filter across all shares are scanned.",
+      "properties": {
+        "share": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for the file share to scan. If not provided, the file filter will apply across all shares."
+        },
+        "file": {
+          "$ref": "#/definitions/MatchFilter",
+          "description": "Optional filter for specific file(s). If share is specified, this filters files within that share. If share is not specified, this filters files across all shares."
+        }
+      }
+    },
+    "FilesScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results of the files that were scanned.",
+      "properties": {
+        "totalFilesScanned": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total number of files that were scanned."
+        },
+        "maliciousFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of malicious files that were detected during the scan."
+        },
+        "skippedFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of files that were skipped."
+        },
+        "failedFilesCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of failed file scans."
+        },
+        "scannedFilesInGB": {
+          "type": "number",
+          "format": "double",
+          "description": "The number of gigabytes of data that were scanned."
+        }
+      }
+    },
+    "MalwareScan": {
+      "type": "object",
+      "description": "Describes the state of a malware scan operation.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MalwareScanProperties"
+        }
+      }
+    },
+    "MalwareScanFilters": {
+      "type": "object",
+      "description": "Filters to scope the malware scan.",
+      "properties": {
+        "blobs": {
+          "$ref": "#/definitions/BlobScanFilter",
+          "description": "Optional filter for blob scanning. Specifies which blobs to scan."
+        },
+        "files": {
+          "$ref": "#/definitions/FileScanFilter",
+          "description": "Optional filter for file scanning. Specifies which files to scan."
+        }
+      }
+    },
+    "MalwareScanProperties": {
+      "type": "object",
+      "properties": {
+        "scanId": {
+          "type": "string",
+          "description": "The identifier of the scan."
+        },
+        "scanStatus": {
+          "type": "string",
+          "description": "A status code of the scan operation."
+        },
+        "scanStatusMessage": {
+          "type": "string",
+          "description": "A description of the status of the scan."
+        },
+        "scanStartTime": {
+          "type": "string",
+          "description": "The time at which the scan had been initiated."
+        },
+        "scanEndTime": {
+          "type": "string",
+          "description": "The time at which the scan has ended. Only available for a scan which has terminated."
+        },
+        "scanSummary": {
+          "$ref": "#/definitions/ScanSummary",
+          "description": "A summary of the scan results."
+        }
+      }
+    },
+    "MalwareScanningProperties": {
+      "type": "object",
+      "description": "Properties of Malware Scanning.",
+      "properties": {
+        "onUpload": {
+          "$ref": "#/definitions/OnUploadProperties",
+          "description": "Properties of On Upload malware scanning."
+        },
+        "scanResultsEventGridTopicResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Resource id of an Event Grid Topic to send scan results to.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.EventGrid/topics"
+              }
+            ]
+          }
+        },
+        "blobScanResultsOptions": {
+          "type": "string",
+          "description": "Optional. Write scan result on BlobIndexTags by default.",
+          "default": "BlobIndexTags",
+          "enum": [
+            "BlobIndexTags",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "BlobScanResultsOptions",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "BlobIndexTags",
+                "value": "BlobIndexTags",
+                "description": "Write scan results on the blobs index tags."
+              },
+              {
+                "name": "None",
+                "value": "None",
+                "description": "Do not write scan results on the blobs index tags."
+              }
+            ]
+          }
+        },
+        "automatedResponse": {
+          "type": "string",
+          "description": "Optional. Specifies the automated response action to take when malware is detected.",
+          "default": "None",
+          "enum": [
+            "None",
+            "BlobSoftDelete"
+          ],
+          "x-ms-enum": {
+            "name": "AutomatedResponseType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No automated response will be taken when malware is detected."
+              },
+              {
+                "name": "BlobSoftDelete",
+                "value": "BlobSoftDelete",
+                "description": "The blob will be soft deleted when malware is detected."
+              }
+            ]
+          }
+        },
+        "operationStatus": {
+          "$ref": "#/definitions/Common.OperationStatus",
+          "description": "Upon failure or partial success. Additional data describing Malware Scanning enable/disable operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "MatchFilter": {
+      "type": "object",
+      "description": "Filter with value and matching strategy.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The value to match against."
+        },
+        "match": {
+          "$ref": "#/definitions/MatchType",
+          "description": "The matching strategy for the filter."
+        }
+      },
+      "required": [
+        "value",
+        "match"
+      ]
+    },
+    "MatchType": {
+      "type": "string",
+      "description": "The matching strategy for the filter.",
+      "enum": [
+        "Prefix",
+        "Exact"
+      ],
+      "x-ms-enum": {
+        "name": "MatchType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Prefix",
+            "value": "Prefix",
+            "description": "Match resources with values starting with the specified string."
+          },
+          {
+            "name": "Exact",
+            "value": "Exact",
+            "description": "Match resources with the exact value specified."
+          }
+        ]
+      }
+    },
+    "OnUploadFilters": {
+      "type": "object",
+      "description": "Optional. Determine which blobs get scanned by On Upload malware scanning. An Or operation is performed between each filter type.",
+      "properties": {
+        "excludeBlobsWithPrefix": {
+          "type": "array",
+          "description": "Optional. A list of prefixes to exclude from on-upload malware scanning.\nFormat: `container-name/blob-name` (start with the container name; do not include the storage account name).\nExclude entire containers: Use prefix of container names you want to exclude without a trailing `/`.\nExclude a single container: Add a trailing slash `/` after the container name to avoid excluding other containers with similar prefixes.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeBlobsWithSuffix": {
+          "type": "array",
+          "description": "Optional. A list of suffixes to exclude from on-upload malware scanning. Suffixes match only the end of blob names, and should be used for file extensions or blob name endings only.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeBlobsLargerThan": {
+          "description": "Optional. Specifies the maximum size in bytes for blobs to be scanned. This parameter accepts a single positive integer value. Blobs larger than this value will be excluded from scanning.",
+          "x-nullable": true
+        }
+      }
+    },
+    "OnUploadProperties": {
+      "type": "object",
+      "description": "Properties of On Upload malware scanning.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether On Upload malware scanning should be enabled."
+        },
+        "capGBPerMonth": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Defines the max GB to be scanned per Month. Set to -1 if no capping is needed. If not specified, the default value is -1."
+        },
+        "filters": {
+          "$ref": "#/definitions/OnUploadFilters",
+          "description": "Optional. Determine which blobs get scanned by On Upload malware scanning. An Or operation is performed between each filter type.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ScanSummary": {
+      "type": "object",
+      "description": "A summary of the scan results.",
+      "properties": {
+        "blobs": {
+          "$ref": "#/definitions/BlobsScanSummary",
+          "description": "A summary of the scan results of the blobs that were scanned."
+        },
+        "files": {
+          "$ref": "#/definitions/FilesScanSummary",
+          "description": "A summary of the scan results of the files that were scanned."
+        },
+        "estimatedScanCostUSD": {
+          "type": "number",
+          "format": "double",
+          "description": "The estimated cost of the scan. Only available for a scan which has terminated."
+        }
+      }
+    },
+    "SensitiveDataDiscoveryProperties": {
+      "type": "object",
+      "description": "Properties of Sensitive Data Discovery.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether Sensitive Data Discovery should be enabled."
+        },
+        "operationStatus": {
+          "$ref": "#/definitions/Common.OperationStatus",
+          "description": "Upon failure or partial success. Additional data describing Sensitive Data Discovery enable/disable operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "StartMalwareScanRequest": {
+      "type": "object",
+      "description": "Request body for starting a malware scan with optional filters.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StartMalwareScanRequestProperties",
+          "description": "Properties for the malware scan request."
+        }
+      }
+    },
+    "StartMalwareScanRequestProperties": {
+      "type": "object",
+      "description": "Properties for the malware scan request.",
+      "properties": {
+        "filters": {
+          "$ref": "#/definitions/MalwareScanFilters",
+          "description": "Optional filters to scope the malware scan to specific blobs or files."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/defenderForStorageSettings.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/defenderForStorageSettings.json
@@ -768,6 +768,11 @@
         "overrideSubscriptionLevelSettings": {
           "type": "boolean",
           "description": "Indicates whether the settings defined for this storage account should override the settings defined for the subscription."
+        },
+        "managedBy": {
+          "$ref": "#/definitions/ManagedByType",
+          "description": "Indicates whether this resource's Defender for Storage settings are managed by a higher MDC enforcement scope and which component is managing them. When set to a value other than 'None', the resource-level settings become read-only and can only be modified by the managing component. Possible values: 'None' (not managed), 'MicrosoftDefenderXDR' (managed by Microsoft Defender XDR), 'SubscriptionSettingsEnforcer' (managed by subscription-level settings enforcer).",
+          "readOnly": true
         }
       }
     },
@@ -938,11 +943,57 @@
             ]
           }
         },
+        "scannerResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Resource id of the scanner resource (e.g., securityOperator or dataScanner) whose identity will be used for malware scanning.",
+          "x-nullable": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Security/securityOperators"
+              },
+              {
+                "type": "Microsoft.Security/dataScanners"
+              }
+            ]
+          }
+        },
         "operationStatus": {
           "$ref": "#/definitions/Common.OperationStatus",
           "description": "Upon failure or partial success. Additional data describing Malware Scanning enable/disable operation.",
           "readOnly": true
         }
+      }
+    },
+    "ManagedByType": {
+      "type": "string",
+      "description": "Indicates whether this resource's Defender for Storage settings are managed by a higher MDC enforcement scope and which component is managing them.",
+      "enum": [
+        "None",
+        "MicrosoftDefenderXDR",
+        "SubscriptionSettingsEnforcer"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedByType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "The resource's Defender for Storage settings are not managed by a higher enforcement scope."
+          },
+          {
+            "name": "MicrosoftDefenderXDR",
+            "value": "MicrosoftDefenderXDR",
+            "description": "The resource's Defender for Storage settings are managed by Microsoft Defender XDR."
+          },
+          {
+            "name": "SubscriptionSettingsEnforcer",
+            "value": "SubscriptionSettingsEnforcer",
+            "description": "The resource's Defender for Storage settings are managed by the subscription-level settings enforcer."
+          }
+        ]
       }
     },
     "MatchFilter": {
@@ -1059,6 +1110,22 @@
         "isEnabled": {
           "type": "boolean",
           "description": "Indicates whether Sensitive Data Discovery should be enabled."
+        },
+        "scannerResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Resource id of the scanner resource (e.g., securityOperator or dataScanner) whose identity will be used for sensitive data discovery.",
+          "x-nullable": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Security/securityOperators"
+              },
+              {
+                "type": "Microsoft.Security/dataScanners"
+              }
+            ]
+          }
         },
         "operationStatus": {
           "$ref": "#/definitions/Common.OperationStatus",

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/CancelMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/CancelMalwareScan_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "3fd3c1be-dbff-4d6e-985f-43f9ec1b1146",
+          "scanStatus": "Canceling",
+          "scanStatusMessage": "The scan request is being canceled upon user request"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_CancelMalwareScan",
+  "title": "Cancel a Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Get",
+  "title": "Gets the Defender for Storage settings for the specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetDefenderForStorageSettings_example.json
@@ -31,11 +31,14 @@
               },
               "isEnabled": true
             },
-            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
-            "isEnabled": true
+            "isEnabled": true,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
           }
         }
       }

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/GetMalwareScan_example.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "scanId": "latest",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanEndTime": "2025-09-01T12:21:17.5648386Z",
+          "scanId": "0ce362c5-87a5-4030-ba6a-109566cd7b3d",
+          "scanStartTime": "2025-09-01T12:20:14.6364816Z",
+          "scanStatus": "Completed",
+          "scanSummary": {
+            "blobs": {
+              "failedBlobsCount": 0,
+              "maliciousBlobsCount": 10,
+              "scannedBlobsInGB": 0.019550956785678864,
+              "skippedBlobsCount": 0,
+              "totalBlobsScanned": 40
+            },
+            "estimatedScanCostUSD": 0.0029326435178518295,
+            "files": {
+              "failedFilesCount": 0,
+              "maliciousFilesCount": 2,
+              "scannedFilesInGB": 10.5,
+              "skippedFilesCount": 0,
+              "totalFilesScanned": 150
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_GetMalwareScan",
+  "title": "Gets the Defender for Storage malware scan for the specified storage resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.Security/defenderForStorageSettings",
+            "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+            "properties": {
+              "isEnabled": true,
+              "malwareScanning": {
+                "automatedResponse": "BlobSoftDelete",
+                "blobScanResultsOptions": "BlobIndexTags",
+                "onUpload": {
+                  "capGBPerMonth": 10000,
+                  "filters": {
+                    "excludeBlobsLargerThan": 1024,
+                    "excludeBlobsWithPrefix": [
+                      "sample-container/logs",
+                      "single-excluded-container/",
+                      "excluded-containers"
+                    ],
+                    "excludeBlobsWithSuffix": [
+                      ".log",
+                      ".jpg"
+                    ]
+                  },
+                  "isEnabled": true
+                },
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+              },
+              "overrideSubscriptionLevelSettings": true,
+              "sensitiveDataDiscovery": {
+                "isEnabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_List",
+  "title": "Lists the Defender for Storage settings for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/ListDefenderForStorageSettings_example.json
@@ -32,11 +32,14 @@
                   },
                   "isEnabled": true
                 },
-                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+                "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+                "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
               },
+              "managedBy": "None",
               "overrideSubscriptionLevelSettings": true,
               "sensitiveDataDiscovery": {
-                "isEnabled": true
+                "isEnabled": true,
+                "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
               }
             }
           }

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -22,11 +22,13 @@
             },
             "isEnabled": true
           },
-          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+          "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
         },
         "overrideSubscriptionLevelSettings": true,
         "sensitiveDataDiscovery": {
-          "isEnabled": true
+          "isEnabled": true,
+          "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator"
         }
       }
     },
@@ -63,11 +65,14 @@
             "operationStatus": {
               "code": "Succeeded"
             },
-            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic",
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator"
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
             "isEnabled": true,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator",
             "operationStatus": {
               "code": "Succeeded"
             }
@@ -89,14 +94,17 @@
               "capGBPerMonth": -1,
               "isEnabled": false
             },
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/malwareScanningOperator",
             "operationStatus": {
               "code": "PartialSuccess",
               "message": "Failed to setup data scanner."
             }
           },
+          "managedBy": "None",
           "overrideSubscriptionLevelSettings": true,
           "sensitiveDataDiscovery": {
             "isEnabled": false,
+            "scannerResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/sensitiveDataDiscoveryOperator",
             "operationStatus": {
               "code": "PartialSuccess",
               "message": "Failed to setup data scanner."

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/PutDefenderForStorageSettings_example.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "defenderForStorageSetting": {
+      "properties": {
+        "isEnabled": true,
+        "malwareScanning": {
+          "automatedResponse": "BlobSoftDelete",
+          "blobScanResultsOptions": "BlobIndexTags",
+          "onUpload": {
+            "capGBPerMonth": 10000,
+            "filters": {
+              "excludeBlobsLargerThan": 1024,
+              "excludeBlobsWithPrefix": [
+                "unscanned-container",
+                "sample-container/logs"
+              ],
+              "excludeBlobsWithSuffix": [
+                ".log",
+                ".jpg"
+              ]
+            },
+            "isEnabled": true
+          },
+          "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+        },
+        "overrideSubscriptionLevelSettings": true,
+        "sensitiveDataDiscovery": {
+          "isEnabled": true
+        }
+      }
+    },
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "BlobSoftDelete",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": 10000,
+              "filters": {
+                "excludeBlobsLargerThan": 1024,
+                "excludeBlobsWithPrefix": [
+                  "sample-container/logs",
+                  "single-excluded-container/",
+                  "excluded-containers"
+                ],
+                "excludeBlobsWithSuffix": [
+                  ".log",
+                  ".jpg"
+                ]
+              },
+              "isEnabled": true
+            },
+            "operationStatus": {
+              "code": "Succeeded"
+            },
+            "scanResultsEventGridTopicResourceId": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.EventGrid/topics/sampletopic"
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": true,
+            "operationStatus": {
+              "code": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.Security/defenderForStorageSettings",
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount/providers/Microsoft.Security/defenderForStorageSettings/current",
+        "properties": {
+          "isEnabled": true,
+          "malwareScanning": {
+            "automatedResponse": "None",
+            "blobScanResultsOptions": "BlobIndexTags",
+            "onUpload": {
+              "capGBPerMonth": -1,
+              "isEnabled": false
+            },
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          },
+          "overrideSubscriptionLevelSettings": true,
+          "sensitiveDataDiscovery": {
+            "isEnabled": false,
+            "operationStatus": {
+              "code": "PartialSuccess",
+              "message": "Failed to setup data scanner."
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_Create",
+  "title": "Creates or updates the Defender for Storage settings on a specified resource."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/StartMalwareScan_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/Security/preview/2026-03-01-preview/examples/DefenderForStorage/StartMalwareScan_example.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01-preview",
+    "resourceId": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/resourceGroups/SampleRG/providers/Microsoft.Storage/storageAccounts/samplestorageaccount",
+    "settingName": "current",
+    "body": {
+      "properties": {
+        "filters": {
+          "blobs": {
+            "container": {
+              "value": "mycontainer",
+              "match": "Exact"
+            },
+            "blob": {
+              "value": "myblob.txt",
+              "match": "Exact"
+            }
+          },
+          "files": {
+            "share": {
+              "value": "myshare",
+              "match": "Exact"
+            },
+            "file": {
+              "value": "dir",
+              "match": "Prefix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "scanId": "fc831479-412f-4bc2-8333-a8edda751a80",
+          "scanStatus": "Queued",
+          "scanStatusMessage": "The scan request has been queued for scanning"
+        }
+      }
+    }
+  },
+  "operationId": "DefenderForStorage_StartMalwareScan",
+  "title": "Initiate a Defender for Storage malware scan for the specified storage account."
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/readme.md
+++ b/specification/security/resource-manager/Microsoft.Security/Security/readme.md
@@ -210,6 +210,15 @@ input-file:
   - preview/2025-10-01-preview/pricings.json
 ```
 
+### Tag: package-preview-2026-03-01-preview
+
+These settings apply only when `--tag=package-preview-2026-03-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-03-01-preview'
+input-file:
+  - preview/2026-03-01-preview/defenderForStorageSettings.json
+```
+
 ### Tag: package-preview-2026-01-01-preview
 
 These settings apply only when `--tag=package-preview-2026-01-01-preview` is specified on the command line.
@@ -714,7 +723,7 @@ input-file:
 - preview/2023-12-01-preview/security-Automations.json
 - preview/2024-08-01-preview/securityConnectors.json
 - stable/2025-05-04/security-Assessment.json
-- preview/2026-01-01-preview/defenderForStorageSettings.json
+- preview/2026-03-01-preview/defenderForStorageSettings.json
 - preview/2025-11-01-preview/securityConnectorsDevOps.json
 - preview/2025-10-01-preview/security-Operations.json
 - stable/2017-08-01/complianceResults.json


### PR DESCRIPTION
## Summary

Adds a new preview API version **2026-03-01-preview** to the `Microsoft.Security` `DefenderForStorageSettings` TypeSpec project, built on top of the merged **2026-01-01-preview**.

Authored in TypeSpec. Structured **copy-first** for reviewability:

1. **Initial commit — pure copy.** Duplicates 2026-01-01-preview as 2026-03-01-preview with no behavior change (adds the version to the enum, copies examples, adds the readme tag, points the composite default tag at 2026-03-01-preview). The generated `defenderForStorageSettings.json` is identical to 2026-01-01-preview except the version string.
2. **Follow-up commit — additions.** Applies the actual 2026-03-01-preview changes on top (see below), so the review diff isolates exactly what is new.

## What's new in 2026-03-01-preview (per-extension scanner identity)

- **`scannerResourceId`** (nullable ARM id of `Microsoft.Security/securityOperators` or `Microsoft.Security/dataScanners`) on both `MalwareScanningProperties` and `SensitiveDataDiscoveryProperties` — the scanner identity used for malware scanning / sensitive data discovery.
- **`managedBy`** (read-only `ManagedByType` enum: `None`, `MicrosoftDefenderXDR`, `SubscriptionSettingsEnforcer`) on `DefenderForStorageSettingProperties` — indicates whether the resource's settings are managed by a higher MDC enforcement scope.

All additions are declared with `@added(v2026_03_01_preview)`, so the published 2025-09-01-preview and 2026-01-01-preview outputs are byte-for-byte unchanged. The changes are additive and backwards-compatible.

## Validation

- `tsp compile` clean; TypeSpec validation passes.
- 2025-09-01-preview and 2026-01-01-preview outputs confirmed unchanged.
- 2026-03-01-preview differs from 2026-01-01-preview by exactly the two additions above.
