### PR TITLE
fix(machinelearningservices): backfill missing 2024-10-01-preview examples

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/createOrUpdate.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "acaEnvironmentConnections": [
+          "sampleAcaEnvironmentConnection"
+        ],
+        "aiServicesConnections": [
+          "sampleAIServiceConnection"
+        ],
+        "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet",
+        "storageConnections": [
+          "sampleStorageConnection"
+        ],
+        "threadStorageConnections": [
+          "sampleThreadStorageConnection"
+        ],
+        "vectorStoreConnections": [
+          "sampleVectorStoreConnection"
+        ]
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "CapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate CapabilityHost."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "CapabilityHosts_Delete",
+  "title": "Delete CapabilityHost."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/CapabilityHost/get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "messages": [
+            "string"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CapabilityHosts_Get",
+  "title": "Get CapabilityHost."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/AKSCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/AKSCompute.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "AKS",
+        "properties": {
+          "agentCount": 4
+        },
+        "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "properties": {
+            "agentCount": 4
+          },
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "provisioningState": "Updating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Update an AKS Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/AmlCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/AmlCompute.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "AmlCompute",
+        "properties": {
+          "scaleSettings": {
+            "maxNodeCount": 4,
+            "minNodeCount": 4,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "allocationState": "Resizing",
+            "allocationStateTransitionTime": "2017-09-27T22:28:08.998Z",
+            "currentNodeCount": 0,
+            "enableNodePublicIp": true,
+            "errors": null,
+            "isolatedNetwork": false,
+            "nodeStateCounts": {
+              "idleNodeCount": 0,
+              "leavingNodeCount": 0,
+              "preemptedNodeCount": 0,
+              "preparingNodeCount": 0,
+              "runningNodeCount": 0,
+              "unusableNodeCount": 0
+            },
+            "osType": "Windows",
+            "remoteLoginPortPublicAccess": "Enabled",
+            "scaleSettings": {
+              "maxNodeCount": 1,
+              "minNodeCount": 0,
+              "nodeIdleTimeBeforeScaleDown": "PT5M"
+            },
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "targetNodeCount": 1,
+            "virtualMachineImage": null,
+            "vmPriority": "Dedicated",
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "provisioningState": "Updating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Update a AML Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicAKSCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicAKSCompute.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "AKS"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AKS",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AKS",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an AKS Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicAmlCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicAmlCompute.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "AmlCompute",
+        "properties": {
+          "enableNodePublicIp": true,
+          "isolatedNetwork": false,
+          "osType": "Windows",
+          "remoteLoginPortPublicAccess": "NotSpecified",
+          "scaleSettings": {
+            "maxNodeCount": 1,
+            "minNodeCount": 0,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          },
+          "virtualMachineImage": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myImageGallery/images/myImageDefinition/versions/0.0.1"
+          },
+          "vmPriority": "Dedicated",
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AmlCompute",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AmlCompute",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create a AML Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicDataFactoryCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/BasicDataFactoryCompute.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "DataFactory"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "DataFactory",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "DataFactory",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create a DataFactory Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstance.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstance.json
@@ -1,0 +1,114 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "applicationSharingPolicy": "Personal",
+          "autologgerSettings": {
+            "mlflowAutologger": "Enabled"
+          },
+          "computeInstanceAuthorizationType": "personal",
+          "customServices": [
+            {
+              "name": "rstudio-workbench",
+              "docker": {
+                "privileged": true
+              },
+              "endpoints": [
+                {
+                  "name": "connect",
+                  "hostIp": null,
+                  "published": 4444,
+                  "target": 8787,
+                  "protocol": "http"
+                }
+              ],
+              "environmentVariables": {
+                "RSP_LICENSE": {
+                  "type": "local",
+                  "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                }
+              },
+              "image": {
+                "type": "docker",
+                "reference": "ghcr.io/azure/rstudio-workbench:latest"
+              },
+              "kernel": {
+                "argv": [
+                  "option1",
+                  "option2",
+                  "option3"
+                ],
+                "displayName": "TestKernel",
+                "language": "python"
+              },
+              "volumes": [
+                {
+                  "type": "bind",
+                  "readOnly": true,
+                  "source": "/mnt/azureuser/",
+                  "target": "/home/testuser/"
+                }
+              ]
+            }
+          ],
+          "enableOSPatching": true,
+          "enableRootAccess": true,
+          "enableSSO": true,
+          "personalComputeInstanceSettings": {
+            "assignedUser": {
+              "objectId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          "releaseQuotaOnStop": true,
+          "sshSettings": {
+            "sshPublicAccess": "Disabled"
+          },
+          "subnet": {
+            "id": "test-subnet-resource-id"
+          },
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstanceMinimal.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstanceMinimal.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute with minimal inputs"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstanceWithSchedules.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/ComputeInstanceWithSchedules.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "applicationSharingPolicy": "Personal",
+          "computeInstanceAuthorizationType": "personal",
+          "personalComputeInstanceSettings": {
+            "assignedUser": {
+              "objectId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          "schedules": {
+            "computeStartStop": [
+              {
+                "action": "Stop",
+                "cron": {
+                  "expression": "0 18 * * *",
+                  "startTime": "2021-04-23T01:30:00",
+                  "timeZone": "Pacific Standard Time"
+                },
+                "status": "Enabled",
+                "triggerType": "Cron"
+              }
+            ]
+          },
+          "sshSettings": {
+            "sshPublicAccess": "Disabled"
+          },
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute with Schedules"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/KubernetesCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/createOrUpdate/KubernetesCompute.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "Kubernetes",
+        "properties": {
+          "defaultInstanceType": "defaultInstanceType",
+          "instanceTypes": {
+            "defaultInstanceType": {
+              "nodeSelector": null,
+              "resources": {
+                "limits": {
+                  "cpu": "1",
+                  "memory": "4Gi",
+                  "nvidia.com/gpu": null
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "4Gi",
+                  "nvidia.com/gpu": null
+                }
+              }
+            }
+          },
+          "namespace": "default"
+        },
+        "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Creating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Creating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Attach a Kubernetes Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "underlyingResourceAction": "Delete",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Compute_Delete",
+  "title": "Delete Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/AKSCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/AKSCompute.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a AKS Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/AmlCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/AmlCompute.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "allocationState": "Resizing",
+            "allocationStateTransitionTime": "2017-09-27T22:28:08.998Z",
+            "currentNodeCount": 0,
+            "enableNodePublicIp": true,
+            "errors": null,
+            "isolatedNetwork": false,
+            "nodeStateCounts": {
+              "idleNodeCount": 0,
+              "leavingNodeCount": 0,
+              "preemptedNodeCount": 0,
+              "preparingNodeCount": 0,
+              "runningNodeCount": 0,
+              "unusableNodeCount": 0
+            },
+            "osType": "Windows",
+            "remoteLoginPortPublicAccess": "Enabled",
+            "scaleSettings": {
+              "maxNodeCount": 1,
+              "minNodeCount": 0,
+              "nodeIdleTimeBeforeScaleDown": "PT5M"
+            },
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "targetNodeCount": 1,
+            "virtualMachineImage": null,
+            "vmPriority": "Dedicated",
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a AML Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/ComputeInstance.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/ComputeInstance.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "ComputeInstance",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "applicationSharingPolicy": "Shared",
+            "applications": [
+              {
+                "displayName": "Jupyter",
+                "endpointUri": "https://compute123.eastus2.azureml.net/jupyter"
+              }
+            ],
+            "computeInstanceAuthorizationType": "personal",
+            "connectivityEndpoints": {
+              "privateIpAddress": "10.0.0.1",
+              "publicIpAddress": "10.0.0.1"
+            },
+            "createdBy": {
+              "userId": "00000000-0000-0000-0000-000000000000",
+              "userName": "foobar@microsoft.com",
+              "userOrgId": "00000000-0000-0000-0000-000000000000"
+            },
+            "customServices": [
+              {
+                "name": "rstudio-workbench",
+                "docker": {
+                  "privileged": true
+                },
+                "endpoints": [
+                  {
+                    "name": "connect",
+                    "hostIp": null,
+                    "published": 4444,
+                    "target": 8787,
+                    "protocol": "http"
+                  }
+                ],
+                "environmentVariables": {
+                  "RSP_LICENSE": {
+                    "type": "local",
+                    "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                  }
+                },
+                "image": {
+                  "type": "docker",
+                  "reference": "ghcr.io/azure/rstudio-workbench:latest"
+                },
+                "volumes": [
+                  {
+                    "type": "bind",
+                    "bind": {
+                      "createHostPath": true,
+                      "propagation": "test",
+                      "selinux": "test"
+                    },
+                    "consistency": "test",
+                    "readOnly": true,
+                    "source": "/mnt/azureuser/",
+                    "target": "/home/testuser/",
+                    "tmpfs": {
+                      "size": 10
+                    },
+                    "volume": {
+                      "nocopy": true
+                    }
+                  }
+                ]
+              }
+            ],
+            "enableOSPatching": true,
+            "enableRootAccess": true,
+            "enableSSO": true,
+            "errors": null,
+            "osImageMetadata": {
+              "currentImageVersion": "22.06.14",
+              "isLatestOsImageVersion": false,
+              "latestImageVersion": "22.07.22"
+            },
+            "personalComputeInstanceSettings": {
+              "assignedUser": {
+                "objectId": "00000000-0000-0000-0000-000000000000",
+                "tenantId": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "releaseQuotaOnStop": true,
+            "sshSettings": {
+              "adminUserName": "azureuser",
+              "sshPort": 22,
+              "sshPublicAccess": "Enabled"
+            },
+            "state": "Running",
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get an ComputeInstance"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/KubernetesCompute.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/get/KubernetesCompute.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "isAttachedCompute": true,
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a Kubernetes Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/getAllowedVMSizesForResize.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/getAllowedVMSizesForResize.json
@@ -1,0 +1,257 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_DS1_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 7168,
+            "memoryGB": 3.5,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 1
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 14336,
+            "memoryGB": 7,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.29,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.58,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.17,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 16
+          },
+          {
+            "name": "Standard_DS11_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.18,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS12_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.37,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.74,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS14_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.48,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 229376,
+            "memoryGB": 112,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 16
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_getAllowedResizeSizes",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/list.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "compute123",
+            "type": "Microsoft.MachineLearningServices/workspaces/computes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+            "location": "eastus",
+            "properties": {
+              "description": "some compute",
+              "computeType": "AKS",
+              "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+              "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+              "provisioningState": "Succeeded",
+              "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+            }
+          },
+          {
+            "name": "compute1234",
+            "type": "Microsoft.MachineLearningServices/workspaces/computes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute1234",
+            "location": "eastus",
+            "properties": {
+              "description": "some compute",
+              "computeType": "AKS",
+              "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+              "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+              "provisioningState": "Succeeded",
+              "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute1234-56826-c9b00420020b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_List",
+  "title": "Get Computes"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/listKeys.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "adminKubeConfig": "admin kube config...",
+        "computeType": "AKS",
+        "imagePullSecretName": "the image pull secret name",
+        "userKubeConfig": "user kube config..."
+      }
+    }
+  },
+  "operationId": "Compute_ListKeys",
+  "title": "List AKS Compute Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/listNodes.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/listNodes.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123/listNodes?api-version=2025-07-01-preview&$skip=2",
+        "nodes": [
+          {
+            "nodeId": "tvm-3601533753_1-20170719t162906z",
+            "nodeState": "running",
+            "port": 50000,
+            "privateIpAddress": "13.84.190.124",
+            "publicIpAddress": "13.84.190.134",
+            "runId": "2f378a44-38f2-443a-9f0d-9909d0b47890"
+          },
+          {
+            "nodeId": "tvm-3601533753_2-20170719t162906z",
+            "nodeState": "idle",
+            "port": 50001,
+            "privateIpAddress": "13.84.190.124",
+            "publicIpAddress": "13.84.190.134"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_ListNodes",
+  "title": "Get compute nodes information for a compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/patch.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/patch.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "properties": {
+        "properties": {
+          "scaleSettings": {
+            "maxNodeCount": 4,
+            "minNodeCount": 4,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "provisioningState": "Updating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_Update",
+  "title": "Update a AmlCompute Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/resize.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/resize.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "targetVMSize": "Standard_DS11_v2"
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Resize",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/restart.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/restart.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Restart",
+  "title": "Restart ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/start.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/start.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Start",
+  "title": "Start ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/stop.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/stop.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Stop",
+  "title": "Stop ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateCustomServices.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateCustomServices.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "customServices": [
+      {
+        "name": "rstudio-workbench",
+        "docker": {
+          "privileged": true
+        },
+        "endpoints": [
+          {
+            "name": "connect",
+            "hostIp": null,
+            "published": 4444,
+            "target": 8787,
+            "protocol": "http"
+          }
+        ],
+        "environmentVariables": {
+          "RSP_LICENSE": {
+            "type": "local",
+            "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+          }
+        },
+        "image": {
+          "type": "docker",
+          "reference": "ghcr.io/azure/rstudio-workbench:latest"
+        },
+        "volumes": [
+          {
+            "type": "bind",
+            "readOnly": true,
+            "source": "/mnt/azureuser/",
+            "target": "/home/testuser/"
+          }
+        ]
+      }
+    ],
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateCustomServices",
+  "title": "Update Custom Services"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateDataMounts.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateDataMounts.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "dataMounts": [
+      {
+        "mountAction": "Mount",
+        "mountMode": "ReadOnly",
+        "mountName": "hello",
+        "mountPath": "/some/random/path/on/host",
+        "source": "azureml://subscriptions/some-sub/resourcegroups/some-rg/workspaces/some-ws/data/some-data-asset-name/versions/some-data-asset-version",
+        "sourceType": "URI"
+      }
+    ],
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateDataMounts",
+  "title": "Update Data Mounts"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateIdleShutdownSetting.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Compute/updateIdleShutdownSetting.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "idleTimeBeforeShutdown": "PT120M"
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateIdleShutdownSetting",
+  "title": "Update idle shutdown setting of ComputeInstance"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/DataReference/getBlobReferenceSAS.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/DataReference/getBlobReferenceSAS.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "assetId": "string",
+      "blobUri": "https://www.contoso.com/example"
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "NoCredentials"
+          },
+          "storageAccountArmId": "string"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataReferences_GetBlobReferenceSAS",
+  "title": "GetBlobReferenceSAS Data Reference."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureBlobWAccountKey/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureBlobWAccountKey/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "containerName": "string",
+        "credentials": {
+          "credentialsType": "AccountKey",
+          "secrets": {
+            "key": "string",
+            "secretsType": "AccountKey"
+          }
+        },
+        "datastoreType": "AzureBlob",
+        "endpoint": "core.windows.net",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "https"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (AzureBlob w/ AccountKey)."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureDataLakeGen1WServicePrincipal/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureDataLakeGen1WServicePrincipal/createOrUpdate.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "credentials": {
+          "authorityUrl": "string",
+          "clientId": "00000000-1111-2222-3333-444444444444",
+          "credentialsType": "ServicePrincipal",
+          "resourceUrl": "string",
+          "secrets": {
+            "clientSecret": "string",
+            "secretsType": "ServicePrincipal"
+          },
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "datastoreType": "AzureDataLakeGen1",
+        "properties": null,
+        "storeName": "string",
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen1",
+          "properties": null,
+          "storeName": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen1",
+          "properties": null,
+          "storeName": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure Data Lake Gen1 w/ ServicePrincipal)."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureDataLakeGen2WServicePrincipal/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureDataLakeGen2WServicePrincipal/createOrUpdate.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "credentials": {
+          "authorityUrl": "string",
+          "clientId": "00000000-1111-2222-3333-444444444444",
+          "credentialsType": "ServicePrincipal",
+          "resourceUrl": "string",
+          "secrets": {
+            "clientSecret": "string",
+            "secretsType": "ServicePrincipal"
+          },
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "datastoreType": "AzureDataLakeGen2",
+        "endpoint": "string",
+        "filesystem": "string",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen2",
+          "endpoint": "string",
+          "filesystem": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen2",
+          "endpoint": "string",
+          "filesystem": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure Data Lake Gen2 w/ Service Principal)."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureFileWAccountKey/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/AzureFileWAccountKey/createOrUpdate.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "credentials": {
+          "credentialsType": "AccountKey",
+          "secrets": {
+            "key": "string",
+            "secretsType": "AccountKey"
+          }
+        },
+        "datastoreType": "AzureFile",
+        "endpoint": "string",
+        "fileShareName": "string",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureFile",
+          "endpoint": "string",
+          "fileShareName": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureFile",
+          "endpoint": "string",
+          "fileShareName": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure File store w/ AccountKey)."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Datastores_Delete",
+  "title": "Delete datastore."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_Get",
+  "title": "Get datastore."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "isDefault": false,
+    "names": [
+      "string"
+    ],
+    "orderBy": "string",
+    "orderByAsc": false,
+    "resourceGroupName": "test-rg",
+    "searchText": "string",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/datastores?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "accountName": "string",
+              "containerName": "string",
+              "credentials": {
+                "credentialsType": "AccountKey",
+                "secrets": {
+                  "secretsType": "AccountKey"
+                }
+              },
+              "datastoreType": "AzureBlob",
+              "endpoint": "core.windows.net",
+              "isDefault": false,
+              "properties": null,
+              "tags": {
+                "string": "string"
+              },
+              "protocol": "https"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_List",
+  "title": "List datastores."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/listSecrets.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Datastore/listSecrets.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "expirableSecret": false,
+      "expireAfterHours": 1
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key": "string",
+        "secretsType": "AccountKey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_ListSecrets",
+  "title": "Get datastore secrets."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/create.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "Azure.OpenAI",
+        "model": {
+          "name": "text-davinci-003",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+      }
+    },
+    "deploymentName": "text-davinci-003",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_CreateOrUpdate",
+  "title": "Create Endpoint Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EndpointDeployment_Delete",
+  "title": "Delete Endpoint Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/get.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "text-davinci-003",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_Get",
+  "title": "Get Endpoint Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/getDeployments.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/getDeployments.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_List",
+  "title": "Get Endpoint Deployments"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/getInWorkspace.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/Deployment/getInWorkspace.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_GetInWorkspace",
+  "title": "Get Endpoint Deployments In Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/create.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "SystemManaged",
+        "basePolicyName": "112",
+        "completionBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ],
+        "contentFilters": [
+          {
+            "name": "policyName",
+            "allowedContentLevel": "Low",
+            "blocking": false,
+            "enabled": false,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Blocking",
+        "promptBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ]
+      }
+    },
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicy_Create",
+  "title": "Create Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RaiPolicy_Delete",
+  "title": "Delete Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicy_Get",
+  "title": "Get Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/RaiPolicy/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/onlineEndpoints/endpoint-1/raiPolicies?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+            "properties": {
+              "type": "SystemManaged",
+              "basePolicyName": "112",
+              "completionBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ],
+              "contentFilters": [
+                {
+                  "name": "policyName",
+                  "allowedContentLevel": "Low",
+                  "blocking": false,
+                  "enabled": false,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Blocking",
+              "promptBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicies_List",
+  "title": "List Rai policies"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/create.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "name": "Azure.OpenAI",
+        "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+        "endpointType": "Azure.OpenAI"
+      }
+    },
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Azure.OpenAI",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+        "properties": {
+          "name": "Azure.OpenAI",
+          "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+          "endpointType": "Azure.OpenAI",
+          "endpointUri": "https://www.contoso.com/",
+          "failureReason": "some_string",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Endpoint_CreateOrUpdate",
+  "title": "Create Endpoint"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Azure.OpenAI",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+        "properties": {
+          "name": "Azure.OpenAI",
+          "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+          "endpointType": "Azure.OpenAI",
+          "endpointUri": "https://www.contoso.com/",
+          "failureReason": "some_string",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Endpoint_Get",
+  "title": "Get Endpoint"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/getModels.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/getModels.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Endpoint_GetModels",
+  "title": "Get Endpoint Models"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/list.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$skip": "skip_string",
+    "api-version": "2024-10-01-preview",
+    "endpointType": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "Azure.OpenAI",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+            "properties": {
+              "name": "Azure.OpenAI",
+              "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+              "endpointType": "Azure.OpenAI",
+              "endpointUri": "https://www.contoso.com/",
+              "failureReason": "some_string",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "some_string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "some_string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Endpoint_List",
+  "title": "List Endpoint"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/listKeys.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": {
+          "key1": "some_string",
+          "key2": "some_string"
+        }
+      }
+    }
+  },
+  "operationId": "Endpoint_ListKeys",
+  "title": "List Endpoint Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/regenerateKey.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Endpoint/regenerateKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyName": "Key1"
+    },
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "some_string",
+        "key2": "some_string"
+      }
+    }
+  },
+  "operationId": "Endpoint_RegenerateKeys",
+  "title": "Regenerate Endpoint Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ExternalFQDN/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ExternalFQDN/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "category": "Azure Active Directory",
+              "endpoints": [
+                {
+                  "domainName": "login.microsoftonline.com",
+                  "endpointDetails": [
+                    {
+                      "port": 443
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "properties": {
+              "category": "Azure portal",
+              "endpoints": [
+                {
+                  "domainName": "management.azure.com",
+                  "endpointDetails": [
+                    {
+                      "port": 443
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListOutboundNetworkDependenciesEndpoints",
+  "title": "ListOutboundNetworkDependenciesEndpoints"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Feature/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Feature/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "featureName": "string",
+    "featuresetName": "string",
+    "featuresetVersion": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "Float",
+          "featureName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:51",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:51",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Features_Get",
+  "title": "Get Feature."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Feature/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Feature/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "description": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "featureName": "string",
+    "featuresetName": "string",
+    "featuresetVersion": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/features?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "Boolean",
+              "featureName": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:50",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:50",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Features_List",
+  "title": "List Feature."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/getDeltaModelsStatusAsync.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/getDeltaModelsStatusAsync.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "deltaModels": [
+        "string"
+      ],
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actualInstanceCount": 0,
+        "deltaModels": {
+          "string": [
+            {
+              "count": 0,
+              "sampleInstanceID": "string",
+              "status": "string"
+            }
+          ]
+        },
+        "expectedInstanceCount": 0,
+        "revisionId": "string",
+        "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_GetDeltaModelsStatusAsync",
+  "title": "GetDeltaModelsStatusAsync Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/listDeltaModelsAsync.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/listDeltaModelsAsync.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "count": -1,
+      "skipToken": "string",
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups/testInferenceGroupName/listDeltaModels?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          "string"
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_ListDeltaModelsAsync",
+  "title": "ListDeltaModelsAsync Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/modifyDeltaModelsAsync.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/InferenceGroup/modifyDeltaModelsAsync.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "addDeltaModels": [
+        "string"
+      ],
+      "removeDeltaModels": [
+        "string"
+      ],
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/...pathToOperationStatus.."
+      }
+    }
+  },
+  "operationId": "InferenceGroups_ModifyDeltaModelsAsync",
+  "title": "ModifyDeltaModelsAsync Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/createOrUpdate.json
@@ -1,0 +1,254 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "string",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "isArchived": false,
+        "jobType": "AutoML",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+            }
+          }
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        },
+        "taskDetails": {
+          "limitSettings": {
+            "maxTrials": 2
+          },
+          "modelSettings": {
+            "validationCropSize": 2
+          },
+          "searchSpace": [
+            {
+              "validationCropSize": "choice(2, 360)"
+            }
+          ],
+          "targetColumnName": "string",
+          "taskType": "ImageClassification",
+          "trainingData": {
+            "jobInputType": "mltable",
+            "uri": "string"
+          }
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate AutoML Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/get.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get AutoML Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/AutoMLJob/list.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "experimentName": "string",
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "AutoML",
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+                  }
+                }
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "Scheduled",
+              "tags": {
+                "string": "string"
+              },
+              "taskDetails": {
+                "limitSettings": {
+                  "maxTrials": 2
+                },
+                "modelSettings": {
+                  "validationCropSize": 2
+                },
+                "searchSpace": [
+                  {
+                    "validationCropSize": "choice(2, 360)"
+                  }
+                ],
+                "targetColumnName": "string",
+                "taskType": "ImageClassification",
+                "trainingData": {
+                  "jobInputType": "mltable",
+                  "uri": "string"
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List AutoML Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/createOrUpdate.json
@@ -1,0 +1,257 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeId": "string",
+        "command": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "distribution": {
+          "distributionType": "TensorFlow",
+          "parameterServerCount": 1,
+          "workerCount": 1
+        },
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "string",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "inputs": {
+          "string": {
+            "description": "string",
+            "jobInputType": "literal",
+            "value": "string"
+          }
+        },
+        "jobType": "Command",
+        "limits": {
+          "jobLimitsType": "Command",
+          "timeout": "PT5M"
+        },
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "parentJobName": "ParentRun",
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+            }
+          }
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "a0847709-f5aa-4561-8ba5-d915d403fdcf": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "b8163d40-c351-43d6-8a34-d0cd895b8a5a": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Command Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/get.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "8385cf05-78c0-41ef-b31d-36796a678e19": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Command Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/CommandJob/list.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeId": "string",
+              "command": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "distribution": {
+                "distributionType": "TensorFlow",
+                "parameterServerCount": 1,
+                "workerCount": 1
+              },
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "experimentName": "string",
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "inputs": {
+                "string": {
+                  "description": "string",
+                  "jobInputType": "literal",
+                  "value": "string"
+                }
+              },
+              "jobType": "Command",
+              "limits": {
+                "jobLimitsType": "Command",
+                "timeout": "PT5M"
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "parameters": {
+                "string": "string"
+              },
+              "parentJobName": "ParentRun",
+              "properties": {
+                "string": "string"
+              },
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "7aad5998-6c83-4ca9-b50a-b44dfc43f420": null
+                  }
+                }
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Command Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/createOrUpdate.json
@@ -1,0 +1,217 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "computeId": "gpu-compute",
+        "dataGenerationDetails": {
+          "dataGenerationTaskType": "Conversation",
+          "dataGenerationType": "LabelGeneration",
+          "teacherModelEndpoint": {
+            "endpointName": "newfinetuneinttesting-jbuob"
+          },
+          "trainingData": {
+            "description": null,
+            "jobInputType": "uri_file",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          }
+        },
+        "experimentName": "llm-finetuning",
+        "finetuningDetails": {
+          "studentModel": {
+            "description": null,
+            "jobInputType": "mlflow_model",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+          }
+        },
+        "jobType": "Distillation",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "mlflow_model",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
+        "resources": {
+          "instanceTypes": [
+            "Standard_NC6"
+          ]
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Distillation Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/get.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Distillation Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/DistillationJob/list.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentId": "string",
+              "computeId": "string",
+              "dataGenerationDetails": {
+                "dataGenerationTaskType": "Conversation",
+                "dataGenerationType": "LabelGeneration",
+                "teacherModelEndpoint": {
+                  "endpointName": "newfinetuneinttesting-jbuob"
+                },
+                "trainingData": {
+                  "description": null,
+                  "jobInputType": "uri_file",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+                }
+              },
+              "displayName": "string",
+              "experimentName": "string",
+              "finetuningDetails": {
+                "studentModel": {
+                  "description": null,
+                  "jobInputType": "mlflow_model",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+                }
+              },
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "Distillation",
+              "notificationSetting": {
+                "emailOn": [
+                  "JobFailed"
+                ],
+                "emails": [
+                  "string"
+                ]
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "mlflow_model",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
+              "resources": {
+                "instanceTypes": [
+                  "Standard_NC6"
+                ]
+              },
+              "status": "Created",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Distillation Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/createOrUpdate.json
@@ -1,0 +1,202 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "computeId": "gpu-compute",
+        "experimentName": "llm-finetuning",
+        "fineTuningDetails": {
+          "model": {
+            "description": null,
+            "jobInputType": "mlflow_model",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          },
+          "modelProvider": "Custom",
+          "taskType": "TextCompletion",
+          "trainingData": {
+            "description": null,
+            "jobInputType": "uri_file",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          }
+        },
+        "jobType": "FineTuning",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "mlflow_model",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
+        "resources": {
+          "instanceTypes": [
+            "Standard_NC6"
+          ]
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate FineTuning Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/get.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get FineTuning Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/FineTuningJob/list.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentId": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "experimentName": "string",
+              "fineTuningDetails": {
+                "model": {
+                  "description": null,
+                  "jobInputType": "mlflow_model",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+                },
+                "modelProvider": "Custom",
+                "taskType": "TextCompletion",
+                "trainingData": {
+                  "description": null,
+                  "jobInputType": "uri_file",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+                }
+              },
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "FineTuning",
+              "notificationSetting": {
+                "emailOn": [
+                  "JobFailed"
+                ],
+                "emails": [
+                  "string"
+                ]
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "mlflow_model",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
+              "resources": {
+                "instanceTypes": [
+                  "Standard_NC6"
+                ]
+              },
+              "status": "Created",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List FineTuning Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/createOrUpdate.json
@@ -1,0 +1,170 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "experimentName": "string",
+        "inputs": {
+          "string": {
+            "description": "string",
+            "jobInputType": "literal",
+            "value": "string"
+          }
+        },
+        "jobType": "Pipeline",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "Upload",
+            "uri": "string"
+          }
+        },
+        "properties": {
+          "string": "string"
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "settings": {},
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Pipeline Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/get.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Pipeline Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/PipelineJob/list.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "experimentName": "string",
+              "inputs": {
+                "string": {
+                  "description": "string",
+                  "jobInputType": "literal",
+                  "value": "string"
+                }
+              },
+              "jobType": "Pipeline",
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "Upload",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "settings": {},
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Pipeline Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/createOrUpdate.json
@@ -1,0 +1,248 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "earlyTermination": {
+          "delayEvaluation": 1,
+          "evaluationInterval": 1,
+          "policyType": "MedianStopping"
+        },
+        "experimentName": "string",
+        "jobType": "Sweep",
+        "limits": {
+          "jobLimitsType": "Sweep",
+          "maxConcurrentTrials": 1,
+          "maxTotalTrials": 1,
+          "trialTimeout": "PT1S"
+        },
+        "objective": {
+          "goal": "Minimize",
+          "primaryMetric": "string"
+        },
+        "properties": {
+          "string": "string"
+        },
+        "samplingAlgorithm": {
+          "samplingAlgorithmType": "Grid"
+        },
+        "searchSpace": {
+          "string": {}
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        },
+        "trial": {
+          "codeId": "string",
+          "command": "string",
+          "distribution": {
+            "distributionType": "Mpi",
+            "processCountPerInstance": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+              }
+            }
+          }
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Sweep Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/get.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Sweep Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/SweepJob/list.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "earlyTermination": {
+                "delayEvaluation": 1,
+                "evaluationInterval": 1,
+                "policyType": "MedianStopping"
+              },
+              "experimentName": "string",
+              "jobType": "Sweep",
+              "limits": {
+                "jobLimitsType": "Sweep",
+                "maxConcurrentTrials": 1,
+                "maxTotalTrials": 1,
+                "trialTimeout": "PT1S"
+              },
+              "objective": {
+                "goal": "Minimize",
+                "primaryMetric": "string"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "samplingAlgorithm": {
+                "samplingAlgorithmType": "Grid"
+              },
+              "searchSpace": {
+                "string": {}
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              },
+              "trial": {
+                "codeId": "string",
+                "command": "string",
+                "distribution": {
+                  "distributionType": "Mpi",
+                  "processCountPerInstance": 1
+                },
+                "environmentId": "string",
+                "environmentVariables": {
+                  "string": "string"
+                },
+                "resources": {
+                  "instanceCount": 1,
+                  "instanceType": "string",
+                  "properties": {
+                    "string": {
+                      "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                    }
+                  }
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Sweep Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/cancel.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/cancel.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Jobs_Cancel",
+  "title": "Cancel Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Job/delete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "204": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Jobs_Delete",
+  "title": "Delete Job."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateManagedNetworkV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateManagedNetworkV2.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "enableNetworkMonitor": true,
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Put",
+  "title": "Put ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateRule.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateRule.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_CreateOrUpdate",
+  "title": "CreateOrUpdate ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateRuleV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/createOrUpdateRuleV2.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "errorInformation": null,
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OutboundRule_CreateOrUpdate",
+  "title": "CreateOrUpdate OutboundRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/deleteRule.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/deleteRule.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedNetworkSettingsRule_Delete",
+  "title": "Delete ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/deleteRuleV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/deleteRuleV2.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OutboundRule_Delete",
+  "title": "Delete OutboundRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getManagedNetworkV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getManagedNetworkV2.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Get",
+  "title": "Get ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getRule.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getRule.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_Get",
+  "title": "Get ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getRuleV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/getRuleV2.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "errorInformation": null,
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OutboundRule_Get",
+  "title": "Get OutboundRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listManagedNetworkV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listManagedNetworkV2.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+            "properties": {
+              "managedNetwork": {
+                "firewallPublicIpAddress": "22.22.131.49",
+                "firewallSku": "Standard",
+                "isolationMode": "AllowOnlyApprovedOutbound",
+                "networkId": "00000000-1111-2222-3333-444444444444",
+                "outboundRules": {
+                  "rule_name_1": {
+                    "type": "FQDN",
+                    "category": "UserDefined",
+                    "destination": "destination_endpoint",
+                    "errorInformation": null,
+                    "status": "Active"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettings_List",
+  "title": "List ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listRule.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listRule.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_List",
+  "title": "List ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listRuleV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/listRuleV2.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OutboundRule_List",
+  "title": "List OutboundRules"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/patchManagedNetworkV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/patchManagedNetworkV2.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "enableNetworkMonitor": true,
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Patch",
+  "title": "Patch ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/postOutboundRulesV2.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/postOutboundRulesV2.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "enableNetworkMonitor": true,
+        "firewallSku": "Standard",
+        "isolationMode": "AllowOnlyApprovedOutbound",
+        "outboundRules": {
+          "rule_name_1": {
+            "type": "FQDN",
+            "category": "UserDefined",
+            "destination": "destination_endpoint"
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": null,
+              "status": "Active"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OutboundRules_Post",
+  "title": "Post OutboundRules"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/provision.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/ManagedNetwork/provision.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "includeSpark": false
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sparkReady": true,
+        "status": "Active"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+  "title": "Provision ManagedNetwork"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Notebook/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Notebook/listKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryAccessKey": null,
+        "secondaryAccessKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListNotebookKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Notebook/prepare.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Notebook/prepare.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "fqdn": "testnotebook.notebooks.azure.com",
+        "notebookPreparationError": {
+          "errorMessage": "general error",
+          "statusCode": 500
+        },
+        "resourceId": "aabbccddee112233445566778899"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_PrepareNotebook",
+  "title": "Prepare Notebook"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/createOrUpdate.json
@@ -1,0 +1,246 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "appInsightsEnabled": false,
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "containerResourceRequirements": {
+          "containerResourceLimits": {
+            "cpu": "\"1\"",
+            "gpu": "\"1\"",
+            "memory": "\"2Gi\""
+          },
+          "containerResourceRequests": {
+            "cpu": "\"1\"",
+            "gpu": "\"1\"",
+            "memory": "\"2Gi\""
+          }
+        },
+        "endpointComputeType": "Kubernetes",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "instanceType": "string",
+        "livenessProbe": {
+          "failureThreshold": 1,
+          "initialDelay": "PT5M",
+          "period": "PT5M",
+          "successThreshold": 1,
+          "timeout": "PT5M"
+        },
+        "model": "string",
+        "modelMountPath": "string",
+        "properties": {
+          "string": "string"
+        },
+        "requestSettings": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "maxQueueWait": "PT5M",
+          "requestTimeout": "PT5M"
+        },
+        "scaleSettings": {
+          "scaleType": "Default"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/get.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_Get",
+  "title": "Get Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/listSkus.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments/testDeploymentName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "Microsoft.MachineLearning.Services/endpoints/deployments",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_ListSkus",
+  "title": "List Kubernetes Online Deployment Skus."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/KubernetesOnlineDeployment/update.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_Update",
+  "title": "Update Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/createOrUpdate.json
@@ -1,0 +1,231 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "appInsightsEnabled": false,
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "endpointComputeType": "Managed",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "instanceType": "string",
+        "livenessProbe": {
+          "failureThreshold": 1,
+          "initialDelay": "PT5M",
+          "period": "PT5M",
+          "successThreshold": 1,
+          "timeout": "PT5M"
+        },
+        "model": "string",
+        "modelMountPath": "string",
+        "properties": {
+          "string": "string"
+        },
+        "readinessProbe": {
+          "failureThreshold": 30,
+          "initialDelay": "PT1S",
+          "period": "PT10S",
+          "successThreshold": 1,
+          "timeout": "PT2S"
+        },
+        "requestSettings": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "maxQueueWait": "PT5M",
+          "requestTimeout": "PT5M"
+        },
+        "scaleSettings": {
+          "scaleType": "Default"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Managed Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/get.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_Get",
+  "title": "Get Managed Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/listSkus.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments/testDeploymentName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "Microsoft.MachineLearning.Services/endpoints/deployments",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_ListSkus",
+  "title": "List Managed Online Deployment Skus."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/ManagedOnlineDeployment/update.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_Update",
+  "title": "Update Managed Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/getLogs.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/getLogs.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "containerType": "StorageInitializer",
+      "tail": 0
+    },
+    "deploymentName": "testDeployment",
+    "endpointName": "testEndpoint",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "content": "string"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_GetLogs",
+  "title": "Get Online Deployment Logs."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/OnlineDeployment/list.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "appInsightsEnabled": false,
+              "codeConfiguration": {
+                "codeId": "string",
+                "scoringScript": "string"
+              },
+              "containerResourceRequirements": {
+                "containerResourceLimits": {
+                  "cpu": "\"1\"",
+                  "gpu": "\"1\"",
+                  "memory": "\"2Gi\""
+                },
+                "containerResourceRequests": {
+                  "cpu": "\"1\"",
+                  "gpu": "\"1\"",
+                  "memory": "\"2Gi\""
+                }
+              },
+              "endpointComputeType": "Kubernetes",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "instanceType": "string",
+              "livenessProbe": {
+                "failureThreshold": 1,
+                "initialDelay": "PT5M",
+                "period": "PT5M",
+                "successThreshold": 1,
+                "timeout": "PT5M"
+              },
+              "model": "string",
+              "modelMountPath": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "requestSettings": {
+                "maxConcurrentRequestsPerInstance": 1,
+                "maxQueueWait": "PT5M",
+                "requestTimeout": "PT5M"
+              },
+              "scaleSettings": {
+                "scaleType": "Default"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_List",
+  "title": "List Online Deployments."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/getAvailable.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/getAvailable.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "total": 1
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_GetAvailable",
+  "title": "Get available MaaS PTU quota."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/list.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/locations/eastus/ptuQuotas?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "modelCollection": "string",
+            "quota": 1,
+            "usageDetails": [
+              {
+                "collectionQuotaUsage": 1,
+                "deploymentName": "string",
+                "resourceGroup": "string",
+                "usage": 1,
+                "workspaceName": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_List",
+  "title": "List MaaS PTU usage and quota."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/listAvailable.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PTUQuota/listAvailable.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/locations/eastus/ptuQuotas/available?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "properties": {
+              "total": 1
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_ListAvailable",
+  "title": "List available MaaS PTU quota."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/createOrUpdate.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "WorkspacePutPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "WorkspacePutPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/get.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "WorkspaceGetPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateEndpointConnection/list.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "StorageAccountListPrivateEndpointConnections"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateLinkResource/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/PrivateLinkResource/list.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "amlworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateLinkResources",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateLinkResources/amlworkspace",
+            "properties": {
+              "groupId": "amlworkspace",
+              "requiredMembers": [
+                "default"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_List",
+  "title": "WorkspaceListPrivateLinkResources"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Quota/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Quota/list.json
@@ -1,0 +1,417 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 48,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quota",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Quotas_List",
+  "title": "List workspace quotas by VMFamily"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Quota/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Quota/update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "parameters": {
+      "value": [
+        {
+          "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+          "limit": 100,
+          "unit": "Count"
+        },
+        {
+          "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+          "limit": 200,
+          "unit": "Count"
+        }
+      ]
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 100,
+            "status": "Success",
+            "unit": "Count"
+          },
+          {
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 200,
+            "status": "Success",
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Quotas_Update",
+  "title": "update quotas"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/createOrUpdate.json
@@ -1,0 +1,280 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "discoveryUrl": "string",
+        "intellectualPropertyPublisher": "string",
+        "managedResourceGroup": {
+          "resourceId": "string"
+        },
+        "mlFlowRegistryUri": "string",
+        "publicNetworkAccess": "string",
+        "regionDetails": [
+          {
+            "acrDetails": [
+              {
+                "systemCreatedAcrAccount": {
+                  "acrAccountName": "string",
+                  "acrAccountSku": "string",
+                  "armResourceId": {
+                    "resourceId": "string"
+                  }
+                }
+              }
+            ],
+            "location": "string",
+            "storageAccountDetails": [
+              {
+                "systemCreatedStorageAccount": {
+                  "allowBlobPublicAccess": false,
+                  "armResourceId": {
+                    "resourceId": "string"
+                  },
+                  "storageAccountHnsEnabled": false,
+                  "storageAccountName": "string",
+                  "storageAccountType": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "registryPrivateEndpointConnections": [
+          {
+            "id": "string",
+            "location": "string",
+            "properties": {
+              "groupIds": [
+                "string"
+              ],
+              "privateEndpoint": {
+                "subnetArmId": "string"
+              },
+              "provisioningState": "string",
+              "registryPrivateLinkServiceConnectionState": {
+                "description": "string",
+                "actionsRequired": "string",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry with system created accounts."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location",
+        "Retry-After": 100
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Registries_Delete",
+  "title": "Delete Registry."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/get.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:40",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:40",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_Get",
+  "title": "Get Registry with system created accounts."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/list.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "discoveryUrl": "string",
+              "intellectualPropertyPublisher": "string",
+              "managedResourceGroup": {
+                "resourceId": "string"
+              },
+              "mlFlowRegistryUri": "string",
+              "publicNetworkAccess": "string",
+              "regionDetails": [
+                {
+                  "acrDetails": [
+                    {
+                      "systemCreatedAcrAccount": {
+                        "acrAccountName": "string",
+                        "acrAccountSku": "string",
+                        "armResourceId": {
+                          "resourceId": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "location": "string",
+                  "storageAccountDetails": [
+                    {
+                      "systemCreatedStorageAccount": {
+                        "allowBlobPublicAccess": false,
+                        "armResourceId": {
+                          "resourceId": "string"
+                        },
+                        "storageAccountHnsEnabled": false,
+                        "storageAccountName": "string",
+                        "storageAccountType": "string"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "registryPrivateEndpointConnections": [
+                {
+                  "id": "string",
+                  "location": "string",
+                  "properties": {
+                    "groupIds": [
+                      "string"
+                    ],
+                    "privateEndpoint": {
+                      "id": "string",
+                      "subnetArmId": "string"
+                    },
+                    "provisioningState": "string",
+                    "registryPrivateLinkServiceConnectionState": {
+                      "description": "string",
+                      "actionsRequired": "string",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ]
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:40",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:40",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_List",
+  "title": "List registries with system created accounts."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/listBySubscription.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/listBySubscription.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.MachineLearningServices/registries?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "discoveryUrl": "string",
+              "intellectualPropertyPublisher": "string",
+              "managedResourceGroup": {
+                "resourceId": "string"
+              },
+              "mlFlowRegistryUri": "string",
+              "publicNetworkAccess": "string",
+              "regionDetails": [
+                {
+                  "acrDetails": [
+                    {
+                      "systemCreatedAcrAccount": {
+                        "acrAccountName": "string",
+                        "acrAccountSku": "string",
+                        "armResourceId": {
+                          "resourceId": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "location": "string",
+                  "storageAccountDetails": [
+                    {
+                      "systemCreatedStorageAccount": {
+                        "allowBlobPublicAccess": false,
+                        "armResourceId": {
+                          "resourceId": "string"
+                        },
+                        "storageAccountHnsEnabled": false,
+                        "storageAccountName": "string",
+                        "storageAccountType": "string"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "registryPrivateEndpointConnections": [
+                {
+                  "id": "string",
+                  "location": "string",
+                  "properties": {
+                    "groupIds": [
+                      "string"
+                    ],
+                    "privateEndpoint": {
+                      "id": "string",
+                      "subnetArmId": "string"
+                    },
+                    "provisioningState": "string",
+                    "registryPrivateLinkServiceConnectionState": {
+                      "description": "string",
+                      "actionsRequired": "string",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ]
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:15",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_ListBySubscription",
+  "title": "List registries by subscription."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/removeRegions.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/removeRegions.json
@@ -1,0 +1,190 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "discoveryUrl": "string",
+        "intellectualPropertyPublisher": "string",
+        "managedResourceGroup": {
+          "resourceId": "string"
+        },
+        "mlFlowRegistryUri": "string",
+        "publicNetworkAccess": "string",
+        "regionDetails": [
+          {
+            "acrDetails": [
+              {
+                "systemCreatedAcrAccount": {
+                  "acrAccountName": "string",
+                  "acrAccountSku": "string",
+                  "armResourceId": {
+                    "resourceId": "string"
+                  }
+                }
+              }
+            ],
+            "location": "string",
+            "storageAccountDetails": [
+              {
+                "systemCreatedStorageAccount": {
+                  "allowBlobPublicAccess": false,
+                  "armResourceId": {
+                    "resourceId": "string"
+                  },
+                  "storageAccountHnsEnabled": false,
+                  "storageAccountName": "string",
+                  "storageAccountType": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "registryPrivateEndpointConnections": [
+          {
+            "id": "string",
+            "location": "string",
+            "properties": {
+              "groupIds": [
+                "string"
+              ],
+              "privateEndpoint": {
+                "subnetArmId": "string"
+              },
+              "provisioningState": "string",
+              "registryPrivateLinkServiceConnectionState": {
+                "description": "string",
+                "actionsRequired": "string",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:01",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:01",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location",
+        "Retry-After": 100
+      }
+    }
+  },
+  "operationId": "Registries_RemoveRegions",
+  "title": "Remove regions from registry"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registries/update.json
@@ -1,0 +1,124 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Basic"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:02",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:02",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_Update",
+  "title": "Update Registry with system created accounts."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryCodeContainers_Delete",
+  "title": "Delete Registry Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_Get",
+  "title": "Get Registry Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeContainer/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/codes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/registries/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testContainer2",
+            "type": "Microsoft.MachineLearningServices/registries/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer2",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_List",
+  "title": "List Registry Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "TemporaryBlobReference"
+    },
+    "codeName": "string",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeUri": "https://blobStorage/folderName",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryCodeVersions_Delete",
+  "title": "Delete Registry Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_Get",
+  "title": "Get Registry Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/CodeVersion/list.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/codes/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeUri": "https://blobStorage/folderName",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_List",
+  "title": "List Registry Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryComponentContainers_Delete",
+  "title": "Delete Registry Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_Get",
+  "title": "Get Registry Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentContainer/list.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "componentName": "testContainer",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/components?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_List",
+  "title": "List Registry Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/createOrUpdate.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "componentSpec": {
+          "8ced901b-d826-477d-bfef-329da9672513": null
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "2de2e74e-457d-4447-a581-933abc2b9d96": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "a6c1349d-5e45-48da-92c3-3ce176cb30e9": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryComponentVersions_Delete",
+  "title": "Delete Registry Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "1a7c40b5-2029-4f5f-a8d6-fd0822038773": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_Get",
+  "title": "Get Registry Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ComponentVersion/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/components/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentSpec": {
+                "50acbce5-cccc-475a-8ac6-c4da402afbd8": null
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_List",
+  "title": "List Registry Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "uri_folder",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_folder",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryDataContainers_Delete",
+  "title": "Delete Registry Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_Get",
+  "title": "Get Registry Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/registryList.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataContainer/registryList.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/data?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "uri_folder",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:15",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_List",
+  "title": "RegistryList Registry Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "None"
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/createOrUpdate.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "mltable",
+        "dataUri": "string",
+        "isAnonymous": false,
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "referencedUris": [
+          "string"
+        ],
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryDataVersions_Delete",
+  "title": "Delete Registry Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_Get",
+  "title": "Get Registry Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/registryList.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/DataVersionBase/registryList.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$tags": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ArchivedOnly",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/data/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "mltable",
+              "dataUri": "string",
+              "isAnonymous": false,
+              "isArchived": false,
+              "properties": {
+                "string": "string"
+              },
+              "referencedUris": [
+                "string"
+              ],
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:48",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_List",
+  "title": "RegistryList Registry Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        },
+        "tags": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        }
+      }
+    },
+    "environmentName": "testEnvironment",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.300Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.300Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.301Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.301Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryEnvironmentContainers_Delete",
+  "title": "Delete Registry Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testEnvironment",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_Get",
+  "title": "Get Registry Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentContainer/list.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/environments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testEnvironment",
+            "type": "Microsoft.MachineLearningServices/registries/environments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_List",
+  "title": "List Registry Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/createOrUpdate.json
@@ -1,0 +1,140 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "build": {
+          "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+          "dockerfilePath": "prod/Dockerfile"
+        },
+        "condaFile": "string",
+        "image": "docker.io/tensorflow/serving:latest",
+        "inferenceConfig": {
+          "livenessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "readinessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "scoringRoute": {
+            "path": "string",
+            "port": 1
+          }
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryEnvironmentVersions_Delete",
+  "title": "Delete Registry Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/get.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_Get",
+  "title": "Get Registry Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/EnvironmentVersion/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-regsitry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/environments/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "build": {
+                "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+                "dockerfilePath": "prod/Dockerfile"
+              },
+              "condaFile": "string",
+              "environmentType": "Curated",
+              "image": "docker.io/tensorflow/serving:latest",
+              "inferenceConfig": {
+                "livenessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "readinessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "scoringRoute": {
+                  "path": "string",
+                  "port": 1
+                }
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_List",
+  "title": "List Registry Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Model container description",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryModelContainers_Delete",
+  "title": "Delete Registry Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_Get",
+  "title": "Get Registry Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/models?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/registries/models",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+            "properties": {
+              "description": "Model container description",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_List",
+  "title": "List Registry Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "TemporaryBlobReference"
+    },
+    "modelName": "string",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "flavors": {
+          "string": {
+            "data": {
+              "string": "string"
+            }
+          }
+        },
+        "isAnonymous": false,
+        "modelType": "CustomModel",
+        "modelUri": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryModelVersions_Delete",
+  "title": "Delete Registry Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_Get",
+  "title": "Get Registry Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Registry/ModelVersion/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "description": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "offset": 1,
+    "properties": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/models/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "flavors": {
+                "string": {
+                  "data": {
+                    "string": "string"
+                  }
+                }
+              },
+              "isAnonymous": false,
+              "modelType": "CustomModel",
+              "modelUri": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_List",
+  "title": "List Registry Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/createOrUpdate.json
@@ -1,0 +1,121 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "action": {
+          "actionType": "InvokeBatchEndpoint",
+          "endpointInvocationDefinition": {
+            "9965593e-526f-4b89-bb36-761138cf2794": null
+          }
+        },
+        "displayName": "string",
+        "isEnabled": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        },
+        "trigger": {
+          "endTime": "string",
+          "expression": "string",
+          "startTime": "string",
+          "timeZone": "string",
+          "triggerType": "Cron"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "d77a9a9a-4bb5-4c0c-8a77-459be8b82b9f": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "13ea51e0-ff28-49c3-a85d-9b5199eb14e5": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Failed",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_CreateOrUpdate",
+  "title": "CreateOrUpdate Schedule."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/delete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "204": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Schedules_Delete",
+  "title": "Delete Schedule."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/get.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "a108545b-def1-4c86-8e53-dbcb1de3a8bc": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_Get",
+  "title": "Get Schedule."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Schedule/list.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/schedules?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "action": {
+                "actionType": "InvokeBatchEndpoint",
+                "endpointInvocationDefinition": {
+                  "00cd1396-a094-4d48-8d86-14c43a55a6af": null
+                }
+              },
+              "displayName": "string",
+              "isEnabled": false,
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Deleting",
+              "tags": {
+                "string": "string"
+              },
+              "trigger": {
+                "endTime": "string",
+                "expression": "string",
+                "startTime": "string",
+                "timeZone": "string",
+                "triggerType": "Cron"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_List",
+  "title": "List Schedules."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Usage/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Usage/list.json
@@ -1,0 +1,402 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Clusters",
+              "value": "Clusters"
+            },
+            "type": "Microsoft.MachineLearningServices/totalCores/usages",
+            "currentValue": 7,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 100,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Total Cluster Dedicated Regional vCPUs",
+              "value": "Total Cluster Dedicated Regional vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/dedicatedCores/usages",
+            "currentValue": 14,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 48,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_dsv2/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster2_dsv2/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 12,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_nc/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluser1_nc/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Total Cluster LowPriority Regional vCPUs",
+              "value": "Total Cluster LowPriority Regional vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/lowPriorityCores/usages",
+            "currentValue": 18,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 50,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster LowPriority vCPUs",
+              "value": "Standard D Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_D_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard DSv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_DSv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard Dv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_Dv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard FSv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_FSv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 18,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 12,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluster2_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluster3_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard NCv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster LowPriority vCPUs",
+              "value": "Standard NCv3 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv3_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster LowPriority vCPUs",
+              "value": "Standard ND Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_ND_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard NDv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NDv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster LowPriority vCPUs",
+              "value": "Standard NV Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NV_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_List",
+  "title": "List Usages"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/VirtualMachineSize/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/VirtualMachineSize/list.json
@@ -1,0 +1,390 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_DS1_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.13,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.01,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.05,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 7168,
+            "memoryGB": 3.5,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 1
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.03,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.1,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.25,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 14336,
+            "memoryGB": 7,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.2,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.06,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.5,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.29,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.12,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.4,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 1.01,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.58,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.17,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.81,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 2.02,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.23,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 16
+          },
+          {
+            "name": "Standard_DS11_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.26,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.18,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.11,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.04,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS12_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.37,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.53,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.21,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.42,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.74,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 1.06,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS14_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.3,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.48,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.84,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 2.11,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 229376,
+            "memoryGB": 112,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 16
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineSizes_List",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/createOrUpdate.json
@@ -1,0 +1,222 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "compute": "string",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "errorThreshold": 1,
+        "loggingLevel": "Info",
+        "maxConcurrencyPerInstance": 1,
+        "miniBatchSize": 1,
+        "model": {
+          "assetId": "string",
+          "referenceType": "Id"
+        },
+        "outputAction": "SummaryOnly",
+        "outputFileName": "string",
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "cd3c37dc-2876-4ca4-8a54-21bd7619724a": null
+            }
+          }
+        },
+        "retrySettings": {
+          "maxRetries": 1,
+          "timeout": "PT5M"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "4939850d-8eae-4343-8566-0826259a2ad1": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "b76755e4-16bf-45d4-b625-6634df7444cc": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BatchDeployments_Delete",
+  "title": "Delete Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/get.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "843c2bb4-e5f1-4267-98c8-ba22a99dbb00": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_Get",
+  "title": "Get Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/list.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/batchEndpoints/testEndpointName/deployments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "codeConfiguration": {
+                "codeId": "string",
+                "scoringScript": "string"
+              },
+              "compute": "string",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "errorThreshold": 1,
+              "loggingLevel": "Info",
+              "maxConcurrencyPerInstance": 1,
+              "miniBatchSize": 1,
+              "model": {
+                "assetId": "string",
+                "referenceType": "Id"
+              },
+              "outputAction": "SummaryOnly",
+              "outputFileName": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "a3c13e2e-a213-4cac-9f5a-b49966906ad6": null
+                  }
+                }
+              },
+              "retrySettings": {
+                "maxRetries": 1,
+                "timeout": "PT5M"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_List",
+  "title": "List Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchDeployment/update.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "1e5e1cf9-b0ea-4cf6-9764-e750bf85c10a": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "BatchDeployments_Update",
+  "title": "Update Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/createOrUpdate.json
@@ -1,0 +1,141 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AMLToken",
+        "defaults": {
+          "deploymentName": "string"
+        },
+        "properties": {
+          "string": "string"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testBatchEndpoint",
+    "resourceGroupName": "resourceGroup-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BatchEndpoints_Delete",
+  "title": "Delete Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/get.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_Get",
+  "title": "Get Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/batchEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AMLToken",
+              "defaults": {
+                "deploymentName": "string"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "scoringUri": "https://www.contoso.com/example",
+              "swaggerUri": "https://www.contoso.com/example"
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_List",
+  "title": "List Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_ListKeys",
+  "title": "ListKeys Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/BatchEndpoint/update.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "BatchEndpoints_Update",
+  "title": "Update Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "CodeContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "CodeContainers_Delete",
+  "title": "Delete Workspace Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "CodeContainers_Get",
+  "title": "Get Workspace Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeContainer/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "testcode",
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/codes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/workspaces/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testContainer2",
+            "type": "Microsoft.MachineLearningServices/workspaces/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer2",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CodeContainers_List",
+  "title": "List Workspace Code Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "None"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeUri": "https://blobStorage/folderName",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "CodeVersions_Delete",
+  "title": "Delete Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_Get",
+  "title": "Get Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/list.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/codes/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeUri": "https://blobStorage/folderName",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_List",
+  "title": "List Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/publish.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/CodeVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "CodeVersions_Publish",
+  "title": "Publish Workspace Code Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ComponentContainers_Delete",
+  "title": "Delete Workspace Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_Get",
+  "title": "Get Workspace Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentContainer/list.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/components?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_List",
+  "title": "List Workspace Component Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/createOrUpdate.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "componentSpec": {
+          "8ced901b-d826-477d-bfef-329da9672513": null
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "2de2e74e-457d-4447-a581-933abc2b9d96": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "a6c1349d-5e45-48da-92c3-3ce176cb30e9": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ComponentVersions_Delete",
+  "title": "Delete Workspace Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "1a7c40b5-2029-4f5f-a8d6-fd0822038773": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_Get",
+  "title": "Get Workspace Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/components/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentSpec": {
+                "50acbce5-cccc-475a-8ac6-c4da402afbd8": null
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_List",
+  "title": "List Workspace Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/publish.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ComponentVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ComponentVersions_Publish",
+  "title": "Publish Workspace Component Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "UriFile",
+        "properties": {
+          "properties1": "value1",
+          "properties2": "value2"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DataContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataContainers_Delete",
+  "title": "Delete Workspace Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DataContainers_Get",
+  "title": "Get Workspace Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataContainer/list.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "data123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/data?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "datastore123",
+            "type": "Microsoft.MachineLearningServices/workspaces/data",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+            "properties": {
+              "description": "string",
+              "dataType": "UriFile",
+              "properties": {
+                "properties1": "value1",
+                "properties2": "value2"
+              },
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "datastore124",
+            "type": "Microsoft.MachineLearningServices/workspaces/data",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer124",
+            "properties": {
+              "description": "string",
+              "dataType": "UriFile",
+              "properties": {
+                "properties1": "value1",
+                "properties2": "value2"
+              },
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DataContainers_List",
+  "title": "List Workspace Data Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "uri_file",
+        "dataUri": "string",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataVersions_Delete",
+  "title": "Delete Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_Get",
+  "title": "Get Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$tags": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/data/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "uri_file",
+              "dataUri": "string",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_List",
+  "title": "List Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/publish.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/DataVersionBase/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "DataVersions_Publish",
+  "title": "Publish Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "testEnvironment",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        },
+        "tags": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.300Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.300Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.301Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.301Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EnvironmentContainers_Delete",
+  "title": "Delete Workspace Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testEnvironment",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_Get",
+  "title": "Get Workspace Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/environments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testEnvironment",
+            "type": "Microsoft.MachineLearningServices/workspaces/environments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_List",
+  "title": "List Workspace Environment Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/createOrUpdate.json
@@ -1,0 +1,140 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "build": {
+          "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+          "dockerfilePath": "prod/Dockerfile"
+        },
+        "condaFile": "string",
+        "image": "docker.io/tensorflow/serving:latest",
+        "inferenceConfig": {
+          "livenessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "readinessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "scoringRoute": {
+            "path": "string",
+            "port": 1
+          }
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EnvironmentVersions_Delete",
+  "title": "Delete Workspace Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/get.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_Get",
+  "title": "Get Workspace Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/environments/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "build": {
+                "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+                "dockerfilePath": "prod/Dockerfile"
+              },
+              "condaFile": "string",
+              "environmentType": "Curated",
+              "image": "docker.io/tensorflow/serving:latest",
+              "inferenceConfig": {
+                "livenessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "readinessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "scoringRoute": {
+                  "path": "string",
+                  "port": 1
+                }
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_List",
+  "title": "List Workspace Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/publish.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/EnvironmentVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "EnvironmentVersions_Publish",
+  "title": "Publish Workspace Environment Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/createOrUpdate.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:48",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:48",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturesetContainers_Delete",
+  "title": "Delete Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/getEntity.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/getEntity.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Deleting",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:49",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:49",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_GetEntity",
+  "title": "GetEntity Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetContainer/list.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ArchivedOnly",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featuresets?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:46",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:46",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_List",
+  "title": "List Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/backfill.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/backfill.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "description": "string",
+      "dataAvailabilityStatus": [
+        "None"
+      ],
+      "displayName": "string",
+      "featureWindow": {
+        "featureWindowEnd": "2020-01-01T12:34:56.999+00:51",
+        "featureWindowStart": "2020-01-01T12:34:56.999+00:51"
+      },
+      "jobId": "string",
+      "resource": {
+        "instanceType": "string"
+      },
+      "sparkConfiguration": {
+        "string": "string"
+      },
+      "tags": {
+        "string": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "jobIds": [
+          "string",
+          "string"
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "FeaturesetVersions_Backfill",
+  "title": "Backfill Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/createOrUpdate.json
@@ -1,0 +1,221 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "entities": [
+          "string"
+        ],
+        "isAnonymous": false,
+        "isArchived": false,
+        "materializationSettings": {
+          "notification": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "resource": {
+            "instanceType": "string"
+          },
+          "schedule": {
+            "endTime": "string",
+            "frequency": "Day",
+            "interval": 1,
+            "schedule": {
+              "hours": [
+                1
+              ],
+              "minutes": [
+                1
+              ],
+              "monthDays": [
+                1
+              ],
+              "weekDays": [
+                "Monday"
+              ]
+            },
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Recurrence"
+          },
+          "sparkConfiguration": {
+            "string": "string"
+          },
+          "storeType": "Online"
+        },
+        "properties": {
+          "string": "string"
+        },
+        "specification": {
+          "path": "string"
+        },
+        "stage": "string",
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobFailed"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Day",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "OnlineAndOffline"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Deleting",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobCancelled"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Hour",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "Offline"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Failed",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturesetVersions_Delete",
+  "title": "Delete Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/get.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobFailed"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Minute",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "None"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_Get",
+  "title": "Get Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturesetVersion/list.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featuresets/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "entities": [
+                "string"
+              ],
+              "isAnonymous": false,
+              "isArchived": false,
+              "materializationSettings": {
+                "notification": {
+                  "emailOn": [
+                    "JobCompleted"
+                  ],
+                  "emails": [
+                    "string"
+                  ]
+                },
+                "resource": {
+                  "instanceType": "string"
+                },
+                "schedule": {
+                  "endTime": "string",
+                  "frequency": "Month",
+                  "interval": 1,
+                  "schedule": {
+                    "hours": [
+                      1
+                    ],
+                    "minutes": [
+                      1
+                    ],
+                    "monthDays": [
+                      1
+                    ],
+                    "weekDays": [
+                      "Saturday"
+                    ]
+                  },
+                  "startTime": "string",
+                  "timeZone": "string",
+                  "triggerType": "Recurrence"
+                },
+                "sparkConfiguration": {
+                  "string": "string"
+                },
+                "storeType": "Offline"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "specification": {
+                "path": "string"
+              },
+              "stage": "string",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:49",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:49",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_List",
+  "title": "List Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/createOrUpdate.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturestoreEntityContainers_Delete",
+  "title": "Delete Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/getEntity.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/getEntity.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:43",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:43",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_GetEntity",
+  "title": "GetEntity Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityContainer/list.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featurestoreEntities?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:43",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:43",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_List",
+  "title": "List Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/createOrUpdate.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "indexColumns": [
+          {
+            "columnName": "string",
+            "dataType": "Datetime"
+          }
+        ],
+        "isAnonymous": false,
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Integer"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:58",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:58",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Integer"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Canceled",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:58",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:58",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturestoreEntityVersions_Delete",
+  "title": "Delete Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Datetime"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:57",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:57",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_Get",
+  "title": "Get Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/FeaturestoreEntityVersion/list.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ActiveOnly",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featurestoreEntities/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "indexColumns": [
+                {
+                  "columnName": "string",
+                  "dataType": "Datetime"
+                }
+              ],
+              "isAnonymous": false,
+              "isArchived": false,
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:55",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:55",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_List",
+  "title": "List Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/createOrUpdate.json
@@ -1,0 +1,147 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AAD",
+        "groupName": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "requestConfiguration": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "requestTimeout": "PT5M"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:19",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:19",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:19",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:19",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferenceEndpoints_Delete",
+  "title": "Delete Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/get.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "requestConfiguration": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "requestTimeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:20",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_Get",
+  "title": "Get Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/list.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "CreatedAtAsc",
+    "poolName": "string",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AAD",
+              "endpointUri": "https://www.contoso.com/example",
+              "groupName": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Canceled",
+              "requestConfiguration": {
+                "maxConcurrentRequestsPerInstance": 1,
+                "requestTimeout": "PT5M"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Standard"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:20",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_List",
+  "title": "List Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceEndpoint/update.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "requestConfiguration": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "requestTimeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:20",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferenceEndpoints_Update",
+  "title": "Update Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/createOrUpdate.json
@@ -1,0 +1,230 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "environmentConfiguration": {
+          "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+          "environmentVariables": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "readinessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "startupProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "modelConfiguration": {
+          "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+        },
+        "nodeSkuType": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "scaleUnitSize": 1
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Updating",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [],
+          "provisioningState": "Deleting",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferenceGroups_Delete",
+  "title": "Delete Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/get.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:17",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_Get",
+  "title": "Get Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/getStatus.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/getStatus.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actualCapacityInfo": {
+          "failed": 1,
+          "outdatedFailed": 1,
+          "outdatedSucceeded": 1,
+          "succeeded": 1,
+          "total": 1
+        },
+        "endpointCount": 1,
+        "requestedCapacity": 1
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_GetStatus",
+  "title": "GetStatus Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/list.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "CreatedAtDesc",
+    "poolName": "string",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "environmentConfiguration": {
+                "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+                "environmentVariables": [
+                  {
+                    "key": "string",
+                    "value": "string"
+                  }
+                ],
+                "livenessProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                },
+                "readinessProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                },
+                "startupProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                }
+              },
+              "modelConfiguration": {
+                "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+              },
+              "nodeSkuType": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Failed",
+              "scaleUnitSize": 1
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:17",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_List",
+  "title": "List Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/listSkus.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups/testInferenceGroupName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "string",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_ListSkus",
+  "title": "ListSkus Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferenceGroup/update.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:17",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferenceGroups_Update",
+  "title": "Update Workspace Inference Group."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "scaleUnitConfiguration": {
+          "disablePublicEgress": false,
+          "registries": [
+            "string",
+            "registryName1"
+          ]
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferencePools_Delete",
+  "title": "Delete Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/get.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "scaleUnitConfiguration": {
+            "disablePublicEgress": false,
+            "registries": [
+              "string",
+              "registryName1"
+            ]
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_Get",
+  "title": "Get Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/list.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "UpdatedAtAsc",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferencePools?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "UserAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Failed",
+              "scaleUnitConfiguration": {
+                "disablePublicEgress": false,
+                "registries": [
+                  "string",
+                  "registryName1"
+                ]
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Premium"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_List",
+  "title": "List Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/InferencePool/update.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "scaleUnitConfiguration": {
+            "disablePublicEgress": false,
+            "registries": [
+              "string",
+              "registryName1"
+            ]
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferencePools_Update",
+  "title": "Update Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/createOrUpdate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "modelId": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Suspended",
+          "modelId": "string",
+          "provisioningState": "Failed"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Suspended",
+          "modelId": "string",
+          "provisioningState": "Failed"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "MarketplaceSubscriptions_Delete",
+  "title": "Delete Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/get.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Subscribed",
+          "modelId": "string",
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_Get",
+  "title": "Get Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/MarketplaceSubscription/list.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/marketplaceSubscriptions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "marketplacePlan": {
+                "offerId": "string",
+                "planId": "string",
+                "publisherId": "string"
+              },
+              "marketplaceSubscriptionStatus": "Suspended",
+              "modelId": "string",
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:06",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:06",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_List",
+  "title": "List Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Model container description",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "ModelContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ModelContainers_Delete",
+  "title": "Delete Workspace Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "ModelContainers_Get",
+  "title": "Get Workspace Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/models?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/workspaces/models",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+            "properties": {
+              "description": "Model container description",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ModelContainers_List",
+  "title": "List Workspace Model Container."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "flavors": {
+          "string": {
+            "data": {
+              "string": "string"
+            }
+          }
+        },
+        "isAnonymous": false,
+        "modelType": "CustomModel",
+        "modelUri": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ModelVersions_Delete",
+  "title": "Delete Workspace Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_Get",
+  "title": "Get Workspace Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "string",
+    "description": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "offset": 1,
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/models/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "flavors": {
+                "string": {
+                  "data": {
+                    "string": "string"
+                  }
+                }
+              },
+              "isAnonymous": false,
+              "modelType": "CustomModel",
+              "modelUri": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_List",
+  "title": "List Workspace Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/publish.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ModelVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ModelVersions_Publish",
+  "title": "Publish Workspace Model Version."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineDeployment/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineDeployment/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeployment",
+    "endpointName": "testEndpoint",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OnlineDeployments_Delete",
+  "title": "Delete Workspace Online Deployment."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/createOrUpdate.json
@@ -1,0 +1,144 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AMLToken",
+        "compute": "string",
+        "properties": {
+          "string": "string"
+        },
+        "traffic": {
+          "string": 1
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OnlineEndpoints_Delete",
+  "title": "Delete Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/get.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_Get",
+  "title": "Get Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/getToken.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/getToken.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "accessToken": "string",
+        "expiryTimeUtc": 1,
+        "refreshAfterTimeUtc": 1,
+        "tokenType": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_GetToken",
+  "title": "GetToken Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/list.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "computeType": "Managed",
+    "count": 1,
+    "orderBy": "CreatedAtDesc",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AMLToken",
+              "compute": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "scoringUri": "https://www.contoso.com/example",
+              "swaggerUri": "https://www.contoso.com/example",
+              "traffic": {
+                "string": 1
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_List",
+  "title": "List Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_ListKeys",
+  "title": "ListKeys Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/regenerateKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/regenerateKeys.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyType": "Primary",
+      "keyValue": "string"
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "OnlineEndpoints_RegenerateKeys",
+  "title": "RegenerateKeys Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/OnlineEndpoint/update.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineEndpoints_Update",
+  "title": "Update Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/createOrUpdate.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "authMode": "Key",
+        "contentSafety": {
+          "contentSafetyLevel": "Blocking",
+          "contentSafetyStatus": "Enabled"
+        },
+        "modelSettings": {
+          "modelId": "string"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Deferred",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Deleting",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Updating"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Deferred",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Deleting",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Failed"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ServerlessEndpoints_Delete",
+  "title": "Delete Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/get.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Blocking",
+            "contentSafetyStatus": "Enabled"
+          },
+          "endpointState": "Suspending",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Premium"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_Get",
+  "title": "Get Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/list.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/serverlessEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "UserAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "authMode": "Key",
+              "contentSafety": {
+                "contentSafetyLevel": "Blocking",
+                "contentSafetyStatus": "Disabled"
+              },
+              "endpointState": "Reinstating",
+              "inferenceEndpoint": {
+                "headers": {
+                  "string": "string"
+                },
+                "uri": "https://www.contoso.com/example"
+              },
+              "marketplaceSubscriptionId": "string",
+              "modelSettings": {
+                "modelId": "string"
+              },
+              "provisioningState": "Updating"
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Basic"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:12",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:12",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_List",
+  "title": "List Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_ListKeys",
+  "title": "ListKeys Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/regenerateKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/regenerateKeys.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyType": "Primary",
+      "keyValue": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "ServerlessEndpoints_RegenerateKeys",
+  "title": "RegenerateKeys Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/ServerlessEndpoint/update.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Premium"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Blocking",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Suspended",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Creating"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "ServerlessEndpoints_Update",
+  "title": "Update Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/create.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {}
+        }
+      },
+      "location": "eastus2euap",
+      "properties": {
+        "description": "test description",
+        "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+        "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+          },
+          "keyVaultProperties": {
+            "identityClientId": "",
+            "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+            "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+          },
+          "status": "Enabled"
+        },
+        "friendlyName": "HelloName",
+        "hbiWorkspace": false,
+        "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+        "sharedPrivateLinkResources": [
+          {
+            "name": "testdbresource",
+            "properties": {
+              "groupId": "Sql",
+              "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testdbresource/privateLinkResources/Sql",
+              "requestMessage": "Please approve",
+              "status": "Approved"
+            }
+          }
+        ],
+        "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "test description",
+          "allowPublicAccessWhenBehindVnet": false,
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "enableDataIsolation": false,
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+            },
+            "keyVaultProperties": {
+              "identityClientId": "",
+              "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+              "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+            },
+            "status": "Enabled"
+          },
+          "friendlyName": "HelloName",
+          "hbiWorkspace": false,
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "publicNetworkAccess": "Disabled",
+          "sharedPrivateLinkResources": [
+            {
+              "name": "testdbresource",
+              "properties": {
+                "groupId": "Sql",
+                "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testdbresource/privateLinkResources/Sql",
+                "requestMessage": "Please approve",
+                "status": "Approved"
+              }
+            }
+          ],
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_CreateOrUpdate",
+  "title": "Create Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Workspaces_Delete",
+  "title": "Delete Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/diagnose.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/diagnose.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "value": {
+        "applicationInsights": {},
+        "containerRegistry": {},
+        "dnsResolution": {},
+        "keyVault": {},
+        "nsg": {},
+        "others": {},
+        "resourceLock": {},
+        "storageAccount": {},
+        "udr": {}
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": {
+          "applicationInsightsResults": [],
+          "containerRegistryResults": [],
+          "dnsResolutionResults": [
+            {
+              "code": "CustomDNSInUse",
+              "level": "Warning",
+              "message": "We have detected an on-premise dns server is configured. Please make sure conditional forwarding is configured correctly according to doc https://foo"
+            }
+          ],
+          "keyVaultResults": [],
+          "networkSecurityRuleResults": [],
+          "otherResults": [],
+          "resourceLockResults": [],
+          "storageAccountResults": [],
+          "userDefinedRouteResults": []
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_Diagnose",
+  "title": "Diagnose Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/get.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "test description",
+          "allowPublicAccessWhenBehindVnet": false,
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+            },
+            "keyVaultProperties": {
+              "identityClientId": "",
+              "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+              "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+            },
+            "status": "Enabled"
+          },
+          "friendlyName": "HelloName",
+          "hbiWorkspace": false,
+          "imageBuildCompute": "testcompute",
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "managedNetwork": {
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "some_string": {
+                "type": "FQDN",
+                "category": "Required",
+                "destination": "some_string",
+                "status": "Inactive"
+              }
+            },
+            "status": {
+              "sparkReady": false,
+              "status": "Active"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "testprivatelinkconnection",
+              "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+              "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/testprivatelinkconnection",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "privateLinkCount": 0,
+          "publicNetworkAccess": "Disabled",
+          "serviceProvisionedResourceGroup": "testworkspace_0000111122223333",
+          "sharedPrivateLinkResources": [
+            {
+              "name": "testcosmosdbresource",
+              "properties": {
+                "groupId": "Sql",
+                "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testcosmosdbresource/privateLinkResources/Sql",
+                "requestMessage": "Please approve",
+                "status": "Approved"
+              }
+            }
+          ],
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    }
+  },
+  "operationId": "Workspaces_Get",
+  "title": "Get Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listByResourceGroup.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listByResourceGroup.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+            }
+          },
+          {
+            "name": "testworkspace1",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace1",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistryNew",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName 1",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkvNew",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccountOld"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListByResourceGroup",
+  "title": "Get Workspaces by Resource Group"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listBySubscription.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listBySubscription.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/workspaces?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+            }
+          },
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-5678/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistryNew",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkvNew",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccountOld"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListBySubscription",
+  "title": "Get Workspaces by subscription"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listKeys.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "appInsightsInstrumentationKey": null,
+        "containerRegistryCredentials": {
+          "location": null,
+          "passwords": [
+            {
+              "name": "password",
+              "value": "<value>"
+            },
+            {
+              "name": "password2",
+              "value": "0KARRQoQHSUq1yViPWg7YFernOS=Ic/t"
+            }
+          ],
+          "username": "testdemoworkjmjmeykp"
+        },
+        "notebookAccessKeys": {
+          "primaryAccessKey": null,
+          "secondaryAccessKey": null
+        },
+        "userStorageArmId": "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/ragargeastus2euap/providers/Microsoft.Storage/storageAccounts/testdemoworkazashomr",
+        "userStorageKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listNotebookAccessToken.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listNotebookAccessToken.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiresIn": 28800,
+        "hostName": "Host product name",
+        "notebookResourceId": "94350843095843059",
+        "publicDns": "resource.notebooks.azure.net",
+        "scope": "aznb_identity",
+        "tokenType": "Bearer"
+      }
+    }
+  },
+  "operationId": "Workspaces_ListNotebookAccessToken",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listStorageAccountKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/listStorageAccountKeys.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "userStorageKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListStorageAccountKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/operationsList.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/operationsList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/write",
+            "display": {
+              "operation": "Create/Update Machine Learning workspaces",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          },
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/delete",
+            "display": {
+              "operation": "Delete Machine Learning workspaces",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          },
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/listkeys/action",
+            "display": {
+              "operation": "List workspace Keys",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/resyncKeys.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/resyncKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_ResyncKeys",
+  "title": "Resync Workspace Keys"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/Workspace/update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "new description",
+        "friendlyName": "New friendly name",
+        "publicNetworkAccess": "Disabled"
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "new description",
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "friendlyName": "New friendly name",
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "publicNetworkAccess": "Disabled",
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_Update",
+  "title": "Update Workspace"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/create.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Basic blocklist description"
+      }
+    },
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklist_Create",
+  "title": "Create Rai Blocklist"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklist_Delete",
+  "title": "Delete Rai Blocklist"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklist_Get",
+  "title": "Get Rai Blocklist"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklist/list.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiBlocklists?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiBlocklistName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+            "properties": {
+              "description": "Basic blocklist description"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklists_List",
+  "title": "List Rai Blocklist"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/addBulk.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/addBulk.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": [
+      {
+        "name": "myblocklistitem1",
+        "properties": {
+          "isRegex": true,
+          "pattern": "^[a-z0-9_-]{2,16}$"
+        }
+      },
+      {
+        "name": "myblocklistitem2",
+        "properties": {
+          "isRegex": false,
+          "pattern": "blockwords"
+        }
+      }
+    ],
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myblocklist",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "properties": {
+          "description": "Brief description of the blocklist"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_AddBulk",
+  "title": "Create Bulk Rai Blocklist Items"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/create.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "isRegex": false,
+        "pattern": "Pattern To Block"
+      }
+    },
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Create",
+  "title": "Create RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Delete",
+  "title": "Delete RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/deleteBulk.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/deleteBulk.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": [
+      "myblocklistitem1",
+      "myblocklistitem2"
+    ],
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklistItem_DeleteBulk",
+  "title": "Delete Bulk Rai Blocklist Items"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Get",
+  "title": "Get Rai RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiBlocklistItem/list.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiBlocklists/raiBlocklist-1/raiBlocklistItems?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiBlocklistItemName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Pattern To Block"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItems_List",
+  "title": "List RaiBlocklist Items"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/create.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "SystemManaged",
+        "basePolicyName": "112",
+        "completionBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ],
+        "contentFilters": [
+          {
+            "name": "policyName",
+            "allowedContentLevel": "Low",
+            "blocking": false,
+            "enabled": false,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Blocking",
+        "promptBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ]
+      }
+    },
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicy_Create",
+  "title": "Create Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiPolicy_Delete",
+  "title": "Delete Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicy_Get",
+  "title": "Get Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/RaiPolicy/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiPolicies?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+            "properties": {
+              "type": "SystemManaged",
+              "basePolicyName": "112",
+              "completionBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ],
+              "contentFilters": [
+                {
+                  "name": "policyName",
+                  "allowedContentLevel": "Low",
+                  "blocking": false,
+                  "enabled": false,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Blocking",
+              "promptBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicies_List",
+  "title": "List Rai policy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/create.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/create.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "www.facebook.com"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "www.facebook.com"
+        }
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_Create",
+  "title": "CreateWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/createDeployment.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/createDeployment.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "Azure.OpenAI",
+        "model": {
+          "name": "text-davinci-003",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+      }
+    },
+    "connectionName": "testConnection",
+    "deploymentName": "text-davinci-003",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "Connection_CreateOrUpdateDeployment",
+  "title": "Create Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/delete.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WorkspaceConnections_Delete",
+  "title": "DeleteWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/deleteDeployment.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/deleteDeployment.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "deploymentName": "testDeploymentName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Connection_DeleteDeployment",
+  "title": "Delete Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/get.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "www.facebook.com"
+        }
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_Get",
+  "title": "GetWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/getDeployment.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/getDeployment.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "deploymentName": "text-davinci-003",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "Connection_GetDeployment",
+  "title": "Get Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/getModels.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/getModels.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_GetModels",
+  "title": "Get Azure OpenAI Connection Models"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/list.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "category": "ContainerRegistry",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "www.facebook.com",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/linkedWorkspaces/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "www.facebook.com"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/linkedWorkspaces/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "www.facebook.com"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_List",
+  "title": "ListWorkspaceConnections"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listConnectionModels.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listConnectionModels.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "connectionIds": [
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-2"
+                ],
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "connectionIds": [
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1"
+                ],
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_GetAllModels",
+  "title": "Get models under the Azure ML workspace for all Azure OpenAI connections that the user can deploy"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listDeployments.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listDeployments.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_ListDeployments",
+  "title": "List Azure OpenAI Connection Deployments"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listSecrets.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/listSecrets.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "CustomKeys",
+          "credentials": {
+            "accessKeyId": "some_string",
+            "secretAccessKey": "some_string"
+          },
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "WorkspaceConnections_ListSecrets",
+  "title": "GetWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/testConnection.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/testConnection.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "target_url"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_TestConnection",
+  "title": "TestWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/update.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceConnection/update.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "WorkspaceConnections_Update",
+  "title": "UpdateWorkspaceConnection"
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceFeature/list.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2024-10-01-preview/WorkspaceFeature/list.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "description": "Create, edit or delete AutoML experiments in the SDK",
+            "displayName": "Create edit experiments UI",
+            "id": "automatedml_createeditexperimentsui"
+          },
+          {
+            "description": "Upgrade workspace from Basic to enterprise from the UI",
+            "displayName": "Upgrade workspace UI",
+            "id": "workspace_upgradeworkspaceui"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WorkspaceFeatures_List",
+  "title": "List Workspace features"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/createOrUpdate.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "acaEnvironmentConnections": [
+          "sampleAcaEnvironmentConnection"
+        ],
+        "aiServicesConnections": [
+          "sampleAIServiceConnection"
+        ],
+        "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet",
+        "storageConnections": [
+          "sampleStorageConnection"
+        ],
+        "threadStorageConnections": [
+          "sampleThreadStorageConnection"
+        ],
+        "vectorStoreConnections": [
+          "sampleVectorStoreConnection"
+        ]
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "CapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate CapabilityHost."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "CapabilityHosts_Delete",
+  "title": "Delete CapabilityHost."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/CapabilityHost/get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "capabilityHostName",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.MachineLearningServices/workspaces/capabilityHosts",
+        "id": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "acaEnvironmentConnections": [
+            "sampleAcaEnvironmentConnection"
+          ],
+          "aiServicesConnections": [
+            "sampleAIServiceConnection"
+          ],
+          "customerSubnet": "subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "messages": [
+            "string"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "sampleStorageConnection"
+          ],
+          "tags": {
+            "string": "string"
+          },
+          "threadStorageConnections": [
+            "sampleThreadStorageConnection"
+          ],
+          "vectorStoreConnections": [
+            "sampleVectoStoreConnection"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CapabilityHosts_Get",
+  "title": "Get CapabilityHost."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/AKSCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/AKSCompute.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "AKS",
+        "properties": {
+          "agentCount": 4
+        },
+        "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "properties": {
+            "agentCount": 4
+          },
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "provisioningState": "Updating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Update an AKS Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/AmlCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/AmlCompute.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "AmlCompute",
+        "properties": {
+          "scaleSettings": {
+            "maxNodeCount": 4,
+            "minNodeCount": 4,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "allocationState": "Resizing",
+            "allocationStateTransitionTime": "2017-09-27T22:28:08.998Z",
+            "currentNodeCount": 0,
+            "enableNodePublicIp": true,
+            "errors": null,
+            "isolatedNetwork": false,
+            "nodeStateCounts": {
+              "idleNodeCount": 0,
+              "leavingNodeCount": 0,
+              "preemptedNodeCount": 0,
+              "preparingNodeCount": 0,
+              "runningNodeCount": 0,
+              "unusableNodeCount": 0
+            },
+            "osType": "Windows",
+            "remoteLoginPortPublicAccess": "Enabled",
+            "scaleSettings": {
+              "maxNodeCount": 1,
+              "minNodeCount": 0,
+              "nodeIdleTimeBeforeScaleDown": "PT5M"
+            },
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "targetNodeCount": 1,
+            "virtualMachineImage": null,
+            "vmPriority": "Dedicated",
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "provisioningState": "Updating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Update a AML Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicAKSCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicAKSCompute.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "AKS"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AKS",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AKS",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an AKS Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicAmlCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicAmlCompute.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "AmlCompute",
+        "properties": {
+          "enableNodePublicIp": true,
+          "isolatedNetwork": false,
+          "osType": "Windows",
+          "remoteLoginPortPublicAccess": "NotSpecified",
+          "scaleSettings": {
+            "maxNodeCount": 1,
+            "minNodeCount": 0,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          },
+          "virtualMachineImage": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myImageGallery/images/myImageDefinition/versions/0.0.1"
+          },
+          "vmPriority": "Dedicated",
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AmlCompute",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "AmlCompute",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create a AML Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicDataFactoryCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/BasicDataFactoryCompute.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "DataFactory"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "DataFactory",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "DataFactory",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create a DataFactory Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstance.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstance.json
@@ -1,0 +1,114 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "applicationSharingPolicy": "Personal",
+          "autologgerSettings": {
+            "mlflowAutologger": "Enabled"
+          },
+          "computeInstanceAuthorizationType": "personal",
+          "customServices": [
+            {
+              "name": "rstudio-workbench",
+              "docker": {
+                "privileged": true
+              },
+              "endpoints": [
+                {
+                  "name": "connect",
+                  "hostIp": null,
+                  "published": 4444,
+                  "target": 8787,
+                  "protocol": "http"
+                }
+              ],
+              "environmentVariables": {
+                "RSP_LICENSE": {
+                  "type": "local",
+                  "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                }
+              },
+              "image": {
+                "type": "docker",
+                "reference": "ghcr.io/azure/rstudio-workbench:latest"
+              },
+              "kernel": {
+                "argv": [
+                  "option1",
+                  "option2",
+                  "option3"
+                ],
+                "displayName": "TestKernel",
+                "language": "python"
+              },
+              "volumes": [
+                {
+                  "type": "bind",
+                  "readOnly": true,
+                  "source": "/mnt/azureuser/",
+                  "target": "/home/testuser/"
+                }
+              ]
+            }
+          ],
+          "enableOSPatching": true,
+          "enableRootAccess": true,
+          "enableSSO": true,
+          "personalComputeInstanceSettings": {
+            "assignedUser": {
+              "objectId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          "releaseQuotaOnStop": true,
+          "sshSettings": {
+            "sshPublicAccess": "Disabled"
+          },
+          "subnet": {
+            "id": "test-subnet-resource-id"
+          },
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstanceMinimal.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstanceMinimal.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute with minimal inputs"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstanceWithSchedules.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/ComputeInstanceWithSchedules.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "computeType": "ComputeInstance",
+        "properties": {
+          "applicationSharingPolicy": "Personal",
+          "computeInstanceAuthorizationType": "personal",
+          "personalComputeInstanceSettings": {
+            "assignedUser": {
+              "objectId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          "schedules": {
+            "computeStartStop": [
+              {
+                "action": "Stop",
+                "cron": {
+                  "expression": "0 18 * * *",
+                  "startTime": "2021-04-23T01:30:00",
+                  "timeZone": "Pacific Standard Time"
+                },
+                "status": "Enabled",
+                "triggerType": "Cron"
+              }
+            ]
+          },
+          "sshSettings": {
+            "sshPublicAccess": "Disabled"
+          },
+          "vmSize": "STANDARD_NC6"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "computeType": "ComputeInstance",
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Create an ComputeInstance Compute with Schedules"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/KubernetesCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/createOrUpdate/KubernetesCompute.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "location": "eastus",
+      "properties": {
+        "description": "some compute",
+        "computeType": "Kubernetes",
+        "properties": {
+          "defaultInstanceType": "defaultInstanceType",
+          "instanceTypes": {
+            "defaultInstanceType": {
+              "nodeSelector": null,
+              "resources": {
+                "limits": {
+                  "cpu": "1",
+                  "memory": "4Gi",
+                  "nvidia.com/gpu": null
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "4Gi",
+                  "nvidia.com/gpu": null
+                }
+              }
+            }
+          },
+          "namespace": "default"
+        },
+        "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Creating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Creating",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_CreateOrUpdate",
+  "title": "Attach a Kubernetes Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "underlyingResourceAction": "Delete",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Compute_Delete",
+  "title": "Delete Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/AKSCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/AKSCompute.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AKS",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a AKS Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/AmlCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/AmlCompute.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "allocationState": "Resizing",
+            "allocationStateTransitionTime": "2017-09-27T22:28:08.998Z",
+            "currentNodeCount": 0,
+            "enableNodePublicIp": true,
+            "errors": null,
+            "isolatedNetwork": false,
+            "nodeStateCounts": {
+              "idleNodeCount": 0,
+              "leavingNodeCount": 0,
+              "preemptedNodeCount": 0,
+              "preparingNodeCount": 0,
+              "runningNodeCount": 0,
+              "unusableNodeCount": 0
+            },
+            "osType": "Windows",
+            "remoteLoginPortPublicAccess": "Enabled",
+            "scaleSettings": {
+              "maxNodeCount": 1,
+              "minNodeCount": 0,
+              "nodeIdleTimeBeforeScaleDown": "PT5M"
+            },
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "targetNodeCount": 1,
+            "virtualMachineImage": null,
+            "vmPriority": "Dedicated",
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a AML Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/ComputeInstance.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/ComputeInstance.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "ComputeInstance",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "applicationSharingPolicy": "Shared",
+            "applications": [
+              {
+                "displayName": "Jupyter",
+                "endpointUri": "https://compute123.eastus2.azureml.net/jupyter"
+              }
+            ],
+            "computeInstanceAuthorizationType": "personal",
+            "connectivityEndpoints": {
+              "privateIpAddress": "10.0.0.1",
+              "publicIpAddress": "10.0.0.1"
+            },
+            "createdBy": {
+              "userId": "00000000-0000-0000-0000-000000000000",
+              "userName": "foobar@microsoft.com",
+              "userOrgId": "00000000-0000-0000-0000-000000000000"
+            },
+            "customServices": [
+              {
+                "name": "rstudio-workbench",
+                "docker": {
+                  "privileged": true
+                },
+                "endpoints": [
+                  {
+                    "name": "connect",
+                    "hostIp": null,
+                    "published": 4444,
+                    "target": 8787,
+                    "protocol": "http"
+                  }
+                ],
+                "environmentVariables": {
+                  "RSP_LICENSE": {
+                    "type": "local",
+                    "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                  }
+                },
+                "image": {
+                  "type": "docker",
+                  "reference": "ghcr.io/azure/rstudio-workbench:latest"
+                },
+                "volumes": [
+                  {
+                    "type": "bind",
+                    "bind": {
+                      "createHostPath": true,
+                      "propagation": "test",
+                      "selinux": "test"
+                    },
+                    "consistency": "test",
+                    "readOnly": true,
+                    "source": "/mnt/azureuser/",
+                    "target": "/home/testuser/",
+                    "tmpfs": {
+                      "size": 10
+                    },
+                    "volume": {
+                      "nocopy": true
+                    }
+                  }
+                ]
+              }
+            ],
+            "enableOSPatching": true,
+            "enableRootAccess": true,
+            "enableSSO": true,
+            "errors": null,
+            "osImageMetadata": {
+              "currentImageVersion": "22.06.14",
+              "isLatestOsImageVersion": false,
+              "latestImageVersion": "22.07.22"
+            },
+            "personalComputeInstanceSettings": {
+              "assignedUser": {
+                "objectId": "00000000-0000-0000-0000-000000000000",
+                "tenantId": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "releaseQuotaOnStop": true,
+            "sshSettings": {
+              "adminUserName": "azureuser",
+              "sshPort": 22,
+              "sshPublicAccess": "Enabled"
+            },
+            "state": "Running",
+            "subnet": {
+              "id": "test-subnet-resource-id"
+            },
+            "vmSize": "STANDARD_NC6"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get an ComputeInstance"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/KubernetesCompute.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/get/KubernetesCompute.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus",
+        "properties": {
+          "description": "some compute",
+          "computeType": "Kubernetes",
+          "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+          "isAttachedCompute": true,
+          "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+          "properties": {
+            "defaultInstanceType": "defaultInstanceType",
+            "extensionInstanceReleaseTrain": "stable",
+            "extensionPrincipalId": null,
+            "instanceTypes": {
+              "defaultInstanceType": {
+                "nodeSelector": null,
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi",
+                    "nvidia.com/gpu": null
+                  }
+                }
+              }
+            },
+            "namespace": "default",
+            "relayConnectionString": null,
+            "serviceBusConnectionString": null,
+            "vcName": null
+          },
+          "provisioningState": "Succeeded",
+          "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+        }
+      }
+    }
+  },
+  "operationId": "Compute_Get",
+  "title": "Get a Kubernetes Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/getAllowedVMSizesForResize.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/getAllowedVMSizesForResize.json
@@ -1,0 +1,257 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_DS1_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 7168,
+            "memoryGB": 3.5,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 1
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 14336,
+            "memoryGB": 7,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.29,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.58,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.17,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 16
+          },
+          {
+            "name": "Standard_DS11_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.18,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS12_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.37,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.74,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS14_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.48,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 229376,
+            "memoryGB": 112,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 16
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_getAllowedResizeSizes",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/list.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "compute123",
+            "type": "Microsoft.MachineLearningServices/workspaces/computes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+            "location": "eastus",
+            "properties": {
+              "description": "some compute",
+              "computeType": "AKS",
+              "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+              "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+              "provisioningState": "Succeeded",
+              "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute123-56826-c9b00420020b2"
+            }
+          },
+          {
+            "name": "compute1234",
+            "type": "Microsoft.MachineLearningServices/workspaces/computes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute1234",
+            "location": "eastus",
+            "properties": {
+              "description": "some compute",
+              "computeType": "AKS",
+              "createdOn": "2021-04-01T22:00:00.0000000+00:00",
+              "modifiedOn": "2021-04-01T22:00:00.0000000+00:00",
+              "provisioningState": "Succeeded",
+              "resourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/testrg123/providers/Microsoft.ContainerService/managedClusters/compute1234-56826-c9b00420020b2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_List",
+  "title": "Get Computes"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/listKeys.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "adminKubeConfig": "admin kube config...",
+        "computeType": "AKS",
+        "imagePullSecretName": "the image pull secret name",
+        "userKubeConfig": "user kube config..."
+      }
+    }
+  },
+  "operationId": "Compute_ListKeys",
+  "title": "List AKS Compute Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/listNodes.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/listNodes.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123/listNodes?api-version=2025-07-01-preview&$skip=2",
+        "nodes": [
+          {
+            "nodeId": "tvm-3601533753_1-20170719t162906z",
+            "nodeState": "running",
+            "port": 50000,
+            "privateIpAddress": "13.84.190.124",
+            "publicIpAddress": "13.84.190.134",
+            "runId": "2f378a44-38f2-443a-9f0d-9909d0b47890"
+          },
+          {
+            "nodeId": "tvm-3601533753_2-20170719t162906z",
+            "nodeState": "idle",
+            "port": 50001,
+            "privateIpAddress": "13.84.190.124",
+            "publicIpAddress": "13.84.190.134"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Compute_ListNodes",
+  "title": "Get compute nodes information for a compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/patch.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/patch.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "properties": {
+        "properties": {
+          "scaleSettings": {
+            "maxNodeCount": 4,
+            "minNodeCount": 4,
+            "nodeIdleTimeBeforeScaleDown": "PT5M"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "compute123",
+        "type": "Microsoft.MachineLearningServices/workspaces/computes",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/computes/compute123",
+        "location": "eastus2",
+        "properties": {
+          "description": "some compute",
+          "computeType": "AmlCompute",
+          "provisioningState": "Updating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Compute_Update",
+  "title": "Update a AmlCompute Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/resize.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/resize.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "targetVMSize": "Standard_DS11_v2"
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Resize",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/restart.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/restart.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Restart",
+  "title": "Restart ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/start.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/start.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Start",
+  "title": "Start ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/stop.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/stop.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Compute_Stop",
+  "title": "Stop ComputeInstance Compute"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateCustomServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateCustomServices.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "customServices": [
+      {
+        "name": "rstudio-workbench",
+        "docker": {
+          "privileged": true
+        },
+        "endpoints": [
+          {
+            "name": "connect",
+            "hostIp": null,
+            "published": 4444,
+            "target": 8787,
+            "protocol": "http"
+          }
+        ],
+        "environmentVariables": {
+          "RSP_LICENSE": {
+            "type": "local",
+            "value": "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+          }
+        },
+        "image": {
+          "type": "docker",
+          "reference": "ghcr.io/azure/rstudio-workbench:latest"
+        },
+        "volumes": [
+          {
+            "type": "bind",
+            "readOnly": true,
+            "source": "/mnt/azureuser/",
+            "target": "/home/testuser/"
+          }
+        ]
+      }
+    ],
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateCustomServices",
+  "title": "Update Custom Services"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateDataMounts.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateDataMounts.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "dataMounts": [
+      {
+        "mountAction": "Mount",
+        "mountMode": "ReadOnly",
+        "mountName": "hello",
+        "mountPath": "/some/random/path/on/host",
+        "source": "azureml://subscriptions/some-sub/resourcegroups/some-rg/workspaces/some-ws/data/some-data-asset-name/versions/some-data-asset-version",
+        "sourceType": "URI"
+      }
+    ],
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateDataMounts",
+  "title": "Update Data Mounts"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateIdleShutdownSetting.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Compute/updateIdleShutdownSetting.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "computeName": "compute123",
+    "parameters": {
+      "idleTimeBeforeShutdown": "PT120M"
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Compute_UpdateIdleShutdownSetting",
+  "title": "Update idle shutdown setting of ComputeInstance"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/DataReference/getBlobReferenceSAS.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/DataReference/getBlobReferenceSAS.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "assetId": "string",
+      "blobUri": "https://www.contoso.com/example"
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "NoCredentials"
+          },
+          "storageAccountArmId": "string"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataReferences_GetBlobReferenceSAS",
+  "title": "GetBlobReferenceSAS Data Reference."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureBlobWAccountKey/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureBlobWAccountKey/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "containerName": "string",
+        "credentials": {
+          "credentialsType": "AccountKey",
+          "secrets": {
+            "key": "string",
+            "secretsType": "AccountKey"
+          }
+        },
+        "datastoreType": "AzureBlob",
+        "endpoint": "core.windows.net",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "https"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (AzureBlob w/ AccountKey)."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureDataLakeGen1WServicePrincipal/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureDataLakeGen1WServicePrincipal/createOrUpdate.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "credentials": {
+          "authorityUrl": "string",
+          "clientId": "00000000-1111-2222-3333-444444444444",
+          "credentialsType": "ServicePrincipal",
+          "resourceUrl": "string",
+          "secrets": {
+            "clientSecret": "string",
+            "secretsType": "ServicePrincipal"
+          },
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "datastoreType": "AzureDataLakeGen1",
+        "properties": null,
+        "storeName": "string",
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen1",
+          "properties": null,
+          "storeName": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen1",
+          "properties": null,
+          "storeName": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure Data Lake Gen1 w/ ServicePrincipal)."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureDataLakeGen2WServicePrincipal/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureDataLakeGen2WServicePrincipal/createOrUpdate.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "credentials": {
+          "authorityUrl": "string",
+          "clientId": "00000000-1111-2222-3333-444444444444",
+          "credentialsType": "ServicePrincipal",
+          "resourceUrl": "string",
+          "secrets": {
+            "clientSecret": "string",
+            "secretsType": "ServicePrincipal"
+          },
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "datastoreType": "AzureDataLakeGen2",
+        "endpoint": "string",
+        "filesystem": "string",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen2",
+          "endpoint": "string",
+          "filesystem": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "authorityUrl": "string",
+            "clientId": "00000000-1111-2222-3333-444444444444",
+            "credentialsType": "ServicePrincipal",
+            "resourceUrl": "string",
+            "secrets": {
+              "secretsType": "ServicePrincipal"
+            },
+            "tenantId": "00000000-1111-2222-3333-444444444444"
+          },
+          "datastoreType": "AzureDataLakeGen2",
+          "endpoint": "string",
+          "filesystem": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure Data Lake Gen2 w/ Service Principal)."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureFileWAccountKey/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/AzureFileWAccountKey/createOrUpdate.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "accountName": "string",
+        "credentials": {
+          "credentialsType": "AccountKey",
+          "secrets": {
+            "key": "string",
+            "secretsType": "AccountKey"
+          }
+        },
+        "datastoreType": "AzureFile",
+        "endpoint": "string",
+        "fileShareName": "string",
+        "properties": null,
+        "tags": {
+          "string": "string"
+        },
+        "protocol": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "skipValidation": false,
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureFile",
+          "endpoint": "string",
+          "fileShareName": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureFile",
+          "endpoint": "string",
+          "fileShareName": "string",
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_CreateOrUpdate",
+  "title": "CreateOrUpdate datastore (Azure File store w/ AccountKey)."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Datastores_Delete",
+  "title": "Delete datastore."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "accountName": "string",
+          "containerName": "string",
+          "credentials": {
+            "credentialsType": "AccountKey",
+            "secrets": {
+              "secretsType": "AccountKey"
+            }
+          },
+          "datastoreType": "AzureBlob",
+          "endpoint": "core.windows.net",
+          "isDefault": false,
+          "properties": null,
+          "tags": {
+            "string": "string"
+          },
+          "protocol": "https"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_Get",
+  "title": "Get datastore."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "isDefault": false,
+    "names": [
+      "string"
+    ],
+    "orderBy": "string",
+    "orderByAsc": false,
+    "resourceGroupName": "test-rg",
+    "searchText": "string",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/datastores?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "accountName": "string",
+              "containerName": "string",
+              "credentials": {
+                "credentialsType": "AccountKey",
+                "secrets": {
+                  "secretsType": "AccountKey"
+                }
+              },
+              "datastoreType": "AzureBlob",
+              "endpoint": "core.windows.net",
+              "isDefault": false,
+              "properties": null,
+              "tags": {
+                "string": "string"
+              },
+              "protocol": "https"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_List",
+  "title": "List datastores."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/listSecrets.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Datastore/listSecrets.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "expirableSecret": false,
+      "expireAfterHours": 1
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key": "string",
+        "secretsType": "AccountKey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Datastores_ListSecrets",
+  "title": "Get datastore secrets."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/create.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "Azure.OpenAI",
+        "model": {
+          "name": "text-davinci-003",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+      }
+    },
+    "deploymentName": "text-davinci-003",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_CreateOrUpdate",
+  "title": "Create Endpoint Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EndpointDeployment_Delete",
+  "title": "Delete Endpoint Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/get.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "text-davinci-003",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_Get",
+  "title": "Get Endpoint Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/getDeployments.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/getDeployments.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_List",
+  "title": "Get Endpoint Deployments"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/getInWorkspace.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/Deployment/getInWorkspace.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/endpoints/Azure.OpenAI/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EndpointDeployment_GetInWorkspace",
+  "title": "Get Endpoint Deployments In Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/create.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "SystemManaged",
+        "basePolicyName": "112",
+        "completionBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ],
+        "contentFilters": [
+          {
+            "name": "policyName",
+            "allowedContentLevel": "Low",
+            "blocking": false,
+            "enabled": false,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Blocking",
+        "promptBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ]
+      }
+    },
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicy_Create",
+  "title": "Create Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RaiPolicy_Delete",
+  "title": "Delete Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicy_Get",
+  "title": "Get Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/RaiPolicy/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/onlineEndpoints/endpoint-1/raiPolicies?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints/raiPolicies",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI/raiPolicies/raiPolicyName",
+            "properties": {
+              "type": "SystemManaged",
+              "basePolicyName": "112",
+              "completionBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ],
+              "contentFilters": [
+                {
+                  "name": "policyName",
+                  "allowedContentLevel": "Low",
+                  "blocking": false,
+                  "enabled": false,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Blocking",
+              "promptBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RaiPolicies_List",
+  "title": "List Rai policies"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/create.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "name": "Azure.OpenAI",
+        "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+        "endpointType": "Azure.OpenAI"
+      }
+    },
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Azure.OpenAI",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+        "properties": {
+          "name": "Azure.OpenAI",
+          "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+          "endpointType": "Azure.OpenAI",
+          "endpointUri": "https://www.contoso.com/",
+          "failureReason": "some_string",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Endpoint_CreateOrUpdate",
+  "title": "Create Endpoint"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Azure.OpenAI",
+        "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+        "properties": {
+          "name": "Azure.OpenAI",
+          "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+          "endpointType": "Azure.OpenAI",
+          "endpointUri": "https://www.contoso.com/",
+          "failureReason": "some_string",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Endpoint_Get",
+  "title": "Get Endpoint"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/getModels.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/getModels.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Endpoint_GetModels",
+  "title": "Get Endpoint Models"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/list.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$skip": "skip_string",
+    "api-version": "2024-10-01-preview",
+    "endpointType": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "Azure.OpenAI",
+            "type": "Microsoft.MachineLearningServices/workspaces/endpoints",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/endpoints/Azure.OpenAI",
+            "properties": {
+              "name": "Azure.OpenAI",
+              "associatedResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveService/account/account-1",
+              "endpointType": "Azure.OpenAI",
+              "endpointUri": "https://www.contoso.com/",
+              "failureReason": "some_string",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "some_string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "some_string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Endpoint_List",
+  "title": "List Endpoint"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/listKeys.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": {
+          "key1": "some_string",
+          "key2": "some_string"
+        }
+      }
+    }
+  },
+  "operationId": "Endpoint_ListKeys",
+  "title": "List Endpoint Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/regenerateKey.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Endpoint/regenerateKey.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyName": "Key1"
+    },
+    "endpointName": "Azure.OpenAI",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "some_string",
+        "key2": "some_string"
+      }
+    }
+  },
+  "operationId": "Endpoint_RegenerateKeys",
+  "title": "Regenerate Endpoint Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ExternalFQDN/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ExternalFQDN/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "category": "Azure Active Directory",
+              "endpoints": [
+                {
+                  "domainName": "login.microsoftonline.com",
+                  "endpointDetails": [
+                    {
+                      "port": 443
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "properties": {
+              "category": "Azure portal",
+              "endpoints": [
+                {
+                  "domainName": "management.azure.com",
+                  "endpointDetails": [
+                    {
+                      "port": 443
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListOutboundNetworkDependenciesEndpoints",
+  "title": "ListOutboundNetworkDependenciesEndpoints"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Feature/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Feature/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "featureName": "string",
+    "featuresetName": "string",
+    "featuresetVersion": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "Float",
+          "featureName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:51",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:51",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Features_Get",
+  "title": "Get Feature."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Feature/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Feature/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "description": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "featureName": "string",
+    "featuresetName": "string",
+    "featuresetVersion": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/features?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "Boolean",
+              "featureName": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:50",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:50",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Features_List",
+  "title": "List Feature."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/getDeltaModelsStatusAsync.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/getDeltaModelsStatusAsync.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "deltaModels": [
+        "string"
+      ],
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actualInstanceCount": 0,
+        "deltaModels": {
+          "string": [
+            {
+              "count": 0,
+              "sampleInstanceID": "string",
+              "status": "string"
+            }
+          ]
+        },
+        "expectedInstanceCount": 0,
+        "revisionId": "string",
+        "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_GetDeltaModelsStatusAsync",
+  "title": "GetDeltaModelsStatusAsync Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/listDeltaModelsAsync.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/listDeltaModelsAsync.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "count": -1,
+      "skipToken": "string",
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups/testInferenceGroupName/listDeltaModels?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          "string"
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_ListDeltaModelsAsync",
+  "title": "ListDeltaModelsAsync Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/modifyDeltaModelsAsync.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/InferenceGroup/modifyDeltaModelsAsync.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "addDeltaModels": [
+        "string"
+      ],
+      "removeDeltaModels": [
+        "string"
+      ],
+      "targetBaseModel": "azureml://registries/test-registry/models/modelabc/versions/1"
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/...pathToOperationStatus.."
+      }
+    }
+  },
+  "operationId": "InferenceGroups_ModifyDeltaModelsAsync",
+  "title": "ModifyDeltaModelsAsync Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/createOrUpdate.json
@@ -1,0 +1,254 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "string",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "isArchived": false,
+        "jobType": "AutoML",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+            }
+          }
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        },
+        "taskDetails": {
+          "limitSettings": {
+            "maxTrials": 2
+          },
+          "modelSettings": {
+            "validationCropSize": 2
+          },
+          "searchSpace": [
+            {
+              "validationCropSize": "choice(2, 360)"
+            }
+          ],
+          "targetColumnName": "string",
+          "taskType": "ImageClassification",
+          "trainingData": {
+            "jobInputType": "mltable",
+            "uri": "string"
+          }
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate AutoML Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/get.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "AutoML",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "Scheduled",
+          "tags": {
+            "string": "string"
+          },
+          "taskDetails": {
+            "limitSettings": {
+              "maxTrials": 2
+            },
+            "modelSettings": {
+              "validationCropSize": 2
+            },
+            "searchSpace": [
+              {
+                "validationCropSize": "choice(2, 360)"
+              }
+            ],
+            "targetColumnName": "string",
+            "taskType": "ImageClassification",
+            "trainingData": {
+              "jobInputType": "mltable",
+              "uri": "string"
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get AutoML Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/AutoMLJob/list.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "experimentName": "string",
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "AutoML",
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "9bec0ab0-c62f-4fa9-a97c-7b24bbcc90ad": null
+                  }
+                }
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "Scheduled",
+              "tags": {
+                "string": "string"
+              },
+              "taskDetails": {
+                "limitSettings": {
+                  "maxTrials": 2
+                },
+                "modelSettings": {
+                  "validationCropSize": 2
+                },
+                "searchSpace": [
+                  {
+                    "validationCropSize": "choice(2, 360)"
+                  }
+                ],
+                "targetColumnName": "string",
+                "taskType": "ImageClassification",
+                "trainingData": {
+                  "jobInputType": "mltable",
+                  "uri": "string"
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List AutoML Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/createOrUpdate.json
@@ -1,0 +1,257 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeId": "string",
+        "command": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "distribution": {
+          "distributionType": "TensorFlow",
+          "parameterServerCount": 1,
+          "workerCount": 1
+        },
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "string",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "inputs": {
+          "string": {
+            "description": "string",
+            "jobInputType": "literal",
+            "value": "string"
+          }
+        },
+        "jobType": "Command",
+        "limits": {
+          "jobLimitsType": "Command",
+          "timeout": "PT5M"
+        },
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "parentJobName": "ParentRun",
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+            }
+          }
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "a0847709-f5aa-4561-8ba5-d915d403fdcf": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "b8163d40-c351-43d6-8a34-d0cd895b8a5a": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Command Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/get.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeId": "string",
+          "command": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "distribution": {
+            "distributionType": "TensorFlow",
+            "parameterServerCount": 1,
+            "workerCount": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "string",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Command",
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT5M"
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "parameters": {
+            "string": "string"
+          },
+          "parentJobName": "ParentRun",
+          "properties": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "8385cf05-78c0-41ef-b31d-36796a678e19": null
+              }
+            }
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Command Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/CommandJob/list.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeId": "string",
+              "command": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "distribution": {
+                "distributionType": "TensorFlow",
+                "parameterServerCount": 1,
+                "workerCount": 1
+              },
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "experimentName": "string",
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "inputs": {
+                "string": {
+                  "description": "string",
+                  "jobInputType": "literal",
+                  "value": "string"
+                }
+              },
+              "jobType": "Command",
+              "limits": {
+                "jobLimitsType": "Command",
+                "timeout": "PT5M"
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "parameters": {
+                "string": "string"
+              },
+              "parentJobName": "ParentRun",
+              "properties": {
+                "string": "string"
+              },
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "7aad5998-6c83-4ca9-b50a-b44dfc43f420": null
+                  }
+                }
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Command Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/createOrUpdate.json
@@ -1,0 +1,217 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "computeId": "gpu-compute",
+        "dataGenerationDetails": {
+          "dataGenerationTaskType": "Conversation",
+          "dataGenerationType": "LabelGeneration",
+          "teacherModelEndpoint": {
+            "endpointName": "newfinetuneinttesting-jbuob"
+          },
+          "trainingData": {
+            "description": null,
+            "jobInputType": "uri_file",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          }
+        },
+        "experimentName": "llm-finetuning",
+        "finetuningDetails": {
+          "studentModel": {
+            "description": null,
+            "jobInputType": "mlflow_model",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+          }
+        },
+        "jobType": "Distillation",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "mlflow_model",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
+        "resources": {
+          "instanceTypes": [
+            "Standard_NC6"
+          ]
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Distillation Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/get.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "dataGenerationDetails": {
+            "dataGenerationTaskType": "Conversation",
+            "dataGenerationType": "LabelGeneration",
+            "teacherModelEndpoint": {
+              "endpointName": "newfinetuneinttesting-jbuob"
+            },
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            }
+          },
+          "displayName": "string",
+          "experimentName": "string",
+          "finetuningDetails": {
+            "studentModel": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "Distillation",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Distillation Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/DistillationJob/list.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentId": "string",
+              "computeId": "string",
+              "dataGenerationDetails": {
+                "dataGenerationTaskType": "Conversation",
+                "dataGenerationType": "LabelGeneration",
+                "teacherModelEndpoint": {
+                  "endpointName": "newfinetuneinttesting-jbuob"
+                },
+                "trainingData": {
+                  "description": null,
+                  "jobInputType": "uri_file",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+                }
+              },
+              "displayName": "string",
+              "experimentName": "string",
+              "finetuningDetails": {
+                "studentModel": {
+                  "description": null,
+                  "jobInputType": "mlflow_model",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Meta-Llama-3.1-8B-Instruct/versions/1"
+                }
+              },
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "Distillation",
+              "notificationSetting": {
+                "emailOn": [
+                  "JobFailed"
+                ],
+                "emails": [
+                  "string"
+                ]
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "mlflow_model",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
+              "resources": {
+                "instanceTypes": [
+                  "Standard_NC6"
+                ]
+              },
+              "status": "Created",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Distillation Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/createOrUpdate.json
@@ -1,0 +1,202 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "computeId": "gpu-compute",
+        "experimentName": "llm-finetuning",
+        "fineTuningDetails": {
+          "model": {
+            "description": null,
+            "jobInputType": "mlflow_model",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          },
+          "modelProvider": "Custom",
+          "taskType": "TextCompletion",
+          "trainingData": {
+            "description": null,
+            "jobInputType": "uri_file",
+            "mode": "ReadOnlyMount",
+            "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+          }
+        },
+        "jobType": "FineTuning",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "mlflow_model",
+            "mode": "ReadWriteMount",
+            "uri": "string"
+          }
+        },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
+        "resources": {
+          "instanceTypes": [
+            "Standard_NC6"
+          ]
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate FineTuning Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/get.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentId": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "fineTuningDetails": {
+            "model": {
+              "description": null,
+              "jobInputType": "mlflow_model",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+            },
+            "modelProvider": "Custom",
+            "taskType": "TextCompletion",
+            "trainingData": {
+              "description": null,
+              "jobInputType": "uri_file",
+              "mode": "ReadOnlyMount",
+              "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+            }
+          },
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "isArchived": false,
+          "jobType": "FineTuning",
+          "notificationSetting": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "mlflow_model",
+              "mode": "ReadWriteMount",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "resources": {
+            "instanceTypes": [
+              "Standard_NC6"
+            ]
+          },
+          "status": "Created",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get FineTuning Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/FineTuningJob/list.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentId": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "experimentName": "string",
+              "fineTuningDetails": {
+                "model": {
+                  "description": null,
+                  "jobInputType": "mlflow_model",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://registries/azureml-meta/models/Llama-2-7b/versions/11"
+                },
+                "modelProvider": "Custom",
+                "taskType": "TextCompletion",
+                "trainingData": {
+                  "description": null,
+                  "jobInputType": "uri_file",
+                  "mode": "ReadOnlyMount",
+                  "uri": "azureml://datastores/workspaceblobstore/paths/UI/2023-06-06_175927_UTC/small_train.jsonl"
+                }
+              },
+              "identity": {
+                "identityType": "AMLToken"
+              },
+              "isArchived": false,
+              "jobType": "FineTuning",
+              "notificationSetting": {
+                "emailOn": [
+                  "JobFailed"
+                ],
+                "emails": [
+                  "string"
+                ]
+              },
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "mlflow_model",
+                  "mode": "ReadWriteMount",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
+              "resources": {
+                "instanceTypes": [
+                  "Standard_NC6"
+                ]
+              },
+              "status": "Created",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List FineTuning Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/createOrUpdate.json
@@ -1,0 +1,170 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "experimentName": "string",
+        "inputs": {
+          "string": {
+            "description": "string",
+            "jobInputType": "literal",
+            "value": "string"
+          }
+        },
+        "jobType": "Pipeline",
+        "outputs": {
+          "string": {
+            "description": "string",
+            "jobOutputType": "uri_file",
+            "mode": "Upload",
+            "uri": "string"
+          }
+        },
+        "properties": {
+          "string": "string"
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "settings": {},
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Pipeline Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/get.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "experimentName": "string",
+          "inputs": {
+            "string": {
+              "description": "string",
+              "jobInputType": "literal",
+              "value": "string"
+            }
+          },
+          "jobType": "Pipeline",
+          "outputs": {
+            "string": {
+              "description": "string",
+              "jobOutputType": "uri_file",
+              "mode": "Upload",
+              "uri": "string"
+            }
+          },
+          "properties": {
+            "string": "string"
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "settings": {},
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Pipeline Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/PipelineJob/list.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "experimentName": "string",
+              "inputs": {
+                "string": {
+                  "description": "string",
+                  "jobInputType": "literal",
+                  "value": "string"
+                }
+              },
+              "jobType": "Pipeline",
+              "outputs": {
+                "string": {
+                  "description": "string",
+                  "jobOutputType": "uri_file",
+                  "mode": "Upload",
+                  "uri": "string"
+                }
+              },
+              "properties": {
+                "string": "string"
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "settings": {},
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Pipeline Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/createOrUpdate.json
@@ -1,0 +1,248 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "computeId": "string",
+        "displayName": "string",
+        "earlyTermination": {
+          "delayEvaluation": 1,
+          "evaluationInterval": 1,
+          "policyType": "MedianStopping"
+        },
+        "experimentName": "string",
+        "jobType": "Sweep",
+        "limits": {
+          "jobLimitsType": "Sweep",
+          "maxConcurrentTrials": 1,
+          "maxTotalTrials": 1,
+          "trialTimeout": "PT1S"
+        },
+        "objective": {
+          "goal": "Minimize",
+          "primaryMetric": "string"
+        },
+        "properties": {
+          "string": "string"
+        },
+        "samplingAlgorithm": {
+          "samplingAlgorithmType": "Grid"
+        },
+        "searchSpace": {
+          "string": {}
+        },
+        "services": {
+          "string": {
+            "endpoint": "string",
+            "jobServiceType": "string",
+            "port": 1,
+            "properties": {
+              "string": "string"
+            }
+          }
+        },
+        "tags": {
+          "string": "string"
+        },
+        "trial": {
+          "codeId": "string",
+          "command": "string",
+          "distribution": {
+            "distributionType": "Mpi",
+            "processCountPerInstance": 1
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+              }
+            }
+          }
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Sweep Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/get.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "computeId": "string",
+          "displayName": "string",
+          "earlyTermination": {
+            "delayEvaluation": 1,
+            "evaluationInterval": 1,
+            "policyType": "MedianStopping"
+          },
+          "experimentName": "string",
+          "jobType": "Sweep",
+          "limits": {
+            "jobLimitsType": "Sweep",
+            "maxConcurrentTrials": 1,
+            "maxTotalTrials": 1,
+            "trialTimeout": "PT1S"
+          },
+          "objective": {
+            "goal": "Minimize",
+            "primaryMetric": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "samplingAlgorithm": {
+            "samplingAlgorithmType": "Grid"
+          },
+          "searchSpace": {
+            "string": {}
+          },
+          "services": {
+            "string": {
+              "endpoint": "string",
+              "errorMessage": "string",
+              "jobServiceType": "string",
+              "port": 1,
+              "properties": {
+                "string": "string"
+              },
+              "status": "string"
+            }
+          },
+          "status": "NotStarted",
+          "tags": {
+            "string": "string"
+          },
+          "trial": {
+            "codeId": "string",
+            "command": "string",
+            "distribution": {
+              "distributionType": "Mpi",
+              "processCountPerInstance": 1
+            },
+            "environmentId": "string",
+            "environmentVariables": {
+              "string": "string"
+            },
+            "resources": {
+              "instanceCount": 1,
+              "instanceType": "string",
+              "properties": {
+                "string": {
+                  "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                }
+              }
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Sweep Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/SweepJob/list.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "jobType": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tag": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/jobs?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "computeId": "string",
+              "displayName": "string",
+              "earlyTermination": {
+                "delayEvaluation": 1,
+                "evaluationInterval": 1,
+                "policyType": "MedianStopping"
+              },
+              "experimentName": "string",
+              "jobType": "Sweep",
+              "limits": {
+                "jobLimitsType": "Sweep",
+                "maxConcurrentTrials": 1,
+                "maxTotalTrials": 1,
+                "trialTimeout": "PT1S"
+              },
+              "objective": {
+                "goal": "Minimize",
+                "primaryMetric": "string"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "samplingAlgorithm": {
+                "samplingAlgorithmType": "Grid"
+              },
+              "searchSpace": {
+                "string": {}
+              },
+              "services": {
+                "string": {
+                  "endpoint": "string",
+                  "errorMessage": "string",
+                  "jobServiceType": "string",
+                  "port": 1,
+                  "properties": {
+                    "string": "string"
+                  },
+                  "status": "string"
+                }
+              },
+              "status": "NotStarted",
+              "tags": {
+                "string": "string"
+              },
+              "trial": {
+                "codeId": "string",
+                "command": "string",
+                "distribution": {
+                  "distributionType": "Mpi",
+                  "processCountPerInstance": 1
+                },
+                "environmentId": "string",
+                "environmentVariables": {
+                  "string": "string"
+                },
+                "resources": {
+                  "instanceCount": 1,
+                  "instanceType": "string",
+                  "properties": {
+                    "string": {
+                      "e6b6493e-7d5e-4db3-be1e-306ec641327e": null
+                    }
+                  }
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_List",
+  "title": "List Sweep Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/cancel.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/cancel.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Jobs_Cancel",
+  "title": "Cancel Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Job/delete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "id": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "204": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Jobs_Delete",
+  "title": "Delete Job."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "enableNetworkMonitor": true,
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Put",
+  "title": "Put ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateRule.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateRule.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_CreateOrUpdate",
+  "title": "CreateOrUpdate ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateRuleV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/createOrUpdateRuleV2.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "errorInformation": null,
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OutboundRule_CreateOrUpdate",
+  "title": "CreateOrUpdate OutboundRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/deleteRule.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/deleteRule.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedNetworkSettingsRule_Delete",
+  "title": "Delete ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/deleteRuleV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/deleteRuleV2.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OutboundRule_Delete",
+  "title": "Delete OutboundRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getManagedNetworkV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getManagedNetworkV2.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Get",
+  "title": "Get ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getRule.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getRule.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_Get",
+  "title": "Get ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getRuleV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/getRuleV2.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "workspace/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "errorInformation": null,
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OutboundRule_Get",
+  "title": "Get OutboundRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listManagedNetworkV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listManagedNetworkV2.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+            "properties": {
+              "managedNetwork": {
+                "firewallPublicIpAddress": "22.22.131.49",
+                "firewallSku": "Standard",
+                "isolationMode": "AllowOnlyApprovedOutbound",
+                "networkId": "00000000-1111-2222-3333-444444444444",
+                "outboundRules": {
+                  "rule_name_1": {
+                    "type": "FQDN",
+                    "category": "UserDefined",
+                    "destination": "destination_endpoint",
+                    "errorInformation": null,
+                    "status": "Active"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettings_List",
+  "title": "List ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listRule.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listRule.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedNetworkSettingsRule_List",
+  "title": "List ManagedNetworkSettingsRule"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listRuleV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/listRuleV2.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OutboundRule_List",
+  "title": "List OutboundRules"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/patchManagedNetworkV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/patchManagedNetworkV2.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "enableNetworkMonitor": true,
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.MachineLearningServices/workspaces/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "errorInformation": null,
+                "status": "Active"
+              }
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkSettings_Patch",
+  "title": "Patch ManagedNetworkSettings"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/postOutboundRulesV2.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/postOutboundRulesV2.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "enableNetworkMonitor": true,
+        "firewallSku": "Standard",
+        "isolationMode": "AllowOnlyApprovedOutbound",
+        "outboundRules": {
+          "rule_name_1": {
+            "type": "FQDN",
+            "category": "UserDefined",
+            "destination": "destination_endpoint"
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "workspace/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": null,
+              "status": "Active"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OutboundRules_Post",
+  "title": "Post OutboundRules"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/provision.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/ManagedNetwork/provision.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "includeSpark": false
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sparkReady": true,
+        "status": "Active"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    }
+  },
+  "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+  "title": "Provision ManagedNetwork"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Notebook/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Notebook/listKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryAccessKey": null,
+        "secondaryAccessKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListNotebookKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Notebook/prepare.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Notebook/prepare.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "fqdn": "testnotebook.notebooks.azure.com",
+        "notebookPreparationError": {
+          "errorMessage": "general error",
+          "statusCode": 500
+        },
+        "resourceId": "aabbccddee112233445566778899"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_PrepareNotebook",
+  "title": "Prepare Notebook"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/createOrUpdate.json
@@ -1,0 +1,246 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "appInsightsEnabled": false,
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "containerResourceRequirements": {
+          "containerResourceLimits": {
+            "cpu": "\"1\"",
+            "gpu": "\"1\"",
+            "memory": "\"2Gi\""
+          },
+          "containerResourceRequests": {
+            "cpu": "\"1\"",
+            "gpu": "\"1\"",
+            "memory": "\"2Gi\""
+          }
+        },
+        "endpointComputeType": "Kubernetes",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "instanceType": "string",
+        "livenessProbe": {
+          "failureThreshold": 1,
+          "initialDelay": "PT5M",
+          "period": "PT5M",
+          "successThreshold": 1,
+          "timeout": "PT5M"
+        },
+        "model": "string",
+        "modelMountPath": "string",
+        "properties": {
+          "string": "string"
+        },
+        "requestSettings": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "maxQueueWait": "PT5M",
+          "requestTimeout": "PT5M"
+        },
+        "scaleSettings": {
+          "scaleType": "Default"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/get.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_Get",
+  "title": "Get Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/listSkus.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments/testDeploymentName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "Microsoft.MachineLearning.Services/endpoints/deployments",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_ListSkus",
+  "title": "List Kubernetes Online Deployment Skus."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/KubernetesOnlineDeployment/update.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "containerResourceRequirements": {
+            "containerResourceLimits": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            },
+            "containerResourceRequests": {
+              "cpu": "\"1\"",
+              "gpu": "\"1\"",
+              "memory": "\"2Gi\""
+            }
+          },
+          "endpointComputeType": "Kubernetes",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_Update",
+  "title": "Update Kubernetes Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/createOrUpdate.json
@@ -1,0 +1,231 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "appInsightsEnabled": false,
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "endpointComputeType": "Managed",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "instanceType": "string",
+        "livenessProbe": {
+          "failureThreshold": 1,
+          "initialDelay": "PT5M",
+          "period": "PT5M",
+          "successThreshold": 1,
+          "timeout": "PT5M"
+        },
+        "model": "string",
+        "modelMountPath": "string",
+        "properties": {
+          "string": "string"
+        },
+        "readinessProbe": {
+          "failureThreshold": 30,
+          "initialDelay": "PT1S",
+          "period": "PT10S",
+          "successThreshold": 1,
+          "timeout": "PT2S"
+        },
+        "requestSettings": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "maxQueueWait": "PT5M",
+          "requestTimeout": "PT5M"
+        },
+        "scaleSettings": {
+          "scaleType": "Default"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Managed Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/get.json
@@ -1,0 +1,93 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_Get",
+  "title": "Get Managed Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/listSkus.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments/testDeploymentName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "Microsoft.MachineLearning.Services/endpoints/deployments",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_ListSkus",
+  "title": "List Managed Online Deployment Skus."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/ManagedOnlineDeployment/update.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "appInsightsEnabled": false,
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "endpointComputeType": "Managed",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "instanceType": "string",
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "model": "string",
+          "modelMountPath": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "readinessProbe": {
+            "failureThreshold": 30,
+            "initialDelay": "PT1S",
+            "period": "PT10S",
+            "successThreshold": 1,
+            "timeout": "PT2S"
+          },
+          "requestSettings": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "maxQueueWait": "PT5M",
+            "requestTimeout": "PT5M"
+          },
+          "scaleSettings": {
+            "scaleType": "Default"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_Update",
+  "title": "Update Managed Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/getLogs.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/getLogs.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "containerType": "StorageInitializer",
+      "tail": 0
+    },
+    "deploymentName": "testDeployment",
+    "endpointName": "testEndpoint",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "content": "string"
+      }
+    }
+  },
+  "operationId": "OnlineDeployments_GetLogs",
+  "title": "Get Online Deployment Logs."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/OnlineDeployment/list.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints/testEndpointName/deployments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "appInsightsEnabled": false,
+              "codeConfiguration": {
+                "codeId": "string",
+                "scoringScript": "string"
+              },
+              "containerResourceRequirements": {
+                "containerResourceLimits": {
+                  "cpu": "\"1\"",
+                  "gpu": "\"1\"",
+                  "memory": "\"2Gi\""
+                },
+                "containerResourceRequests": {
+                  "cpu": "\"1\"",
+                  "gpu": "\"1\"",
+                  "memory": "\"2Gi\""
+                }
+              },
+              "endpointComputeType": "Kubernetes",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "instanceType": "string",
+              "livenessProbe": {
+                "failureThreshold": 1,
+                "initialDelay": "PT5M",
+                "period": "PT5M",
+                "successThreshold": 1,
+                "timeout": "PT5M"
+              },
+              "model": "string",
+              "modelMountPath": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "requestSettings": {
+                "maxConcurrentRequestsPerInstance": 1,
+                "maxQueueWait": "PT5M",
+                "requestTimeout": "PT5M"
+              },
+              "scaleSettings": {
+                "scaleType": "Default"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineDeployments_List",
+  "title": "List Online Deployments."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/getAvailable.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/getAvailable.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "total": 1
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_GetAvailable",
+  "title": "Get available MaaS PTU quota."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/list.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/locations/eastus/ptuQuotas?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "modelCollection": "string",
+            "quota": 1,
+            "usageDetails": [
+              {
+                "collectionQuotaUsage": 1,
+                "deploymentName": "string",
+                "resourceGroup": "string",
+                "usage": 1,
+                "workspaceName": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_List",
+  "title": "List MaaS PTU usage and quota."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/listAvailable.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PTUQuota/listAvailable.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "location": "location",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/locations/eastus/ptuQuotas/available?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "properties": {
+              "total": 1
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PTUQuota_ListAvailable",
+  "title": "List available MaaS PTU quota."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/createOrUpdate.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "title": "WorkspacePutPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "WorkspacePutPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/get.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "WorkspaceGetPrivateEndpointConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateEndpointConnection/list.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "StorageAccountListPrivateEndpointConnections"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateLinkResource/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/PrivateLinkResource/list.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "monitor": "true",
+    "resourceGroupName": "rg-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "amlworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces/privateLinkResources",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateLinkResources/amlworkspace",
+            "properties": {
+              "groupId": "amlworkspace",
+              "requiredMembers": [
+                "default"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_List",
+  "title": "WorkspaceListPrivateLinkResources"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Quota/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Quota/list.json
@@ -1,0 +1,417 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 48,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quota",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 12,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace3/quotas/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Quotas_List",
+  "title": "List workspace quotas by VMFamily"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Quota/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Quota/update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "parameters": {
+      "value": [
+        {
+          "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+          "limit": 100,
+          "unit": "Count"
+        },
+        {
+          "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+          "limit": 200,
+          "unit": "Count"
+        }
+      ]
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 100,
+            "status": "Success",
+            "unit": "Count"
+          },
+          {
+            "type": "Microsoft.MachineLearningServices/workspaces/quotas",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/quotas/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 200,
+            "status": "Success",
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Quotas_Update",
+  "title": "update quotas"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/createOrUpdate.json
@@ -1,0 +1,280 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "discoveryUrl": "string",
+        "intellectualPropertyPublisher": "string",
+        "managedResourceGroup": {
+          "resourceId": "string"
+        },
+        "mlFlowRegistryUri": "string",
+        "publicNetworkAccess": "string",
+        "regionDetails": [
+          {
+            "acrDetails": [
+              {
+                "systemCreatedAcrAccount": {
+                  "acrAccountName": "string",
+                  "acrAccountSku": "string",
+                  "armResourceId": {
+                    "resourceId": "string"
+                  }
+                }
+              }
+            ],
+            "location": "string",
+            "storageAccountDetails": [
+              {
+                "systemCreatedStorageAccount": {
+                  "allowBlobPublicAccess": false,
+                  "armResourceId": {
+                    "resourceId": "string"
+                  },
+                  "storageAccountHnsEnabled": false,
+                  "storageAccountName": "string",
+                  "storageAccountType": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "registryPrivateEndpointConnections": [
+          {
+            "id": "string",
+            "location": "string",
+            "properties": {
+              "groupIds": [
+                "string"
+              ],
+              "privateEndpoint": {
+                "subnetArmId": "string"
+              },
+              "provisioningState": "string",
+              "registryPrivateLinkServiceConnectionState": {
+                "description": "string",
+                "actionsRequired": "string",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry with system created accounts."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location",
+        "Retry-After": 100
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Registries_Delete",
+  "title": "Delete Registry."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/get.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:40",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:40",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_Get",
+  "title": "Get Registry with system created accounts."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/list.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "discoveryUrl": "string",
+              "intellectualPropertyPublisher": "string",
+              "managedResourceGroup": {
+                "resourceId": "string"
+              },
+              "mlFlowRegistryUri": "string",
+              "publicNetworkAccess": "string",
+              "regionDetails": [
+                {
+                  "acrDetails": [
+                    {
+                      "systemCreatedAcrAccount": {
+                        "acrAccountName": "string",
+                        "acrAccountSku": "string",
+                        "armResourceId": {
+                          "resourceId": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "location": "string",
+                  "storageAccountDetails": [
+                    {
+                      "systemCreatedStorageAccount": {
+                        "allowBlobPublicAccess": false,
+                        "armResourceId": {
+                          "resourceId": "string"
+                        },
+                        "storageAccountHnsEnabled": false,
+                        "storageAccountName": "string",
+                        "storageAccountType": "string"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "registryPrivateEndpointConnections": [
+                {
+                  "id": "string",
+                  "location": "string",
+                  "properties": {
+                    "groupIds": [
+                      "string"
+                    ],
+                    "privateEndpoint": {
+                      "id": "string",
+                      "subnetArmId": "string"
+                    },
+                    "provisioningState": "string",
+                    "registryPrivateLinkServiceConnectionState": {
+                      "description": "string",
+                      "actionsRequired": "string",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ]
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:40",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:40",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_List",
+  "title": "List registries with system created accounts."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/listBySubscription.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/listBySubscription.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.MachineLearningServices/registries?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "discoveryUrl": "string",
+              "intellectualPropertyPublisher": "string",
+              "managedResourceGroup": {
+                "resourceId": "string"
+              },
+              "mlFlowRegistryUri": "string",
+              "publicNetworkAccess": "string",
+              "regionDetails": [
+                {
+                  "acrDetails": [
+                    {
+                      "systemCreatedAcrAccount": {
+                        "acrAccountName": "string",
+                        "acrAccountSku": "string",
+                        "armResourceId": {
+                          "resourceId": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "location": "string",
+                  "storageAccountDetails": [
+                    {
+                      "systemCreatedStorageAccount": {
+                        "allowBlobPublicAccess": false,
+                        "armResourceId": {
+                          "resourceId": "string"
+                        },
+                        "storageAccountHnsEnabled": false,
+                        "storageAccountName": "string",
+                        "storageAccountType": "string"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "registryPrivateEndpointConnections": [
+                {
+                  "id": "string",
+                  "location": "string",
+                  "properties": {
+                    "groupIds": [
+                      "string"
+                    ],
+                    "privateEndpoint": {
+                      "id": "string",
+                      "subnetArmId": "string"
+                    },
+                    "provisioningState": "string",
+                    "registryPrivateLinkServiceConnectionState": {
+                      "description": "string",
+                      "actionsRequired": "string",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ]
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:15",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_ListBySubscription",
+  "title": "List registries by subscription."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/removeRegions.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/removeRegions.json
@@ -1,0 +1,190 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "discoveryUrl": "string",
+        "intellectualPropertyPublisher": "string",
+        "managedResourceGroup": {
+          "resourceId": "string"
+        },
+        "mlFlowRegistryUri": "string",
+        "publicNetworkAccess": "string",
+        "regionDetails": [
+          {
+            "acrDetails": [
+              {
+                "systemCreatedAcrAccount": {
+                  "acrAccountName": "string",
+                  "acrAccountSku": "string",
+                  "armResourceId": {
+                    "resourceId": "string"
+                  }
+                }
+              }
+            ],
+            "location": "string",
+            "storageAccountDetails": [
+              {
+                "systemCreatedStorageAccount": {
+                  "allowBlobPublicAccess": false,
+                  "armResourceId": {
+                    "resourceId": "string"
+                  },
+                  "storageAccountHnsEnabled": false,
+                  "storageAccountName": "string",
+                  "storageAccountType": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "registryPrivateEndpointConnections": [
+          {
+            "id": "string",
+            "location": "string",
+            "properties": {
+              "groupIds": [
+                "string"
+              ],
+              "privateEndpoint": {
+                "subnetArmId": "string"
+              },
+              "provisioningState": "string",
+              "registryPrivateLinkServiceConnectionState": {
+                "description": "string",
+                "actionsRequired": "string",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:01",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:01",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location",
+        "Retry-After": 100
+      }
+    }
+  },
+  "operationId": "Registries_RemoveRegions",
+  "title": "Remove regions from registry"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registries/update.json
@@ -1,0 +1,124 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Basic"
+      },
+      "tags": {}
+    },
+    "registryName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "discoveryUrl": "string",
+          "intellectualPropertyPublisher": "string",
+          "managedResourceGroup": {
+            "resourceId": "string"
+          },
+          "mlFlowRegistryUri": "string",
+          "publicNetworkAccess": "string",
+          "regionDetails": [
+            {
+              "acrDetails": [
+                {
+                  "systemCreatedAcrAccount": {
+                    "acrAccountName": "string",
+                    "acrAccountSku": "string",
+                    "armResourceId": {
+                      "resourceId": "string"
+                    }
+                  }
+                }
+              ],
+              "location": "string",
+              "storageAccountDetails": [
+                {
+                  "systemCreatedStorageAccount": {
+                    "allowBlobPublicAccess": false,
+                    "armResourceId": {
+                      "resourceId": "string"
+                    },
+                    "storageAccountHnsEnabled": false,
+                    "storageAccountName": "string",
+                    "storageAccountType": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "registryPrivateEndpointConnections": [
+            {
+              "id": "string",
+              "location": "string",
+              "properties": {
+                "groupIds": [
+                  "string"
+                ],
+                "privateEndpoint": {
+                  "id": "string",
+                  "subnetArmId": "string"
+                },
+                "provisioningState": "string",
+                "registryPrivateLinkServiceConnectionState": {
+                  "description": "string",
+                  "actionsRequired": "string",
+                  "status": "Approved"
+                }
+              }
+            }
+          ]
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:02",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:02",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Registries_Update",
+  "title": "Update Registry with system created accounts."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryCodeContainers_Delete",
+  "title": "Delete Registry Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_Get",
+  "title": "Get Registry Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeContainer/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/codes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/registries/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testContainer2",
+            "type": "Microsoft.MachineLearningServices/registries/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/codes/testContainer2",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryCodeContainers_List",
+  "title": "List Registry Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "TemporaryBlobReference"
+    },
+    "codeName": "string",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeUri": "https://blobStorage/folderName",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryCodeVersions_Delete",
+  "title": "Delete Registry Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_Get",
+  "title": "Get Registry Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/CodeVersion/list.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "codeName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/codes/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeUri": "https://blobStorage/folderName",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryCodeVersions_List",
+  "title": "List Registry Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryComponentContainers_Delete",
+  "title": "Delete Registry Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_Get",
+  "title": "Get Registry Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentContainer/list.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "componentName": "testContainer",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/components?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentContainers_List",
+  "title": "List Registry Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/createOrUpdate.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "componentSpec": {
+          "8ced901b-d826-477d-bfef-329da9672513": null
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "2de2e74e-457d-4447-a581-933abc2b9d96": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "a6c1349d-5e45-48da-92c3-3ce176cb30e9": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryComponentVersions_Delete",
+  "title": "Delete Registry Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "1a7c40b5-2029-4f5f-a8d6-fd0822038773": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_Get",
+  "title": "Get Registry Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ComponentVersion/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "componentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/components/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentSpec": {
+                "50acbce5-cccc-475a-8ac6-c4da402afbd8": null
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryComponentVersions_List",
+  "title": "List Registry Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "uri_folder",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_folder",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryDataContainers_Delete",
+  "title": "Delete Registry Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_Get",
+  "title": "Get Registry Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/registryList.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataContainer/registryList.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/data?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "uri_folder",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:15",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataContainers_List",
+  "title": "RegistryList Registry Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "None"
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/createOrUpdate.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "mltable",
+        "dataUri": "string",
+        "isAnonymous": false,
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "referencedUris": [
+          "string"
+        ],
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryDataVersions_Delete",
+  "title": "Delete Registry Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "mltable",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "referencedUris": [
+            "string"
+          ],
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_Get",
+  "title": "Get Registry Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/registryList.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/DataVersionBase/registryList.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$tags": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ArchivedOnly",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/data/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "mltable",
+              "dataUri": "string",
+              "isAnonymous": false,
+              "isArchived": false,
+              "properties": {
+                "string": "string"
+              },
+              "referencedUris": [
+                "string"
+              ],
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:48",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryDataVersions_List",
+  "title": "RegistryList Registry Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        },
+        "tags": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        }
+      }
+    },
+    "environmentName": "testEnvironment",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.300Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.300Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.301Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.301Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryEnvironmentContainers_Delete",
+  "title": "Delete Registry Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testEnvironment",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/registries/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_Get",
+  "title": "Get Registry Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentContainer/list.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "environmentName": "testContainer",
+    "registryName": "testregistry",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/environments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testEnvironment",
+            "type": "Microsoft.MachineLearningServices/registries/environments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/testregistry/environments/testEnvironment",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryEnvironmentContainers_List",
+  "title": "List Registry Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/createOrUpdate.json
@@ -1,0 +1,140 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "build": {
+          "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+          "dockerfilePath": "prod/Dockerfile"
+        },
+        "condaFile": "string",
+        "image": "docker.io/tensorflow/serving:latest",
+        "inferenceConfig": {
+          "livenessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "readinessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "scoringRoute": {
+            "path": "string",
+            "port": 1
+          }
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryEnvironmentVersions_Delete",
+  "title": "Delete Registry Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/get.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_Get",
+  "title": "Get Registry Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/EnvironmentVersion/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "environmentName": "string",
+    "registryName": "my-aml-regsitry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/environments/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "build": {
+                "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+                "dockerfilePath": "prod/Dockerfile"
+              },
+              "condaFile": "string",
+              "environmentType": "Curated",
+              "image": "docker.io/tensorflow/serving:latest",
+              "inferenceConfig": {
+                "livenessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "readinessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "scoringRoute": {
+                  "path": "string",
+                  "port": 1
+                }
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryEnvironmentVersions_List",
+  "title": "List Registry Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Model container description",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryModelContainers_Delete",
+  "title": "Delete Registry Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "testContainer",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/registries/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_Get",
+  "title": "Get Registry Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "registryName": "registry123",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/models?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/registries/models",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registry123/models/testContainer",
+            "properties": {
+              "description": "Model container description",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RegistryModelContainers_List",
+  "title": "List Registry Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "TemporaryBlobReference"
+    },
+    "modelName": "string",
+    "registryName": "registryName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Registry Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "flavors": {
+          "string": {
+            "data": {
+              "string": "string"
+            }
+          }
+        },
+        "isAnonymous": false,
+        "modelType": "CustomModel",
+        "modelUri": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Registry Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RegistryModelVersions_Delete",
+  "title": "Delete Registry Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_Get",
+  "title": "Get Registry Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Registry/ModelVersion/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "description": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "modelName": "string",
+    "offset": 1,
+    "properties": "string",
+    "registryName": "my-aml-registry",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "version": "string"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/registries/registries123/models/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "flavors": {
+                "string": {
+                  "data": {
+                    "string": "string"
+                  }
+                }
+              },
+              "isAnonymous": false,
+              "modelType": "CustomModel",
+              "modelUri": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "RegistryModelVersions_List",
+  "title": "List Registry Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/createOrUpdate.json
@@ -1,0 +1,121 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "action": {
+          "actionType": "InvokeBatchEndpoint",
+          "endpointInvocationDefinition": {
+            "9965593e-526f-4b89-bb36-761138cf2794": null
+          }
+        },
+        "displayName": "string",
+        "isEnabled": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        },
+        "trigger": {
+          "endTime": "string",
+          "expression": "string",
+          "startTime": "string",
+          "timeZone": "string",
+          "triggerType": "Cron"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "d77a9a9a-4bb5-4c0c-8a77-459be8b82b9f": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "13ea51e0-ff28-49c3-a85d-9b5199eb14e5": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Failed",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_CreateOrUpdate",
+  "title": "CreateOrUpdate Schedule."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/delete.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    },
+    "204": {
+      "headers": {
+        "location": "http://subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/my-favorite-aml-job"
+      }
+    }
+  },
+  "operationId": "Schedules_Delete",
+  "title": "Delete Schedule."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/get.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "action": {
+            "actionType": "InvokeBatchEndpoint",
+            "endpointInvocationDefinition": {
+              "a108545b-def1-4c86-8e53-dbcb1de3a8bc": null
+            }
+          },
+          "displayName": "string",
+          "isEnabled": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          },
+          "trigger": {
+            "endTime": "string",
+            "expression": "string",
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Cron"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_Get",
+  "title": "Get Schedule."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Schedule/list.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/schedules?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "action": {
+                "actionType": "InvokeBatchEndpoint",
+                "endpointInvocationDefinition": {
+                  "00cd1396-a094-4d48-8d86-14c43a55a6af": null
+                }
+              },
+              "displayName": "string",
+              "isEnabled": false,
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Deleting",
+              "tags": {
+                "string": "string"
+              },
+              "trigger": {
+                "endTime": "string",
+                "expression": "string",
+                "startTime": "string",
+                "timeZone": "string",
+                "triggerType": "Cron"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Schedules_List",
+  "title": "List Schedules."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Usage/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Usage/list.json
@@ -1,0 +1,402 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Clusters",
+              "value": "Clusters"
+            },
+            "type": "Microsoft.MachineLearningServices/totalCores/usages",
+            "currentValue": 7,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 100,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Total Cluster Dedicated Regional vCPUs",
+              "value": "Total Cluster Dedicated Regional vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/dedicatedCores/usages",
+            "currentValue": 14,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs",
+              "value": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_D_Family_Cluster_Dedicated_vCPUs",
+            "limit": 48,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 2,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_dsv2/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster2_dsv2/usages/Standard_DSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_Dv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_FSv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 12,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_nc/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs",
+              "value": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspaces/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluser1_nc/usages/Standard_NC_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv3_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs",
+              "value": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_ND_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NDv2_Family_Cluster_Dedicated_vCPUs",
+            "limit": 0,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs",
+              "value": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NV_Family_Cluster_Dedicated_vCPUs",
+            "limit": 24,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Total Cluster LowPriority Regional vCPUs",
+              "value": "Total Cluster LowPriority Regional vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/lowPriorityCores/usages",
+            "currentValue": 18,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages",
+            "limit": 50,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard D Family Cluster LowPriority vCPUs",
+              "value": "Standard D Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_D_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard DSv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard DSv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_DSv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard Dv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard Dv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_Dv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard FSv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard FSv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_FSv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 18,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace1/computes/demo_cluster1_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/usages",
+            "currentValue": 12,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluster2_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NC Family Cluster LowPriority vCPUs",
+              "value": "Standard NC Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/workspace/computes/usages",
+            "currentValue": 6,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/demo_workspace2/computes/demo_cluster3_lowPriority_nc/usages/Standard_NC_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard NCv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NCv3 Family Cluster LowPriority vCPUs",
+              "value": "Standard NCv3 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NCv3_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard ND Family Cluster LowPriority vCPUs",
+              "value": "Standard ND Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_ND_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NDv2 Family Cluster LowPriority vCPUs",
+              "value": "Standard NDv2 Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NDv2_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Standard NV Family Cluster LowPriority vCPUs",
+              "value": "Standard NV Family Cluster LowPriority vCPUs"
+            },
+            "type": "Microsoft.MachineLearningServices/vmFamily/usages",
+            "currentValue": 0,
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/usages/Standard_NV_Family_Cluster_LowPriority_vCPUs",
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_List",
+  "title": "List Usages"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/VirtualMachineSize/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/VirtualMachineSize/list.json
@@ -1,0 +1,390 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "location": "eastus",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_DS1_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.13,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.01,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.05,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 7168,
+            "memoryGB": 3.5,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 1
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.03,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.1,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.25,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 14336,
+            "memoryGB": 7,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.2,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.06,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.5,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.29,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.12,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.4,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 1.01,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.58,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.17,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.81,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 2.02,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.23,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance",
+              "MIR"
+            ],
+            "vCPUs": 16
+          },
+          {
+            "name": "Standard_DS11_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.26,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.18,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.11,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.04,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 2
+          },
+          {
+            "name": "Standard_DS12_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.37,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.53,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.21,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.07,
+                  "vmTier": "LowPriority"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 4
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.15,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.42,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.74,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 1.06,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 8
+          },
+          {
+            "name": "Standard_DS14_v2",
+            "estimatedVMPrices": {
+              "billingCurrency": "USD",
+              "unitOfMeasure": "OneHour",
+              "values": [
+                {
+                  "osType": "Linux",
+                  "retailPrice": 0.3,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Linux",
+                  "retailPrice": 1.48,
+                  "vmTier": "Standard"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 0.84,
+                  "vmTier": "LowPriority"
+                },
+                {
+                  "osType": "Windows",
+                  "retailPrice": 2.11,
+                  "vmTier": "Standard"
+                }
+              ]
+            },
+            "family": "standardDSv2Family",
+            "gpus": 0,
+            "lowPriorityCapable": true,
+            "maxResourceVolumeMB": 229376,
+            "memoryGB": 112,
+            "osVhdSizeMB": 1047552,
+            "premiumIO": true,
+            "supportedComputeTypes": [
+              "AmlCompute",
+              "ComputeInstance"
+            ],
+            "vCPUs": 16
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineSizes_List",
+  "title": "List VM Sizes"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/createOrUpdate.json
@@ -1,0 +1,222 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "codeConfiguration": {
+          "codeId": "string",
+          "scoringScript": "string"
+        },
+        "compute": "string",
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "errorThreshold": 1,
+        "loggingLevel": "Info",
+        "maxConcurrencyPerInstance": 1,
+        "miniBatchSize": 1,
+        "model": {
+          "assetId": "string",
+          "referenceType": "Id"
+        },
+        "outputAction": "SummaryOnly",
+        "outputFileName": "string",
+        "properties": {
+          "string": "string"
+        },
+        "resources": {
+          "instanceCount": 1,
+          "instanceType": "string",
+          "properties": {
+            "string": {
+              "cd3c37dc-2876-4ca4-8a54-21bd7619724a": null
+            }
+          }
+        },
+        "retrySettings": {
+          "maxRetries": 1,
+          "timeout": "PT5M"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "4939850d-8eae-4343-8566-0826259a2ad1": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "b76755e4-16bf-45d4-b625-6634df7444cc": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BatchDeployments_Delete",
+  "title": "Delete Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/get.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "843c2bb4-e5f1-4267-98c8-ba22a99dbb00": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_Get",
+  "title": "Get Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/list.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/batchEndpoints/testEndpointName/deployments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "codeConfiguration": {
+                "codeId": "string",
+                "scoringScript": "string"
+              },
+              "compute": "string",
+              "environmentId": "string",
+              "environmentVariables": {
+                "string": "string"
+              },
+              "errorThreshold": 1,
+              "loggingLevel": "Info",
+              "maxConcurrencyPerInstance": 1,
+              "miniBatchSize": 1,
+              "model": {
+                "assetId": "string",
+                "referenceType": "Id"
+              },
+              "outputAction": "SummaryOnly",
+              "outputFileName": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "resources": {
+                "instanceCount": 1,
+                "instanceType": "string",
+                "properties": {
+                  "string": {
+                    "a3c13e2e-a213-4cac-9f5a-b49966906ad6": null
+                  }
+                }
+              },
+              "retrySettings": {
+                "maxRetries": 1,
+                "timeout": "PT5M"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchDeployments_List",
+  "title": "List Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchDeployment/update.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string"
+      },
+      "tags": {}
+    },
+    "deploymentName": "testDeploymentName",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "codeConfiguration": {
+            "codeId": "string",
+            "scoringScript": "string"
+          },
+          "compute": "string",
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "errorThreshold": 1,
+          "loggingLevel": "Info",
+          "maxConcurrencyPerInstance": 1,
+          "miniBatchSize": 1,
+          "model": {
+            "assetId": "string",
+            "referenceType": "Id"
+          },
+          "outputAction": "SummaryOnly",
+          "outputFileName": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "resources": {
+            "instanceCount": 1,
+            "instanceType": "string",
+            "properties": {
+              "string": {
+                "1e5e1cf9-b0ea-4cf6-9764-e750bf85c10a": null
+              }
+            }
+          },
+          "retrySettings": {
+            "maxRetries": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "BatchDeployments_Update",
+  "title": "Update Workspace Batch Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/createOrUpdate.json
@@ -1,0 +1,141 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AMLToken",
+        "defaults": {
+          "deploymentName": "string"
+        },
+        "properties": {
+          "string": "string"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testBatchEndpoint",
+    "resourceGroupName": "resourceGroup-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BatchEndpoints_Delete",
+  "title": "Delete Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/get.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_Get",
+  "title": "Get Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/batchEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AMLToken",
+              "defaults": {
+                "deploymentName": "string"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "scoringUri": "https://www.contoso.com/example",
+              "swaggerUri": "https://www.contoso.com/example"
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_List",
+  "title": "List Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BatchEndpoints_ListKeys",
+  "title": "ListKeys Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/BatchEndpoint/update.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "defaults": {
+            "deploymentName": "string"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "BatchEndpoints_Update",
+  "title": "Update Workspace Batch Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "CodeContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "CodeContainers_Delete",
+  "title": "Delete Workspace Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/codes",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "CodeContainers_Get",
+  "title": "Get Workspace Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeContainer/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "testcode",
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/codes?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/workspaces/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testContainer2",
+            "type": "Microsoft.MachineLearningServices/workspaces/codes",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/codes/testContainer2",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "property1": "string",
+                "property2": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-08-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-08-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CodeContainers_List",
+  "title": "List Workspace Code Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/createOrGetStartPendingUpload.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/createOrGetStartPendingUpload.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "pendingUploadId": "string",
+      "pendingUploadType": "None"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "blobReferenceForConsumption": {
+          "blobUri": "https://www.contoso.com/example",
+          "credential": {
+            "credentialType": "SAS",
+            "sasUri": "https://www.contoso.com/example"
+          },
+          "storageAccountArmId": "string"
+        },
+        "pendingUploadId": "string",
+        "pendingUploadType": "None"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_CreateOrGetStartPendingUpload",
+  "title": "CreateOrGetStartPendingUpload Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "codeUri": "https://blobStorage/folderName",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "CodeVersions_Delete",
+  "title": "Delete Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "codeUri": "https://blobStorage/folderName",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_Get",
+  "title": "Get Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/list.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/codes/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "codeUri": "https://blobStorage/folderName",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "CodeVersions_List",
+  "title": "List Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/publish.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/CodeVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "CodeVersions_Publish",
+  "title": "Publish Workspace Code Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ComponentContainers_Delete",
+  "title": "Delete Workspace Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_Get",
+  "title": "Get Workspace Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentContainer/list.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/components?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentContainers_List",
+  "title": "List Workspace Component Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/createOrUpdate.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "componentSpec": {
+          "8ced901b-d826-477d-bfef-329da9672513": null
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "2de2e74e-457d-4447-a581-933abc2b9d96": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "a6c1349d-5e45-48da-92c3-3ce176cb30e9": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ComponentVersions_Delete",
+  "title": "Delete Workspace Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "componentSpec": {
+            "1a7c40b5-2029-4f5f-a8d6-fd0822038773": null
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_Get",
+  "title": "Get Workspace Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/components/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "componentSpec": {
+                "50acbce5-cccc-475a-8ac6-c4da402afbd8": null
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ComponentVersions_List",
+  "title": "List Workspace Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/publish.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ComponentVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ComponentVersions_Publish",
+  "title": "Publish Workspace Component Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/createOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "UriFile",
+        "properties": {
+          "properties1": "value1",
+          "properties2": "value2"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DataContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataContainers_Delete",
+  "title": "Delete Workspace Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "datacontainer123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "datacontainer123",
+        "type": "Microsoft.MachineLearningServices/workspaces/data",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+        "properties": {
+          "description": "string",
+          "dataType": "UriFile",
+          "properties": {
+            "properties1": "value1",
+            "properties2": "value2"
+          },
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DataContainers_Get",
+  "title": "Get Workspace Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataContainer/list.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "data123",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/data?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "datastore123",
+            "type": "Microsoft.MachineLearningServices/workspaces/data",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer123",
+            "properties": {
+              "description": "string",
+              "dataType": "UriFile",
+              "properties": {
+                "properties1": "value1",
+                "properties2": "value2"
+              },
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "datastore124",
+            "type": "Microsoft.MachineLearningServices/workspaces/data",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/data/datacontainer124",
+            "properties": {
+              "description": "string",
+              "dataType": "UriFile",
+              "properties": {
+                "properties1": "value1",
+                "properties2": "value2"
+              },
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DataContainers_List",
+  "title": "List Workspace Data Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "dataType": "uri_file",
+        "dataUri": "string",
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataVersions_Delete",
+  "title": "Delete Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "dataType": "uri_file",
+          "dataUri": "string",
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_Get",
+  "title": "Get Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/list.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$tags": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/data/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "dataType": "uri_file",
+              "dataUri": "string",
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DataVersions_List",
+  "title": "List Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/publish.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/DataVersionBase/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "DataVersions_Publish",
+  "title": "Publish Workspace Data Version Base."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/createOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "name": "testEnvironment",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "properties": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        },
+        "tags": {
+          "additionalProp1": "string",
+          "additionalProp2": "string",
+          "additionalProp3": "string"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.300Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.300Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "properties": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          },
+          "tags": {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-04T03:39:11.301Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-04T03:39:11.301Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EnvironmentContainers_Delete",
+  "title": "Delete Workspace Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testEnvironment",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testEnvironment",
+        "type": "Microsoft.MachineLearningServices/workspaces/environments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+        "properties": {
+          "description": "string",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_Get",
+  "title": "Get Workspace Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "$skipToken": "skiptoken",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/environments?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testEnvironment",
+            "type": "Microsoft.MachineLearningServices/workspaces/environments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/environments/testEnvironment",
+            "properties": {
+              "description": "string",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EnvironmentContainers_List",
+  "title": "List Workspace Environment Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/createOrUpdate.json
@@ -1,0 +1,140 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "build": {
+          "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+          "dockerfilePath": "prod/Dockerfile"
+        },
+        "condaFile": "string",
+        "image": "docker.io/tensorflow/serving:latest",
+        "inferenceConfig": {
+          "livenessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "readinessRoute": {
+            "path": "string",
+            "port": 1
+          },
+          "scoringRoute": {
+            "path": "string",
+            "port": 1
+          }
+        },
+        "isAnonymous": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "EnvironmentVersions_Delete",
+  "title": "Delete Workspace Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/get.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "build": {
+            "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+            "dockerfilePath": "prod/Dockerfile"
+          },
+          "condaFile": "string",
+          "environmentType": "Curated",
+          "image": "docker.io/tensorflow/serving:latest",
+          "inferenceConfig": {
+            "livenessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "readinessRoute": {
+              "path": "string",
+              "port": 1
+            },
+            "scoringRoute": {
+              "path": "string",
+              "port": 1
+            }
+          },
+          "isAnonymous": false,
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_Get",
+  "title": "Get Workspace Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/list.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "name": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/environments/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "build": {
+                "contextUri": "https://storage-account.blob.core.windows.net/azureml/DockerBuildContext/95ddede6b9b8c4e90472db3acd0a8d28/",
+                "dockerfilePath": "prod/Dockerfile"
+              },
+              "condaFile": "string",
+              "environmentType": "Curated",
+              "image": "docker.io/tensorflow/serving:latest",
+              "inferenceConfig": {
+                "livenessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "readinessRoute": {
+                  "path": "string",
+                  "port": 1
+                },
+                "scoringRoute": {
+                  "path": "string",
+                  "port": 1
+                }
+              },
+              "isAnonymous": false,
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "EnvironmentVersions_List",
+  "title": "List Workspace Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/publish.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/EnvironmentVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "EnvironmentVersions_Publish",
+  "title": "Publish Workspace Environment Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/createOrUpdate.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:48",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:48",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:48",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturesetContainers_Delete",
+  "title": "Delete Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/getEntity.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/getEntity.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Deleting",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:49",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:49",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_GetEntity",
+  "title": "GetEntity Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetContainer/list.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ArchivedOnly",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featuresets?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:46",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:46",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetContainers_List",
+  "title": "List Workspace Featureset Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/backfill.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/backfill.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "description": "string",
+      "dataAvailabilityStatus": [
+        "None"
+      ],
+      "displayName": "string",
+      "featureWindow": {
+        "featureWindowEnd": "2020-01-01T12:34:56.999+00:51",
+        "featureWindowStart": "2020-01-01T12:34:56.999+00:51"
+      },
+      "jobId": "string",
+      "resource": {
+        "instanceType": "string"
+      },
+      "sparkConfiguration": {
+        "string": "string"
+      },
+      "tags": {
+        "string": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "jobIds": [
+          "string",
+          "string"
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "FeaturesetVersions_Backfill",
+  "title": "Backfill Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/createOrUpdate.json
@@ -1,0 +1,221 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "entities": [
+          "string"
+        ],
+        "isAnonymous": false,
+        "isArchived": false,
+        "materializationSettings": {
+          "notification": {
+            "emailOn": [
+              "JobFailed"
+            ],
+            "emails": [
+              "string"
+            ]
+          },
+          "resource": {
+            "instanceType": "string"
+          },
+          "schedule": {
+            "endTime": "string",
+            "frequency": "Day",
+            "interval": 1,
+            "schedule": {
+              "hours": [
+                1
+              ],
+              "minutes": [
+                1
+              ],
+              "monthDays": [
+                1
+              ],
+              "weekDays": [
+                "Monday"
+              ]
+            },
+            "startTime": "string",
+            "timeZone": "string",
+            "triggerType": "Recurrence"
+          },
+          "sparkConfiguration": {
+            "string": "string"
+          },
+          "storeType": "Online"
+        },
+        "properties": {
+          "string": "string"
+        },
+        "specification": {
+          "path": "string"
+        },
+        "stage": "string",
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobFailed"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Day",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "OnlineAndOffline"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Deleting",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobCancelled"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Hour",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "Offline"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Failed",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturesetVersions_Delete",
+  "title": "Delete Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/get.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "entities": [
+            "string"
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "materializationSettings": {
+            "notification": {
+              "emailOn": [
+                "JobFailed"
+              ],
+              "emails": [
+                "string"
+              ]
+            },
+            "resource": {
+              "instanceType": "string"
+            },
+            "schedule": {
+              "endTime": "string",
+              "frequency": "Minute",
+              "interval": 1,
+              "schedule": {
+                "hours": [
+                  1
+                ],
+                "minutes": [
+                  1
+                ],
+                "monthDays": [
+                  1
+                ],
+                "weekDays": [
+                  "Wednesday"
+                ]
+              },
+              "startTime": "string",
+              "timeZone": "string",
+              "triggerType": "Recurrence"
+            },
+            "sparkConfiguration": {
+              "string": "string"
+            },
+            "storeType": "None"
+          },
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "specification": {
+            "path": "string"
+          },
+          "stage": "string",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:52",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:52",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_Get",
+  "title": "Get Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturesetVersion/list.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featuresets/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "entities": [
+                "string"
+              ],
+              "isAnonymous": false,
+              "isArchived": false,
+              "materializationSettings": {
+                "notification": {
+                  "emailOn": [
+                    "JobCompleted"
+                  ],
+                  "emails": [
+                    "string"
+                  ]
+                },
+                "resource": {
+                  "instanceType": "string"
+                },
+                "schedule": {
+                  "endTime": "string",
+                  "frequency": "Month",
+                  "interval": 1,
+                  "schedule": {
+                    "hours": [
+                      1
+                    ],
+                    "minutes": [
+                      1
+                    ],
+                    "monthDays": [
+                      1
+                    ],
+                    "weekDays": [
+                      "Saturday"
+                    ]
+                  },
+                  "startTime": "string",
+                  "timeZone": "string",
+                  "triggerType": "Recurrence"
+                },
+                "sparkConfiguration": {
+                  "string": "string"
+                },
+                "storeType": "Offline"
+              },
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "specification": {
+                "path": "string"
+              },
+              "stage": "string",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:49",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:49",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturesetVersions_List",
+  "title": "List Workspace Featureset Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/createOrUpdate.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:38",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:38",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturestoreEntityContainers_Delete",
+  "title": "Delete Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/getEntity.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/getEntity.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "isArchived": false,
+          "latestVersion": "string",
+          "nextVersion": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Updating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:43",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:43",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_GetEntity",
+  "title": "GetEntity Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityContainer/list.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "All",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featurestoreEntities?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "isArchived": false,
+              "latestVersion": "string",
+              "nextVersion": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Canceled",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:43",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:43",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityContainers_List",
+  "title": "List Workspace Featurestore Entity Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/createOrUpdate.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "indexColumns": [
+          {
+            "columnName": "string",
+            "dataType": "Datetime"
+          }
+        ],
+        "isAnonymous": false,
+        "isArchived": false,
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Integer"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:58",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:58",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Integer"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Canceled",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:58",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:58",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "FeaturestoreEntityVersions_Delete",
+  "title": "Delete Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/get.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "indexColumns": [
+            {
+              "columnName": "string",
+              "dataType": "Datetime"
+            }
+          ],
+          "isAnonymous": false,
+          "isArchived": false,
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:57",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:57",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_Get",
+  "title": "Get Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/FeaturestoreEntityVersion/list.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "listViewType": "ActiveOnly",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/featurestoreEntities/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "indexColumns": [
+                {
+                  "columnName": "string",
+                  "dataType": "Datetime"
+                }
+              ],
+              "isAnonymous": false,
+              "isArchived": false,
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:55",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:55",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "FeaturestoreEntityVersions_List",
+  "title": "List Workspace Featurestore Entity Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/createOrUpdate.json
@@ -1,0 +1,147 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AAD",
+        "groupName": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "requestConfiguration": {
+          "maxConcurrentRequestsPerInstance": 1,
+          "requestTimeout": "PT5M"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:19",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:19",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:19",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:19",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferenceEndpoints_Delete",
+  "title": "Delete Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/get.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "requestConfiguration": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "requestTimeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:20",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_Get",
+  "title": "Get Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/list.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "CreatedAtAsc",
+    "poolName": "string",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AAD",
+              "endpointUri": "https://www.contoso.com/example",
+              "groupName": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Canceled",
+              "requestConfiguration": {
+                "maxConcurrentRequestsPerInstance": 1,
+                "requestTimeout": "PT5M"
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Standard"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:20",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "ManagedIdentity"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceEndpoints_List",
+  "title": "List Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceEndpoint/update.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AAD",
+          "endpointUri": "https://www.contoso.com/example",
+          "groupName": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "requestConfiguration": {
+            "maxConcurrentRequestsPerInstance": 1,
+            "requestTimeout": "PT5M"
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:20",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:20",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferenceEndpoints_Update",
+  "title": "Update Workspace Inference Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/createOrUpdate.json
@@ -1,0 +1,230 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "environmentConfiguration": {
+          "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+          "environmentVariables": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "livenessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "readinessProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          },
+          "startupProbe": {
+            "failureThreshold": 1,
+            "initialDelay": "PT5M",
+            "period": "PT5M",
+            "successThreshold": 1,
+            "timeout": "PT5M"
+          }
+        },
+        "modelConfiguration": {
+          "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+        },
+        "nodeSkuType": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "scaleUnitSize": 1
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Updating",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [],
+          "provisioningState": "Deleting",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:15",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:15",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferenceGroups_Delete",
+  "title": "Delete Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/get.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "None",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:17",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_Get",
+  "title": "Get Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/getStatus.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/getStatus.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "actualCapacityInfo": {
+          "failed": 1,
+          "outdatedFailed": 1,
+          "outdatedSucceeded": 1,
+          "succeeded": 1,
+          "total": 1
+        },
+        "endpointCount": 1,
+        "requestedCapacity": 1
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_GetStatus",
+  "title": "GetStatus Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/list.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "CreatedAtDesc",
+    "poolName": "string",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "environmentConfiguration": {
+                "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+                "environmentVariables": [
+                  {
+                    "key": "string",
+                    "value": "string"
+                  }
+                ],
+                "livenessProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                },
+                "readinessProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                },
+                "startupProbe": {
+                  "failureThreshold": 1,
+                  "initialDelay": "PT5M",
+                  "period": "PT5M",
+                  "successThreshold": 1,
+                  "timeout": "PT5M"
+                }
+              },
+              "modelConfiguration": {
+                "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+              },
+              "nodeSkuType": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Failed",
+              "scaleUnitSize": 1
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:17",
+              "createdBy": "string",
+              "createdByType": "Key",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_List",
+  "title": "List Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/listSkus.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/listSkus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferenceGroups/testInferenceGroupName/skus?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "capacity": {
+              "default": 1,
+              "maximum": 1,
+              "minimum": 1,
+              "scaleType": "Automatic"
+            },
+            "resourceType": "string",
+            "sku": {
+              "name": "string",
+              "tier": "Free"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferenceGroups_ListSkus",
+  "title": "ListSkus Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferenceGroup/update.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "groupName": "string",
+    "poolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "environmentConfiguration": {
+            "environmentId": "azureml://registries/test-registry/models/enginefeed/versions/1",
+            "environmentVariables": [
+              {
+                "key": "string",
+                "value": "string"
+              }
+            ],
+            "livenessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "readinessProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            },
+            "startupProbe": {
+              "failureThreshold": 1,
+              "initialDelay": "PT5M",
+              "period": "PT5M",
+              "successThreshold": 1,
+              "timeout": "PT5M"
+            }
+          },
+          "modelConfiguration": {
+            "modelId": "azureml://registries/test-registry/models/modelabc/versions/1"
+          },
+          "nodeSkuType": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Failed",
+          "scaleUnitSize": 1
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:17",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:17",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferenceGroups_Update",
+  "title": "Update Workspace Inference Group."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "properties": [
+          {
+            "key": "string",
+            "value": "string"
+          }
+        ],
+        "scaleUnitConfiguration": {
+          "disablePublicEgress": false,
+          "registries": [
+            "string",
+            "registryName1"
+          ]
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InferencePools_Delete",
+  "title": "Delete Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/get.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "scaleUnitConfiguration": {
+            "disablePublicEgress": false,
+            "registries": [
+              "string",
+              "registryName1"
+            ]
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:21",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:21",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_Get",
+  "title": "Get Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/list.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "count": 1,
+    "orderBy": "UpdatedAtAsc",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/inferencePools?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "UserAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "properties": [
+                {
+                  "key": "string",
+                  "value": "string"
+                }
+              ],
+              "provisioningState": "Failed",
+              "scaleUnitConfiguration": {
+                "disablePublicEgress": false,
+                "registries": [
+                  "string",
+                  "registryName1"
+                ]
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Premium"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:22",
+              "createdBy": "string",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Application"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "InferencePools_List",
+  "title": "List Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/InferencePool/update.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "inferencePoolName": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "properties": [
+            {
+              "key": "string",
+              "value": "string"
+            }
+          ],
+          "provisioningState": "Canceled",
+          "scaleUnitConfiguration": {
+            "disablePublicEgress": false,
+            "registries": [
+              "string",
+              "registryName1"
+            ]
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:22",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:22",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/locations/centraluseuap/mfeOperationResults/prefix:F0C6B8EC-0D53-432C-913B-1CD9E8CDE3A0"
+      }
+    }
+  },
+  "operationId": "InferencePools_Update",
+  "title": "Update Workspace Inference Pool."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/createOrUpdate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "modelId": "string"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Suspended",
+          "modelId": "string",
+          "provisioningState": "Failed"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "Key",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Suspended",
+          "modelId": "string",
+          "provisioningState": "Failed"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "MarketplaceSubscriptions_Delete",
+  "title": "Delete Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/get.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "marketplacePlan": {
+            "offerId": "string",
+            "planId": "string",
+            "publisherId": "string"
+          },
+          "marketplaceSubscriptionStatus": "Subscribed",
+          "modelId": "string",
+          "provisioningState": "Canceled"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:08",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:08",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "ManagedIdentity"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_Get",
+  "title": "Get Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/MarketplaceSubscription/list.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/marketplaceSubscriptions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "marketplacePlan": {
+                "offerId": "string",
+                "planId": "string",
+                "publisherId": "string"
+              },
+              "marketplaceSubscriptionStatus": "Suspended",
+              "modelId": "string",
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:06",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:06",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "Key"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "MarketplaceSubscriptions_List",
+  "title": "List Workspace Marketplace Subscription."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/createOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Model container description",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "ModelContainers_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ModelContainers_Delete",
+  "title": "Delete Workspace Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testContainer",
+        "type": "Microsoft.MachineLearningServices/workspaces/models",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+        "properties": {
+          "description": "Model container description",
+          "tags": {
+            "tag1": "value1",
+            "tag2": "value2"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-12-01T12:00:00.000Z",
+          "createdBy": "John Smith",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+          "lastModifiedBy": "John Smith",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "ModelContainers_Get",
+  "title": "Get Workspace Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelContainer/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "name": "testContainer",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/models?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testContainer",
+            "type": "Microsoft.MachineLearningServices/workspaces/models",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspace123/models/testContainer",
+            "properties": {
+              "description": "Model container description",
+              "tags": {
+                "tag1": "value1",
+                "tag2": "value2"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-12-01T12:00:00.000Z",
+              "createdBy": "John Smith",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-12-01T12:00:00.000Z",
+              "lastModifiedBy": "John Smith",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ModelContainers_List",
+  "title": "List Workspace Model Container."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/createOrUpdate.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "string",
+        "flavors": {
+          "string": {
+            "data": {
+              "string": "string"
+            }
+          }
+        },
+        "isAnonymous": false,
+        "modelType": "CustomModel",
+        "modelUri": "string",
+        "properties": {
+          "string": "string"
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ModelVersions_Delete",
+  "title": "Delete Workspace Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "properties": {
+          "description": "string",
+          "flavors": {
+            "string": {
+              "data": {
+                "string": "string"
+              }
+            }
+          },
+          "isAnonymous": false,
+          "modelType": "CustomModel",
+          "modelUri": "string",
+          "properties": {
+            "string": "string"
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_Get",
+  "title": "Get Workspace Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/list.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "name": "string",
+    "description": "string",
+    "$orderBy": "string",
+    "$skipToken": "string",
+    "$top": 1,
+    "api-version": "2024-10-01-preview",
+    "offset": 1,
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/models/string/versions?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "properties": {
+              "description": "string",
+              "flavors": {
+                "string": {
+                  "data": {
+                    "string": "string"
+                  }
+                }
+              },
+              "isAnonymous": false,
+              "modelType": "CustomModel",
+              "modelUri": "string",
+              "properties": {
+                "string": "string"
+              },
+              "tags": {
+                "string": "string"
+              }
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ModelVersions_List",
+  "title": "List Workspace Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/publish.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ModelVersion/publish.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "destinationName": "string",
+      "destinationVersion": "string",
+      "registryName": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "version": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ModelVersions_Publish",
+  "title": "Publish Workspace Model Version."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineDeployment/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineDeployment/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "deploymentName": "testDeployment",
+    "endpointName": "testEndpoint",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OnlineDeployments_Delete",
+  "title": "Delete Workspace Online Deployment."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/createOrUpdate.json
@@ -1,0 +1,144 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "description": "string",
+        "authMode": "AMLToken",
+        "compute": "string",
+        "properties": {
+          "string": "string"
+        },
+        "traffic": {
+          "string": 1
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Free"
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "OnlineEndpoints_Delete",
+  "title": "Delete Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/get.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_Get",
+  "title": "Get Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/getToken.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/getToken.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "accessToken": "string",
+        "expiryTimeUtc": 1,
+        "refreshAfterTimeUtc": 1,
+        "tokenType": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_GetToken",
+  "title": "GetToken Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/list.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "name": "string",
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "computeType": "Managed",
+    "count": 1,
+    "orderBy": "CreatedAtDesc",
+    "properties": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "tags": "string",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/onlineEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "description": "string",
+              "authMode": "AMLToken",
+              "compute": "string",
+              "properties": {
+                "string": "string"
+              },
+              "provisioningState": "Creating",
+              "scoringUri": "https://www.contoso.com/example",
+              "swaggerUri": "https://www.contoso.com/example",
+              "traffic": {
+                "string": 1
+              }
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Free"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "string",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_List",
+  "title": "List Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "OnlineEndpoints_ListKeys",
+  "title": "ListKeys Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/regenerateKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/regenerateKeys.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyType": "Primary",
+      "keyValue": "string"
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "OnlineEndpoints_RegenerateKeys",
+  "title": "RegenerateKeys Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/OnlineEndpoint/update.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "tags": {}
+    },
+    "endpointName": "testEndpointName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "description": "string",
+          "authMode": "AMLToken",
+          "compute": "string",
+          "properties": {
+            "string": "string"
+          },
+          "provisioningState": "Creating",
+          "scoringUri": "https://www.contoso.com/example",
+          "swaggerUri": "https://www.contoso.com/example",
+          "traffic": {
+            "string": 1
+          }
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "OnlineEndpoints_Update",
+  "title": "Update Workspace Online Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/createOrUpdate.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/createOrUpdate.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "kind": "string",
+      "location": "string",
+      "properties": {
+        "authMode": "Key",
+        "contentSafety": {
+          "contentSafetyLevel": "Blocking",
+          "contentSafetyStatus": "Enabled"
+        },
+        "modelSettings": {
+          "modelId": "string"
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Standard"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Deferred",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Deleting",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Updating"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Deferred",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Deleting",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Failed"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Standard"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:14",
+          "createdBy": "string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:14",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Key"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_CreateOrUpdate",
+  "title": "CreateOrUpdate Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ServerlessEndpoints_Delete",
+  "title": "Delete Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/get.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Blocking",
+            "contentSafetyStatus": "Enabled"
+          },
+          "endpointState": "Suspending",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Premium"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_Get",
+  "title": "Get Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/list.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "$skipToken": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/my-aml-workspace/serverlessEndpoints?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "string",
+            "type": "string",
+            "id": "string",
+            "identity": {
+              "type": "UserAssigned",
+              "principalId": "00000000-1111-2222-3333-444444444444",
+              "tenantId": "00000000-1111-2222-3333-444444444444",
+              "userAssignedIdentities": {
+                "string": {
+                  "clientId": "00000000-1111-2222-3333-444444444444",
+                  "principalId": "00000000-1111-2222-3333-444444444444"
+                }
+              }
+            },
+            "kind": "string",
+            "location": "string",
+            "properties": {
+              "authMode": "Key",
+              "contentSafety": {
+                "contentSafetyLevel": "Blocking",
+                "contentSafetyStatus": "Disabled"
+              },
+              "endpointState": "Reinstating",
+              "inferenceEndpoint": {
+                "headers": {
+                  "string": "string"
+                },
+                "uri": "https://www.contoso.com/example"
+              },
+              "marketplaceSubscriptionId": "string",
+              "modelSettings": {
+                "modelId": "string"
+              },
+              "provisioningState": "Updating"
+            },
+            "sku": {
+              "name": "string",
+              "capacity": 1,
+              "family": "string",
+              "size": "string",
+              "tier": "Basic"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999+00:12",
+              "createdBy": "string",
+              "createdByType": "ManagedIdentity",
+              "lastModifiedAt": "2020-01-01T12:34:56.999+00:12",
+              "lastModifiedBy": "string",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_List",
+  "title": "List Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/listKeys.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ServerlessEndpoints_ListKeys",
+  "title": "ListKeys Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/regenerateKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/regenerateKeys.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "keyType": "Primary",
+      "keyValue": "string"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "string",
+        "secondaryKey": "string"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "ServerlessEndpoints_RegenerateKeys",
+  "title": "RegenerateKeys Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/ServerlessEndpoint/update.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "string",
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "None",
+        "userAssignedIdentities": {
+          "string": {}
+        }
+      },
+      "sku": {
+        "name": "string",
+        "capacity": 1,
+        "family": "string",
+        "size": "string",
+        "tier": "Premium"
+      },
+      "tags": {}
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "type": "string",
+        "id": "string",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "string": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "kind": "string",
+        "location": "string",
+        "properties": {
+          "authMode": "Key",
+          "contentSafety": {
+            "contentSafetyLevel": "Blocking",
+            "contentSafetyStatus": "Disabled"
+          },
+          "endpointState": "Suspended",
+          "inferenceEndpoint": {
+            "headers": {
+              "string": "string"
+            },
+            "uri": "https://www.contoso.com/example"
+          },
+          "marketplaceSubscriptionId": "string",
+          "modelSettings": {
+            "modelId": "string"
+          },
+          "provisioningState": "Creating"
+        },
+        "sku": {
+          "name": "string",
+          "capacity": 1,
+          "family": "string",
+          "size": "string",
+          "tier": "Free"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999+00:13",
+          "createdBy": "string",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999+00:13",
+          "lastModifiedBy": "string",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {}
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "ServerlessEndpoints_Update",
+  "title": "Update Workspace Serverless Endpoint."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/create.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {}
+        }
+      },
+      "location": "eastus2euap",
+      "properties": {
+        "description": "test description",
+        "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+        "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+          },
+          "keyVaultProperties": {
+            "identityClientId": "",
+            "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+            "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+          },
+          "status": "Enabled"
+        },
+        "friendlyName": "HelloName",
+        "hbiWorkspace": false,
+        "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+        "sharedPrivateLinkResources": [
+          {
+            "name": "testdbresource",
+            "properties": {
+              "groupId": "Sql",
+              "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testdbresource/privateLinkResources/Sql",
+              "requestMessage": "Please approve",
+              "status": "Approved"
+            }
+          }
+        ],
+        "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "test description",
+          "allowPublicAccessWhenBehindVnet": false,
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "enableDataIsolation": false,
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+            },
+            "keyVaultProperties": {
+              "identityClientId": "",
+              "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+              "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+            },
+            "status": "Enabled"
+          },
+          "friendlyName": "HelloName",
+          "hbiWorkspace": false,
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "publicNetworkAccess": "Disabled",
+          "sharedPrivateLinkResources": [
+            {
+              "name": "testdbresource",
+              "properties": {
+                "groupId": "Sql",
+                "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testdbresource/privateLinkResources/Sql",
+                "requestMessage": "Please approve",
+                "status": "Approved"
+              }
+            }
+          ],
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_CreateOrUpdate",
+  "title": "Create Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Workspaces_Delete",
+  "title": "Delete Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/diagnose.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/diagnose.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "value": {
+        "applicationInsights": {},
+        "containerRegistry": {},
+        "dnsResolution": {},
+        "keyVault": {},
+        "nsg": {},
+        "others": {},
+        "resourceLock": {},
+        "storageAccount": {},
+        "udr": {}
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": {
+          "applicationInsightsResults": [],
+          "containerRegistryResults": [],
+          "dnsResolutionResults": [
+            {
+              "code": "CustomDNSInUse",
+              "level": "Warning",
+              "message": "We have detected an on-premise dns server is configured. Please make sure conditional forwarding is configured correctly according to doc https://foo"
+            }
+          ],
+          "keyVaultResults": [],
+          "networkSecurityRuleResults": [],
+          "otherResults": [],
+          "resourceLockResults": [],
+          "storageAccountResults": [],
+          "userDefinedRouteResults": []
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_Diagnose",
+  "title": "Diagnose Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/get.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai": {
+              "clientId": "00000000-1111-2222-3333-444444444444",
+              "principalId": "00000000-1111-2222-3333-444444444444"
+            }
+          }
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "test description",
+          "allowPublicAccessWhenBehindVnet": false,
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testuai"
+            },
+            "keyVaultProperties": {
+              "identityClientId": "",
+              "keyIdentifier": "https://testkv.vault.azure.net/keys/testkey/aabbccddee112233445566778899aabb",
+              "keyVaultArmId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv"
+            },
+            "status": "Enabled"
+          },
+          "friendlyName": "HelloName",
+          "hbiWorkspace": false,
+          "imageBuildCompute": "testcompute",
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "managedNetwork": {
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "some_string": {
+                "type": "FQDN",
+                "category": "Required",
+                "destination": "some_string",
+                "status": "Inactive"
+              }
+            },
+            "status": {
+              "sparkReady": false,
+              "status": "Active"
+            }
+          },
+          "privateEndpointConnections": [
+            {
+              "name": "testprivatelinkconnection",
+              "type": "Microsoft.MachineLearningServices/workspaces/privateEndpointConnections",
+              "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/privateEndpointConnections/testprivatelinkconnection",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-1234/providers/Microsoft.Network/privateEndpoints/petest01"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "privateLinkCount": 0,
+          "publicNetworkAccess": "Disabled",
+          "serviceProvisionedResourceGroup": "testworkspace_0000111122223333",
+          "sharedPrivateLinkResources": [
+            {
+              "name": "testcosmosdbresource",
+              "properties": {
+                "groupId": "Sql",
+                "privateLinkResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.DocumentDB/databaseAccounts/testcosmosdbresource/privateLinkResources/Sql",
+                "requestMessage": "Please approve",
+                "status": "Approved"
+              }
+            }
+          ],
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    }
+  },
+  "operationId": "Workspaces_Get",
+  "title": "Get Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listByResourceGroup.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listByResourceGroup.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+            }
+          },
+          {
+            "name": "testworkspace1",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace1",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistryNew",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName 1",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkvNew",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccountOld"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListByResourceGroup",
+  "title": "Get Workspaces by Resource Group"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listBySubscription.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listBySubscription.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.MachineLearningServices/workspaces?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+            }
+          },
+          {
+            "name": "testworkspace",
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-5678/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+            "location": "eastus2euap",
+            "properties": {
+              "description": "test description",
+              "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+              "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistryNew",
+              "discoveryUrl": "http://example.com",
+              "friendlyName": "HelloName",
+              "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkvNew",
+              "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccountOld"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Workspaces_ListBySubscription",
+  "title": "Get Workspaces by subscription"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listKeys.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "appInsightsInstrumentationKey": null,
+        "containerRegistryCredentials": {
+          "location": null,
+          "passwords": [
+            {
+              "name": "password",
+              "value": "<value>"
+            },
+            {
+              "name": "password2",
+              "value": "0KARRQoQHSUq1yViPWg7YFernOS=Ic/t"
+            }
+          ],
+          "username": "testdemoworkjmjmeykp"
+        },
+        "notebookAccessKeys": {
+          "primaryAccessKey": null,
+          "secondaryAccessKey": null
+        },
+        "userStorageArmId": "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/ragargeastus2euap/providers/Microsoft.Storage/storageAccounts/testdemoworkazashomr",
+        "userStorageKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listNotebookAccessToken.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listNotebookAccessToken.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiresIn": 28800,
+        "hostName": "Host product name",
+        "notebookResourceId": "94350843095843059",
+        "publicDns": "resource.notebooks.azure.net",
+        "scope": "aznb_identity",
+        "tokenType": "Bearer"
+      }
+    }
+  },
+  "operationId": "Workspaces_ListNotebookAccessToken",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listStorageAccountKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/listStorageAccountKeys.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "userStorageKey": null
+      }
+    }
+  },
+  "operationId": "Workspaces_ListStorageAccountKeys",
+  "title": "List Workspace Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/operationsList.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/operationsList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/write",
+            "display": {
+              "operation": "Create/Update Machine Learning workspaces",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          },
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/delete",
+            "display": {
+              "operation": "Delete Machine Learning workspaces",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          },
+          {
+            "name": "Microsoft.MachineLearningServices/workspaces/listkeys/action",
+            "display": {
+              "operation": "List workspace Keys",
+              "provider": "Microsoft MachineLearningServices",
+              "resource": "workspaces"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/resyncKeys.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/resyncKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "workspaceName": "workspaces123"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_ResyncKeys",
+  "title": "Resync Workspace Keys"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/Workspace/update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "new description",
+        "friendlyName": "New friendly name",
+        "publicNetworkAccess": "Disabled"
+      }
+    },
+    "resourceGroupName": "workspace-1234",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.MachineLearningServices/workspaces/testworkspace",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-1111-2222-3333-444444444444",
+          "tenantId": "00000000-1111-2222-3333-444444444444"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "description": "new description",
+          "applicationInsights": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/microsoft.insights/components/testinsights",
+          "containerRegistry": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.ContainerRegistry/registries/testRegistry",
+          "discoveryUrl": "http://example.com",
+          "friendlyName": "New friendly name",
+          "keyVault": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/workspace-1234/providers/Microsoft.KeyVault/vaults/testkv",
+          "publicNetworkAccess": "Disabled",
+          "storageAccount": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/accountcrud-1234/providers/Microsoft.Storage/storageAccounts/testStorageAccount"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "Workspaces_Update",
+  "title": "Update Workspace"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/create.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "description": "Basic blocklist description"
+      }
+    },
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklist_Create",
+  "title": "Create Rai Blocklist"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklist_Delete",
+  "title": "Delete Rai Blocklist"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklist_Get",
+  "title": "Get Rai Blocklist"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklist/list.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiBlocklists?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiBlocklistName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName",
+            "properties": {
+              "description": "Basic blocklist description"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklists_List",
+  "title": "List Rai Blocklist"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/addBulk.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/addBulk.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": [
+      {
+        "name": "myblocklistitem1",
+        "properties": {
+          "isRegex": true,
+          "pattern": "^[a-z0-9_-]{2,16}$"
+        }
+      },
+      {
+        "name": "myblocklistitem2",
+        "properties": {
+          "isRegex": false,
+          "pattern": "blockwords"
+        }
+      }
+    ],
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myblocklist",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "properties": {
+          "description": "Brief description of the blocklist"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_AddBulk",
+  "title": "Create Bulk Rai Blocklist Items"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/create.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "isRegex": false,
+        "pattern": "Pattern To Block"
+      }
+    },
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Create",
+  "title": "Create RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Delete",
+  "title": "Delete RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/deleteBulk.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/deleteBulk.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": [
+      "myblocklistitem1",
+      "myblocklistitem2"
+    ],
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiBlocklistItem_DeleteBulk",
+  "title": "Delete Bulk Rai Blocklist Items"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItem_Get",
+  "title": "Get Rai RaiBlocklist Item"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiBlocklistItem/list.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiBlocklists/raiBlocklist-1/raiBlocklistItems?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiBlocklistItemName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiBlocklists/raiBlocklistItem",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Pattern To Block"
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiBlocklistItems_List",
+  "title": "List RaiBlocklist Items"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/create.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "SystemManaged",
+        "basePolicyName": "112",
+        "completionBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ],
+        "contentFilters": [
+          {
+            "name": "policyName",
+            "allowedContentLevel": "Low",
+            "blocking": false,
+            "enabled": false,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Blocking",
+        "promptBlocklists": [
+          {
+            "blocking": false,
+            "blocklistName": "blocklistName"
+          }
+        ]
+      }
+    },
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicy_Create",
+  "title": "Create Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionRaiPolicy_Delete",
+  "title": "Delete Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+        "properties": {
+          "type": "SystemManaged",
+          "basePolicyName": "112",
+          "completionBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ],
+          "contentFilters": [
+            {
+              "name": "policyName",
+              "allowedContentLevel": "Low",
+              "blocking": false,
+              "enabled": false,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Blocking",
+          "promptBlocklists": [
+            {
+              "blocking": false,
+              "blocklistName": "blocklistName"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicy_Get",
+  "title": "Get Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/RaiPolicy/list.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.MachineLearningServices/workspaces/workspaces123/connections/connection-1/raiPolicies?api-version=2025-07-01-preview&$skip=2",
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/raiPolicies",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-workspace-name/connections/testConnection/raiPolicies/raiPolicyName",
+            "properties": {
+              "type": "SystemManaged",
+              "basePolicyName": "112",
+              "completionBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ],
+              "contentFilters": [
+                {
+                  "name": "policyName",
+                  "allowedContentLevel": "Low",
+                  "blocking": false,
+                  "enabled": false,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Blocking",
+              "promptBlocklists": [
+                {
+                  "blocking": false,
+                  "blocklistName": "blocklistName"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T00:00:00Z",
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedAt": "2020-01-01T00:00:00Z",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectionRaiPolicies_List",
+  "title": "List Rai policy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/create.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/create.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "www.facebook.com"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "www.facebook.com"
+        }
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_Create",
+  "title": "CreateWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/createDeployment.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/createDeployment.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "type": "Azure.OpenAI",
+        "model": {
+          "name": "text-davinci-003",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+      }
+    },
+    "connectionName": "testConnection",
+    "deploymentName": "text-davinci-003",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "Connection_CreateOrUpdateDeployment",
+  "title": "Create Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/delete.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "WorkspaceConnections_Delete",
+  "title": "DeleteWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/deleteDeployment.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/deleteDeployment.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "deploymentName": "testDeploymentName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Connection_DeleteDeployment",
+  "title": "Delete Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/get.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "www.facebook.com"
+        }
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_Get",
+  "title": "GetWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/getDeployment.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/getDeployment.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "deploymentName": "text-davinci-003",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "text-davinci-003",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+        "properties": {
+          "type": "Azure.OpenAI",
+          "model": {
+            "name": "text-davinci-003",
+            "format": "OpenAI",
+            "source": null,
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "raiPolicyName": "Microsoft.Default",
+          "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+        },
+        "systemData": {
+          "createdBy": "00000000-1111-2222-3333-444444444444",
+          "createdByType": "Application",
+          "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  },
+  "operationId": "Connection_GetDeployment",
+  "title": "Get Azure OpenAI Connection Deployment"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/getModels.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/getModels.json
@@ -1,0 +1,125 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_GetModels",
+  "title": "Get Azure OpenAI Connection Models"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/list.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "category": "ContainerRegistry",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "www.facebook.com",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/linkedWorkspaces/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "www.facebook.com"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/linkedWorkspaces/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "www.facebook.com"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_List",
+  "title": "ListWorkspaceConnections"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listConnectionModels.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listConnectionModels.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "aml-workspace-name"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "connectionIds": [
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-2"
+                ],
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.ada"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          },
+          {
+            "name": "babbage",
+            "format": "OpenAI",
+            "capabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false",
+              "scaleType": "Manual",
+              "search": "true"
+            },
+            "deprecation": {
+              "fineTune": "2024-07-05T00:00:00+00:00",
+              "inference": "2024-07-05T00:00:00+00:00"
+            },
+            "finetuneCapabilities": {
+              "FineTuneTokensMaxValue": "2000000000",
+              "completion": "true",
+              "scaleType": "Manual,Standard",
+              "search": "true"
+            },
+            "isDefaultVersion": false,
+            "maxCapacity": 3,
+            "skus": [
+              {
+                "name": "Standard",
+                "capacity": {
+                  "maximum": 10000
+                },
+                "connectionIds": [
+                  "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1"
+                ],
+                "deprecationDate": "2024-03-01T00:00:00+00:00",
+                "rateLimits": [
+                  {
+                    "count": 1,
+                    "renewalPeriod": 10,
+                    "rules": []
+                  },
+                  {
+                    "count": 1000,
+                    "renewalPeriod": 60,
+                    "rules": []
+                  }
+                ],
+                "usageName": "OpenAI.Standard.babbage"
+              }
+            ],
+            "systemData": {
+              "createdBy": "Microsoft",
+              "createdByType": null,
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": null
+            },
+            "version": "1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_GetAllModels",
+  "title": "Get models under the Azure ML workspace for all Azure OpenAI connections that the user can deploy"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listDeployments.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listDeployments.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "testConnection",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "text-davinci-003",
+            "type": "Microsoft.MachineLearningServices/workspaces/connections/deployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/testworkspace/connections/testConnection/deployments/text-davinci-003",
+            "properties": {
+              "type": "Azure.OpenAI",
+              "model": {
+                "name": "text-davinci-003",
+                "format": "OpenAI",
+                "source": null,
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "raiPolicyName": "Microsoft.Default",
+              "versionUpgradeOption": "OnceNewDefaultVersionAvailable"
+            },
+            "systemData": {
+              "createdBy": "00000000-1111-2222-3333-444444444444",
+              "createdByType": "Application",
+              "lastModifiedBy": "00000000-1111-2222-3333-444444444444",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Connection_ListDeployments",
+  "title": "List Azure OpenAI Connection Deployments"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listSecrets.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/listSecrets.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "CustomKeys",
+          "credentials": {
+            "accessKeyId": "some_string",
+            "secretAccessKey": "some_string"
+          },
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "WorkspaceConnections_ListSecrets",
+  "title": "GetWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/testConnection.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/testConnection.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "target_url"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "WorkspaceConnections_TestConnection",
+  "title": "TestWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/update.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceConnection/update.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "body": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "workspace-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.MachineLearningServices/workspaces/workspace-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T00:00:00Z",
+          "createdBy": "some_string",
+          "createdByType": "ManagedIdentity",
+          "lastModifiedAt": "2020-01-01T00:00:00Z",
+          "lastModifiedBy": "some_string",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "WorkspaceConnections_Update",
+  "title": "UpdateWorkspaceConnection"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceFeature/list.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/examples/WorkspaceFeature/list.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2024-10-01-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "description": "Create, edit or delete AutoML experiments in the SDK",
+            "displayName": "Create edit experiments UI",
+            "id": "automatedml_createeditexperimentsui"
+          },
+          {
+            "description": "Upgrade workspace from Basic to enterprise from the UI",
+            "displayName": "Upgrade workspace UI",
+            "id": "workspace_upgradeworkspaceui"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "WorkspaceFeatures_List",
+  "title": "List Workspace features"
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/openapi.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2024-10-01-preview/openapi.json
@@ -230,6 +230,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/Workspace/operationsList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -272,6 +277,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List available MaaS PTU quota.": {
+            "$ref": "./examples/PTUQuota/listAvailable.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -305,6 +315,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get available MaaS PTU quota.": {
+            "$ref": "./examples/PTUQuota/getAvailable.json"
           }
         }
       }
@@ -346,6 +361,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List MaaS PTU usage and quota.": {
+            "$ref": "./examples/PTUQuota/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -378,6 +398,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List workspace quotas by VMFamily": {
+            "$ref": "./examples/Quota/list.json"
           }
         },
         "x-ms-pageable": {
@@ -422,6 +447,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "update quotas": {
+            "$ref": "./examples/Quota/update.json"
+          }
         }
       }
     },
@@ -452,6 +482,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Usages": {
+            "$ref": "./examples/Usage/list.json"
           }
         },
         "x-ms-pageable": {
@@ -487,6 +522,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "List VM Sizes": {
+            "$ref": "./examples/VirtualMachineSize/list.json"
+          }
         }
       }
     },
@@ -518,6 +558,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List registries by subscription.": {
+            "$ref": "./examples/Registries/listBySubscription.json"
           }
         },
         "x-ms-pageable": {
@@ -575,6 +620,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Workspaces by subscription": {
+            "$ref": "./examples/Workspace/listBySubscription.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -611,6 +661,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List registries with system created accounts.": {
+            "$ref": "./examples/Registries/list.json"
           }
         },
         "x-ms-pageable": {
@@ -657,6 +712,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry with system created accounts.": {
+            "$ref": "./examples/Registries/get.json"
           }
         }
       },
@@ -726,6 +786,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry with system created accounts.": {
+            "$ref": "./examples/Registries/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
           "final-state-schema": "#/definitions/Registry"
@@ -779,6 +844,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Update Registry with system created accounts.": {
+            "$ref": "./examples/Registries/update.json"
           }
         }
       },
@@ -841,6 +911,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Registry.": {
+            "$ref": "./examples/Registries/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -895,6 +970,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Code Container.": {
+            "$ref": "./examples/Registry/CodeContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -947,6 +1027,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Code Container.": {
+            "$ref": "./examples/Registry/CodeContainer/get.json"
           }
         }
       },
@@ -1024,6 +1109,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Code Container.": {
+            "$ref": "./examples/Registry/CodeContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/CodeContainer"
@@ -1095,6 +1185,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Code Container.": {
+            "$ref": "./examples/Registry/CodeContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1174,6 +1269,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Code Version.": {
+            "$ref": "./examples/Registry/CodeVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -1233,6 +1333,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Code Version.": {
+            "$ref": "./examples/Registry/CodeVersion/get.json"
           }
         }
       },
@@ -1317,6 +1422,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Code Version.": {
+            "$ref": "./examples/Registry/CodeVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/CodeVersion"
@@ -1397,6 +1507,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Registry Code Version.": {
+            "$ref": "./examples/Registry/CodeVersion/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -1467,6 +1582,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrGetStartPendingUpload Registry Code Version.": {
+            "$ref": "./examples/Registry/CodeVersion/createOrGetStartPendingUpload.json"
+          }
         }
       }
     },
@@ -1516,6 +1636,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Registry Component Container.": {
+            "$ref": "./examples/Registry/ComponentContainer/list.json"
           }
         },
         "x-ms-pageable": {
@@ -1570,6 +1695,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Component Container.": {
+            "$ref": "./examples/Registry/ComponentContainer/get.json"
           }
         }
       },
@@ -1647,6 +1777,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Component Container.": {
+            "$ref": "./examples/Registry/ComponentContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/ComponentContainer"
@@ -1718,6 +1853,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Component Container.": {
+            "$ref": "./examples/Registry/ComponentContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1797,6 +1937,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Component Version.": {
+            "$ref": "./examples/Registry/ComponentVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -1856,6 +2001,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Component Version.": {
+            "$ref": "./examples/Registry/ComponentVersion/get.json"
           }
         }
       },
@@ -1940,6 +2090,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Component Version.": {
+            "$ref": "./examples/Registry/ComponentVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/ComponentVersion"
@@ -2018,6 +2173,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Component Version.": {
+            "$ref": "./examples/Registry/ComponentVersion/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -2105,6 +2265,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "RegistryList Registry Data Container.": {
+            "$ref": "./examples/Registry/DataContainer/registryList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -2156,6 +2321,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Data Container.": {
+            "$ref": "./examples/Registry/DataContainer/get.json"
           }
         }
       },
@@ -2238,6 +2408,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Data Container.": {
+            "$ref": "./examples/Registry/DataContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/DataContainer"
@@ -2308,6 +2483,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Data Container.": {
+            "$ref": "./examples/Registry/DataContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -2424,6 +2604,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "RegistryList Registry Data Version Base.": {
+            "$ref": "./examples/Registry/DataVersionBase/registryList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -2482,6 +2667,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Data Version Base.": {
+            "$ref": "./examples/Registry/DataVersionBase/get.json"
           }
         }
       },
@@ -2571,6 +2761,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Data Version Base.": {
+            "$ref": "./examples/Registry/DataVersionBase/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/DataVersionBase"
@@ -2650,6 +2845,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Registry Data Version Base.": {
+            "$ref": "./examples/Registry/DataVersionBase/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2719,6 +2919,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrGetStartPendingUpload Registry Data Version Base.": {
+            "$ref": "./examples/Registry/DataVersionBase/createOrGetStartPendingUpload.json"
+          }
         }
       }
     },
@@ -2785,6 +2990,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetBlobReferenceSAS Data Reference.": {
+            "$ref": "./examples/DataReference/getBlobReferenceSAS.json"
           }
         }
       }
@@ -2868,6 +3078,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Environment Container.": {
+            "$ref": "./examples/Registry/EnvironmentContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -2920,6 +3135,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Environment Container.": {
+            "$ref": "./examples/Registry/EnvironmentContainer/get.json"
           }
         }
       },
@@ -3002,6 +3222,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Environment Container.": {
+            "$ref": "./examples/Registry/EnvironmentContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/EnvironmentContainer"
@@ -3073,6 +3298,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Environment Container.": {
+            "$ref": "./examples/Registry/EnvironmentContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3183,6 +3413,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Environment Version.": {
+            "$ref": "./examples/Registry/EnvironmentVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3242,6 +3477,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Environment Version.": {
+            "$ref": "./examples/Registry/EnvironmentVersion/get.json"
           }
         }
       },
@@ -3326,6 +3566,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Environment Version.": {
+            "$ref": "./examples/Registry/EnvironmentVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/EnvironmentVersion"
@@ -3404,6 +3649,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Environment Version.": {
+            "$ref": "./examples/Registry/EnvironmentVersion/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3491,6 +3741,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Model Container.": {
+            "$ref": "./examples/Registry/ModelContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3543,6 +3798,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Model Container.": {
+            "$ref": "./examples/Registry/ModelContainer/get.json"
           }
         }
       },
@@ -3620,6 +3880,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Model Container.": {
+            "$ref": "./examples/Registry/ModelContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/ModelContainer"
@@ -3691,6 +3956,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Registry Model Container.": {
+            "$ref": "./examples/Registry/ModelContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3829,6 +4099,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Registry Model Version.": {
+            "$ref": "./examples/Registry/ModelVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3888,6 +4163,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Registry Model Version.": {
+            "$ref": "./examples/Registry/ModelVersion/get.json"
           }
         }
       },
@@ -3972,6 +4252,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Registry Model Version.": {
+            "$ref": "./examples/Registry/ModelVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/ModelVersion"
@@ -4052,6 +4337,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Registry Model Version.": {
+            "$ref": "./examples/Registry/ModelVersion/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -4121,6 +4411,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrGetStartPendingUpload Registry Model Version.": {
+            "$ref": "./examples/Registry/ModelVersion/createOrGetStartPendingUpload.json"
           }
         }
       }
@@ -4194,6 +4489,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Remove regions from registry": {
+            "$ref": "./examples/Registries/removeRegions.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/Registry"
@@ -4254,6 +4554,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Workspaces by Resource Group": {
+            "$ref": "./examples/Workspace/listByResourceGroup.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -4298,6 +4603,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace": {
+            "$ref": "./examples/Workspace/get.json"
           }
         }
       },
@@ -4362,6 +4672,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Create Workspace": {
+            "$ref": "./examples/Workspace/create.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4433,6 +4748,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace": {
+            "$ref": "./examples/Workspace/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/Workspace"
@@ -4501,6 +4821,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Workspace": {
+            "$ref": "./examples/Workspace/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -4563,6 +4888,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -4614,6 +4944,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/get.json"
           }
         }
       },
@@ -4693,6 +5028,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4776,6 +5116,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BatchEndpoint"
@@ -4846,6 +5191,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4924,6 +5274,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Batch Deployment.": {
+            "$ref": "./examples/Workspace/BatchDeployment/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -4982,6 +5337,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Batch Deployment.": {
+            "$ref": "./examples/Workspace/BatchDeployment/get.json"
           }
         }
       },
@@ -5068,6 +5428,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Batch Deployment.": {
+            "$ref": "./examples/Workspace/BatchDeployment/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -5158,6 +5523,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Batch Deployment.": {
+            "$ref": "./examples/Workspace/BatchDeployment/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BatchDeployment"
@@ -5237,6 +5607,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Workspace Batch Deployment.": {
+            "$ref": "./examples/Workspace/BatchDeployment/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -5290,6 +5665,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "ListKeys Workspace Batch Endpoint.": {
+            "$ref": "./examples/Workspace/BatchEndpoint/listKeys.json"
+          }
         }
       }
     },
@@ -5339,6 +5719,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get CapabilityHost.": {
+            "$ref": "./examples/CapabilityHost/get.json"
           }
         }
       },
@@ -5420,6 +5805,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate CapabilityHost.": {
+            "$ref": "./examples/CapabilityHost/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/CapabilityHost"
@@ -5489,6 +5879,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete CapabilityHost.": {
+            "$ref": "./examples/CapabilityHost/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -5543,6 +5938,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Code Container.": {
+            "$ref": "./examples/Workspace/CodeContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5594,6 +5994,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Code Container.": {
+            "$ref": "./examples/Workspace/CodeContainer/get.json"
           }
         }
       },
@@ -5658,6 +6063,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Code Container.": {
+            "$ref": "./examples/Workspace/CodeContainer/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -5705,6 +6115,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Code Container.": {
+            "$ref": "./examples/Workspace/CodeContainer/delete.json"
           }
         }
       }
@@ -5793,6 +6208,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5851,6 +6271,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/get.json"
           }
         }
       },
@@ -5922,6 +6347,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -5976,6 +6406,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/delete.json"
           }
         }
       }
@@ -6055,6 +6490,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Publish Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/publish.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -6123,6 +6563,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrGetStartPendingUpload Workspace Code Version.": {
+            "$ref": "./examples/Workspace/CodeVersion/createOrGetStartPendingUpload.json"
           }
         }
       }
@@ -6206,6 +6651,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Component Container.": {
+            "$ref": "./examples/Workspace/ComponentContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -6257,6 +6707,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Component Container.": {
+            "$ref": "./examples/Workspace/ComponentContainer/get.json"
           }
         }
       },
@@ -6321,6 +6776,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Component Container.": {
+            "$ref": "./examples/Workspace/ComponentContainer/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -6368,6 +6828,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Component Container.": {
+            "$ref": "./examples/Workspace/ComponentContainer/delete.json"
           }
         }
       }
@@ -6473,6 +6938,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Component Version.": {
+            "$ref": "./examples/Workspace/ComponentVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -6531,6 +7001,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Component Version.": {
+            "$ref": "./examples/Workspace/ComponentVersion/get.json"
           }
         }
       },
@@ -6602,6 +7077,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Component Version.": {
+            "$ref": "./examples/Workspace/ComponentVersion/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -6656,6 +7136,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Component Version.": {
+            "$ref": "./examples/Workspace/ComponentVersion/delete.json"
           }
         }
       }
@@ -6735,6 +7220,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Publish Workspace Component Version.": {
+            "$ref": "./examples/Workspace/ComponentVersion/publish.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -6788,6 +7278,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Computes": {
+            "$ref": "./examples/Compute/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -6839,6 +7334,20 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get a AKS Compute": {
+            "$ref": "./examples/Compute/get/AKSCompute.json"
+          },
+          "Get a AML Compute": {
+            "$ref": "./examples/Compute/get/AmlCompute.json"
+          },
+          "Get a Kubernetes Compute": {
+            "$ref": "./examples/Compute/get/KubernetesCompute.json"
+          },
+          "Get an ComputeInstance": {
+            "$ref": "./examples/Compute/get/ComputeInstance.json"
           }
         }
       },
@@ -6915,6 +7424,35 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Attach a Kubernetes Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/KubernetesCompute.json"
+          },
+          "Create a AML Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/BasicAmlCompute.json"
+          },
+          "Create a DataFactory Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/BasicDataFactoryCompute.json"
+          },
+          "Create an AKS Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/BasicAKSCompute.json"
+          },
+          "Create an ComputeInstance Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/ComputeInstance.json"
+          },
+          "Create an ComputeInstance Compute with Schedules": {
+            "$ref": "./examples/Compute/createOrUpdate/ComputeInstanceWithSchedules.json"
+          },
+          "Create an ComputeInstance Compute with minimal inputs": {
+            "$ref": "./examples/Compute/createOrUpdate/ComputeInstanceMinimal.json"
+          },
+          "Update a AML Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/AmlCompute.json"
+          },
+          "Update an AKS Compute": {
+            "$ref": "./examples/Compute/createOrUpdate/AKSCompute.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ComputeResource"
@@ -6986,6 +7524,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Update a AmlCompute Compute": {
+            "$ref": "./examples/Compute/patch.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7080,6 +7623,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Compute": {
+            "$ref": "./examples/Compute/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7142,6 +7690,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Update Custom Services": {
+            "$ref": "./examples/Compute/updateCustomServices.json"
+          }
         }
       }
     },
@@ -7191,6 +7744,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List VM Sizes": {
+            "$ref": "./examples/Compute/getAllowedVMSizesForResize.json"
           }
         }
       }
@@ -7242,6 +7800,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "List AKS Compute Keys": {
+            "$ref": "./examples/Compute/listKeys.json"
+          }
         }
       }
     },
