### PR TITLE
Add knowledge toolbox and web source APIs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -15,6 +15,7 @@ import "./src/evaluations/routes.tsp";
 import "./src/evaluators/routes.tsp";
 import "./src/indexes/routes.tsp";
 import "./src/insights/routes.tsp";
+import "./src/knowledge-sources/routes.tsp";
 import "./src/managed-blueprints/routes.tsp";
 import "./src/models/routes.tsp";
 import "./src/memory-stores/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6,6 +6,9 @@
   },
   "tags": [
     {
+      "name": "Knowledge Sources"
+    },
+    {
       "name": "Responses Root",
       "description": "Responses"
     },
@@ -7702,6 +7705,407 @@
         },
         "tags": [
           "Insights"
+        ]
+      }
+    },
+    "/knowledge_sources": {
+      "post": {
+        "operationId": "createKnowledgeSource",
+        "summary": "Create a knowledge source",
+        "description": "Creates a knowledge source in the current project.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 256,
+                    "description": "The name and identifier of the knowledge source."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "web"
+                    ],
+                    "description": "The kind of knowledge source. Always `web`."
+                  }
+                },
+                "required": [
+                  "name",
+                  "kind"
+                ],
+                "unevaluatedProperties": {}
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listKnowledgeSources",
+        "summary": "List knowledge sources",
+        "description": "Lists knowledge sources in the current project.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/KnowledgeSourceObject"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ]
+      }
+    },
+    "/knowledge_sources/{name}": {
+      "post": {
+        "operationId": "updateKnowledgeSource",
+        "summary": "Update a knowledge source",
+        "description": "Updates the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name and identifier of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "web"
+                    ],
+                    "description": "The kind of knowledge source. Always `web`."
+                  }
+                },
+                "unevaluatedProperties": {}
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getKnowledgeSource",
+        "summary": "Get a knowledge source",
+        "description": "Retrieves the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteKnowledgeSource",
+        "summary": "Delete a knowledge source",
+        "description": "Deletes the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
         ]
       }
     },
@@ -25628,6 +26032,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "kind": {
+                    "$ref": "#/components/schemas/ToolboxKind",
+                    "description": "The kind of toolbox version. When omitted, the service interprets it as `default`."
+                  },
                   "description": {
                     "type": "string",
                     "maxLength": 512,
@@ -25645,23 +26053,32 @@
                     "items": {
                       "$ref": "#/components/schemas/ToolboxTool"
                     },
-                    "description": "The list of tools to include in this version."
+                    "description": "The list of tools to include in this version. Not allowed when `kind` is `knowledge_base`."
                   },
                   "skills": {
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/ToolboxSkill"
                     },
-                    "description": "The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used."
+                    "description": "The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used. Not allowed when `kind` is `knowledge_base`."
                   },
                   "policies": {
                     "$ref": "#/components/schemas/ToolboxPolicies",
-                    "description": "Policy configuration for this toolbox version."
+                    "description": "Policy configuration for this toolbox version. Not allowed when `kind` is `knowledge_base`."
+                  },
+                  "knowledge_sources": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ToolboxKnowledgeSourceReference"
+                    },
+                    "minItems": 1,
+                    "description": "Knowledge sources for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed."
+                  },
+                  "knowledge_retrieval": {
+                    "$ref": "#/components/schemas/ToolboxKnowledgeRetrieval",
+                    "description": "Retrieval configuration for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -26894,6 +27311,11 @@
             "description": "The operational state of the agent. Controls whether the agent endpoint accepts or rejects requests.",
             "readOnly": true
           },
+          "state_source": {
+            "$ref": "#/components/schemas/AgentStateSource",
+            "description": "The source of the agent's operational state. When the agent is disabled, indicates where the disabled state originates from. Empty when not derived from a specific source.",
+            "readOnly": true
+          },
           "versions": {
             "type": "object",
             "properties": {
@@ -27033,6 +27455,21 @@
           }
         ],
         "description": "The operational state of an agent."
+      },
+      "AgentStateSource": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agent_instance_identity",
+              "agent_blueprint"
+            ]
+          }
+        ],
+        "description": "Indicates the source of an agent's operational state. Empty when the state is not derived from a specific source."
       },
       "AgentTaxonomyInput": {
         "type": "object",
@@ -34845,6 +35282,29 @@
           }
         ],
         "description": "Extensible status values shared by Foundry jobs."
+      },
+      "KnowledgeSourceObject": {
+        "type": "object",
+        "required": [
+          "name",
+          "kind"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The name and identifier of the knowledge source."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "web"
+            ],
+            "description": "The kind of knowledge source. Always `web`."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "A reusable knowledge source in the current Foundry project."
       },
       "LoraConfig": {
         "type": "object",
@@ -76988,6 +77448,41 @@
           ]
         }
       },
