### PR TITLE
Add PATCH agentpool, list-operations-by-agentpool, and operationType/subOperationType in OperationStatusResult

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPool.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPool.tsp
@@ -151,6 +151,45 @@ interface AgentPools {
   >;
 
   /**
+   * Updates an agent pool in the specified managed cluster. Visit https://aka.ms/aks/concurrent-node-operations for more information.
+   */
+  @added(Versions.v2026_06_02_preview)
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
+    AgentPool,
+    PatchModel = AgentPoolUpdate,
+    LroHeaders = ArmAsyncOperationHeaderWithLocation<FinalResult = AgentPool> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Parameters = {
+      /**
+       * The request should only proceed if an entity matches this string.
+       */
+      @header
+      ifMatch?: string;
+    }
+  >;
+
+  /**
+   * Gets a list of operations in the specified agent pool.
+   */
+  @list
+  @get
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/operations")
+  @added(Versions.v2026_06_02_preview)
+  listByAgentPool is AgentPoolsOps.ActionSync<
+    AgentPool,
+    void,
+    ArmResponse<OperationStatusResultList>,
+    Parameters = {
+      /**
+       * If true, only return operations that are currently active (not terminal).
+       */
+      @query
+      activeOnly?: boolean;
+    }
+  >;
+
+  /**
    * Get the status of a specific operation in the specified agent pool.
    */
   @get
@@ -159,7 +198,7 @@ interface AgentPools {
   getByAgentPool is AgentPoolsOps.ActionSync<
     AgentPool,
     void,
-    ArmResponse<Azure.ResourceManager.CommonTypes.OperationStatusResult>,
+    ArmResponse<OperationStatusResult>,
     Parameters = {
       /**
        * The ID of an ongoing async operation.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1182,3 +1182,69 @@ model AgentPoolDeleteMachinesParameter {
    */
   machineNames: string[];
 }
+
+/**
+ * Agent pool.
+ */
+@added(Versions.v2026_06_02_preview)
+model AgentPoolUpdate {
+  /**
+   * Properties for the agent pool.
+   */
+  properties?: AgentPoolUpdateProperties;
+}
+
+/**
+ * Properties for the agent pool.
+ */
+@added(Versions.v2026_06_02_preview)
+model AgentPoolUpdateProperties {
+  /**
+   * Number of agents (VMs) to host docker containers.
+   */
+  count?: int32;
+
+  /**
+   * Specifications on VirtualMachines agent pool.
+   */
+  virtualMachinesProfile?: AgentPoolUpdateVirtualMachinesProfile;
+}
+
+/**
+ * Specifications on VirtualMachines agent pool.
+ */
+@added(Versions.v2026_06_02_preview)
+model AgentPoolUpdateVirtualMachinesProfile {
+  /**
+   * Specifications on how to scale a VirtualMachines agent pool.
+   */
+  scale?: AgentPoolUpdateScaleProfile;
+}
+
+/**
+ * Specifications on how to scale a VirtualMachines agent pool.
+ */
+@added(Versions.v2026_06_02_preview)
+model AgentPoolUpdateScaleProfile {
+  /**
+   * Specifications on how to scale the VirtualMachines agent pool to a fixed size.
+   */
+  @identifiers(#[])
+  manual?: AgentPoolUpdateManualScaleProfile[];
+}
+
+/**
+ * Specifications on number of machines.
+ */
+@added(Versions.v2026_06_02_preview)
+model AgentPoolUpdateManualScaleProfile {
+  /**
+   * VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'.
+   */
+  size?: string;
+
+  /**
+   * Number of nodes.
+   */
+  count?: int32;
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/BackCompatible.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/BackCompatible.tsp
@@ -186,8 +186,10 @@ model AgentPoolCustomize
 @@clientName(ManagedNamespaces.update::parameters.properties, "parameters");
 
 @@clientName(AgentPools.createOrUpdate::parameters.resource, "parameters");
+@@clientName(AgentPools.update::parameters.properties, "parameters");
 @@clientName(AgentPools.deleteMachines::parameters.body, "machines");
 @@clientLocation(AgentPools.getByAgentPool, "OperationStatusResult", "!csharp");
+@@clientLocation(AgentPools.listByAgentPool, "OperationStatusResult", "!csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Property flatten for SDK backward compatibility."
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(AgentPool.properties);
 
@@ -265,6 +267,7 @@ model AgentPoolCustomize
 );
 
 @@clientLocation(AgentPools.getByAgentPool, "OperationStatusResult");
+@@clientLocation(AgentPools.listByAgentPool, "OperationStatusResult");
 
 @@clientLocation(AgentPoolUpgradeProfiles.getUpgradeProfile, AgentPools);
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/BackCompatible.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/BackCompatible.tsp
@@ -189,7 +189,11 @@ model AgentPoolCustomize
 @@clientName(AgentPools.update::parameters.properties, "parameters");
 @@clientName(AgentPools.deleteMachines::parameters.body, "machines");
 @@clientLocation(AgentPools.getByAgentPool, "OperationStatusResult", "!csharp");
-@@clientLocation(AgentPools.listByAgentPool, "OperationStatusResult", "!csharp");
+@@clientLocation(
+  AgentPools.listByAgentPool,
+  "OperationStatusResult",
+  "!csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Property flatten for SDK backward compatibility."
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(AgentPool.properties);
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -4365,7 +4365,53 @@ model SubResource {
  * The current status of an async operation.
  */
 model OperationStatusResult {
-  ...Azure.ResourceManager.CommonTypes.OperationStatusResult;
+  /**
+   * Fully qualified ID for the async operation.
+   */
+  id?: Azure.Core.armResourceIdentifier;
+
+  /**
+   * Name of the async operation.
+   */
+  name?: string;
+
+  /**
+   * Operation status.
+   */
+  status: string;
+
+  /**
+   * Percent of the operation that is complete.
+   */
+  @minValue(0)
+  @maxValue(100)
+  percentComplete?: float64;
+
+  /**
+   * The start time of the operation.
+   */
+  startTime?: utcDateTime;
+
+  /**
+   * The end time of the operation.
+   */
+  endTime?: utcDateTime;
+
+  /**
+   * The operations list.
+   */
+  operations?: OperationStatusResult[];
+
+  /**
+   * If present, details of the operation error.
+   */
+  error?: Azure.ResourceManager.CommonTypes.ErrorDetail;
+
+  /**
+   * Fully qualified ID of the resource against which the original async operation was started.
+   */
+  @visibility(Lifecycle.Read)
+  resourceId?: Azure.Core.armResourceIdentifier;
 
   /**
    * The type of the operation.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -4362,6 +4362,27 @@ model SubResource {
 }
 
 /**
+ * The current status of an async operation.
+ */
+model OperationStatusResult {
+  ...Azure.ResourceManager.CommonTypes.OperationStatusResult;
+
+  /**
+   * The type of the operation.
+   */
+  @added(Versions.v2026_06_02_preview)
+  @visibility(Lifecycle.Read)
+  operationType?: string;
+
+  /**
+   * The type of the suboperation.
+   */
+  @added(Versions.v2026_06_02_preview)
+  @visibility(Lifecycle.Read)
+  subOperationType?: string;
+}
+
+/**
  * The operations list. It contains an URL link to get the next set of results.
  */
 model OperationStatusResultList is Azure.Core.Page<OperationStatusResult>;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -4364,9 +4364,9 @@ model SubResource {
 /**
  * The current status of an async operation.
  */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "OperationStatusResult follows the ARM common type shape by inheritance."
-model OperationStatusResult
-  extends Azure.ResourceManager.CommonTypes.OperationStatusResult {
+model OperationStatusResult {
+  ...Azure.ResourceManager.CommonTypes.OperationStatusResult;
+
   /**
    * The type of the operation.
    */

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -4364,9 +4364,9 @@ model SubResource {
 /**
  * The current status of an async operation.
  */
-model OperationStatusResult {
-  ...Azure.ResourceManager.CommonTypes.OperationStatusResult;
-
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "OperationStatusResult follows the ARM common type shape by inheritance."
+model OperationStatusResult
+  extends Azure.ResourceManager.CommonTypes.OperationStatusResult {
   /**
    * The type of the operation.
    */

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/ManagedCluster.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/ManagedCluster.tsp
@@ -642,7 +642,7 @@ interface ManagedClusters {
   operationStatusResultGet is ManagedClusterOps.ActionSync<
     ManagedCluster,
     void,
-    ArmResponse<Azure.ResourceManager.CommonTypes.OperationStatusResult>,
+    ArmResponse<OperationStatusResult>,
     Parameters = {
       /**
        * The ID of an ongoing async operation.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -1324,6 +1324,7 @@ namespace Azure.ResourceManager.ContainerService.Models {
 @@scope(ManagedClusters.operationStatusResultList, "!csharp");
 @@scope(ManagedClusters.operationStatusResultGet, "!csharp");
 @@scope(AgentPools.getByAgentPool, "!csharp");
+@@scope(AgentPools.listByAgentPool, "!csharp");
 @@scope(Operations.list, "!csharp");
 
 // we add this model in this namespace in order to replace some models with this model via alternateType decorator

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsUpdate_Scale.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsUpdate_Scale.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 5
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 5,
+          "currentOrchestratorVersion": "1.9.6",
+          "eTag": "ebwiyfneowv",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "upgradeSettings": {
+            "maxSurge": "33%"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview"
+      }
+    }
+  },
+  "operationId": "AgentPools_Update",
+  "title": "Update Agent Pool - Scale VMSS"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsUpdate_ScaleVMs.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/AgentPoolsUpdate_ScaleVMs.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "parameters": {
+      "properties": {
+        "virtualMachinesProfile": {
+          "scale": {
+            "manual": [
+              {
+                "count": 5,
+                "size": "Standard_D2_v2"
+              },
+              {
+                "count": 3,
+                "size": "Standard_D2_v3"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.9.6",
+          "eTag": "ebwiyfneowv",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "virtualMachineNodesStatus": [
+            {
+              "count": 5,
+              "size": "Standard_D2_v2"
+            },
+            {
+              "count": 3,
+              "size": "Standard_D2_v3"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "manual": [
+                {
+                  "count": 5,
+                  "size": "Standard_D2_v2"
+                },
+                {
+                  "count": 3,
+                  "size": "Standard_D2_v3"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview"
+      }
+    }
+  },
+  "operationId": "AgentPools_Update",
+  "title": "Update Agent Pool - Scale VirtualMachines"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultGet.json
@@ -13,7 +13,9 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/00000000-0000-0000-0000-000000000001",
         "percentComplete": 40,
         "startTime": "2023-07-26T12:14:26.3179428Z",
-        "status": "InProgress"
+        "status": "InProgress",
+        "operationType": "PutManagedCluster",
+        "subOperationType": "Upgrading"
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultGetByAgentPool.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultGetByAgentPool.json
@@ -14,7 +14,9 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/00000000-0000-0000-0000-000000000001",
         "percentComplete": 40,
         "startTime": "2023-07-26T12:14:26.3179428Z",
-        "status": "InProgress"
+        "status": "InProgress",
+        "operationType": "PutAgentPool",
+        "subOperationType": "Upgrading"
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultList.json
@@ -14,7 +14,9 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
             "percentComplete": 40,
             "startTime": "2023-07-26T12:14:26.3179428Z",
-            "status": "InProgress"
+            "status": "InProgress",
+            "operationType": "PutManagedCluster",
+            "subOperationType": "Upgrading"
           },
           {
             "name": "d11edb09-6e27-429f-9fe5-17baf773bc4b",
@@ -25,7 +27,9 @@
             },
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4b",
             "startTime": "2023-07-26T12:14:26.3179428Z",
-            "status": "Failed"
+            "status": "Failed",
+            "operationType": "PutManagedCluster",
+            "subOperationType": "Updating"
           }
         ]
       }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultListByAgentPool.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultListByAgentPool.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "status": "ScalingAgentPool: 3/5 nodes completed",
+            "percentComplete": 60,
+            "startTime": "2026-05-06T10:05:00Z",
+            "operationType": "PatchAgentPool",
+            "subOperationType": "Scaling"
+          },
+          {
+            "name": "a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "status": "UpgradingNodes: 8/20 nodes completed",
+            "percentComplete": 40,
+            "startTime": "2026-05-06T10:00:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Upgrading"
+          },
+          {
+            "name": "b33efab1-8f49-641a-b7a7-39dcf995de6c",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/b33efab1-8f49-641a-b7a7-39dcf995de6c",
+            "status": "Failed",
+            "startTime": "2026-05-06T09:50:00Z",
+            "endTime": "2026-05-06T09:55:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Scaling",
+            "error": {
+              "code": "ScaleError",
+              "message": "Failed to scale agent pool nodepool1: insufficient quota for Standard_D2_v2 in eastus"
+            }
+          },
+          {
+            "name": "c44abbf2-9d50-752b-c8b8-40edf006ef7d",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/c44abbf2-9d50-752b-c8b8-40edf006ef7d",
+            "status": "Succeeded",
+            "percentComplete": 100,
+            "startTime": "2026-05-06T09:40:00Z",
+            "endTime": "2026-05-06T09:45:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Creating"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "OperationStatusResult_ListByAgentPool",
+  "title": "List Operations on Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultListByAgentPool_Active.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-06-02-preview/OperationStatusResultListByAgentPool_Active.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "activeOnly": true,
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "status": "ScalingAgentPool: 3/5 nodes completed",
+            "percentComplete": 60,
+            "startTime": "2026-05-06T10:05:00Z",
+            "operationType": "PatchAgentPool",
+            "subOperationType": "Scaling"
+          },
+          {
+            "name": "a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "status": "UpgradingNodes: 8/20 nodes completed",
+            "percentComplete": 40,
+            "startTime": "2026-05-06T10:00:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Upgrading"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "OperationStatusResult_ListByAgentPool",
+  "title": "List Active Operations on Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsUpdate_Scale.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsUpdate_Scale.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 5
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 5,
+          "currentOrchestratorVersion": "1.9.6",
+          "eTag": "ebwiyfneowv",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "upgradeSettings": {
+            "maxSurge": "33%"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview"
+      }
+    }
+  },
+  "operationId": "AgentPools_Update",
+  "title": "Update Agent Pool - Scale VMSS"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsUpdate_ScaleVMs.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/AgentPoolsUpdate_ScaleVMs.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "parameters": {
+      "properties": {
+        "virtualMachinesProfile": {
+          "scale": {
+            "manual": [
+              {
+                "count": 5,
+                "size": "Standard_D2_v2"
+              },
+              {
+                "count": 3,
+                "size": "Standard_D2_v3"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.9.6",
+          "eTag": "ebwiyfneowv",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "virtualMachineNodesStatus": [
+            {
+              "count": 5,
+              "size": "Standard_D2_v2"
+            },
+            {
+              "count": 3,
+              "size": "Standard_D2_v3"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "manual": [
+                {
+                  "count": 5,
+                  "size": "Standard_D2_v2"
+                },
+                {
+                  "count": 3,
+                  "size": "Standard_D2_v3"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-06-02-preview"
+      }
+    }
+  },
+  "operationId": "AgentPools_Update",
+  "title": "Update Agent Pool - Scale VirtualMachines"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultGet.json
@@ -13,7 +13,9 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/00000000-0000-0000-0000-000000000001",
         "percentComplete": 40,
         "startTime": "2023-07-26T12:14:26.3179428Z",
-        "status": "InProgress"
+        "status": "InProgress",
+        "operationType": "PutManagedCluster",
+        "subOperationType": "Upgrading"
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultGetByAgentPool.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultGetByAgentPool.json
@@ -14,7 +14,9 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/00000000-0000-0000-0000-000000000001",
         "percentComplete": 40,
         "startTime": "2023-07-26T12:14:26.3179428Z",
-        "status": "InProgress"
+        "status": "InProgress",
+        "operationType": "PutAgentPool",
+        "subOperationType": "Upgrading"
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultList.json
@@ -14,7 +14,9 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
             "percentComplete": 40,
             "startTime": "2023-07-26T12:14:26.3179428Z",
-            "status": "InProgress"
+            "status": "InProgress",
+            "operationType": "PutManagedCluster",
+            "subOperationType": "Upgrading"
           },
           {
             "name": "d11edb09-6e27-429f-9fe5-17baf773bc4b",
@@ -25,7 +27,9 @@
             },
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4b",
             "startTime": "2023-07-26T12:14:26.3179428Z",
-            "status": "Failed"
+            "status": "Failed",
+            "operationType": "PutManagedCluster",
+            "subOperationType": "Updating"
           }
         ]
       }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultListByAgentPool.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultListByAgentPool.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "status": "ScalingAgentPool: 3/5 nodes completed",
+            "percentComplete": 60,
+            "startTime": "2026-05-06T10:05:00Z",
+            "operationType": "PatchAgentPool",
+            "subOperationType": "Scaling"
+          },
+          {
+            "name": "a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "status": "UpgradingNodes: 8/20 nodes completed",
+            "percentComplete": 40,
+            "startTime": "2026-05-06T10:00:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Upgrading"
+          },
+          {
+            "name": "b33efab1-8f49-641a-b7a7-39dcf995de6c",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/b33efab1-8f49-641a-b7a7-39dcf995de6c",
+            "status": "Failed",
+            "startTime": "2026-05-06T09:50:00Z",
+            "endTime": "2026-05-06T09:55:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Scaling",
+            "error": {
+              "code": "ScaleError",
+              "message": "Failed to scale agent pool nodepool1: insufficient quota for Standard_D2_v2 in eastus"
+            }
+          },
+          {
+            "name": "c44abbf2-9d50-752b-c8b8-40edf006ef7d",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/c44abbf2-9d50-752b-c8b8-40edf006ef7d",
+            "status": "Succeeded",
+            "percentComplete": 100,
+            "startTime": "2026-05-06T09:40:00Z",
+            "endTime": "2026-05-06T09:45:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Creating"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "OperationStatusResult_ListByAgentPool",
+  "title": "List Operations on Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultListByAgentPool_Active.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/examples/OperationStatusResultListByAgentPool_Active.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "activeOnly": true,
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-06-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/d11edb09-6e27-429f-9fe5-17baf773bc4a",
+            "status": "ScalingAgentPool: 3/5 nodes completed",
+            "percentComplete": 60,
+            "startTime": "2026-05-06T10:05:00Z",
+            "operationType": "PatchAgentPool",
+            "subOperationType": "Scaling"
+          },
+          {
+            "name": "a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/operations/a22fdc10-7e38-530f-a6f6-28cbe884cd5b",
+            "status": "UpgradingNodes: 8/20 nodes completed",
+            "percentComplete": 40,
+            "startTime": "2026-05-06T10:00:00Z",
+            "operationType": "PutAgentPool",
+            "subOperationType": "Upgrading"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "OperationStatusResult_ListByAgentPool",
+  "title": "List Active Operations on Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -15277,6 +15277,53 @@
       "type": "object",
       "description": "The current status of an async operation.",
       "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified ID for the async operation."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the async operation."
+        },
+        "status": {
+          "type": "string",
+          "description": "Operation status."
+        },
+        "percentComplete": {
+          "type": "number",
+          "format": "double",
+          "description": "Percent of the operation that is complete.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the operation."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of the operation."
+        },
+        "operations": {
+          "type": "array",
+          "description": "The operations list.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+          }
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "If present, details of the operation error."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified ID of the resource against which the original async operation was started.",
+          "readOnly": true
+        },
         "operationType": {
           "type": "string",
           "description": "The type of the operation.",
@@ -15288,10 +15335,8 @@
           "readOnly": true
         }
       },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
-        }
+      "required": [
+        "status"
       ]
     },
     "OperationStatusResultList": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -1903,6 +1903,107 @@
         },
         "x-ms-long-running-operation": true
       },
+      "patch": {
+        "operationId": "AgentPools_Update",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Updates an agent pool in the specified managed cluster. Visit https://aka.ms/aks/concurrent-node-operations for more information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentPoolUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Agent Pool - Scale VMSS": {
+            "$ref": "./examples/AgentPoolsUpdate_Scale.json"
+          },
+          "Update Agent Pool - Scale VirtualMachines": {
+            "$ref": "./examples/AgentPoolsUpdate_ScaleVMs.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AgentPool"
+        },
+        "x-ms-long-running-operation": true
+      },
       "delete": {
         "operationId": "AgentPools_Delete",
         "tags": [
@@ -2554,6 +2655,78 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/operations": {
+      "get": {
+        "operationId": "OperationStatusResult_ListByAgentPool",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Gets a list of operations in the specified agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "activeOnly",
+            "in": "query",
+            "description": "If true, only return operations that are currently active (not terminal).",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatusResultList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Active Operations on Agent Pool": {
+            "$ref": "./examples/OperationStatusResultListByAgentPool_Active.json"
+          },
+          "List Operations on Agent Pool": {
+            "$ref": "./examples/OperationStatusResultListByAgentPool.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/operations/{operationId}": {
       "get": {
         "operationId": "OperationStatusResult_GetByAgentPool",
@@ -2604,7 +2777,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+              "$ref": "#/definitions/OperationStatusResult"
             }
           },
           "default": {
@@ -5291,7 +5464,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+              "$ref": "#/definitions/OperationStatusResult"
             }
           },
           "default": {
@@ -7739,6 +7912,70 @@
             "description": "Create an Agent Pool for BYO machines running the FlexNode agent."
           }
         ]
+      }
+    },
+    "AgentPoolUpdate": {
+      "type": "object",
+      "description": "Agent pool.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentPoolUpdateProperties",
+          "description": "Properties for the agent pool."
+        }
+      }
+    },
+    "AgentPoolUpdateManualScaleProfile": {
+      "type": "object",
+      "description": "Specifications on number of machines.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes."
+        }
+      }
+    },
+    "AgentPoolUpdateProperties": {
+      "type": "object",
+      "description": "Properties for the agent pool.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of agents (VMs) to host docker containers."
+        },
+        "virtualMachinesProfile": {
+          "$ref": "#/definitions/AgentPoolUpdateVirtualMachinesProfile",
+          "description": "Specifications on VirtualMachines agent pool."
+        }
+      }
+    },
+    "AgentPoolUpdateScaleProfile": {
+      "type": "object",
+      "description": "Specifications on how to scale a VirtualMachines agent pool.",
+      "properties": {
+        "manual": {
+          "type": "array",
+          "description": "Specifications on how to scale the VirtualMachines agent pool to a fixed size.",
+          "items": {
+            "$ref": "#/definitions/AgentPoolUpdateManualScaleProfile"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "AgentPoolUpdateVirtualMachinesProfile": {
+      "type": "object",
+      "description": "Specifications on VirtualMachines agent pool.",
+      "properties": {
+        "scale": {
+          "$ref": "#/definitions/AgentPoolUpdateScaleProfile",
+          "description": "Specifications on how to scale a VirtualMachines agent pool."
+        }
       }
     },
     "AgentPoolUpgradeProfile": {
@@ -15036,6 +15273,72 @@
         "value"
       ]
     },
+    "OperationStatusResult": {
+      "type": "object",
+      "description": "The current status of an async operation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified ID for the async operation."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the async operation."
+        },
+        "status": {
+          "type": "string",
+          "description": "Operation status."
+        },
+        "percentComplete": {
+          "type": "number",
+          "format": "double",
+          "description": "Percent of the operation that is complete.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the operation."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of the operation."
+        },
+        "operations": {
+          "type": "array",
+          "description": "The operations list.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+          }
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "If present, details of the operation error."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified ID of the resource against which the original async operation was started.",
+          "readOnly": true
+        },
+        "operationType": {
+          "type": "string",
+          "description": "The type of the operation.",
+          "readOnly": true
+        },
+        "subOperationType": {
+          "type": "string",
+          "description": "The type of the suboperation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
     "OperationStatusResultList": {
       "type": "object",
       "description": "The operations list. It contains an URL link to get the next set of results.",
@@ -15044,7 +15347,7 @@
           "type": "array",
           "description": "The OperationStatusResult items on this page",
           "items": {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+            "$ref": "#/definitions/OperationStatusResult"
           }
         },
         "nextLink": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -15311,7 +15311,7 @@
           "type": "array",
           "description": "The operations list.",
           "items": {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+            "$ref": "#/definitions/OperationStatusResult"
           }
         },
         "error": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -15277,53 +15277,6 @@
       "type": "object",
       "description": "The current status of an async operation.",
       "properties": {
-        "id": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Fully qualified ID for the async operation."
-        },
-        "name": {
-          "type": "string",
-          "description": "Name of the async operation."
-        },
-        "status": {
-          "type": "string",
-          "description": "Operation status."
-        },
-        "percentComplete": {
-          "type": "number",
-          "format": "double",
-          "description": "Percent of the operation that is complete.",
-          "minimum": 0,
-          "maximum": 100
-        },
-        "startTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The start time of the operation."
-        },
-        "endTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The end time of the operation."
-        },
-        "operations": {
-          "type": "array",
-          "description": "The operations list.",
-          "items": {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
-          }
-        },
-        "error": {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
-          "description": "If present, details of the operation error."
-        },
-        "resourceId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Fully qualified ID of the resource against which the original async operation was started.",
-          "readOnly": true
-        },
         "operationType": {
           "type": "string",
           "description": "The type of the operation.",
@@ -15335,8 +15288,10 @@
           "readOnly": true
         }
       },
-      "required": [
-        "status"
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationStatusResult"
+        }
       ]
     },
     "OperationStatusResultList": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -1558,4 +1558,12 @@ directive:
     from: managedClusters.json
     where: $.definitions.VmSkusListResult
     reason: The List VM Skus API is a proxy for the Compute Resource Skus API. Defining a GET endpoint that follows the SKU contract (which in turn does not follow the standard ARM resource model) is allowed as previously discussed in an ARM API review email thread. (tilovell@microsoft.com, suhasrao@microsoft.com)
+  - suppress: BodyTopLevelProperties
+    from: managedClusters.json
+    where: $.definitions.OperationStatusResult
+    reason: OperationStatusResult mirrors the ARM common type shape (`error`, `operations`, `resourceId`, plus `status`, `percentComplete`, `startTime`, `endTime`, etc.) and adds the AKS-specific read-only `operationType` and `subOperationType` properties. It is only used as an async-operation-status response body, not as a PUT resource body, so the tracked-resource envelope restriction does not apply.
+  - suppress: RequiredPropertiesMissingInResourceModel
+    from: managedClusters.json
+    where: $.definitions.OperationStatusResult
+    reason: OperationStatusResult is an async-operation-status response envelope, not an ARM tracked or proxy resource. It inherits `id` and `name` from the ARM common OperationStatusResult; the tracked-resource-shape check (name/id/type readOnly) does not apply.
 ```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -1565,5 +1565,5 @@ directive:
   - suppress: RequiredPropertiesMissingInResourceModel
     from: managedClusters.json
     where: $.definitions.OperationStatusResult
-    reason: OperationStatusResult is an async-operation-status response envelope, not an ARM tracked or proxy resource. It inherits `id` and `name` from the ARM common OperationStatusResult; the tracked-resource-shape check (name/id/type readOnly) does not apply.
+    reason: OperationStatusResult is an async-operation-status response envelope, not an ARM tracked or proxy resource. It locally declares the ARM common OperationStatusResult fields and adds AKS-specific read-only fields. Therefore, the tracked-resource requirement for read-only name/id/type properties does not apply.
 ```


### PR DESCRIPTION
API proposal: https://github.com/azure-management-and-platforms/aks-handbook/blob/main/api/2026-06-02-preview/concurrent-node-lifecycle-and-pool-operations.md

## API changes

### New operations

| Method | Path | operationId |
|---|---|---|
| `PATCH` | `.../managedClusters/{cluster}/agentPools/{agentPool}` | `AgentPools_Update` |
| `GET`   | `.../managedClusters/{cluster}/agentPools/{agentPool}/operations?activeOnly=…` | `OperationStatusResult_ListByAgentPool` |

- `AgentPools_Update` is a long-running PATCH (`Azure-AsyncOperation` + `Location` + `Retry-After`, `final-state-via: azure-async-operation`), body = `AgentPoolUpdate`, returns full `AgentPool` on success. Supports `If-Match`.
- `OperationStatusResult_ListByAgentPool` mirrors the existing `OperationStatusResult_List` (cluster-scope), plus the `agentPoolName` path param and the `activeOnly` query param. Pageable.

### New models

- `AgentPoolUpdate` → `AgentPoolUpdateProperties { count?, virtualMachinesProfile? }` → `AgentPoolUpdateVirtualMachinesProfile { scale? }` → `AgentPoolUpdateScaleProfile { manual? }` → `AgentPoolUpdateManualScaleProfile { size?, count? }`. Strict subset of `AgentPool` — everything is optional; only scale-related fields are writable through this PATCH.

### Additive changes to existing shapes

- `OperationStatusResult` — added two optional, read-only properties:
  - `operationType?: string`
  - `subOperationType?: string`

  These flow through `OperationStatusResult_Get`, `OperationStatusResult_List`, `OperationStatusResult_GetByAgentPool`, and `OperationStatusResult_ListByAgentPool`.

## Files touched

- TypeSpec sources:
  - `AgentPool.tsp` — new `update` and `listByAgentPool` operations; switched `getByAgentPool` response to the local `OperationStatusResult`.
  - `AgentPoolModels.tsp` — new `AgentPoolUpdate*` models.
  - `CommonModels.tsp` — new local `OperationStatusResult` (spread of the ARM common type) with the two new `@added` properties.
  - `ManagedCluster.tsp` — switched `operationStatusResultGet` response to the local `OperationStatusResult` (list already flowed through the local type via `OperationStatusResultList`).
  - `BackCompatible.tsp` — `@@clientLocation(AgentPools.listByAgentPool, "OperationStatusResult")` + `@@clientName(AgentPools.update::parameters.properties, "parameters")`, mirroring the existing `getByAgentPool` pattern.
  - `client.tsp` — `@@scope(AgentPools.listByAgentPool, "!csharp")`, matching the other `operationStatusResult*` operations.
- Examples (TypeSpec-owned, under `aks/examples/2026-06-02-preview/`):
  - New: `AgentPoolsUpdate_Scale.json`, `AgentPoolsUpdate_ScaleVMs.json`, `OperationStatusResultListByAgentPool.json`, `OperationStatusResultListByAgentPool_Active.json`.
  - Updated to include the new fields: `OperationStatusResultGet.json`, `OperationStatusResultList.json`, `OperationStatusResultGetByAgentPool.json`.
- Regenerated (do not hand-edit): `aks/preview/2026-06-02-preview/managedClusters.json` and everything under `aks/preview/2026-06-02-preview/examples/`. Produced by `npx tsp compile .` from the `aks/` directory.