@@ -7291,6 +7854,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get compute nodes information for a compute": {
+            "$ref": "./examples/Compute/listNodes.json"
           }
         },
         "x-ms-pageable": {
@@ -7364,6 +7932,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List VM Sizes": {
+            "$ref": "./examples/Compute/resize.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7424,6 +7997,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Restart ComputeInstance Compute": {
+            "$ref": "./examples/Compute/restart.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7488,6 +8066,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Start ComputeInstance Compute": {
+            "$ref": "./examples/Compute/start.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7548,6 +8131,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Stop ComputeInstance Compute": {
+            "$ref": "./examples/Compute/stop.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7613,6 +8201,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Update Data Mounts": {
+            "$ref": "./examples/Compute/updateDataMounts.json"
+          }
         }
       }
     },
@@ -7668,6 +8261,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Update idle shutdown setting of ComputeInstance": {
+            "$ref": "./examples/Compute/updateIdleShutdownSetting.json"
           }
         }
       }
@@ -7735,6 +8333,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "ListWorkspaceConnections": {
+            "$ref": "./examples/WorkspaceConnection/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -7787,6 +8390,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/get.json"
           }
         }
       },
@@ -7846,6 +8454,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/create.json"
+          }
         }
       },
       "patch": {
@@ -7904,6 +8517,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "UpdateWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/update.json"
+          }
         }
       },
       "delete": {
@@ -7952,6 +8570,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/delete.json"
           }
         }
       }
