### PR TITLE
AKS: normalize Python IPv6 count client name

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -96,6 +96,11 @@ using Microsoft.ContainerService;
   "count_ipv6",
   "python"
 );
+@@clientName(
+  ManagedClusterManagedOutboundIPProfile.countIPv6,
+  "count_ipv6",
+  "python"
+);
 
 @@clientName(
   ManagedClusterPodIdentityProvisioningError.error,


### PR DESCRIPTION
## What changed

- Adds a Python-specific `@@clientName` customization for `ManagedClusterManagedOutboundIPProfile.countIPv6`.
- Generates the property as `count_ipv6`, matching the existing load-balancer managed outbound IP property instead of the default `count_i_pv6` conversion.

## Why

Both REST properties use the wire name `countIPv6`, but only the older load-balancer property had the Python naming customization. This keeps the Python SDK surface consistent before the NAT gateway IPv6 property progresses beyond preview.

This PR is stacked on and targets #44949.

## Validation

- `npx tsp compile specification/containerservice/resource-manager/Microsoft.ContainerService/aks --warn-as-error`
- `npx tsp format --check specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp`
- `git diff --check`