### PR TITLE
Add contextual names for Authorization .NET models

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
@@ -328,7 +328,18 @@ union RoleManagementScopeType {
 );
 @@clientName(
   Microsoft.Authorization.NotificationDeliveryMechanism,
-  "NotificationDeliveryType",
+  "RoleManagementNotificationDeliveryType",
+  "csharp"
+);
+// Keep the resource's full properties wrapper distinct from the expanded public model below.
+@@clientName(
+  Microsoft.Authorization.RoleManagementPolicyAssignmentProperties,
+  "RoleManagementPolicyAssignmentDataProperties",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Authorization.PolicyAssignmentProperties,
+  "RoleManagementPolicyAssignmentProperties",
   "csharp"
 );
 @@clientName(
@@ -353,7 +364,12 @@ union RoleManagementScopeType {
 );
 @@clientName(
   Microsoft.Authorization.RoleManagementPolicyNotificationRule.notificationType,
-  "NotificationDeliveryType",
+  "RoleManagementNotificationDeliveryType",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Authorization.RoleManagementPolicyAssignmentProperties.policyAssignmentProperties,
+  "RoleManagementPolicyAssignmentProperties",
   "csharp"
 );
 @@clientName(

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
@@ -91,7 +91,7 @@ union RoleManagementScopeType {
 @@alternateType(
   Microsoft.RoleAssignment.RoleAssignmentProperties.principalType,
   Microsoft.Common.PrincipalType,
-  "java,python"
+  "csharp,java,python"
 );
 
 // Restore C# GA resource, model, and extensible-enum names.


### PR DESCRIPTION
Adds C# client names for the two contextual naming suggestions from Azure/azure-sdk-for-net#61053 review 4783552863.

The resource-level properties wrapper is given a distinct internal C# name so the expanded public model can use RoleManagementPolicyAssignmentProperties.