@@ -8010,6 +8633,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Azure OpenAI Connection Deployments": {
+            "$ref": "./examples/WorkspaceConnection/listDeployments.json"
           }
         },
         "x-ms-pageable": {
@@ -8072,6 +8700,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure OpenAI Connection Deployment": {
+            "$ref": "./examples/WorkspaceConnection/getDeployment.json"
           }
         }
       },
@@ -8164,6 +8797,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Azure OpenAI Connection Deployment": {
+            "$ref": "./examples/WorkspaceConnection/createDeployment.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/EndpointDeploymentResourcePropertiesBasicResource"
@@ -8244,6 +8882,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Azure OpenAI Connection Deployment": {
+            "$ref": "./examples/WorkspaceConnection/deleteDeployment.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -8297,6 +8940,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/listSecrets.json"
           }
         }
       }
@@ -8355,6 +9003,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure OpenAI Connection Models": {
+            "$ref": "./examples/WorkspaceConnection/getModels.json"
           }
         },
         "x-ms-pageable": {
@@ -8418,6 +9071,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Rai Blocklist": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklist/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8478,6 +9136,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Rai Blocklist": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklist/get.json"
           }
         }
       },
@@ -8570,6 +9233,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Rai Blocklist": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklist/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/RaiBlocklistPropertiesBasicResource"
@@ -8648,6 +9316,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Rai Blocklist": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklist/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -8739,6 +9412,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Bulk Rai Blocklist Items": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/addBulk.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/RaiBlocklistItemPropertiesBasicResourceArray"
@@ -8826,6 +9504,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Bulk Rai Blocklist Items": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/deleteBulk.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -8896,6 +9579,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List RaiBlocklist Items": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8964,6 +9652,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Rai RaiBlocklist Item": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/get.json"
           }
         }
       },