+      "ToolboxKind": {
+        "type": "string",
+        "enum": [
+          "default",
+          "knowledge_base"
+        ],
+        "description": "The kind of content stored in a toolbox."
+      },
+      "ToolboxKnowledgeRetrieval": {
+        "type": "object",
+        "properties": {
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The models that may be used for retrieval and answer synthesis."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Retrieval and answer-synthesis configuration for a knowledge-base toolbox.\n\nAdditional properties map to Search Knowledge Base retrieval properties and\nare retained so retrieval behavior can evolve without requiring a new\ntoolbox contract for each additive option."
+      },
+      "ToolboxKnowledgeSourceReference": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the knowledge source."
+          }
+        },
+        "description": "A knowledge source used by a knowledge-base toolbox."
+      },
       "ToolboxObject": {
         "type": "object",
         "required": [
@@ -77005,12 +77500,16 @@
             "maxLength": 256,
             "description": "The name of the toolbox."
           },
+          "kind": {
+            "$ref": "#/components/schemas/ToolboxKind",
+            "description": "The kind of toolbox. Existing toolboxes that omit this property are interpreted as `default`."
+          },
           "default_version": {
             "type": "string",
             "description": "The version identifier that the toolbox currently points to. Defaults to the latest version. Can be changed via updateToolbox."
           }
         },
-        "description": "A toolbox that stores reusable tool definitions for agents."
+        "description": "A toolbox that stores reusable tools or knowledge-retrieval configuration."
       },
       "ToolboxPolicies": {
         "type": "object",
@@ -77169,8 +77668,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {
@@ -77211,23 +77709,39 @@
             "format": "unixtime",
             "description": "The Unix timestamp (seconds) when the toolbox version was created."
           },
+          "kind": {
+            "$ref": "#/components/schemas/ToolboxKind",
+            "description": "The kind of toolbox version. Existing versions that omit this property are interpreted as `default`."
+          },
           "tools": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToolboxTool"
             },
-            "description": "The list of tools contained in this toolbox version."
+            "description": "The list of tools contained in this toolbox version. Not allowed when `kind` is `knowledge_base`."
           },
           "skills": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToolboxSkill"
             },
-            "description": "The list of skill sources included in this toolbox version."
+            "description": "The list of skill sources included in this toolbox version. Not allowed when `kind` is `knowledge_base`."
           },
           "policies": {
             "$ref": "#/components/schemas/ToolboxPolicies",
-            "description": "Policy configuration for the toolbox version."
+            "description": "Policy configuration for the toolbox version. Not allowed when `kind` is `knowledge_base`."
+          },
+          "knowledge_sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxKnowledgeSourceReference"
+            },
+            "minItems": 1,
+            "description": "Knowledge sources for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed."
+          },
+          "knowledge_retrieval": {
+            "$ref": "#/components/schemas/ToolboxKnowledgeRetrieval",
+            "description": "Retrieval configuration for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed."
           }
         },
         "description": "A specific version of a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -3,6 +3,7 @@ info:
   title: Microsoft Foundry
   version: v1
 tags:
+  - name: Knowledge Sources
   - name: Responses Root
     description: Responses
   - name: Responses
@@ -5110,6 +5111,279 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Insights
+  /knowledge_sources:
+    post:
+      operationId: createKnowledgeSource
+      summary: Create a knowledge source
+      description: Creates a knowledge source in the current project.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 256
+                  description: The name and identifier of the knowledge source.
+                kind:
+                  type: string
+                  enum:
+                    - web
+                  description: The kind of knowledge source. Always `web`.
+              required:
+                - name
+                - kind
+              unevaluatedProperties: {}
+    get:
+      operationId: listKnowledgeSources
+      summary: List knowledge sources
+      description: Lists knowledge sources in the current project.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/KnowledgeSourceObject'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+  /knowledge_sources/{name}:
+    post:
+      operationId: updateKnowledgeSource
+      summary: Update a knowledge source
+      description: Updates the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name and identifier of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                kind:
+                  type: string
+                  enum:
+                    - web
+                  description: The kind of knowledge source. Always `web`.
+              unevaluatedProperties: {}
+    get:
+      operationId: getKnowledgeSource
+      summary: Get a knowledge source
+      description: Retrieves the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+    delete:
+      operationId: deleteKnowledgeSource
+      summary: Delete a knowledge source
+      description: Deletes the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
   /memory_stores:
     post:
       operationId: createMemoryStore
@@ -37425,6 +37699,9 @@ paths:
             schema:
               type: object
               properties:
+                kind:
+                  $ref: '#/components/schemas/ToolboxKind'
+                  description: The kind of toolbox version. When omitted, the service interprets it as `default`.
                 description:
                   type: string
                   maxLength: 512
@@ -37438,17 +37715,24 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/ToolboxTool'
-                  description: The list of tools to include in this version.
+                  description: The list of tools to include in this version. Not allowed when `kind` is `knowledge_base`.
                 skills:
                   type: array
                   items:
                     $ref: '#/components/schemas/ToolboxSkill'
