### PR TITLE
IPAM: add force query parameter (TypeSpec) for 2025-09-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/IpamPool.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/IpamPool.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "./NetworkManager.tsp";
 import "../Common/main.tsp";
@@ -10,6 +11,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 using Common;
 
 namespace Microsoft.Network;
@@ -104,6 +106,13 @@ interface IpamPools {
       #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @header("If-Match")
       `If-Match`?: string;
+
+      /**
+       * When true, force-deletes the pool and its entire descendant hierarchy, bypassing all pre-deletion validations.
+       */
+      @added(Versions.v2025_09_01)
+      @query("force")
+      force?: boolean = false;
     },
     Error = CommonErrorResponse
   >;

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/IpamPools_Delete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/IpamPools_Delete.json
@@ -4,7 +4,8 @@
     "networkManagerName": "TestNetworkManager",
     "poolName": "TestPool",
     "resourceGroupName": "rg1",
-    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+    "subscriptionId": "11111111-1111-1111-1111-111111111111",
+    "force": false
   },
   "title": "IpamPools_Delete",
   "responses": {

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/IpamPools_Delete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/IpamPools_Delete.json
@@ -4,7 +4,8 @@
     "networkManagerName": "TestNetworkManager",
     "poolName": "TestPool",
     "resourceGroupName": "rg1",
-    "subscriptionId": "11111111-1111-1111-1111-111111111111"
+    "subscriptionId": "11111111-1111-1111-1111-111111111111",
+    "force": false
   },
   "title": "IpamPools_Delete",
   "responses": {

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualNetwork.json
@@ -6131,6 +6131,14 @@
             "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "When true, force-deletes the pool and its entire descendant hierarchy, bypassing all pre-deletion validations.",
+            "required": false,
+            "type": "boolean",
+            "default": false
           }
         ],
         "responses": {


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## Purpose of this PR

What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
  - [X] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
  - [ ] Other, please clarify:
    - _edit this with your clarification_

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [X] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [X] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://aka.ms/azurerpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [X] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## Additional information

<details>
<summary> Viewing API changes</summary>

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

</details>
<details>
<summary>Suppressing failures</summary>

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[suppressions guide](https://aka.ms/azsdk/pr-suppressions) to get approval.

</details>
## Changes

 Adds optional `force` query parameter to the **IpamPools_Delete** operation for the `2025-09-01` API version. When set to `true`, force-deletes the pool and its entire descendant hierarchy, bypassing all pre-deletion validations. This ports the change from #42550 onto the `Vslokar/release-microsoft-network-2025-09-01` release branch, targeting the `2025-09-01` API version only.

 ### TypeSpec changes (`Network/IpamPool.tsp`)
 - Added `force` optional boolean query parameter to the delete operation's Parameters block (with `@added(Versions.v2025_09_01)` versioning decorator)
 - Added `import "@typespec/versioning"` and `using TypeSpec.Versioning;`

 ### Generated swagger changes
 - `stable/2025-09-01/virtualNetwork.json`: Added `force` query parameter on `IpamPools_Delete` operation

 ### Updated example files
 - `IpamPools_Delete.json` — Updated to include `"force": false`

## Getting help

- First, please carefully read through this PR description, from top to bottom. Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- For help with ARM review (PR workflow diagram Step 2), see https://aka.ms/azsdk/pr-arm-review.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
- For guidance on SDK breaking change review, refer to https://aka.ms/ci-fix.