@@ -9064,6 +9757,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create RaiBlocklist Item": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/RaiBlocklistItemPropertiesBasicResource"
@@ -9152,6 +9850,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete RaiBlocklist Item": {
+            "$ref": "./examples/WorkspaceConnection/RaiBlocklistItem/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -9214,6 +9917,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Rai policy": {
+            "$ref": "./examples/WorkspaceConnection/RaiPolicy/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -9274,6 +9982,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Rai policy": {
+            "$ref": "./examples/WorkspaceConnection/RaiPolicy/get.json"
           }
         }
       },
@@ -9366,6 +10079,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Rai policy": {
+            "$ref": "./examples/WorkspaceConnection/RaiPolicy/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/RaiPolicyPropertiesBasicResource"
@@ -9446,6 +10164,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Rai policy": {
+            "$ref": "./examples/WorkspaceConnection/RaiPolicy/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -9516,6 +10239,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "TestWorkspaceConnection": {
+            "$ref": "./examples/WorkspaceConnection/testConnection.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -9603,6 +10331,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Data Container.": {
+            "$ref": "./examples/Workspace/DataContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -9654,6 +10387,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Data Container.": {
+            "$ref": "./examples/Workspace/DataContainer/get.json"
           }
         }
       },
@@ -9718,6 +10456,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Data Container.": {
+            "$ref": "./examples/Workspace/DataContainer/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -9765,6 +10508,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Data Container.": {
+            "$ref": "./examples/Workspace/DataContainer/delete.json"
           }
         }
       }