-                  description: The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used.
+                  description: The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used. Not allowed when `kind` is `knowledge_base`.
                 policies:
                   $ref: '#/components/schemas/ToolboxPolicies'
-                  description: Policy configuration for this toolbox version.
-              required:
-                - tools
+                  description: Policy configuration for this toolbox version. Not allowed when `kind` is `knowledge_base`.
+                knowledge_sources:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ToolboxKnowledgeSourceReference'
+                  minItems: 1
+                  description: Knowledge sources for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.
+                knowledge_retrieval:
+                  $ref: '#/components/schemas/ToolboxKnowledgeRetrieval'
+                  description: Retrieval configuration for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.
     get:
       operationId: listToolboxVersions
       summary: List toolbox versions
@@ -38329,6 +38613,10 @@ components:
           $ref: '#/components/schemas/AgentState'
           description: The operational state of the agent. Controls whether the agent endpoint accepts or rejects requests.
           readOnly: true
+        state_source:
+          $ref: '#/components/schemas/AgentStateSource'
+          description: The source of the agent's operational state. When the agent is disabled, indicates where the disabled state originates from. Empty when not derived from a specific source.
+          readOnly: true
         versions:
           type: object
           properties:
@@ -38428,6 +38716,14 @@ components:
             - enabled
             - disabled
       description: The operational state of an agent.
+    AgentStateSource:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agent_instance_identity
+            - agent_blueprint
+      description: Indicates the source of an agent's operational state. Empty when the state is not derived from a specific source.
     AgentTaxonomyInput:
       type: object
       required:
@@ -44124,6 +44420,23 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    KnowledgeSourceObject:
+      type: object
+      required:
+        - name
+        - kind
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: The name and identifier of the knowledge source.
+        kind:
+          type: string
+          enum:
+            - web
+          description: The kind of knowledge source. Always `web`.
+      unevaluatedProperties: {}
+      description: A reusable knowledge source in the current Foundry project.
     LoraConfig:
       type: object
       properties:
@@ -74606,6 +74919,36 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview
+    ToolboxKind:
+      type: string
+      enum:
+        - default
+        - knowledge_base
+      description: The kind of content stored in a toolbox.
+    ToolboxKnowledgeRetrieval:
+      type: object
+      properties:
+        models:
+          type: array
+          items:
+            type: string
+          description: The models that may be used for retrieval and answer synthesis.
+      unevaluatedProperties: {}
+      description: |-
+        Retrieval and answer-synthesis configuration for a knowledge-base toolbox.
+
+        Additional properties map to Search Knowledge Base retrieval properties and
+        are retained so retrieval behavior can evolve without requiring a new
+        toolbox contract for each additive option.
+    ToolboxKnowledgeSourceReference:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of the knowledge source.
+      description: A knowledge source used by a knowledge-base toolbox.
     ToolboxObject:
       type: object
       required:
@@ -74620,10 +74963,13 @@ components:
           type: string
           maxLength: 256
           description: The name of the toolbox.
+        kind:
+          $ref: '#/components/schemas/ToolboxKind'
+          description: The kind of toolbox. Existing toolboxes that omit this property are interpreted as `default`.
         default_version:
           type: string
           description: The version identifier that the toolbox currently points to. Defaults to the latest version. Can be changed via updateToolbox.
-      description: A toolbox that stores reusable tool definitions for agents.
+      description: A toolbox that stores reusable tools or knowledge-retrieval configuration.
     ToolboxPolicies:
       type: object
       properties:
@@ -74744,7 +75090,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           anyOf:
@@ -74778,19 +75123,31 @@ components:
           type: integer
           format: unixtime
           description: The Unix timestamp (seconds) when the toolbox version was created.
+        kind:
+          $ref: '#/components/schemas/ToolboxKind'
+          description: The kind of toolbox version. Existing versions that omit this property are interpreted as `default`.
         tools:
           type: array
           items:
             $ref: '#/components/schemas/ToolboxTool'
-          description: The list of tools contained in this toolbox version.
+          description: The list of tools contained in this toolbox version. Not allowed when `kind` is `knowledge_base`.
         skills:
           type: array
           items:
             $ref: '#/components/schemas/ToolboxSkill'
-          description: The list of skill sources included in this toolbox version.
+          description: The list of skill sources included in this toolbox version. Not allowed when `kind` is `knowledge_base`.
         policies:
           $ref: '#/components/schemas/ToolboxPolicies'
-          description: Policy configuration for the toolbox version.
+          description: Policy configuration for the toolbox version. Not allowed when `kind` is `knowledge_base`.
+        knowledge_sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxKnowledgeSourceReference'
+          minItems: 1
+          description: Knowledge sources for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.
+        knowledge_retrieval:
+          $ref: '#/components/schemas/ToolboxKnowledgeRetrieval'
+          description: Retrieval configuration for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.
       description: A specific version of a toolbox.
     TraceIdTraceSource:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -9,6 +9,9 @@
       "name": "EvaluationSuiteGenerationJobs"
     },
     {
+      "name": "Knowledge Sources"
+    },
+    {
       "name": "Responses Root",
       "description": "Responses"
     },
