### PR TITLE
Enable AlertsManagement provisioning emitter

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertProcessingRules/tspconfig.yaml
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertProcessingRules/tspconfig.yaml
@@ -43,6 +43,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.AlertProcessingRules"
     emitter-output-dir: "{output-dir}/sdk/alertsmanagement/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.AlertsManagement"
+    emitter-output-dir: "{output-dir}/sdk/alertsmanagement/{namespace}"
+    api-version: "2021-08-08"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary

- enable the C# provisioning emitter for Azure AlertsManagement
- target API version `2021-08-08`

## Validation

- TypeSpec validation passed locally
- Generated `Azure.Provisioning.AlertsManagement` successfully from this spec commit