@@ -9877,6 +10625,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Data Version Base.": {
+            "$ref": "./examples/Workspace/DataVersionBase/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -9935,6 +10688,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Data Version Base.": {
+            "$ref": "./examples/Workspace/DataVersionBase/get.json"
           }
         }
       },
@@ -10006,6 +10764,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Data Version Base.": {
+            "$ref": "./examples/Workspace/DataVersionBase/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -10060,6 +10823,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Data Version Base.": {
+            "$ref": "./examples/Workspace/DataVersionBase/delete.json"
           }
         }
       }
@@ -10137,6 +10905,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Publish Workspace Data Version Base.": {
+            "$ref": "./examples/Workspace/DataVersionBase/publish.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -10242,6 +11015,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List datastores.": {
+            "$ref": "./examples/Datastore/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -10293,6 +11071,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get datastore.": {
+            "$ref": "./examples/Datastore/get.json"
           }
         }
       },
@@ -10365,6 +11148,20 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate datastore (Azure Data Lake Gen1 w/ ServicePrincipal).": {
+            "$ref": "./examples/Datastore/AzureDataLakeGen1WServicePrincipal/createOrUpdate.json"
+          },
+          "CreateOrUpdate datastore (Azure Data Lake Gen2 w/ Service Principal).": {
+            "$ref": "./examples/Datastore/AzureDataLakeGen2WServicePrincipal/createOrUpdate.json"
+          },
+          "CreateOrUpdate datastore (Azure File store w/ AccountKey).": {
+            "$ref": "./examples/Datastore/AzureFileWAccountKey/createOrUpdate.json"
+          },
+          "CreateOrUpdate datastore (AzureBlob w/ AccountKey).": {
+            "$ref": "./examples/Datastore/AzureBlobWAccountKey/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -10412,6 +11209,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete datastore.": {
+            "$ref": "./examples/Datastore/delete.json"
           }
         }
       }