@@ -10244,6 +10247,407 @@
         },
         "tags": [
           "Insights"
+        ]
+      }
+    },
+    "/knowledge_sources": {
+      "post": {
+        "operationId": "createKnowledgeSource",
+        "summary": "Create a knowledge source",
+        "description": "Creates a knowledge source in the current project.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 256,
+                    "description": "The name and identifier of the knowledge source."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "web"
+                    ],
+                    "description": "The kind of knowledge source. Always `web`."
+                  }
+                },
+                "required": [
+                  "name",
+                  "kind"
+                ],
+                "unevaluatedProperties": {}
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listKnowledgeSources",
+        "summary": "List knowledge sources",
+        "description": "Lists knowledge sources in the current project.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/KnowledgeSourceObject"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ]
+      }
+    },
+    "/knowledge_sources/{name}": {
+      "post": {
+        "operationId": "updateKnowledgeSource",
+        "summary": "Update a knowledge source",
+        "description": "Updates the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name and identifier of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "web"
+                    ],
+                    "description": "The kind of knowledge source. Always `web`."
+                  }
+                },
+                "unevaluatedProperties": {}
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getKnowledgeSource",
+        "summary": "Get a knowledge source",
+        "description": "Retrieves the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeSourceObject"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteKnowledgeSource",
+        "summary": "Delete a knowledge source",
+        "description": "Deletes the specified knowledge source.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the knowledge source.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Knowledge Sources"
         ]
       }
     },
@@ -28438,6 +28842,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "kind": {
+                    "$ref": "#/components/schemas/ToolboxKind",
+                    "description": "The kind of toolbox version. When omitted, the service interprets it as `default`."
+                  },
                   "description": {
                     "type": "string",
                     "maxLength": 512,
@@ -28455,23 +28863,32 @@
                     "items": {
                       "$ref": "#/components/schemas/ToolboxTool"
                     },
-                    "description": "The list of tools to include in this version."
+                    "description": "The list of tools to include in this version. Not allowed when `kind` is `knowledge_base`."
                   },
                   "skills": {
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/ToolboxSkill"
                     },
-                    "description": "The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used."
+                    "description": "The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used. Not allowed when `kind` is `knowledge_base`."
                   },
                   "policies": {
                     "$ref": "#/components/schemas/ToolboxPolicies",
-                    "description": "Policy configuration for this toolbox version."
+                    "description": "Policy configuration for this toolbox version. Not allowed when `kind` is `knowledge_base`."
+                  },
+                  "knowledge_sources": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ToolboxKnowledgeSourceReference"
+                    },
+                    "minItems": 1,
+                    "description": "Knowledge sources for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed."
+                  },
+                  "knowledge_retrieval": {
+                    "$ref": "#/components/schemas/ToolboxKnowledgeRetrieval",
+                    "description": "Retrieval configuration for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -30128,6 +30545,11 @@
             "description": "The operational state of the agent. Controls whether the agent endpoint accepts or rejects requests.",
             "readOnly": true
           },
+          "state_source": {
+            "$ref": "#/components/schemas/AgentStateSource",
+            "description": "The source of the agent's operational state. When the agent is disabled, indicates where the disabled state originates from. Empty when not derived from a specific source.",
+            "readOnly": true
+          },
           "versions": {
             "type": "object",
             "properties": {
@@ -30267,6 +30689,21 @@
           }
         ],
         "description": "The operational state of an agent."
+      },
+      "AgentStateSource": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agent_instance_identity",
+              "agent_blueprint"
+            ]
+          }
+        ],
+        "description": "Indicates the source of an agent's operational state. Empty when the state is not derived from a specific source."
       },
       "AgentTaxonomyInput": {
         "type": "object",
@@ -39194,6 +39631,29 @@
           }
         ],
         "description": "Extensible status values shared by Foundry jobs."
+      },
+      "KnowledgeSourceObject": {
+        "type": "object",
+        "required": [
+          "name",
+          "kind"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The name and identifier of the knowledge source."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "web"
+            ],
+            "description": "The kind of knowledge source. Always `web`."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "A reusable knowledge source in the current Foundry project."
       },
       "LoraConfig": {
         "type": "object",
@@ -81572,6 +82032,41 @@
           ]
         }
       },
