### PR TITLE
[BulkActions] C#-only @@clientName renames for .NET SDK review (AZC0030 2nd pass)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -267,3 +267,36 @@ namespace Microsoft.Compute;
   "GetBulkOperationStatusContent",
   "csharp"
 );
+
+// =====================================================================
+// .NET Management SDK review (AZC0030) type-name fixes (C# only)
+// =====================================================================
+// SUFFIX010: "Update" is reserved for PATCH-body models; this is a merge-patch body.
+@@clientName(
+  ScheduledActionsScheduleUpdate,
+  "ScheduledActionsSchedulePatch",
+  "csharp"
+);
+// SUFFIX004: "Options" is reserved for ClientOptions subclasses.
+@@clientName(DeleteOptions, "DeleteConfig", "csharp");
+@@clientName(DiffDiskOptions, "DiffDiskConfig", "csharp");
+// ACRONYM002: fix "Bulkaction" casing to match the "BulkAction*" prefix used package-wide.
+@@clientName(BulkactionVMExtension, "BulkActionVMExtension", "csharp");
+// ACRONYM001: 2-letter acronym "Vm" must be uppercase "VM".
+@@clientName(
+  BulkActionVmExtensionProperties,
+  "BulkActionVMExtensionProperties",
+  "csharp"
+);
+// ARMCOMMON001: avoid redefining the ARM-framework "ResourceType"; use a domain-scoped name.
+@@clientName(ResourceType, "ComputeBulkActionsResourceType", "csharp");
+// ARMCOMMON001: avoid redefining the ARM-framework "SubResource"; use a domain-scoped name.
+@@clientName(SubResource, "ComputeBulkActionsSubResource", "csharp");
+// Contextual naming: "Language" is too generic and collides across packages.
+@@clientName(Language, "ScheduledActionLanguage", "csharp");
+// Contextual naming: scope the generic "ProvisioningState" to its operation.
+@@clientName(
+  ProvisioningState,
+  "BulkInstancesOperationProvisioningState",
+  "csharp"
+);

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -312,32 +312,120 @@ namespace Microsoft.Compute;
 @@clientName(ResourceIdentityType, "ComputeBulkActionsIdentityType", "csharp");
 
 // ACRONYM001: acronym enum members must be PascalCase. exact() preserves the wire value.
-@@clientName(AcceleratorType.GPU, Azure.ClientGenerator.Core.exact("Gpu"), "csharp");
-@@clientName(AcceleratorType.FPGA, Azure.ClientGenerator.Core.exact("Fpga"), "csharp");
-@@clientName(LocalStorageDiskType.HDD, Azure.ClientGenerator.Core.exact("Hdd"), "csharp");
-@@clientName(LocalStorageDiskType.SSD, Azure.ClientGenerator.Core.exact("Ssd"), "csharp");
+@@clientName(
+  AcceleratorType.GPU,
+  Azure.ClientGenerator.Core.exact("Gpu"),
+  "csharp"
+);
+@@clientName(
+  AcceleratorType.FPGA,
+  Azure.ClientGenerator.Core.exact("Fpga"),
+  "csharp"
+);
+@@clientName(
+  LocalStorageDiskType.HDD,
+  Azure.ClientGenerator.Core.exact("Hdd"),
+  "csharp"
+);
+@@clientName(
+  LocalStorageDiskType.SSD,
+  Azure.ClientGenerator.Core.exact("Ssd"),
+  "csharp"
+);
 
 // BOOL001: boolean properties need a verb prefix (Is/Should/Does/etc.).