@@ -10471,6 +11273,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get datastore secrets.": {
+            "$ref": "./examples/Datastore/listSecrets.json"
           }
         }
       }
@@ -10568,6 +11375,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Endpoint Deployments In Workspace": {
+            "$ref": "./examples/Endpoint/Deployment/getInWorkspace.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -10635,6 +11447,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Diagnose Workspace": {
+            "$ref": "./examples/Workspace/diagnose.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -10765,6 +11582,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Endpoint": {
+            "$ref": "./examples/Endpoint/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -10817,6 +11639,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Endpoint": {
+            "$ref": "./examples/Endpoint/get.json"
           }
         }
       },
@@ -10891,6 +11718,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Endpoint": {
+            "$ref": "./examples/Endpoint/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/EndpointResourcePropertiesBasicResource"
@@ -10945,6 +11777,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Endpoint Deployments": {
+            "$ref": "./examples/Endpoint/Deployment/getDeployments.json"
           }
         },
         "x-ms-pageable": {
@@ -11007,6 +11844,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Endpoint Deployment": {
+            "$ref": "./examples/Endpoint/Deployment/get.json"
           }
         }
       },
@@ -11089,6 +11931,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Endpoint Deployment": {
+            "$ref": "./examples/Endpoint/Deployment/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/EndpointDeploymentResourcePropertiesBasicResource"
@@ -11169,6 +12016,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Endpoint Deployment": {
+            "$ref": "./examples/Endpoint/Deployment/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11223,6 +12075,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "List Endpoint Keys": {
+            "$ref": "./examples/Endpoint/listKeys.json"
+          }
         }
       }
     },