+      "ToolboxKind": {
+        "type": "string",
+        "enum": [
+          "default",
+          "knowledge_base"
+        ],
+        "description": "The kind of content stored in a toolbox."
+      },
+      "ToolboxKnowledgeRetrieval": {
+        "type": "object",
+        "properties": {
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The models that may be used for retrieval and answer synthesis."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Retrieval and answer-synthesis configuration for a knowledge-base toolbox.\n\nAdditional properties map to Search Knowledge Base retrieval properties and\nare retained so retrieval behavior can evolve without requiring a new\ntoolbox contract for each additive option."
+      },
+      "ToolboxKnowledgeSourceReference": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the knowledge source."
+          }
+        },
+        "description": "A knowledge source used by a knowledge-base toolbox."
+      },
       "ToolboxObject": {
         "type": "object",
         "required": [
@@ -81589,12 +82084,16 @@
             "maxLength": 256,
             "description": "The name of the toolbox."
           },
+          "kind": {
+            "$ref": "#/components/schemas/ToolboxKind",
+            "description": "The kind of toolbox. Existing toolboxes that omit this property are interpreted as `default`."
+          },
           "default_version": {
             "type": "string",
             "description": "The version identifier that the toolbox currently points to. Defaults to the latest version. Can be changed via updateToolbox."
           }
         },
-        "description": "A toolbox that stores reusable tool definitions for agents."
+        "description": "A toolbox that stores reusable tools or knowledge-retrieval configuration."
       },
       "ToolboxPolicies": {
         "type": "object",
@@ -81755,8 +82254,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {
@@ -81797,23 +82295,39 @@
             "format": "unixtime",
             "description": "The Unix timestamp (seconds) when the toolbox version was created."
           },
+          "kind": {
+            "$ref": "#/components/schemas/ToolboxKind",
+            "description": "The kind of toolbox version. Existing versions that omit this property are interpreted as `default`."
+          },
           "tools": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToolboxTool"
             },
-            "description": "The list of tools contained in this toolbox version."
+            "description": "The list of tools contained in this toolbox version. Not allowed when `kind` is `knowledge_base`."
           },
           "skills": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToolboxSkill"
             },
-            "description": "The list of skill sources included in this toolbox version."
+            "description": "The list of skill sources included in this toolbox version. Not allowed when `kind` is `knowledge_base`."
           },
           "policies": {
             "$ref": "#/components/schemas/ToolboxPolicies",
-            "description": "Policy configuration for the toolbox version."
+            "description": "Policy configuration for the toolbox version. Not allowed when `kind` is `knowledge_base`."
+          },
+          "knowledge_sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxKnowledgeSourceReference"
+            },
+            "minItems": 1,
+            "description": "Knowledge sources for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed."
+          },
+          "knowledge_retrieval": {
+            "$ref": "#/components/schemas/ToolboxKnowledgeRetrieval",
+            "description": "Retrieval configuration for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed."
           }
         },
         "description": "A specific version of a toolbox."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -4,6 +4,7 @@ info:
   version: virtual-public-preview
 tags:
   - name: EvaluationSuiteGenerationJobs
+  - name: Knowledge Sources
   - name: Responses Root
     description: Responses
   - name: Responses
@@ -6785,6 +6786,279 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Insights
+  /knowledge_sources:
+    post:
+      operationId: createKnowledgeSource
+      summary: Create a knowledge source
+      description: Creates a knowledge source in the current project.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 256
+                  description: The name and identifier of the knowledge source.
+                kind:
+                  type: string
+                  enum:
+                    - web
+                  description: The kind of knowledge source. Always `web`.
+              required:
+                - name
+                - kind
+              unevaluatedProperties: {}
+    get:
+      operationId: listKnowledgeSources
+      summary: List knowledge sources
+      description: Lists knowledge sources in the current project.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/KnowledgeSourceObject'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+  /knowledge_sources/{name}:
+    post:
+      operationId: updateKnowledgeSource
+      summary: Update a knowledge source
+      description: Updates the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name and identifier of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                kind:
+                  type: string
+                  enum:
+                    - web
+                  description: The kind of knowledge source. Always `web`.
+              unevaluatedProperties: {}
+    get:
+      operationId: getKnowledgeSource
+      summary: Get a knowledge source
+      description: Retrieves the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeSourceObject'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
+    delete:
+      operationId: deleteKnowledgeSource
+      summary: Delete a knowledge source
+      description: Deletes the specified knowledge source.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the knowledge source.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Knowledge Sources
   /managedAgentIdentityBlueprints:
     get:
       operationId: ManagedAgentIdentityBlueprints_listManagedAgentIdentityBlueprints
@@ -39289,6 +39563,9 @@ paths:
             schema:
               type: object
               properties:
+                kind:
+                  $ref: '#/components/schemas/ToolboxKind'
+                  description: The kind of toolbox version. When omitted, the service interprets it as `default`.
                 description:
                   type: string
                   maxLength: 512
@@ -39302,17 +39579,24 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/ToolboxTool'
-                  description: The list of tools to include in this version.
+                  description: The list of tools to include in this version. Not allowed when `kind` is `knowledge_base`.
                 skills:
                   type: array
                   items:
                     $ref: '#/components/schemas/ToolboxSkill'
