### PR TITLE
AKS: NAT Gateway V2 GA - add natGatewayProfile.sku, drop managedNATGatewayV2 outbound type

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -932,12 +932,6 @@ union OutboundType {
   managedNATGateway: "managedNATGateway",
 
   /**
-   * The AKS-managed NAT gateway V2 is used for egress.
-   */
-  @added(Versions.v2026_06_02_preview)
-  managedNATGatewayV2: "managedNATGatewayV2",
-
-  /**
    * The user-assigned NAT gateway associated to the cluster subnet is used for egress. This is an advanced scenario and requires proper network configuration.
    */
   userAssignedNATGateway: "userAssignedNATGateway",
@@ -2768,10 +2762,34 @@ model ManagedClusterLoadBalancerProfileOutboundIPs {
 }
 
 /**
+ * The SKU of a managed cluster NAT Gateway.
+ */
+@added(Versions.v2026_06_01)
+union ManagedClusterNATGatewaySku {
+  string,
+
+  /**
+   * Use a Standard SKU NAT Gateway.
+   */
+  Standard: "Standard",
+
+  /**
+   * Use a StandardV2 SKU NAT Gateway. This is the default for new clusters in regions where it is available.
+   */
+  StandardV2: "StandardV2",
+}
+
+/**
  * Profile of the managed cluster NAT gateway.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
 model ManagedClusterNATGatewayProfile {
+  /**
+   * The SKU of the managed cluster NAT Gateway. Defaults to 'StandardV2' where available in the region, otherwise 'Standard'.
+   */
+  @added(Versions.v2026_06_01)
+  sku?: ManagedClusterNATGatewaySku;
+
   /**
    * Profile of the managed outbound IP resources of the cluster NAT gateway.
    */

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -517,7 +517,6 @@ using Microsoft.ContainerService;
 );
 @@clientName(OutboundType, "ContainerServiceOutboundType", "csharp");
 @@clientName(OutboundType.managedNATGateway, "ManagedNatGateway", "csharp");
-@@clientName(OutboundType.managedNATGatewayV2, "ManagedNatGatewayV2", "csharp");
 @@clientName(
   OutboundType.userAssignedNATGateway,
   "UserAssignedNatGateway",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -8670,7 +8670,6 @@
             "loadBalancer",
             "userDefinedRouting",
             "managedNATGateway",
-            "managedNATGatewayV2",
             "userAssignedNATGateway",
             "none"
           ],
@@ -8692,11 +8691,6 @@
                 "name": "managedNATGateway",
                 "value": "managedNATGateway",
                 "description": "The AKS-managed NAT gateway is used for egress."
-              },
-              {
-                "name": "managedNATGatewayV2",
-                "value": "managedNATGatewayV2",
-                "description": "The AKS-managed NAT gateway V2 is used for egress."
               },
               {
                 "name": "userAssignedNATGateway",
@@ -12629,6 +12623,10 @@
       "type": "object",
       "description": "Profile of the managed cluster NAT gateway.",
       "properties": {
+        "sku": {
+          "$ref": "#/definitions/ManagedClusterNATGatewaySku",
+          "description": "The SKU of the managed cluster NAT Gateway. Defaults to 'StandardV2' where available in the region, otherwise 'Standard'."
+        },
         "managedOutboundIPProfile": {
           "$ref": "#/definitions/ManagedClusterManagedOutboundIPProfile",
           "description": "Profile of the managed outbound IP resources of the cluster NAT gateway."
@@ -12693,6 +12691,30 @@
           "minimum": 4,
           "maximum": 120
         }
+      }
+    },
+    "ManagedClusterNATGatewaySku": {
+      "type": "string",
+      "description": "The SKU of a managed cluster NAT Gateway.",
+      "enum": [
+        "Standard",
+        "StandardV2"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedClusterNATGatewaySku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Use a Standard SKU NAT Gateway."
+          },
+          {
+            "name": "StandardV2",
+            "value": "StandardV2",
+            "description": "Use a StandardV2 SKU NAT Gateway. This is the default for new clusters in regions where it is available."
+          }
+        ]
       }
     },
     "ManagedClusterNodeProvisioningProfile": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
@@ -8112,6 +8112,10 @@
       "type": "object",
       "description": "Profile of the managed cluster NAT gateway.",
       "properties": {
+        "sku": {
+          "$ref": "#/definitions/ManagedClusterNATGatewaySku",
+          "description": "The SKU of the managed cluster NAT Gateway. Defaults to 'StandardV2' where available in the region, otherwise 'Standard'."
+        },
         "managedOutboundIPProfile": {
           "$ref": "#/definitions/ManagedClusterManagedOutboundIPProfile",
           "description": "Profile of the managed outbound IP resources of the cluster NAT gateway."
@@ -8132,6 +8136,30 @@
           "minimum": 4,
           "maximum": 120
         }
+      }
+    },
+    "ManagedClusterNATGatewaySku": {
+      "type": "string",
+      "description": "The SKU of a managed cluster NAT Gateway.",
+      "enum": [
+        "Standard",
+        "StandardV2"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedClusterNATGatewaySku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Use a Standard SKU NAT Gateway."
+          },
+          {
+            "name": "StandardV2",
+            "value": "StandardV2",
+            "description": "Use a StandardV2 SKU NAT Gateway. This is the default for new clusters in regions where it is available."
+          }
+        ]
       }
     },
     "ManagedClusterNodeProvisioningProfile": {


### PR DESCRIPTION
## Summary

Publishes the NAT Gateway V2 **GA** API surface, matching what already shipped in the AKS private swagger.

On `2026-06-01` (GA) and `2026-06-02-preview`, managed NAT gateway V1 vs V2 is expressed via `outboundType: managedNATGateway` + the new `natGatewayProfile.sku` (`Standard` | `StandardV2`), replacing the preview-only `outboundType: managedNATGatewayV2`.

## Changes

**Source (TypeSpec)**
- `CommonModels.tsp`
  - Add `ManagedClusterNATGatewaySku` union (`Standard`, `StandardV2`) and `natGatewayProfile.sku`, both `@added(Versions.v2026_06_01)`.
  - Remove the `managedNATGatewayV2` value from `OutboundType`. It was `@added(Versions.v2026_06_02_preview)`, so it only existed on the new preview.
- `client.tsp`: drop the now-dangling csharp `@@clientName` for the removed enum value.

**Generated**
- `stable/2026-06-01/managedClusters.json`
- `preview/2026-06-02-preview/managedClusters.json`

## Resulting behavior by API version

| Version | `outboundType: managedNATGatewayV2` | `natGatewayProfile.sku` |
|---|---|---|
| `2026-05-01` (stable) | absent | absent (unchanged) |
| `2026-05-02-preview` | **present** | absent (**unchanged**) |
| `2026-06-01` (GA) | absent | **added** |
| `2026-06-02-preview` | **removed** | **added** |

`2026-05-02-preview` is intentionally untouched and keeps `managedNATGatewayV2` for existing preview users.