@@ -11273,6 +12130,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Endpoint Models": {
+            "$ref": "./examples/Endpoint/getModels.json"
           }
         },
         "x-ms-pageable": {
@@ -11336,6 +12198,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Rai policies": {
+            "$ref": "./examples/Endpoint/RaiPolicy/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -11396,6 +12263,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Rai policy": {
+            "$ref": "./examples/Endpoint/RaiPolicy/get.json"
           }
         }
       },
@@ -11488,6 +12360,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Create Rai policy": {
+            "$ref": "./examples/Endpoint/RaiPolicy/create.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/RaiPolicyPropertiesBasicResource"
@@ -11568,6 +12445,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Rai policy": {
+            "$ref": "./examples/Endpoint/RaiPolicy/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11630,6 +12512,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Regenerate Endpoint Keys": {
+            "$ref": "./examples/Endpoint/regenerateKey.json"
           }
         }
       }
@@ -11713,6 +12600,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Environment Container.": {
+            "$ref": "./examples/Workspace/EnvironmentContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -11764,6 +12656,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Environment Container.": {
+            "$ref": "./examples/Workspace/EnvironmentContainer/get.json"
           }
         }
       },
@@ -11828,6 +12725,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Environment Container.": {
+            "$ref": "./examples/Workspace/EnvironmentContainer/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -11875,6 +12777,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Environment Container.": {
+            "$ref": "./examples/Workspace/EnvironmentContainer/delete.json"
           }
         }
       }