-                  description: The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used.
+                  description: The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used. Not allowed when `kind` is `knowledge_base`.
                 policies:
                   $ref: '#/components/schemas/ToolboxPolicies'
-                  description: Policy configuration for this toolbox version.
-              required:
-                - tools
+                  description: Policy configuration for this toolbox version. Not allowed when `kind` is `knowledge_base`.
+                knowledge_sources:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ToolboxKnowledgeSourceReference'
+                  minItems: 1
+                  description: Knowledge sources for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.
+                knowledge_retrieval:
+                  $ref: '#/components/schemas/ToolboxKnowledgeRetrieval'
+                  description: Retrieval configuration for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.
     get:
       operationId: listToolboxVersions
       summary: List toolbox versions
@@ -40503,6 +40787,10 @@ components:
           $ref: '#/components/schemas/AgentState'
           description: The operational state of the agent. Controls whether the agent endpoint accepts or rejects requests.
           readOnly: true
+        state_source:
+          $ref: '#/components/schemas/AgentStateSource'
+          description: The source of the agent's operational state. When the agent is disabled, indicates where the disabled state originates from. Empty when not derived from a specific source.
+          readOnly: true
         versions:
           type: object
           properties:
@@ -40602,6 +40890,14 @@ components:
             - enabled
             - disabled
       description: The operational state of an agent.
+    AgentStateSource:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agent_instance_identity
+            - agent_blueprint
+      description: Indicates the source of an agent's operational state. Empty when the state is not derived from a specific source.
     AgentTaxonomyInput:
       type: object
       required:
@@ -47115,6 +47411,23 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    KnowledgeSourceObject:
+      type: object
+      required:
+        - name
+        - kind
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: The name and identifier of the knowledge source.
+        kind:
+          type: string
+          enum:
+            - web
+          description: The kind of knowledge source. Always `web`.
+      unevaluatedProperties: {}
+      description: A reusable knowledge source in the current Foundry project.
     LoraConfig:
       type: object
       properties:
@@ -77766,6 +78079,36 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview
+    ToolboxKind:
+      type: string
+      enum:
+        - default
+        - knowledge_base
+      description: The kind of content stored in a toolbox.
+    ToolboxKnowledgeRetrieval:
+      type: object
+      properties:
+        models:
+          type: array
+          items:
+            type: string
+          description: The models that may be used for retrieval and answer synthesis.
+      unevaluatedProperties: {}
+      description: |-
+        Retrieval and answer-synthesis configuration for a knowledge-base toolbox.
+
+        Additional properties map to Search Knowledge Base retrieval properties and
+        are retained so retrieval behavior can evolve without requiring a new
+        toolbox contract for each additive option.
+    ToolboxKnowledgeSourceReference:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of the knowledge source.
+      description: A knowledge source used by a knowledge-base toolbox.
     ToolboxObject:
       type: object
       required:
@@ -77780,10 +78123,13 @@ components:
           type: string
           maxLength: 256
           description: The name of the toolbox.
+        kind:
+          $ref: '#/components/schemas/ToolboxKind'
+          description: The kind of toolbox. Existing toolboxes that omit this property are interpreted as `default`.
         default_version:
           type: string
           description: The version identifier that the toolbox currently points to. Defaults to the latest version. Can be changed via updateToolbox.
-      description: A toolbox that stores reusable tool definitions for agents.
+      description: A toolbox that stores reusable tools or knowledge-retrieval configuration.
     ToolboxPolicies:
       type: object
       properties:
@@ -77906,7 +78252,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           anyOf:
@@ -77940,19 +78285,31 @@ components:
           type: integer
           format: unixtime
           description: The Unix timestamp (seconds) when the toolbox version was created.
+        kind:
+          $ref: '#/components/schemas/ToolboxKind'
+          description: The kind of toolbox version. Existing versions that omit this property are interpreted as `default`.
         tools:
           type: array
           items:
             $ref: '#/components/schemas/ToolboxTool'
-          description: The list of tools contained in this toolbox version.
+          description: The list of tools contained in this toolbox version. Not allowed when `kind` is `knowledge_base`.
         skills:
           type: array
           items:
             $ref: '#/components/schemas/ToolboxSkill'
-          description: The list of skill sources included in this toolbox version.
+          description: The list of skill sources included in this toolbox version. Not allowed when `kind` is `knowledge_base`.
         policies:
           $ref: '#/components/schemas/ToolboxPolicies'
-          description: Policy configuration for the toolbox version.
+          description: Policy configuration for the toolbox version. Not allowed when `kind` is `knowledge_base`.
+        knowledge_sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxKnowledgeSourceReference'
+          minItems: 1
+          description: Knowledge sources for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.
+        knowledge_retrieval:
+          $ref: '#/components/schemas/ToolboxKnowledgeRetrieval'
+          description: Retrieval configuration for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.
       description: A specific version of a toolbox.
     TraceIdTraceSource:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/knowledge-sources/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/knowledge-sources/models.tsp
