### PR TITLE
Add Event Hubs provisioning emitter configuration

### DIFF
--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -4,8 +4,7 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.EventHub;
 
-@@clientName(
-  Microsoft.EventHub,
+@@clientName(Microsoft.EventHub,
   "EventHubManagementClient",
   "python,javascript,java"
 );
@@ -17,66 +16,55 @@ using Microsoft.EventHub;
 @@clientName(TlsVersion.`1.3`, "One3", "go");
 
 // Fix field naming changes for Go SDK backward compatibility
-@@clientName(
-  RetentionDescription.minCompactionLagTimeInMinutes,
+@@clientName(RetentionDescription.minCompactionLagTimeInMinutes,
   "MinCompactionLagInMins",
   "go"
 );
 
 // csharp configuration
-@@clientName(
-  Microsoft.EventHub.EventHubs,
+@@clientName(Microsoft.EventHub.EventHubs,
   "EventHubAuthorizationRule",
   "csharp"
 );
-@@clientName(
-  AuthorizationRules,
+@@clientName(AuthorizationRules,
   "EventHubsNamespaceAuthorizationRule",
   "csharp"
 );
-@@clientName(
-  DisasterRecoveryConfigs,
+@@clientName(DisasterRecoveryConfigs,
   "EventHubsDisasterRecoveryAuthorizationRule",
   "csharp"
 );
-@@clientName(
-  PrivateEndpointConnection,
+@@clientName(PrivateEndpointConnection,
   "EventHubsPrivateEndpointConnection",
   "csharp"
 );
 @@clientName(Clusters.configurationGet, "GetConfiguration", "csharp");
-@@clientName(
-  EHNamespaces.privateLinkResourcesGet,
+@@clientName(EHNamespaces.privateLinkResourcesGet,
   "GetPrivateLinkResources",
   "csharp"
 );
 @@clientName(NetworkRuleSets.getNetworkRuleSet, "GetNetworkRuleSet", "csharp");
-@@clientName(
-  NetworkRuleSets.listNetworkRuleSet,
+@@clientName(NetworkRuleSets.listNetworkRuleSet,
   "ListNetworkRuleSets",
   "csharp"
 );
 @@clientName(EHNamespaces.failover, "FailOver", "csharp");
-@@clientName(
-  EHNamespaces.checkNameAvailability,
+@@clientName(EHNamespaces.checkNameAvailability,
   "CheckEventHubsDisasterRecoveryNameAvailability",
   "csharp"
 );
-@@clientName(
-  NamespacesOperationGroup.checkNameAvailability,
+@@clientName(NamespacesOperationGroup.checkNameAvailability,
   "CheckEventHubsNamespaceNameAvailability",
   "csharp"
 );
-@@clientName(
-  ClustersOperationGroup.listAvailableClusterRegion,
+@@clientName(ClustersOperationGroup.listAvailableClusterRegion,
   "GetAvailableClusterRegionClusters",
   "csharp"
 );
 @@clientName(Clusters.patch, "PatchConfiguration", "csharp");
 @@clientName(CaptureIdentity.type, "IdentityType", "csharp");
 @@clientName(NWRuleSetIpRules.ipMask, "IPMask", "csharp");
-@@clientName(
-  PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
+@@clientName(PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
   "ConnectionState",
   "csharp"
 );
@@ -87,108 +75,90 @@ using Microsoft.EventHub;
 @@alternateType(ClusterProperties.createdAt, utcDateTime, "csharp");
 @@clientName(ClusterProperties.updatedAt, "UpdatedOn", "csharp");
 @@alternateType(ClusterProperties.updatedAt, utcDateTime, "csharp");
-@@alternateType(
-  EHNamespaceProperties.clusterArmId,
+@@alternateType(EHNamespaceProperties.clusterArmId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@clientName(DefaultAction, "EventHubsNetworkRuleSetDefaultAction", "csharp");
-@@clientName(
-  PublicNetworkAccessFlag,
+@@clientName(PublicNetworkAccessFlag,
   "EventHubsPublicNetworkAccessFlag",
   "csharp"
 );
 @@clientName(NWRuleSetIpRules, "EventHubsNetworkRuleSetIPRules", "csharp");
 @@clientName(NetworkRuleIPAction, "EventHubsNetworkRuleIPAction", "csharp");
-@@clientName(
-  NWRuleSetVirtualNetworkRules,
+@@clientName(NWRuleSetVirtualNetworkRules,
   "EventHubsNetworkRuleSetVirtualNetworkRules",
   "csharp"
 );
-@@clientName(
-  EndPointProvisioningState,
+@@clientName(EndPointProvisioningState,
   "EventHubsPrivateEndpointConnectionProvisioningState",
   "csharp"
 );
-@@clientName(
-  ConnectionState,
+@@clientName(ConnectionState,
   "EventHubsPrivateLinkServiceConnectionState",
   "csharp"
 );
-@@clientName(
-  PrivateLinkConnectionStatus,
+@@clientName(PrivateLinkConnectionStatus,
   "EventHubsPrivateLinkConnectionStatus",
   "csharp"
 );
 @@clientName(ProvisioningState, "EventHubsClusterProvisioningState", "csharp");
 @@clientName(CleanupPolicyRetentionDescription.Compact, "Compaction", "csharp");
-@@alternateType(
-  NetworkSecurityPerimeterConfigurationProperties.sourceResourceId,
+@@alternateType(NetworkSecurityPerimeterConfigurationProperties.sourceResourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@clientName(
-  ApplicationGroupPolicy,
+@@clientName(ApplicationGroupPolicy,
   "EventHubsApplicationGroupPolicy",
   "csharp"
 );
-@@clientName(
-  ApplicationGroupPolicy.type,
+@@clientName(ApplicationGroupPolicy.type,
   "ApplicationGroupPolicyType",
   "csharp"
 );
-@@clientName(
-  RegenerateAccessKeyParameters,
+@@clientName(RegenerateAccessKeyParameters,
   "EventHubsRegenerateAccessKeyContent",
   "csharp"
 );
 @@clientName(KeyType, "EventHubsAccessKeyType", "csharp");
 @@clientName(ArmDisasterRecovery, "EventHubsDisasterRecovery", "csharp");
-@@clientName(
-  ProvisioningStateDR,
+@@clientName(ProvisioningStateDR,
   "EventHubsDisasterRecoveryProvisioningState",
   "csharp"
 );
 @@clientName(RoleDisasterRecovery, "EventHubsDisasterRecoveryRole", "csharp");
 @@clientName(Eventhub, "EventHub", "csharp");
 @@clientName(Destination, "EventHubDestination", "csharp");
-@@alternateType(
-  DestinationProperties.storageAccountResourceId,
+@@alternateType(DestinationProperties.storageAccountResourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@clientName(
-  CheckNameAvailabilityParameter,
+@@clientName(CheckNameAvailabilityParameter,
   "EventHubsNameAvailabilityContent",
   "csharp"
 );
-@@clientName(
-  CheckNameAvailabilityResult,
+@@clientName(CheckNameAvailabilityResult,
   "EventHubsNameAvailabilityResult",
   "csharp"
 );
 @@clientName(UnavailableReason, "EventHubsNameUnavailableReason", "csharp");
 @@clientName(FailOver, "EventHubsNamespaceFailover", "csharp");
-@@clientName(
-  GeoDataReplicationProperties,
+@@clientName(GeoDataReplicationProperties,
   "EventHubsNamespaceGeoDataReplicationProperties",
   "csharp"
 );
 @@clientName(GeoDRRoleType, "EventHubsNamespaceGeoDrRoleType", "csharp");
-@@alternateType(
-  NamespaceReplicaLocation.clusterArmId,
+@@alternateType(NamespaceReplicaLocation.clusterArmId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@clientName(Mode, "EventHubsConfidentialComputeMode", "csharp");
 @@clientName(TimestampType, "EventHubsTimestampType", "csharp");
-@@clientName(
-  NamespaceReplicaLocation,
+@@clientName(NamespaceReplicaLocation,
   "EventHubsNamespaceReplicaLocation",
   "csharp"
 );
-@@clientName(
-  NetworkRuleSetListResult,
+@@clientName(NetworkRuleSetListResult,
   "EventHubsNetworkRuleSetListResult",
   "csharp"
 );
@@ -202,85 +172,70 @@ using Microsoft.EventHub;
 // java naming mitigations
 @@clientName(NetworkRuleIPAction, "NetworkRuleIpAction", "java");
 @@clientName(SchemaGroupProperties.eTag, "etag", "java");
-@@clientLocation(
-  NetworkSecurityPerimeterConfigurations.list,
+@@clientLocation(NetworkSecurityPerimeterConfigurations.list,
   "NetworkSecurityPerimeterConfigurations",
   "java"
 );
 
-@@alternateType(
-  DestinationProperties.dataLakeSubscriptionId,
+@@alternateType(DestinationProperties.dataLakeSubscriptionId,
   Azure.Core.uuid,
   "java"
 );
 
 @@clientName(TlsVersion, "EventHubsTlsVersion", "csharp");
-@@clientName(
-  TlsVersion.`1.0`,
+@@clientName(TlsVersion.`1.0`,
   Azure.ClientGenerator.Core.exact("Tls1_0"),
   "csharp"
 );
-@@clientName(
-  TlsVersion.`1.1`,
+@@clientName(TlsVersion.`1.1`,
   Azure.ClientGenerator.Core.exact("Tls1_1"),
   "csharp"
 );
-@@clientName(
-  TlsVersion.`1.2`,
+@@clientName(TlsVersion.`1.2`,
   Azure.ClientGenerator.Core.exact("Tls1_2"),
   "csharp"
 );
-@@clientName(
-  TlsVersion.`1.3`,
+@@clientName(TlsVersion.`1.3`,
   Azure.ClientGenerator.Core.exact("Tls1_3"),
   "csharp"
 );
 @@clientName(PublicNetworkAccess, "EventHubsPublicNetworkAccess", "csharp");
-@@clientName(
-  ProvisioningIssueProperties,
+@@clientName(ProvisioningIssueProperties,
   "EventHubsProvisioningIssueProperties",
   "csharp"
 );
 @@clientName(ProvisioningIssue, "EventHubsProvisioningIssue", "csharp");
 @@usage(ProvisioningIssue, Usage.input, "csharp");
 @@clientName(MetricId, "EventHubsMetricId", "csharp");
-@@clientName(
-  NetworkSecurityPerimeter,
+@@clientName(NetworkSecurityPerimeter,
   "EventHubsNetworkSecurityPerimeter",
   "csharp"
 );
-@@clientName(
-  NetworkSecurityPerimeterConfiguration,
+@@clientName(NetworkSecurityPerimeterConfiguration,
   "EventHubsNetworkSecurityPerimeterConfiguration",
   "csharp"
 );
-@@clientName(
-  NetworkSecurityPerimeterConfigurationPropertiesProfile,
+@@clientName(NetworkSecurityPerimeterConfigurationPropertiesProfile,
   "EventHubsNetworkSecurityPerimeterConfigurationPropertiesProfile",
   "csharp"
 );
-@@clientName(
-  NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation,
+@@clientName(NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation,
   "EventHubsNetworkSecurityPerimeterConfigurationPropertiesResourceAssociation",
   "csharp"
 );
-@@clientName(
-  NetworkSecurityPerimeterConfigurationProvisioningState,
+@@clientName(NetworkSecurityPerimeterConfigurationProvisioningState,
   "EventHubsNetworkSecurityPerimeterConfigurationProvisioningState",
   "csharp"
 );
-@@clientName(
-  NspAccessRuleDirection,
+@@clientName(NspAccessRuleDirection,
   "EventHubsNspAccessRuleDirection",
   "csharp"
 );
-@@clientName(
-  NspAccessRuleProperties,
+@@clientName(NspAccessRuleProperties,
   "EventHubsNspAccessRuleProperties",
   "csharp"
 );
-@@clientName(
-  ResourceAssociationAccessMode,
+@@clientName(ResourceAssociationAccessMode,
   "EventHubsResourceAssociationAccessMode",
   "csharp"
 );
@@ -302,55 +257,45 @@ using Microsoft.EventHub;
 @@usage(ClusterQuotaConfigurationProperties, Usage.input, "csharp");
 @@usage(CheckNameAvailabilityParameter, Usage.input | Usage.output, "csharp");
 @@usage(FailOver, Usage.input | Usage.output, "csharp");
-@@usage(
-  NspAccessRulePropertiesSubscriptionsItem,
+@@usage(NspAccessRulePropertiesSubscriptionsItem,
   Usage.input | Usage.output,
   "csharp"
 );
 // Mark list operations as pageable for C# backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
-  Clusters.listNamespaces,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(Clusters.listNamespaces,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
-  ClustersOperationGroup.listAvailableClusterRegion,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(ClustersOperationGroup.listAvailableClusterRegion,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
-  EHNamespaces.privateLinkResourcesGet,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(EHNamespaces.privateLinkResourcesGet,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
-  NetworkSecurityPerimeterConfigurations.list,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(NetworkSecurityPerimeterConfigurations.list,
   "csharp"
 );
-@@clientLocation(
-  AuthorizationRules.getAuthorizationRule,
+@@clientLocation(AuthorizationRules.getAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(
-  AuthorizationRules.createOrUpdateAuthorizationRule,
+@@clientLocation(AuthorizationRules.createOrUpdateAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(
-  AuthorizationRules.deleteAuthorizationRule,
+@@clientLocation(AuthorizationRules.deleteAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(
-  AuthorizationRules.listAuthorizationRules,
+@@clientLocation(AuthorizationRules.listAuthorizationRules,
   AuthorizationRules,
   "csharp"
 );
 @@clientLocation(AuthorizationRules.listKeys, AuthorizationRules, "csharp");
-@@clientLocation(
-  AuthorizationRules.regenerateKeys,
+@@clientLocation(AuthorizationRules.regenerateKeys,
   AuthorizationRules,
   "csharp"
 );
@@ -362,46 +307,38 @@ using Microsoft.EventHub;
 @@alternateType(ApplicationGroup.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(SchemaGroup.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(NetworkRuleSet.location, Azure.Core.azureLocation, "csharp");
-@@alternateType(
-  PrivateEndpointConnection.location,
+@@alternateType(PrivateEndpointConnection.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(
-  NetworkSecurityPerimeterConfiguration.location,
+@@alternateType(NetworkSecurityPerimeterConfiguration.location,
   Azure.Core.azureLocation,
   "csharp"
 );
 @@alternateType(AvailableCluster.location, Azure.Core.azureLocation, "csharp");
-@@alternateType(
-  NetworkSecurityPerimeter.location,
+@@alternateType(NetworkSecurityPerimeter.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(
-  ArmDisasterRecovery.location,
+@@alternateType(ArmDisasterRecovery.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(
-  EHNamespace.identity,
+@@alternateType(EHNamespace.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
 @@alternateType(KeyVaultProperties.keyVaultUri, url, "csharp");
-@@alternateType(
-  DestinationProperties.dataLakeSubscriptionId,
+@@alternateType(DestinationProperties.dataLakeSubscriptionId,
   Azure.Core.uuid,
   "csharp"
 );
 @@alternateType(SchemaGroupProperties.eTag, Azure.Core.eTag, "csharp");
-@@alternateType(
-  FailOverProperties.primaryLocation,
+@@alternateType(FailOverProperties.primaryLocation,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(
-  EHNamespaceIdListResult.value,
+@@alternateType(EHNamespaceIdListResult.value,
   Azure.ResourceManager.Models.SubResource[],
   "csharp"
 );
@@ -409,25 +346,21 @@ using Microsoft.EventHub;
 @@clientName(IpAddressType, "EventHubsIPAddressType", "csharp");
 @@clientName(EHNamespaceProperties.ipAddressType, "IPAddressType", "csharp");
 @@clientName(NamespaceReplicaLocation.roleType, "RoleType", "csharp");
-@@clientName(
-  NspAccessRulePropertiesSubscriptionsItem,
+@@clientName(NspAccessRulePropertiesSubscriptionsItem,
   "EventHubsNspAccessRulePropertiesSubscriptionsItem",
   "csharp"
 );
-@@clientName(
-  NspAccessRulePropertiesSubscriptionsItem.id,
+@@clientName(NspAccessRulePropertiesSubscriptionsItem.id,
   "SubscriptionId",
   "csharp"
 );
-@@alternateType(
-  Azure.ResourceManager.CommonTypes.Resource.id,
+@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(Subnet.id, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(
-  NspAccessRuleProperties.subscriptions,
+@@alternateType(NspAccessRuleProperties.subscriptions,
   Azure.ResourceManager.Models.SubResource[],
   "csharp"
 );
@@ -435,21 +368,18 @@ using Microsoft.EventHub;
 @@alternateType(EHNamespace, EventHubsNamespace, "csharp");
 @@alternateType(EntityStatus, EventHubEntityStatus, "csharp");
 @@alternateType(NspAccessRule, EventHubsNspAccessRule, "csharp");
-@@alternateType(
-  PrivateLinkResource,
+@@alternateType(PrivateLinkResource,
   EventHubsPrivateLinkResourceData,
   "csharp"
 );
 @@alternateType(Encryption.keySource, EventHubsKeySource, "csharp");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility - flatten properties for C# SDK"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  EventHubsCluster.properties,
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(EventHubsCluster.properties,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility - flatten properties for C# SDK"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  EventHubsNamespace.properties,
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(EventHubsNamespace.properties,
   "csharp"
 );
 
@@ -579,6 +509,31 @@ namespace Microsoft.EventHub {
     `Microsoft.KeyVault`: "Microsoft.KeyVault",
   }
 }
+
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+@@clientOption(EventHubsCluster,
+  "resource-rbac-roles",
+  #{
+    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
+    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
+    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
+    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+  },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+@@clientOption(EventHubsNamespace,
+  "resource-rbac-roles",
+  #{
+    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
+    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
+    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
+    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+  },
+  "csharp"
+);
 
 // We add this model in this namespace in order to replace some models with this model via alternateType decorator
 namespace Azure.ResourceManager.Models {

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -307,6 +307,49 @@ using Microsoft.EventHub;
   Usage.input | Usage.output,
   "csharp"
 );
+
+// Preserve the resource name constraints emitted by the reflection-based provisioning generator.
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  EventHubsCluster,
+  "resource-name-constraint",
+  #{ minLength: 6, maxLength: 50, pattern: "^[a-zA-Z0-9-]+$" },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  EventHubsNamespace,
+  "resource-name-constraint",
+  #{ minLength: 1, maxLength: 256, pattern: "^[a-zA-Z0-9._-]+$" },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  AuthorizationRule,
+  "resource-name-constraint",
+  #{ minLength: 1, maxLength: 50, pattern: "^[a-zA-Z0-9._-]+$" },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  ConsumerGroup,
+  "resource-name-constraint",
+  #{ minLength: 1, maxLength: 50, pattern: "^[a-zA-Z0-9._-]+$" },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  ArmDisasterRecovery,
+  "resource-name-constraint",
+  #{ minLength: 6, maxLength: 50, pattern: "^[a-zA-Z0-9-]+$" },
+  "csharp"
+);
+
 // Mark list operations as pageable for C# backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
 @@Azure.ClientGenerator.Core.Legacy.markAsPageable(

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -4,7 +4,8 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.EventHub;
 
-@@clientName(Microsoft.EventHub,
+@@clientName(
+  Microsoft.EventHub,
   "EventHubManagementClient",
   "python,javascript,java"
 );
@@ -16,55 +17,66 @@ using Microsoft.EventHub;
 @@clientName(TlsVersion.`1.3`, "One3", "go");
 
 // Fix field naming changes for Go SDK backward compatibility
-@@clientName(RetentionDescription.minCompactionLagTimeInMinutes,
+@@clientName(
+  RetentionDescription.minCompactionLagTimeInMinutes,
   "MinCompactionLagInMins",
   "go"
 );
 
 // csharp configuration
-@@clientName(Microsoft.EventHub.EventHubs,
+@@clientName(
+  Microsoft.EventHub.EventHubs,
   "EventHubAuthorizationRule",
   "csharp"
 );
-@@clientName(AuthorizationRules,
+@@clientName(
+  AuthorizationRules,
   "EventHubsNamespaceAuthorizationRule",
   "csharp"
 );
-@@clientName(DisasterRecoveryConfigs,
+@@clientName(
+  DisasterRecoveryConfigs,
   "EventHubsDisasterRecoveryAuthorizationRule",
   "csharp"
 );
-@@clientName(PrivateEndpointConnection,
+@@clientName(
+  PrivateEndpointConnection,
   "EventHubsPrivateEndpointConnection",
   "csharp"
 );
 @@clientName(Clusters.configurationGet, "GetConfiguration", "csharp");
-@@clientName(EHNamespaces.privateLinkResourcesGet,
+@@clientName(
+  EHNamespaces.privateLinkResourcesGet,
   "GetPrivateLinkResources",
   "csharp"
 );
 @@clientName(NetworkRuleSets.getNetworkRuleSet, "GetNetworkRuleSet", "csharp");
-@@clientName(NetworkRuleSets.listNetworkRuleSet,
+@@clientName(
+  NetworkRuleSets.listNetworkRuleSet,
   "ListNetworkRuleSets",
   "csharp"
 );
 @@clientName(EHNamespaces.failover, "FailOver", "csharp");
-@@clientName(EHNamespaces.checkNameAvailability,
+@@clientName(
+  EHNamespaces.checkNameAvailability,
   "CheckEventHubsDisasterRecoveryNameAvailability",
   "csharp"
 );
-@@clientName(NamespacesOperationGroup.checkNameAvailability,
+@@clientName(
+  NamespacesOperationGroup.checkNameAvailability,
   "CheckEventHubsNamespaceNameAvailability",
   "csharp"
 );
-@@clientName(ClustersOperationGroup.listAvailableClusterRegion,
+@@clientName(
+  ClustersOperationGroup.listAvailableClusterRegion,
   "GetAvailableClusterRegionClusters",
   "csharp"
 );
 @@clientName(Clusters.patch, "PatchConfiguration", "csharp");
 @@clientName(CaptureIdentity.type, "IdentityType", "csharp");
 @@clientName(NWRuleSetIpRules.ipMask, "IPMask", "csharp");
-@@clientName(PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
+@@clientName(
+  PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
   "ConnectionState",
   "csharp"
 );
@@ -75,90 +87,108 @@ using Microsoft.EventHub;
 @@alternateType(ClusterProperties.createdAt, utcDateTime, "csharp");
 @@clientName(ClusterProperties.updatedAt, "UpdatedOn", "csharp");
 @@alternateType(ClusterProperties.updatedAt, utcDateTime, "csharp");
-@@alternateType(EHNamespaceProperties.clusterArmId,
+@@alternateType(
+  EHNamespaceProperties.clusterArmId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@clientName(DefaultAction, "EventHubsNetworkRuleSetDefaultAction", "csharp");
-@@clientName(PublicNetworkAccessFlag,
+@@clientName(
+  PublicNetworkAccessFlag,
   "EventHubsPublicNetworkAccessFlag",
   "csharp"
 );
 @@clientName(NWRuleSetIpRules, "EventHubsNetworkRuleSetIPRules", "csharp");
 @@clientName(NetworkRuleIPAction, "EventHubsNetworkRuleIPAction", "csharp");
-@@clientName(NWRuleSetVirtualNetworkRules,
+@@clientName(
+  NWRuleSetVirtualNetworkRules,
   "EventHubsNetworkRuleSetVirtualNetworkRules",
   "csharp"
 );
-@@clientName(EndPointProvisioningState,
+@@clientName(
+  EndPointProvisioningState,
   "EventHubsPrivateEndpointConnectionProvisioningState",
   "csharp"
 );
-@@clientName(ConnectionState,
+@@clientName(
+  ConnectionState,
   "EventHubsPrivateLinkServiceConnectionState",
   "csharp"
 );
-@@clientName(PrivateLinkConnectionStatus,
+@@clientName(
+  PrivateLinkConnectionStatus,
   "EventHubsPrivateLinkConnectionStatus",
   "csharp"
 );
 @@clientName(ProvisioningState, "EventHubsClusterProvisioningState", "csharp");
 @@clientName(CleanupPolicyRetentionDescription.Compact, "Compaction", "csharp");
-@@alternateType(NetworkSecurityPerimeterConfigurationProperties.sourceResourceId,
+@@alternateType(
+  NetworkSecurityPerimeterConfigurationProperties.sourceResourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@clientName(ApplicationGroupPolicy,
+@@clientName(
+  ApplicationGroupPolicy,
   "EventHubsApplicationGroupPolicy",
   "csharp"
 );
-@@clientName(ApplicationGroupPolicy.type,
+@@clientName(
+  ApplicationGroupPolicy.type,
   "ApplicationGroupPolicyType",
   "csharp"
 );
-@@clientName(RegenerateAccessKeyParameters,
+@@clientName(
+  RegenerateAccessKeyParameters,
   "EventHubsRegenerateAccessKeyContent",
   "csharp"
 );
 @@clientName(KeyType, "EventHubsAccessKeyType", "csharp");
 @@clientName(ArmDisasterRecovery, "EventHubsDisasterRecovery", "csharp");
-@@clientName(ProvisioningStateDR,
+@@clientName(
+  ProvisioningStateDR,
   "EventHubsDisasterRecoveryProvisioningState",
   "csharp"
 );
 @@clientName(RoleDisasterRecovery, "EventHubsDisasterRecoveryRole", "csharp");
 @@clientName(Eventhub, "EventHub", "csharp");
 @@clientName(Destination, "EventHubDestination", "csharp");
-@@alternateType(DestinationProperties.storageAccountResourceId,
+@@alternateType(
+  DestinationProperties.storageAccountResourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@clientName(CheckNameAvailabilityParameter,
+@@clientName(
+  CheckNameAvailabilityParameter,
   "EventHubsNameAvailabilityContent",
   "csharp"
 );
-@@clientName(CheckNameAvailabilityResult,
+@@clientName(
+  CheckNameAvailabilityResult,
   "EventHubsNameAvailabilityResult",
   "csharp"
 );
 @@clientName(UnavailableReason, "EventHubsNameUnavailableReason", "csharp");
 @@clientName(FailOver, "EventHubsNamespaceFailover", "csharp");
-@@clientName(GeoDataReplicationProperties,
+@@clientName(
+  GeoDataReplicationProperties,
   "EventHubsNamespaceGeoDataReplicationProperties",
   "csharp"
 );
 @@clientName(GeoDRRoleType, "EventHubsNamespaceGeoDrRoleType", "csharp");
-@@alternateType(NamespaceReplicaLocation.clusterArmId,
+@@alternateType(
+  NamespaceReplicaLocation.clusterArmId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@clientName(Mode, "EventHubsConfidentialComputeMode", "csharp");
 @@clientName(TimestampType, "EventHubsTimestampType", "csharp");
-@@clientName(NamespaceReplicaLocation,
+@@clientName(
+  NamespaceReplicaLocation,
   "EventHubsNamespaceReplicaLocation",
   "csharp"
 );
-@@clientName(NetworkRuleSetListResult,
+@@clientName(
+  NetworkRuleSetListResult,
   "EventHubsNetworkRuleSetListResult",
   "csharp"
 );
@@ -172,70 +202,85 @@ using Microsoft.EventHub;
 // java naming mitigations
 @@clientName(NetworkRuleIPAction, "NetworkRuleIpAction", "java");
 @@clientName(SchemaGroupProperties.eTag, "etag", "java");
-@@clientLocation(NetworkSecurityPerimeterConfigurations.list,
+@@clientLocation(
+  NetworkSecurityPerimeterConfigurations.list,
   "NetworkSecurityPerimeterConfigurations",
   "java"
 );
 
-@@alternateType(DestinationProperties.dataLakeSubscriptionId,
+@@alternateType(
+  DestinationProperties.dataLakeSubscriptionId,
   Azure.Core.uuid,
   "java"
 );
 
 @@clientName(TlsVersion, "EventHubsTlsVersion", "csharp");
-@@clientName(TlsVersion.`1.0`,
+@@clientName(
+  TlsVersion.`1.0`,
   Azure.ClientGenerator.Core.exact("Tls1_0"),
   "csharp"
 );
-@@clientName(TlsVersion.`1.1`,
+@@clientName(
+  TlsVersion.`1.1`,
   Azure.ClientGenerator.Core.exact("Tls1_1"),
   "csharp"
 );
-@@clientName(TlsVersion.`1.2`,
+@@clientName(
+  TlsVersion.`1.2`,
   Azure.ClientGenerator.Core.exact("Tls1_2"),
   "csharp"
 );
-@@clientName(TlsVersion.`1.3`,
+@@clientName(
+  TlsVersion.`1.3`,
   Azure.ClientGenerator.Core.exact("Tls1_3"),
   "csharp"
 );
 @@clientName(PublicNetworkAccess, "EventHubsPublicNetworkAccess", "csharp");
-@@clientName(ProvisioningIssueProperties,
+@@clientName(
+  ProvisioningIssueProperties,
   "EventHubsProvisioningIssueProperties",
   "csharp"
 );
 @@clientName(ProvisioningIssue, "EventHubsProvisioningIssue", "csharp");
 @@usage(ProvisioningIssue, Usage.input, "csharp");
 @@clientName(MetricId, "EventHubsMetricId", "csharp");
-@@clientName(NetworkSecurityPerimeter,
+@@clientName(
+  NetworkSecurityPerimeter,
   "EventHubsNetworkSecurityPerimeter",
   "csharp"
 );
-@@clientName(NetworkSecurityPerimeterConfiguration,
+@@clientName(
+  NetworkSecurityPerimeterConfiguration,
   "EventHubsNetworkSecurityPerimeterConfiguration",
   "csharp"
 );
-@@clientName(NetworkSecurityPerimeterConfigurationPropertiesProfile,
+@@clientName(
+  NetworkSecurityPerimeterConfigurationPropertiesProfile,
   "EventHubsNetworkSecurityPerimeterConfigurationPropertiesProfile",
   "csharp"
 );
-@@clientName(NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation,
+@@clientName(
+  NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation,
   "EventHubsNetworkSecurityPerimeterConfigurationPropertiesResourceAssociation",
   "csharp"
 );
-@@clientName(NetworkSecurityPerimeterConfigurationProvisioningState,
+@@clientName(
+  NetworkSecurityPerimeterConfigurationProvisioningState,
   "EventHubsNetworkSecurityPerimeterConfigurationProvisioningState",
   "csharp"
 );
-@@clientName(NspAccessRuleDirection,
+@@clientName(
+  NspAccessRuleDirection,
   "EventHubsNspAccessRuleDirection",
   "csharp"
 );
-@@clientName(NspAccessRuleProperties,
+@@clientName(
+  NspAccessRuleProperties,
   "EventHubsNspAccessRuleProperties",
   "csharp"
 );
-@@clientName(ResourceAssociationAccessMode,
+@@clientName(
+  ResourceAssociationAccessMode,
   "EventHubsResourceAssociationAccessMode",
   "csharp"
 );
@@ -257,45 +302,55 @@ using Microsoft.EventHub;
 @@usage(ClusterQuotaConfigurationProperties, Usage.input, "csharp");
 @@usage(CheckNameAvailabilityParameter, Usage.input | Usage.output, "csharp");
 @@usage(FailOver, Usage.input | Usage.output, "csharp");
-@@usage(NspAccessRulePropertiesSubscriptionsItem,
+@@usage(
+  NspAccessRulePropertiesSubscriptionsItem,
   Usage.input | Usage.output,
   "csharp"
 );
 // Mark list operations as pageable for C# backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(Clusters.listNamespaces,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  Clusters.listNamespaces,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(ClustersOperationGroup.listAvailableClusterRegion,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ClustersOperationGroup.listAvailableClusterRegion,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(EHNamespaces.privateLinkResourcesGet,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  EHNamespaces.privateLinkResourcesGet,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility with pageable list operations"
-@@Azure.ClientGenerator.Core.Legacy.markAsPageable(NetworkSecurityPerimeterConfigurations.list,
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  NetworkSecurityPerimeterConfigurations.list,
   "csharp"
 );
-@@clientLocation(AuthorizationRules.getAuthorizationRule,
+@@clientLocation(
+  AuthorizationRules.getAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(AuthorizationRules.createOrUpdateAuthorizationRule,
+@@clientLocation(
+  AuthorizationRules.createOrUpdateAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(AuthorizationRules.deleteAuthorizationRule,
+@@clientLocation(
+  AuthorizationRules.deleteAuthorizationRule,
   AuthorizationRules,
   "csharp"
 );
-@@clientLocation(AuthorizationRules.listAuthorizationRules,
+@@clientLocation(
+  AuthorizationRules.listAuthorizationRules,
   AuthorizationRules,
   "csharp"
 );
 @@clientLocation(AuthorizationRules.listKeys, AuthorizationRules, "csharp");
-@@clientLocation(AuthorizationRules.regenerateKeys,
+@@clientLocation(
+  AuthorizationRules.regenerateKeys,
   AuthorizationRules,
   "csharp"
 );
@@ -307,38 +362,46 @@ using Microsoft.EventHub;
 @@alternateType(ApplicationGroup.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(SchemaGroup.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(NetworkRuleSet.location, Azure.Core.azureLocation, "csharp");
-@@alternateType(PrivateEndpointConnection.location,
+@@alternateType(
+  PrivateEndpointConnection.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(NetworkSecurityPerimeterConfiguration.location,
+@@alternateType(
+  NetworkSecurityPerimeterConfiguration.location,
   Azure.Core.azureLocation,
   "csharp"
 );
 @@alternateType(AvailableCluster.location, Azure.Core.azureLocation, "csharp");
-@@alternateType(NetworkSecurityPerimeter.location,
+@@alternateType(
+  NetworkSecurityPerimeter.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(ArmDisasterRecovery.location,
+@@alternateType(
+  ArmDisasterRecovery.location,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(EHNamespace.identity,
+@@alternateType(
+  EHNamespace.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
 @@alternateType(KeyVaultProperties.keyVaultUri, url, "csharp");
-@@alternateType(DestinationProperties.dataLakeSubscriptionId,
+@@alternateType(
+  DestinationProperties.dataLakeSubscriptionId,
   Azure.Core.uuid,
   "csharp"
 );
 @@alternateType(SchemaGroupProperties.eTag, Azure.Core.eTag, "csharp");
-@@alternateType(FailOverProperties.primaryLocation,
+@@alternateType(
+  FailOverProperties.primaryLocation,
   Azure.Core.azureLocation,
   "csharp"
 );
-@@alternateType(EHNamespaceIdListResult.value,
+@@alternateType(
+  EHNamespaceIdListResult.value,
   Azure.ResourceManager.Models.SubResource[],
   "csharp"
 );
@@ -346,21 +409,25 @@ using Microsoft.EventHub;
 @@clientName(IpAddressType, "EventHubsIPAddressType", "csharp");
 @@clientName(EHNamespaceProperties.ipAddressType, "IPAddressType", "csharp");
 @@clientName(NamespaceReplicaLocation.roleType, "RoleType", "csharp");
-@@clientName(NspAccessRulePropertiesSubscriptionsItem,
+@@clientName(
+  NspAccessRulePropertiesSubscriptionsItem,
   "EventHubsNspAccessRulePropertiesSubscriptionsItem",
   "csharp"
 );
-@@clientName(NspAccessRulePropertiesSubscriptionsItem.id,
+@@clientName(
+  NspAccessRulePropertiesSubscriptionsItem.id,
   "SubscriptionId",
   "csharp"
 );
-@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id,
+@@alternateType(
+  Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(Subnet.id, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(NspAccessRuleProperties.subscriptions,
+@@alternateType(
+  NspAccessRuleProperties.subscriptions,
   Azure.ResourceManager.Models.SubResource[],
   "csharp"
 );
@@ -368,18 +435,21 @@ using Microsoft.EventHub;
 @@alternateType(EHNamespace, EventHubsNamespace, "csharp");
 @@alternateType(EntityStatus, EventHubEntityStatus, "csharp");
 @@alternateType(NspAccessRule, EventHubsNspAccessRule, "csharp");
-@@alternateType(PrivateLinkResource,
+@@alternateType(
+  PrivateLinkResource,
   EventHubsPrivateLinkResourceData,
   "csharp"
 );
 @@alternateType(Encryption.keySource, EventHubsKeySource, "csharp");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility - flatten properties for C# SDK"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(EventHubsCluster.properties,
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  EventHubsCluster.properties,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required for backward compatibility - flatten properties for C# SDK"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(EventHubsNamespace.properties,
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  EventHubsNamespace.properties,
   "csharp"
 );
 
@@ -509,31 +579,6 @@ namespace Microsoft.EventHub {
     `Microsoft.KeyVault`: "Microsoft.KeyVault",
   }
 }
-
-#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
-@@clientOption(EventHubsCluster,
-  "resource-rbac-roles",
-  #{
-    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
-    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
-    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
-    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
-    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
-  },
-  "csharp"
-);
-#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
-@@clientOption(EventHubsNamespace,
-  "resource-rbac-roles",
-  #{
-    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
-    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
-    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
-    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
-    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
-  },
-  "csharp"
-);
 
 // We add this model in this namespace in order to replace some models with this model via alternateType decorator
 namespace Azure.ResourceManager.Models {

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/client.tsp
@@ -580,6 +580,33 @@ namespace Microsoft.EventHub {
   }
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+@@clientOption(
+  EventHubsCluster,
+  "resource-rbac-roles",
+  #{
+    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
+    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
+    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
+    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+  },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+@@clientOption(
+  EventHubsNamespace,
+  "resource-rbac-roles",
+  #{
+    AzureEventHubsDataOwner: "f526a384-b230-433a-b45c-95f59c4a2dec",
+    AzureEventHubsDataReceiver: "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+    AzureEventHubsDataSender: "2b629674-e913-4c01-ae53-ef4638d8f975",
+    SchemaRegistryContributor: "5dffeca3-4936-4216-b2bc-10343a5abb25",
+    SchemaRegistryReader: "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+  },
+  "csharp"
+);
+
 // We add this model in this namespace in order to replace some models with this model via alternateType decorator
 namespace Azure.ResourceManager.Models {
   /** Represents a reference to an existing resource by its id. */

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
@@ -57,6 +57,10 @@ options:
     namespace: "{package-name}"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.EventHubs"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.EventHubs"
+    api-version: "2026-01-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/tspconfig.yaml
@@ -59,7 +59,7 @@ options:
     enable-wire-path-attribute: true
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.EventHubs"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.EventHubs"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     api-version: "2026-01-01"
 linter:
   extends:


### PR DESCRIPTION
## Description

Adds the C# provisioning emitter configuration for Event Hubs and supplies the five RBAC roles previously exposed by `Azure.Provisioning.EventHubs` for the cluster and namespace resources.

SDK migration: Azure/azure-sdk-for-net#61377