@@ -11980,6 +12887,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Environment Version.": {
+            "$ref": "./examples/Workspace/EnvironmentVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12038,6 +12950,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Environment Version.": {
+            "$ref": "./examples/Workspace/EnvironmentVersion/get.json"
           }
         }
       },
@@ -12109,6 +13026,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Environment Version.": {
+            "$ref": "./examples/Workspace/EnvironmentVersion/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -12163,6 +13085,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Environment Version.": {
+            "$ref": "./examples/Workspace/EnvironmentVersion/delete.json"
           }
         }
       }
@@ -12242,6 +13169,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Publish Workspace Environment Version.": {
+            "$ref": "./examples/Workspace/EnvironmentVersion/publish.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -12286,6 +13218,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Workspace features": {
+            "$ref": "./examples/WorkspaceFeature/list.json"
           }
         },
         "x-ms-pageable": {
@@ -12409,6 +13346,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Featureset Container.": {
+            "$ref": "./examples/Workspace/FeaturesetContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12460,6 +13402,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetEntity Workspace Featureset Container.": {
+            "$ref": "./examples/Workspace/FeaturesetContainer/getEntity.json"
           }
         }
       },
@@ -12541,6 +13488,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Featureset Container.": {
+            "$ref": "./examples/Workspace/FeaturesetContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/FeaturesetContainer"
@@ -12611,6 +13563,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Featureset Container.": {
+            "$ref": "./examples/Workspace/FeaturesetContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -12756,6 +13713,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Featureset Version.": {
+            "$ref": "./examples/Workspace/FeaturesetVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12814,6 +13776,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Featureset Version.": {
+            "$ref": "./examples/Workspace/FeaturesetVersion/get.json"
           }
         }
       },
@@ -12902,6 +13869,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Featureset Version.": {
+            "$ref": "./examples/Workspace/FeaturesetVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/FeaturesetVersion"
@@ -12979,6 +13951,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Featureset Version.": {
+            "$ref": "./examples/Workspace/FeaturesetVersion/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13063,6 +14040,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Backfill Workspace Featureset Version.": {
+            "$ref": "./examples/Workspace/FeaturesetVersion/backfill.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13196,6 +14178,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Feature.": {
+            "$ref": "./examples/Feature/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -13263,6 +14250,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Feature.": {
+            "$ref": "./examples/Feature/get.json"
           }
         }
       }
@@ -13383,6 +14375,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Featurestore Entity Container.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -13434,6 +14431,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetEntity Workspace Featurestore Entity Container.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityContainer/getEntity.json"
           }
         }
       },
@@ -13515,6 +14517,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Featurestore Entity Container.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityContainer/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/FeaturestoreEntityContainer"
@@ -13585,6 +14592,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Featurestore Entity Container.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityContainer/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13730,6 +14742,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Featurestore Entity Version.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -13788,6 +14805,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Featurestore Entity Version.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityVersion/get.json"
           }
         }
       },
@@ -13876,6 +14898,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Featurestore Entity Version.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityVersion/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/FeaturestoreEntityVersion"
@@ -13953,6 +14980,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Featurestore Entity Version.": {
+            "$ref": "./examples/Workspace/FeaturestoreEntityVersion/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14066,6 +15098,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Inference Pool.": {
+            "$ref": "./examples/Workspace/InferencePool/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -14118,6 +15155,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Inference Pool.": {
+            "$ref": "./examples/Workspace/InferencePool/get.json"
           }
         }
       },
@@ -14193,6 +15235,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Inference Pool.": {
+            "$ref": "./examples/Workspace/InferencePool/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14277,6 +15324,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Inference Pool.": {
+            "$ref": "./examples/Workspace/InferencePool/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/InferencePool"
@@ -14348,6 +15400,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Inference Pool.": {
+            "$ref": "./examples/Workspace/InferencePool/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14469,6 +15526,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Inference Endpoint.": {
+            "$ref": "./examples/Workspace/InferenceEndpoint/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -14529,6 +15591,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Inference Endpoint.": {
+            "$ref": "./examples/Workspace/InferenceEndpoint/get.json"
           }
         }
       },
@@ -14612,6 +15679,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Inference Endpoint.": {
+            "$ref": "./examples/Workspace/InferenceEndpoint/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14705,6 +15777,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Inference Endpoint.": {
+            "$ref": "./examples/Workspace/InferenceEndpoint/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/InferenceEndpoint"
@@ -14784,6 +15861,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Inference Endpoint.": {
+            "$ref": "./examples/Workspace/InferenceEndpoint/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -14905,6 +15987,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -14965,6 +16052,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/get.json"
           }
         }
       },
@@ -15048,6 +16140,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -15140,6 +16237,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/InferenceGroup"
@@ -15221,6 +16323,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -15292,6 +16399,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "GetDeltaModelsStatusAsync Inference Group.": {
+            "$ref": "./examples/InferenceGroup/getDeltaModelsStatusAsync.json"
+          }
         }
       }
     },
@@ -15359,6 +16471,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "ListDeltaModelsAsync Inference Group.": {
+            "$ref": "./examples/InferenceGroup/listDeltaModelsAsync.json"
           }
         },
         "x-ms-pageable": {
@@ -15440,6 +16557,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "ModifyDeltaModelsAsync Inference Group.": {
+            "$ref": "./examples/InferenceGroup/modifyDeltaModelsAsync.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -15501,6 +16623,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "GetStatus Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/getStatus.json"
           }
         }
       }
@@ -15575,6 +16702,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "ListSkus Workspace Inference Group.": {
+            "$ref": "./examples/Workspace/InferenceGroup/listSkus.json"
           }
         },
         "x-ms-pageable": {
@@ -15682,6 +16814,26 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List AutoML Job.": {
+            "$ref": "./examples/Job/AutoMLJob/list.json"
+          },
+          "List Command Job.": {
+            "$ref": "./examples/Job/CommandJob/list.json"
+          },
+          "List Distillation Job.": {
+            "$ref": "./examples/Job/DistillationJob/list.json"
+          },
+          "List FineTuning Job.": {
+            "$ref": "./examples/Job/FineTuningJob/list.json"
+          },
+          "List Pipeline Job.": {
+            "$ref": "./examples/Job/PipelineJob/list.json"
+          },
+          "List Sweep Job.": {
+            "$ref": "./examples/Job/SweepJob/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -15733,6 +16885,26 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get AutoML Job.": {
+            "$ref": "./examples/Job/AutoMLJob/get.json"
+          },
+          "Get Command Job.": {
+            "$ref": "./examples/Job/CommandJob/get.json"
+          },
+          "Get Distillation Job.": {
+            "$ref": "./examples/Job/DistillationJob/get.json"
+          },
+          "Get FineTuning Job.": {
+            "$ref": "./examples/Job/FineTuningJob/get.json"
+          },
+          "Get Pipeline Job.": {
+            "$ref": "./examples/Job/PipelineJob/get.json"
+          },
+          "Get Sweep Job.": {
+            "$ref": "./examples/Job/SweepJob/get.json"
           }
         }
       },
@@ -15796,6 +16968,26 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate AutoML Job.": {
+            "$ref": "./examples/Job/AutoMLJob/createOrUpdate.json"
+          },
+          "CreateOrUpdate Command Job.": {
+            "$ref": "./examples/Job/CommandJob/createOrUpdate.json"
+          },
+          "CreateOrUpdate Distillation Job.": {
+            "$ref": "./examples/Job/DistillationJob/createOrUpdate.json"
+          },
+          "CreateOrUpdate FineTuning Job.": {
+            "$ref": "./examples/Job/FineTuningJob/createOrUpdate.json"
+          },
+          "CreateOrUpdate Pipeline Job.": {
+            "$ref": "./examples/Job/PipelineJob/createOrUpdate.json"
+          },
+          "CreateOrUpdate Sweep Job.": {
+            "$ref": "./examples/Job/SweepJob/createOrUpdate.json"
           }
         }
       },
@@ -15865,6 +17057,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Job.": {
+            "$ref": "./examples/Job/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -15930,6 +17127,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Cancel Job.": {
+            "$ref": "./examples/Job/cancel.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -15976,6 +17178,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get models under the Azure ML workspace for all Azure OpenAI connections that the user can deploy": {
+            "$ref": "./examples/WorkspaceConnection/listConnectionModels.json"
+          }
         }
       }
     },
@@ -16018,6 +17225,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Workspace Keys": {
+            "$ref": "./examples/Workspace/listKeys.json"
           }
         }
       }
@@ -16062,6 +17274,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "List Workspace Keys": {
+            "$ref": "./examples/Workspace/listNotebookAccessToken.json"
+          }
         }
       }
     },
@@ -16104,6 +17321,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Workspace Keys": {
+            "$ref": "./examples/Notebook/listKeys.json"
           }
         }
       }
@@ -16148,6 +17370,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "List Workspace Keys": {
+            "$ref": "./examples/Workspace/listStorageAccountKeys.json"
+          }
         }
       }
     },
@@ -16190,6 +17417,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/listManagedNetworkV2.json"
           }
         },
         "x-ms-pageable": {
@@ -16244,6 +17476,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/getManagedNetworkV2.json"
           }
         }
       },
@@ -16316,6 +17553,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Put ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16393,6 +17635,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Patch ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/patchManagedNetworkV2.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16474,6 +17721,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Post OutboundRules": {
+            "$ref": "./examples/ManagedNetwork/postOutboundRulesV2.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/OutboundRuleListResult"
@@ -16531,6 +17783,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List OutboundRules": {
+            "$ref": "./examples/ManagedNetwork/listRuleV2.json"
           }
         },
         "x-ms-pageable": {
@@ -16593,6 +17850,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/getRuleV2.json"
           }
         }
       },
@@ -16674,6 +17936,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/createOrUpdateRuleV2.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/OutboundRuleBasicResource"
@@ -16747,6 +18014,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/deleteRuleV2.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -16801,6 +18073,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Marketplace Subscription.": {
+            "$ref": "./examples/Workspace/MarketplaceSubscription/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -16852,6 +18129,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Marketplace Subscription.": {
+            "$ref": "./examples/Workspace/MarketplaceSubscription/get.json"
           }
         }
       },
@@ -16928,6 +18210,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Marketplace Subscription.": {
+            "$ref": "./examples/Workspace/MarketplaceSubscription/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/MarketplaceSubscription"
@@ -16995,6 +18282,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Marketplace Subscription.": {
+            "$ref": "./examples/Workspace/MarketplaceSubscription/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -17090,6 +18382,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Model Container.": {
+            "$ref": "./examples/Workspace/ModelContainer/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -17141,6 +18438,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Model Container.": {
+            "$ref": "./examples/Workspace/ModelContainer/get.json"
           }
         }
       },
@@ -17205,6 +18507,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Model Container.": {
+            "$ref": "./examples/Workspace/ModelContainer/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -17252,6 +18559,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Model Container.": {
+            "$ref": "./examples/Workspace/ModelContainer/delete.json"
           }
         }
       }
@@ -17400,6 +18712,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Model Version.": {
+            "$ref": "./examples/Workspace/ModelVersion/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -17458,6 +18775,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Model Version.": {
+            "$ref": "./examples/Workspace/ModelVersion/get.json"
           }
         }
       },
@@ -17529,6 +18851,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Model Version.": {
+            "$ref": "./examples/Workspace/ModelVersion/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -17583,6 +18910,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Model Version.": {
+            "$ref": "./examples/Workspace/ModelVersion/delete.json"
           }
         }
       }
@@ -17660,6 +18992,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Publish Workspace Model Version.": {
+            "$ref": "./examples/Workspace/ModelVersion/publish.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -17810,6 +19147,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -17861,6 +19203,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/get.json"
           }
         }
       },
@@ -17935,6 +19282,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -18018,6 +19370,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/OnlineEndpoint"
@@ -18088,6 +19445,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/delete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -18166,6 +19528,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Online Deployments.": {
+            "$ref": "./examples/OnlineDeployment/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -18224,6 +19591,14 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Kubernetes Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/KubernetesOnlineDeployment/get.json"
+          },
+          "Get Managed Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/ManagedOnlineDeployment/get.json"
           }
         }
       },
@@ -18305,6 +19680,14 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Kubernetes Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/KubernetesOnlineDeployment/createOrUpdate.json"
+          },
+          "CreateOrUpdate Managed Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/ManagedOnlineDeployment/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -18395,6 +19778,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Kubernetes Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/KubernetesOnlineDeployment/update.json"
+          },
+          "Update Managed Online Deployment.": {
+            "$ref": "./examples/OnlineDeployment/ManagedOnlineDeployment/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/OnlineDeployment"
@@ -18474,6 +19865,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Workspace Online Deployment.": {
+            "$ref": "./examples/Workspace/OnlineDeployment/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -18542,6 +19938,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Online Deployment Logs.": {
+            "$ref": "./examples/OnlineDeployment/getLogs.json"
           }
         }
       }
@@ -18616,6 +20017,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Kubernetes Online Deployment Skus.": {
+            "$ref": "./examples/OnlineDeployment/KubernetesOnlineDeployment/listSkus.json"
+          },
+          "List Managed Online Deployment Skus.": {
+            "$ref": "./examples/OnlineDeployment/ManagedOnlineDeployment/listSkus.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -18667,6 +20076,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "ListKeys Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/listKeys.json"
           }
         }
       }
@@ -18739,6 +20153,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "RegenerateKeys Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/regenerateKeys.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -18792,6 +20211,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "GetToken Workspace Online Endpoint.": {
+            "$ref": "./examples/Workspace/OnlineEndpoint/getToken.json"
+          }
         }
       }
     },
@@ -18835,6 +20259,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "ListOutboundNetworkDependenciesEndpoints": {
+            "$ref": "./examples/ExternalFQDN/get.json"
+          }
         }
       }
     },
@@ -18877,6 +20306,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List ManagedNetworkSettingsRule": {
+            "$ref": "./examples/ManagedNetwork/listRule.json"
           }
         },
         "x-ms-pageable": {
@@ -18931,6 +20365,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get ManagedNetworkSettingsRule": {
+            "$ref": "./examples/ManagedNetwork/getRule.json"
           }
         }
       },
@@ -19005,6 +20444,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate ManagedNetworkSettingsRule": {
+            "$ref": "./examples/ManagedNetwork/createOrUpdateRule.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/OutboundRuleBasicResource"
@@ -19073,6 +20517,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete ManagedNetworkSettingsRule": {
+            "$ref": "./examples/ManagedNetwork/deleteRule.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -19134,6 +20583,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Prepare Notebook": {
+            "$ref": "./examples/Notebook/prepare.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/NotebookResourceInfo"
@@ -19180,6 +20634,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListPrivateEndpointConnections": {
+            "$ref": "./examples/PrivateEndpointConnection/list.json"
           }
         },
         "x-ms-pageable": {
@@ -19233,6 +20692,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "WorkspaceGetPrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/get.json"
           }
         }
       },
@@ -19291,6 +20755,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "WorkspacePutPrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/createOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -19339,6 +20808,11 @@
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "WorkspacePutPrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/delete.json"
+          }
         }
       }
     },
@@ -19381,6 +20855,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "WorkspaceListPrivateLinkResources": {
+            "$ref": "./examples/PrivateLinkResource/list.json"
           }
         },
         "x-ms-pageable": {
@@ -19452,6 +20931,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Provision ManagedNetwork": {
+            "$ref": "./examples/ManagedNetwork/provision.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ManagedNetworkProvisionStatus"
@@ -19509,6 +20993,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Resync Workspace Keys": {
+            "$ref": "./examples/Workspace/resyncKeys.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -19596,6 +21085,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Schedules.": {
+            "$ref": "./examples/Schedule/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -19647,6 +21141,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Schedule.": {
+            "$ref": "./examples/Schedule/get.json"
           }
         }
       },
@@ -19723,6 +21222,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CreateOrUpdate Schedule.": {
+            "$ref": "./examples/Schedule/createOrUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "original-uri",
           "final-state-schema": "#/definitions/Schedule"
@@ -19795,6 +21299,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Schedule.": {
+            "$ref": "./examples/Schedule/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -19849,6 +21358,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/list.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -19900,6 +21414,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/get.json"
           }
         }
       },
@@ -19974,6 +21493,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/createOrUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20057,6 +21581,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/update.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ServerlessEndpoint"
@@ -20126,6 +21655,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -20178,6 +21712,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "ListKeys Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/listKeys.json"
           }
         }
       }
@@ -20251,6 +21790,11 @@
             "schema": {
               "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "RegenerateKeys Workspace Serverless Endpoint.": {
+            "$ref": "./examples/Workspace/ServerlessEndpoint/regenerateKeys.json"
           }
         },
         "x-ms-long-running-operation-options": {


### PR DESCRIPTION
## Summary

The `2024-10-01-preview` API version of `Microsoft.MachineLearningServices` is missing all of its operation examples. When this version was migrated to TypeSpec (#40758), its `examples/2024-10-01-preview/` source folder was created containing **only a `.gitkeep` placeholder**, so the generated `openapi.json` shipped with **zero `x-ms-examples`** — even though:

- the version had **311 examples before the migration**, and
- **every sibling version** (e.g. `2025-10-01-preview`) carries a full example set.

This is a pre-existing gap from the TypeSpec migration. It also causes `ModelValidation` to fail on this version whenever its `openapi.json` is otherwise touched (no examples to satisfy the gate).

## What this PR does

Restores the **322 examples** into both trees and regenerates the spec:

- `+322` examples in the TypeSpec source tree (`MachineLearningServices.Management/examples/2024-10-01-preview/`), removing the `.gitkeep`.
- `+322` examples in the resource-manager output tree (`preview/2024-10-01-preview/examples/`).
- Regenerated `preview/2024-10-01-preview/openapi.json`, wiring in **289 `x-ms-examples`** entries.

The examples are sourced from the structurally identical `2025-10-01-preview` set with the `api-version` re-versioned to `2024-10-01-preview`.

## Scope / safety

**Purely additive test fixtures — no API, schema, or contract change.** The `openapi.json` diff consists exclusively of `x-ms-examples` wiring (verified: 0 changes to definitions/properties/paths schemas, 0 removed lines).

## Validation

- ✅ `oav validate-example` — *Validation completes without errors*
- ✅ `oav validate-spec` — *without error*
- ✅ `prettier --check` (repo pinned `3.8.3`, `json-swagger` parser) — *All matched files use Prettier code style!*
- ✅ All 322 `x-ms-examples` `$ref` targets resolve to committed files
- ✅ `openapi.json` diff vs `main` is exclusively `x-ms-examples` additions (no schema/field changes)