-@@clientName(AdditionalCapabilities.ultraSSDEnabled, "IsUltraSsdEnabled", "csharp");
-@@clientName(AdditionalCapabilities.hibernationEnabled, "IsHibernationEnabled", "csharp");
-@@clientName(ExecutionParameters.verifyVmAgentHealth, "ShouldVerifyVmAgentHealth", "csharp");
+@@clientName(
+  AdditionalCapabilities.ultraSSDEnabled,
+  "IsUltraSsdEnabled",
+  "csharp"
+);
+@@clientName(
+  AdditionalCapabilities.hibernationEnabled,
+  "IsHibernationEnabled",
+  "csharp"
+);
+@@clientName(
+  ExecutionParameters.verifyVmAgentHealth,
+  "ShouldVerifyVmAgentHealth",
+  "csharp"
+);
 @@clientName(VirtualMachineReimageParameters.tempDisk, "IsTempDisk", "csharp");
-@@clientName(BulkActionVmExtensionProperties.autoUpgradeMinorVersion, "IsAutoUpgradeMinorVersion", "csharp");
-@@clientName(BulkActionVmExtensionProperties.suppressFailures, "IsSuppressFailures", "csharp");
+@@clientName(
+  BulkActionVmExtensionProperties.autoUpgradeMinorVersion,
+  "IsAutoUpgradeMinorVersion",
+  "csharp"
+);
+@@clientName(
+  BulkActionVmExtensionProperties.suppressFailures,
+  "IsSuppressFailures",
+  "csharp"
+);
 @@clientName(DataDisk.toBeDetached, "IsToBeDetached", "csharp");
-@@clientName(DataDisk.writeAcceleratorEnabled, "IsWriteAcceleratorEnabled", "csharp");
-@@clientName(LinuxConfiguration.provisionVMAgent, "IsProvisionVMAgent", "csharp");
-@@clientName(LinuxVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule, "ShouldBypassPlatformSafetyChecksOnUserSchedule", "csharp");
-@@clientName(NetworkInterfaceReferenceProperties.primary, "IsPrimary", "csharp");
-@@clientName(OSDisk.writeAcceleratorEnabled, "IsWriteAcceleratorEnabled", "csharp");
-@@clientName(OSProfile.requireGuestProvisionSignal, "DoesRequireGuestProvisionSignal", "csharp");
-@@clientName(ProxyAgentSettings.addProxyAgentExtension, "ShouldAddProxyAgentExtension", "csharp");
-@@clientName(AllInstancesDown.automaticallyApprove, "IsAllInstancesDownAutomaticallyApproved", "csharp");
+@@clientName(
+  DataDisk.writeAcceleratorEnabled,
+  "IsWriteAcceleratorEnabled",
+  "csharp"
+);
+@@clientName(
+  LinuxConfiguration.provisionVMAgent,
+  "IsProvisionVMAgent",
+  "csharp"
+);
+@@clientName(
+  LinuxVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule,
+  "ShouldBypassPlatformSafetyChecksOnUserSchedule",
+  "csharp"
+);
+@@clientName(
+  NetworkInterfaceReferenceProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  OSDisk.writeAcceleratorEnabled,
+  "IsWriteAcceleratorEnabled",
+  "csharp"
+);
+@@clientName(
+  OSProfile.requireGuestProvisionSignal,
+  "DoesRequireGuestProvisionSignal",
+  "csharp"
+);
+@@clientName(
+  ProxyAgentSettings.addProxyAgentExtension,
+  "ShouldAddProxyAgentExtension",
+  "csharp"
+);
+@@clientName(
+  AllInstancesDown.automaticallyApprove,
+  "IsAllInstancesDownAutomaticallyApproved",
+  "csharp"
+);
 @@clientName(SecurityProfile.encryptionAtHost, "IsEncryptionAtHost", "csharp");
 @@clientName(UefiSettings.secureBootEnabled, "IsSecureBootEnabled", "csharp");
 @@clientName(UefiSettings.vTpmEnabled, "IsVTpmEnabled", "csharp");
