### PR TITLE
[Azure Stack HCI] Remove redundant EdgeMachine reported storageProfile.disks

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_CreateOrUpdate.json
@@ -111,17 +111,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",
@@ -264,17 +254,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Get.json
@@ -104,17 +104,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListByResourceGroup.json
@@ -103,17 +103,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "osProfile": {
                   "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_ListBySubscription.json
@@ -102,17 +102,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "osProfile": {
                   "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-01/EdgeMachines_Update.json
@@ -108,17 +108,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_CreateOrUpdate.json
@@ -111,17 +111,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",
@@ -293,17 +283,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Get.json
@@ -122,17 +122,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListByResourceGroup.json
@@ -103,17 +103,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "confidentialVmProfile": {
                   "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_ListBySubscription.json
@@ -102,17 +102,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "confidentialVmProfile": {
                   "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-10-15-preview/EdgeMachines_Update.json
@@ -108,17 +108,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7594,13 +7594,6 @@ model StorageProfile {
    */
   @visibility(Lifecycle.Read)
   poolableDisksCount?: int64;
-
-  /**
-   * List of storage disks on the edge machine.
-   */
-  @visibility(Lifecycle.Read)
-  @Azure.ResourceManager.identifiers(#["id"])
-  disks?: EdgeMachineDiskInfo[];
 }
 
 /**
@@ -7841,41 +7834,6 @@ model EdgeMachineStorageAdapterIpInfo {
   subnetMask?: string;
 }
 
-/**
- * Represents a storage disk reported for the edge machine.
- */
-@added(Versions.v2026_10_01)
-model EdgeMachineDiskInfo {
-  /**
-   * The unique identifier of the disk.
-   */
-  @visibility(Lifecycle.Read)
-  id: string;
-
-  /**
-   * The size of the disk in bytes.
-   */
-  @visibility(Lifecycle.Read)
-  sizeInBytes?: string;
-
-  /**
-   * The type of the disk. For example, S2D or SAN.
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /** Model number of the hardware. */
-  @visibility(Lifecycle.Read)
-  `model`?: string;
-
-  /** The manufacturer of the disk. */
-  @visibility(Lifecycle.Read)
-  manufacturer?: string;
-
-  /** Indicates whether the manufacturer is supported. */
-  @visibility(Lifecycle.Read)
-  isSupported?: boolean;
-}
 /**
  * details of validation failure
  */

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_CreateOrUpdate.json
@@ -111,17 +111,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",
@@ -293,17 +283,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Get.json
@@ -122,17 +122,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListByResourceGroup.json
@@ -103,17 +103,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "confidentialVmProfile": {
                   "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_ListBySubscription.json
@@ -102,17 +102,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "confidentialVmProfile": {
                   "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/examples/EdgeMachines_Update.json
@@ -108,17 +108,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "confidentialVmProfile": {
               "igvmStatus": "Enabled",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-10-15-preview/hci.json
@@ -12935,45 +12935,6 @@
         }
       ]
     },
-    "EdgeMachineDiskInfo": {
-      "type": "object",
-      "description": "Represents a storage disk reported for the edge machine.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The unique identifier of the disk.",
-          "readOnly": true
-        },
-        "sizeInBytes": {
-          "type": "string",
-          "description": "The size of the disk in bytes.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of the disk. For example, S2D or SAN.",
-          "readOnly": true
-        },
-        "model": {
-          "type": "string",
-          "description": "Model number of the hardware.",
-          "readOnly": true
-        },
-        "manufacturer": {
-          "type": "string",
-          "description": "The manufacturer of the disk.",
-          "readOnly": true
-        },
-        "isSupported": {
-          "type": "boolean",
-          "description": "Indicates whether the manufacturer is supported.",
-          "readOnly": true
-        }
-      },
-      "required": [
-        "id"
-      ]
-    },
     "EdgeMachineDiskJob": {
       "type": "object",
       "description": "Disk Job resource for managing operations on disks.",
@@ -21354,17 +21315,6 @@
           "format": "int64",
           "description": "Number of storage disks in the device with $CanPool as true.",
           "readOnly": true
-        },
-        "disks": {
-          "type": "array",
-          "description": "List of storage disks on the edge machine.",
-          "items": {
-            "$ref": "#/definitions/EdgeMachineDiskInfo"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": [
-            "id"
-          ]
         }
       }
     },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_CreateOrUpdate.json
@@ -111,17 +111,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",
@@ -264,17 +254,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Get.json
@@ -104,17 +104,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListByResourceGroup.json
@@ -103,17 +103,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "osProfile": {
                   "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_ListBySubscription.json
@@ -102,17 +102,7 @@
                   }
                 },
                 "storageProfile": {
-                  "poolableDisksCount": 4,
-                  "disks": [
-                    {
-                      "id": "5000C500A1B2C3D4",
-                      "sizeInBytes": "1920383410176",
-                      "type": "SSD",
-                      "model": "MZ7LH1T9HMLT",
-                      "manufacturer": "Samsung",
-                      "isSupported": true
-                    }
-                  ]
+                  "poolableDisksCount": 4
                 },
                 "osProfile": {
                   "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/examples/EdgeMachines_Update.json
@@ -108,17 +108,7 @@
               }
             },
             "storageProfile": {
-              "poolableDisksCount": 4,
-              "disks": [
-                {
-                  "id": "5000C500A1B2C3D4",
-                  "sizeInBytes": "1920383410176",
-                  "type": "SSD",
-                  "model": "MZ7LH1T9HMLT",
-                  "manufacturer": "Samsung",
-                  "isSupported": true
-                }
-              ]
+              "poolableDisksCount": 4
             },
             "osProfile": {
               "bootType": "UEFI",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/stable/2026-10-01/hci.json
@@ -10302,45 +10302,6 @@
         }
       ]
     },