@@ -1,0 +1,58 @@
+import "../common/service.tsp";
+
+using TypeSpec.Http;
+
+namespace Azure.AI.Projects;
+
+@doc("A reusable knowledge source in the current Foundry project.")
+model KnowledgeSourceObject {
+  @doc("The name and identifier of the knowledge source.")
+  @maxLength(256)
+  name: string;
+
+  @doc("The kind of knowledge source. Always `web`.")
+  kind: "web";
+
+  /** Additional properties map to the Azure AI Search web knowledge source contract. */
+  ...Record<unknown>;
+}
+
+alias CreateKnowledgeSourceRequest = {
+  @doc("The name and identifier of the knowledge source.")
+  @maxLength(256)
+  name: string;
+
+  @doc("The kind of knowledge source. Always `web`.")
+  kind: "web";
+
+  /** Additional properties map to the Azure AI Search web knowledge source contract. */
+  ...Record<unknown>;
+};
+
+alias UpdateKnowledgeSourceRequest = {
+  @doc("The name and identifier of the knowledge source.")
+  @path
+  name: string;
+
+  @doc("The kind of knowledge source. Always `web`.")
+  kind?: "web";
+
+  /** Additional properties map to the Azure AI Search web knowledge source contract. */
+  ...Record<unknown>;
+};
+
+alias GetKnowledgeSourceRequest = {
+  @doc("The name of the knowledge source.")
+  @path
+  name: string;
+};
+
+alias ListKnowledgeSourcesRequest = {
+  ...CommonPageQueryParameters;
+};
+
+alias DeleteKnowledgeSourceRequest = {
+  @doc("The name of the knowledge source.")
+  @path
+  name: string;
+};