-@@clientName(VirtualMachineNetworkInterfaceConfigurationProperties.primary, "IsPrimary", "csharp");
-@@clientName(VirtualMachineNetworkInterfaceIPConfigurationProperties.primary, "IsPrimary", "csharp");
-@@clientName(VMGalleryApplication.treatFailureAsDeploymentFailure, "IsTreatFailureAsDeploymentFailure", "csharp");
-@@clientName(WindowsConfiguration.provisionVMAgent, "IsProvisionVMAgent", "csharp");
-@@clientName(WindowsVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule, "ShouldBypassPlatformSafetyChecksOnUserSchedule", "csharp");
+@@clientName(
+  VirtualMachineNetworkInterfaceConfigurationProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  VMGalleryApplication.treatFailureAsDeploymentFailure,
+  "IsTreatFailureAsDeploymentFailure",
+  "csharp"
+);
+@@clientName(
+  WindowsConfiguration.provisionVMAgent,
+  "IsProvisionVMAgent",
+  "csharp"
+);
+@@clientName(
+  WindowsVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule,
+  "ShouldBypassPlatformSafetyChecksOnUserSchedule",
+  "csharp"
+);

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -300,3 +300,44 @@ namespace Microsoft.Compute;
   "BulkInstancesOperationProvisioningState",
   "csharp"
 );
+
+// =====================================================================
+// .NET Management SDK review (2nd pass) type-name fixes (C# only)
+// =====================================================================
+// ACRONYM002: fix "Bulkaction" casing to match the package-wide "BulkAction*" prefix.
+@@clientName(BulkactionVMProperties, "BulkActionVMProperties", "csharp");
+
+// ARM common-type conflict: local ResourceIdentityType is shape-identical to
+// Azure.ResourceManager.Models.ResourceIdentityType; scope it to avoid ambiguous references.
+@@clientName(ResourceIdentityType, "ComputeBulkActionsIdentityType", "csharp");
+
+// ACRONYM001: acronym enum members must be PascalCase. exact() preserves the wire value.
+@@clientName(AcceleratorType.GPU, Azure.ClientGenerator.Core.exact("Gpu"), "csharp");
+@@clientName(AcceleratorType.FPGA, Azure.ClientGenerator.Core.exact("Fpga"), "csharp");
+@@clientName(LocalStorageDiskType.HDD, Azure.ClientGenerator.Core.exact("Hdd"), "csharp");
+@@clientName(LocalStorageDiskType.SSD, Azure.ClientGenerator.Core.exact("Ssd"), "csharp");
+
+// BOOL001: boolean properties need a verb prefix (Is/Should/Does/etc.).
+@@clientName(AdditionalCapabilities.ultraSSDEnabled, "IsUltraSsdEnabled", "csharp");
+@@clientName(AdditionalCapabilities.hibernationEnabled, "IsHibernationEnabled", "csharp");
+@@clientName(ExecutionParameters.verifyVmAgentHealth, "ShouldVerifyVmAgentHealth", "csharp");
+@@clientName(VirtualMachineReimageParameters.tempDisk, "IsTempDisk", "csharp");
+@@clientName(BulkActionVmExtensionProperties.autoUpgradeMinorVersion, "IsAutoUpgradeMinorVersion", "csharp");
+@@clientName(BulkActionVmExtensionProperties.suppressFailures, "IsSuppressFailures", "csharp");
+@@clientName(DataDisk.toBeDetached, "IsToBeDetached", "csharp");
+@@clientName(DataDisk.writeAcceleratorEnabled, "IsWriteAcceleratorEnabled", "csharp");
+@@clientName(LinuxConfiguration.provisionVMAgent, "IsProvisionVMAgent", "csharp");
+@@clientName(LinuxVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule, "ShouldBypassPlatformSafetyChecksOnUserSchedule", "csharp");
+@@clientName(NetworkInterfaceReferenceProperties.primary, "IsPrimary", "csharp");
+@@clientName(OSDisk.writeAcceleratorEnabled, "IsWriteAcceleratorEnabled", "csharp");
+@@clientName(OSProfile.requireGuestProvisionSignal, "DoesRequireGuestProvisionSignal", "csharp");
+@@clientName(ProxyAgentSettings.addProxyAgentExtension, "ShouldAddProxyAgentExtension", "csharp");
+@@clientName(AllInstancesDown.automaticallyApprove, "IsAllInstancesDownAutomaticallyApproved", "csharp");
+@@clientName(SecurityProfile.encryptionAtHost, "IsEncryptionAtHost", "csharp");
+@@clientName(UefiSettings.secureBootEnabled, "IsSecureBootEnabled", "csharp");
+@@clientName(UefiSettings.vTpmEnabled, "IsVTpmEnabled", "csharp");
+@@clientName(VirtualMachineNetworkInterfaceConfigurationProperties.primary, "IsPrimary", "csharp");
+@@clientName(VirtualMachineNetworkInterfaceIPConfigurationProperties.primary, "IsPrimary", "csharp");
+@@clientName(VMGalleryApplication.treatFailureAsDeploymentFailure, "IsTreatFailureAsDeploymentFailure", "csharp");
+@@clientName(WindowsConfiguration.provisionVMAgent, "IsProvisionVMAgent", "csharp");
+@@clientName(WindowsVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule, "ShouldBypassPlatformSafetyChecksOnUserSchedule", "csharp");

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -289,7 +289,7 @@ namespace Microsoft.Compute;
   "csharp"
 );
 // ARMCOMMON001: avoid redefining the ARM-framework "ResourceType"; use a domain-scoped name.