-    "EdgeMachineDiskInfo": {
-      "type": "object",
-      "description": "Represents a storage disk reported for the edge machine.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The unique identifier of the disk.",
-          "readOnly": true
-        },
-        "sizeInBytes": {
-          "type": "string",
-          "description": "The size of the disk in bytes.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of the disk. For example, S2D or SAN.",
-          "readOnly": true
-        },
-        "model": {
-          "type": "string",
-          "description": "Model number of the hardware.",
-          "readOnly": true
-        },
-        "manufacturer": {
-          "type": "string",
-          "description": "The manufacturer of the disk.",
-          "readOnly": true
-        },
-        "isSupported": {
-          "type": "boolean",
-          "description": "Indicates whether the manufacturer is supported.",
-          "readOnly": true
-        }
-      },
-      "required": [
-        "id"
-      ]
-    },
     "EdgeMachineDiskJob": {
       "type": "object",
       "description": "Disk Job resource for managing operations on disks.",
@@ -17593,17 +17554,6 @@
           "format": "int64",
           "description": "Number of storage disks in the device with $CanPool as true.",
           "readOnly": true
-        },
-        "disks": {
-          "type": "array",
-          "description": "List of storage disks on the edge machine.",
-          "items": {
-            "$ref": "#/definitions/EdgeMachineDiskInfo"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": [
-            "id"
-          ]
         }
       }
     },


### PR DESCRIPTION
## Summary
Follow-up cleanup on top of #44841. Removes the redundant `storageProfile.disks` reported property (`EdgeMachineDiskInfo`) from `EdgeMachineReportedProperties`.

## Why
The per-disk information reported by the device is already surfaced through the `EdgeMachineDisk` child resource (`DiskReportedProperties`). Under the child-resource parity pattern, duplicating it inline in `EdgeMachineReportedProperties.storageProfile` is redundant.

## Changes
- Remove `StorageProfile.disks` and the now-unused `EdgeMachineDiskInfo` model from `models.tsp`.
- Regenerate `stable/2026-10-01` and `preview/2026-10-15-preview` swagger.
- Remove the `disks` entries from the EdgeMachine examples (Get / ListByResourceGroup / ListBySubscription / CreateOrUpdate / Update).
- `poolableDisksCount` is retained — it is a distinct aggregate property not exposed by any child resource.

## Validation
- `tsp compile .` succeeds.
- `oav validate-example` passes for both API versions.