--- a/specification/ai-foundry/data-plane/Foundry/src/knowledge-sources/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/knowledge-sources/routes.tsp
@@ -1,0 +1,67 @@
+import "../common/models.tsp";
+import "../common/servicepatterns.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+
+namespace Azure.AI.Projects;
+
+@tag("Knowledge Sources")
+interface KnowledgeSources {
+  /** Creates a knowledge source in the current project. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @summary("Create a knowledge source")
+  @operationId("createKnowledgeSource")
+  @post
+  @route("/knowledge_sources")
+  createKnowledgeSource is FoundryDataPlaneOperation<
+    CreateKnowledgeSourceRequest,
+    KnowledgeSourceObject
+  >;
+
+  /** Updates the specified knowledge source. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @summary("Update a knowledge source")
+  @operationId("updateKnowledgeSource")
+  @post
+  @route("/knowledge_sources/{name}")
+  updateKnowledgeSource is FoundryDataPlaneOperation<
+    UpdateKnowledgeSourceRequest,
+    KnowledgeSourceObject
+  >;
+
+  /** Retrieves the specified knowledge source. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @summary("Get a knowledge source")
+  @operationId("getKnowledgeSource")
+  @get
+  @route("/knowledge_sources/{name}")
+  getKnowledgeSource is FoundryDataPlaneOperation<
+    GetKnowledgeSourceRequest,
+    KnowledgeSourceObject
+  >;
+
+  /** Lists knowledge sources in the current project. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @summary("List knowledge sources")
+  @operationId("listKnowledgeSources")
+  @get
+  @list
+  @route("/knowledge_sources")
+  listKnowledgeSources is FoundryDataPlaneOperation<
+    ListKnowledgeSourcesRequest,
+    AgentsPagedResult<KnowledgeSourceObject>
+  >;
+
+  /** Deletes the specified knowledge source. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @summary("Delete a knowledge source")
+  @operationId("deleteKnowledgeSource")
+  @delete
+  @route("/knowledge_sources/{name}")
+  deleteKnowledgeSource is FoundryDataPlaneOperation<
+    DeleteKnowledgeSourceRequest,
+    void
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -266,7 +266,48 @@ model ToolboxSkillReference extends ToolboxSkill {
   version?: string;
 }
 
-@doc("A toolbox that stores reusable tool definitions for agents.")
+/**
+ * The kind of content stored in a toolbox.
+ */
+union ToolboxKind {
+  /**
+   * A toolbox containing reusable tools and skills.
+   */
+  default: "default",
+
+  /**
+   * A toolbox providing knowledge retrieval over configured knowledge sources.
+   */
+  knowledge_base: "knowledge_base",
+}
+
+/**
+ * A knowledge source used by a knowledge-base toolbox.
+ */
+model ToolboxKnowledgeSourceReference {
+  /**
+   * The name of the knowledge source.
+   */
+  name: string;
+}
+
+/**
+ * Retrieval and answer-synthesis configuration for a knowledge-base toolbox.
+ *
+ * Additional properties map to Search Knowledge Base retrieval properties and
+ * are retained so retrieval behavior can evolve without requiring a new
+ * toolbox contract for each additive option.
+ */
+model ToolboxKnowledgeRetrieval {
+  /**
+   * The models that may be used for retrieval and answer synthesis.
+   */
+  models?: string[];
+
+  ...Record<unknown>;
+}
+
+@doc("A toolbox that stores reusable tools or knowledge-retrieval configuration.")
 model ToolboxObject {
   @doc("The unique identifier of the toolbox.")
   id: string;
@@ -274,6 +315,9 @@ model ToolboxObject {
   @doc("The name of the toolbox.")
   @maxLength(256)
   name: string;
+
+  @doc("The kind of toolbox. Existing toolboxes that omit this property are interpreted as `default`.")
+  kind?: ToolboxKind;
 
   @doc("The version identifier that the toolbox currently points to. Defaults to the latest version. Can be changed via updateToolbox.")
   default_version: string;
@@ -301,21 +345,42 @@ model ToolboxVersionObject {
   @encode("unixTimestamp", int32)
   created_at: utcDateTime;
 
-  @doc("The list of tools contained in this toolbox version.")
-  tools: ToolboxTool[];
+  @doc("The kind of toolbox version. Existing versions that omit this property are interpreted as `default`.")
+  kind?: ToolboxKind;
 
-  @doc("The list of skill sources included in this toolbox version.")
+  @doc("The list of tools contained in this toolbox version. Not allowed when `kind` is `knowledge_base`.")
+  tools?: ToolboxTool[];
+
+  @doc("The list of skill sources included in this toolbox version. Not allowed when `kind` is `knowledge_base`.")
   skills?: ToolboxSkill[];
 
-  @doc("Policy configuration for the toolbox version.")
+  @doc("Policy configuration for the toolbox version. Not allowed when `kind` is `knowledge_base`.")
   policies?: ToolboxPolicies;
+
+  @doc("Knowledge sources for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.")
+  @minItems(1)
+  knowledge_sources?: ToolboxKnowledgeSourceReference[];
+
+  @doc("Retrieval configuration for a `knowledge_base` toolbox version. Required for that kind and otherwise not allowed.")
+  knowledge_retrieval?: ToolboxKnowledgeRetrieval;
 }
 
+/**
+ * The contents of a new toolbox version.
+ *
+ * The service validates fields according to `kind`. A `default` toolbox must
+ * contain at least one tool or skill and cannot contain knowledge fields. A
+ * `knowledge_base` toolbox must contain `knowledge_sources` and
+ * `knowledge_retrieval` and cannot contain tools, skills, or policies.
+ */
 alias CreateToolboxVersionRequest = {
   @doc("The name of the toolbox. If the toolbox does not exist, it will be created.")
   @path
   @maxLength(256)
   name: string;
+
+  @doc("The kind of toolbox version. When omitted, the service interprets it as `default`.")
+  kind?: ToolboxKind;
 
   @doc("A human-readable description of the toolbox.")
   @maxLength(512)
@@ -324,14 +389,21 @@ alias CreateToolboxVersionRequest = {
   @doc("Arbitrary key-value metadata to associate with the toolbox.")
   metadata?: Record<string>;
 
-  @doc("The list of tools to include in this version.")
-  tools: ToolboxTool[];
+  @doc("The list of tools to include in this version. Not allowed when `kind` is `knowledge_base`.")
+  tools?: ToolboxTool[];
 
-  @doc("The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used.")
+  @doc("The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used. Not allowed when `kind` is `knowledge_base`.")
   skills?: ToolboxSkill[];
 
-  @doc("Policy configuration for this toolbox version.")
+  @doc("Policy configuration for this toolbox version. Not allowed when `kind` is `knowledge_base`.")
   policies?: ToolboxPolicies;
+
+  @doc("Knowledge sources for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.")
+  @minItems(1)
+  knowledge_sources?: ToolboxKnowledgeSourceReference[];
+
+  @doc("Retrieval configuration for a `knowledge_base` toolbox. Required for that kind and otherwise not allowed.")
+  knowledge_retrieval?: ToolboxKnowledgeRetrieval;
 };
 
 alias GetToolboxRequest = {


### PR DESCRIPTION
## Summary
- add `default` and `knowledge_base` toolbox kinds
- add knowledge-source references and extensible knowledge retrieval configuration
- add project-scoped create, get, list, update, and delete APIs for web knowledge sources
- proxy Azure AI Search knowledge-source properties through wildcard contract fields while strongly typing only `name` and discriminators

## Compatibility
- missing toolbox `kind` remains equivalent to `default`
- `tools` becomes structurally optional and is forbidden when `kind` is `knowledge_base`; service validation enforces kind-specific required and forbidden fields
- default toolboxes continue to require tools or skills through service validation

## Validation
- TypeSpec compiles with warnings treated as errors
- v1 and virtual-public-preview OpenAPI artifacts regenerated
- generated artifacts are byte-stable on regeneration