-@@clientName(ResourceType, "ComputeBulkActionsResourceType", "csharp");
+@@clientName(ResourceType, "ScheduledActionsResourceType", "csharp");
 // ARMCOMMON001: avoid redefining the ARM-framework "SubResource"; use a domain-scoped name.
 @@clientName(SubResource, "ComputeBulkActionsSubResource", "csharp");
 // Contextual naming: "Language" is too generic and collides across packages.


### PR DESCRIPTION
## Summary

C#-only `@@clientName` renames for the BulkActions spec to satisfy the **Azure .NET Management SDK review (AZC0030 family)**. These are `"csharp"`-scoped `@@clientName` decorators in `client.tsp` only — the wire contract, swagger, and all other language SDKs are unchanged.

This is a follow-up (2nd pass) to the initial AZC0030 type renames, addressing the deeper naming review from the automated .NET Management SDK reviewer plus @jsquire.

### Changes (all C#-only, in `Bulkactions/client.tsp`)

**First pass (already in base commit):** 9 type renames (e.g. `SubResource` -> `ComputeBulkActionsSubResource`, VM extension type casing, provisioning-state names).

**Second pass (this PR):**
- **ACRONYM002** — `BulkactionVMProperties` -> `BulkActionVMProperties` (match package-wide `BulkAction*` prefix).
- **ARM common-type conflict** — `ResourceIdentityType` -> `ComputeBulkActionsIdentityType` (local enum is shape-identical to `Azure.ResourceManager.Models.ResourceIdentityType`).
- **ACRONYM001** — acronym enum members via `exact()` so the **wire value is preserved**: `AcceleratorType.GPU->Gpu`, `.FPGA->Fpga`, `LocalStorageDiskType.HDD->Hdd`, `.SSD->Ssd`.
- **BOOL001** — verb prefixes (`Is`/`Should`/`Does`) on 23 boolean properties (e.g. `ultraSSDEnabled->IsUltraSsdEnabled`, `verifyVmAgentHealth->ShouldVerifyVmAgentHealth`, `requireGuestProvisionSignal->DoesRequireGuestProvisionSignal`).

### Impact
- **C# SDK only.** `exact()` is used for enum members to keep serialized wire values identical; property `@@clientName` renames only affect the generated C# member name, not the JSON.
- No swagger / TypeSpec model / other-language changes.

Consumed by azure-sdk-for-net PR Azure/azure-sdk-for-net#61167.
