### PR TITLE
Add voice agent session-start greeting schema

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -37115,6 +37115,51 @@
         ],
         "description": "Extensible status values shared by Foundry jobs."
       },
+      "LlmGeneratedVoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type",
+          "prompt"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "llm_generated"
+            ]
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The non-empty prompt that guides the opening response. Supports template substitution via `structured_inputs`."
+          },
+          "fallback_text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional non-empty deterministic text spoken if generation fails before output starts. Supports template substitution via `structured_inputs`."
+          },
+          "tool_choice": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingToolChoice"
+              }
+            ],
+            "description": "Whether the opening response may use configured session tools. Defaults to `none`.",
+            "default": "none"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceGreetingConfig"
+          }
+        ],
+        "description": "A session-start greeting authored by the configured session model.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
       "LoraConfig": {
         "type": "object",
         "properties": {
@@ -77959,6 +78004,14 @@
             ],
             "description": "A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts."
           },
+          "greeting": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingConfig"
+              }
+            ],
+            "description": "Optional session-start greeting. The service renders greeting strings with `structured_inputs` before the\nlive session starts and sends the result through Voice Live's native initial-session greeting contract.\nOmit this field to wait for user input."
+          },
           "audio": {
             "allOf": [
               {
@@ -80490,6 +80543,37 @@
         ],
         "description": "The transport protocol for telemetry export."
       },
+      "TemplateVoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type",
+          "text"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "template"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The non-empty text to speak. Supports template substitution via `structured_inputs`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceGreetingConfig"
+          }
+        ],
+        "description": "A deterministic session-start greeting synthesized from exact caller-provided text.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",
         "required": [
@@ -82120,6 +82204,62 @@
           }
         ],
         "description": "A function call output item.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingType"
+              }
+            ],
+            "description": "The greeting mode."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "template": "#/components/schemas/TemplateVoiceGreetingConfig",
+            "llm_generated": "#/components/schemas/LlmGeneratedVoiceGreetingConfig"
+          }
+        },
+        "description": "A proactive assistant greeting produced once at the start of a voice session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingToolChoice": {
+        "type": "string",
+        "enum": [
+          "none",
+          "auto",
+          "required"
+        ],
+        "description": "Tool-selection policy for an LLM-generated session-start greeting.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingType": {
+        "type": "string",
+        "enum": [
+          "template",
+          "llm_generated"
+        ],
+        "description": "The supported session-start greeting modes.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "PromptVoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -45398,6 +45398,35 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    LlmGeneratedVoiceGreetingConfig:
+      type: object
+      required:
+        - type
+        - prompt
+      properties:
+        type:
+          type: string
+          enum:
+            - llm_generated
+        prompt:
+          type: string
+          minLength: 1
+          description: The non-empty prompt that guides the opening response. Supports template substitution via `structured_inputs`.
+        fallback_text:
+          type: string
+          minLength: 1
+          description: Optional non-empty deterministic text spoken if generation fails before output starts. Supports template substitution via `structured_inputs`.
+        tool_choice:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingToolChoice'
+          description: Whether the opening response may use configured session tools. Defaults to `none`.
+          default: none
+      allOf:
+        - $ref: '#/components/schemas/VoiceGreetingConfig'
+      description: A session-start greeting authored by the configured session model.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
     LoraConfig:
       type: object
       properties:
@@ -74372,6 +74401,13 @@ components:
             - type: string
             - type: 'null'
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
+        greeting:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingConfig'
+          description: |-
+            Optional session-start greeting. The service renders greeting strings with `structured_inputs` before the
+            live session starts and sends the result through Voice Live's native initial-session greeting contract.
+            Omit this field to wait for user input.
         audio:
           allOf:
             - $ref: '#/components/schemas/VoiceAudioConfig'
@@ -76050,6 +76086,26 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
+    TemplateVoiceGreetingConfig:
+      type: object
+      required:
+        - type
+        - text
+      properties:
+        type:
+          type: string
+          enum:
+            - template
+        text:
+          type: string
+          minLength: 1
+          description: The non-empty text to speak. Supports template substitution via `structured_inputs`.
+      allOf:
+        - $ref: '#/components/schemas/VoiceGreetingConfig'
+      description: A deterministic session-start greeting synthesized from exact caller-provided text.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
     TestingCriterionAzureAIEvaluator:
       type: object
       required:
@@ -77121,6 +77177,43 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
       description: A function call output item.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingConfig:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingType'
+          description: The greeting mode.
+      discriminator:
+        propertyName: type
+        mapping:
+          template: '#/components/schemas/TemplateVoiceGreetingConfig'
+          llm_generated: '#/components/schemas/LlmGeneratedVoiceGreetingConfig'
+      description: A proactive assistant greeting produced once at the start of a voice session.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingToolChoice:
+      type: string
+      enum:
+        - none
+        - auto
+        - required
+      description: Tool-selection policy for an LLM-generated session-start greeting.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingType:
+      type: string
+      enum:
+        - template
+        - llm_generated
+      description: The supported session-start greeting modes.
       x-ms-foundry-meta:
         required_previews:
           - PromptVoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -41640,6 +41640,51 @@
         ],
         "description": "Extensible status values shared by Foundry jobs."
       },
+      "LlmGeneratedVoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type",
+          "prompt"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "llm_generated"
+            ]
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The non-empty prompt that guides the opening response. Supports template substitution via `structured_inputs`."
+          },
+          "fallback_text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional non-empty deterministic text spoken if generation fails before output starts. Supports template substitution via `structured_inputs`."
+          },
+          "tool_choice": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingToolChoice"
+              }
+            ],
+            "description": "Whether the opening response may use configured session tools. Defaults to `none`.",
+            "default": "none"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceGreetingConfig"
+          }
+        ],
+        "description": "A session-start greeting authored by the configured session model.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
       "LoraConfig": {
         "type": "object",
         "properties": {
@@ -82699,6 +82744,14 @@
             ],
             "description": "A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts."
           },
+          "greeting": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingConfig"
+              }
+            ],
+            "description": "Optional session-start greeting. The service renders greeting strings with `structured_inputs` before the\nlive session starts and sends the result through Voice Live's native initial-session greeting contract.\nOmit this field to wait for user input."
+          },
           "audio": {
             "allOf": [
               {
@@ -85256,6 +85309,37 @@
         ],
         "description": "The transport protocol for telemetry export."
       },
+      "TemplateVoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type",
+          "text"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "template"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The non-empty text to speak. Supports template substitution via `structured_inputs`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceGreetingConfig"
+          }
+        ],
+        "description": "A deterministic session-start greeting synthesized from exact caller-provided text.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",
         "required": [
@@ -86971,6 +87055,62 @@
           }
         ],
         "description": "A function call output item.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingConfig": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VoiceGreetingType"
+              }
+            ],
+            "description": "The greeting mode."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "template": "#/components/schemas/TemplateVoiceGreetingConfig",
+            "llm_generated": "#/components/schemas/LlmGeneratedVoiceGreetingConfig"
+          }
+        },
+        "description": "A proactive assistant greeting produced once at the start of a voice session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingToolChoice": {
+        "type": "string",
+        "enum": [
+          "none",
+          "auto",
+          "required"
+        ],
+        "description": "Tool-selection policy for an LLM-generated session-start greeting.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "PromptVoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceGreetingType": {
+        "type": "string",
+        "enum": [
+          "template",
+          "llm_generated"
+        ],
+        "description": "The supported session-start greeting modes.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "PromptVoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -48433,6 +48433,35 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    LlmGeneratedVoiceGreetingConfig:
+      type: object
+      required:
+        - type
+        - prompt
+      properties:
+        type:
+          type: string
+          enum:
+            - llm_generated
+        prompt:
+          type: string
+          minLength: 1
+          description: The non-empty prompt that guides the opening response. Supports template substitution via `structured_inputs`.
+        fallback_text:
+          type: string
+          minLength: 1
+          description: Optional non-empty deterministic text spoken if generation fails before output starts. Supports template substitution via `structured_inputs`.
+        tool_choice:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingToolChoice'
+          description: Whether the opening response may use configured session tools. Defaults to `none`.
+          default: none
+      allOf:
+        - $ref: '#/components/schemas/VoiceGreetingConfig'
+      description: A session-start greeting authored by the configured session model.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
     LoraConfig:
       type: object
       properties:
@@ -77559,6 +77588,13 @@ components:
             - type: string
             - type: 'null'
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
+        greeting:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingConfig'
+          description: |-
+            Optional session-start greeting. The service renders greeting strings with `structured_inputs` before the
+            live session starts and sends the result through Voice Live's native initial-session greeting contract.
+            Omit this field to wait for user input.
         audio:
           allOf:
             - $ref: '#/components/schemas/VoiceAudioConfig'
@@ -79254,6 +79290,26 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
+    TemplateVoiceGreetingConfig:
+      type: object
+      required:
+        - type
+        - text
+      properties:
+        type:
+          type: string
+          enum:
+            - template
+        text:
+          type: string
+          minLength: 1
+          description: The non-empty text to speak. Supports template substitution via `structured_inputs`.
+      allOf:
+        - $ref: '#/components/schemas/VoiceGreetingConfig'
+      description: A deterministic session-start greeting synthesized from exact caller-provided text.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
     TestingCriterionAzureAIEvaluator:
       type: object
       required:
@@ -80379,6 +80435,43 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
       description: A function call output item.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingConfig:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/VoiceGreetingType'
+          description: The greeting mode.
+      discriminator:
+        propertyName: type
+        mapping:
+          template: '#/components/schemas/TemplateVoiceGreetingConfig'
+          llm_generated: '#/components/schemas/LlmGeneratedVoiceGreetingConfig'
+      description: A proactive assistant greeting produced once at the start of a voice session.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingToolChoice:
+      type: string
+      enum:
+        - none
+        - auto
+        - required
+      description: Tool-selection policy for an LLM-generated session-start greeting.
+      x-ms-foundry-meta:
+        required_previews:
+          - PromptVoiceAgents=V1Preview
+    VoiceGreetingType:
+      type: string
+      enum:
+        - template
+        - llm_generated
+      description: The supported session-start greeting modes.
       x-ms-foundry-meta:
         required_previews:
           - PromptVoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -362,6 +362,13 @@ model PromptVoiceAgentDefinition extends AgentDefinition {
   instructions?: string | null;
 
   @doc("""
+    Optional session-start greeting. The service renders greeting strings with `structured_inputs` before the
+    live session starts and sends the result through Voice Live's native initial-session greeting contract.
+    Omit this field to wait for user input.
+    """)
+  greeting?: VoiceGreetingConfig;
+
+  @doc("""
     The audio stack configuration (input/output format, voice, turn detection, noise reduction, transcription),
     following the OpenAI Realtime session schema that Voice Live implements and extends. Authored here as the
     control-plane defaults; a client may override the overridable fields per session at connect time.
@@ -434,6 +441,59 @@ union VoiceAgentTool {
 
   @doc("A reference to a Foundry toolbox, executed by Voice Live via the toolbox MCP endpoint.")
   toolbox: VoiceToolboxTool,
+}
+
+@doc("A proactive assistant greeting produced once at the start of a voice session.")
+@discriminator("type")
+@extension("x-ms-foundry-meta", PromptVoiceAgentRequiredPreview)
+model VoiceGreetingConfig {
+  @doc("The greeting mode.")
+  type: VoiceGreetingType;
+}
+
+@doc("The supported session-start greeting modes.")
+@extension("x-ms-foundry-meta", PromptVoiceAgentRequiredPreview)
+union VoiceGreetingType {
+  @doc("Speak caller-provided text through the normal assistant speech-output path.")
+  template: "template",
+
+  @doc("Ask the configured session model to generate the opening response.")
+  llm_generated: "llm_generated",
+}
+
+@doc("A deterministic session-start greeting synthesized from exact caller-provided text.")
+@extension("x-ms-foundry-meta", PromptVoiceAgentRequiredPreview)
+model TemplateVoiceGreetingConfig extends VoiceGreetingConfig {
+  type: VoiceGreetingType.template;
+
+  @doc("The non-empty text to speak. Supports template substitution via `structured_inputs`.")
+  @minLength(1)
+  text: string;
+}
+
+@doc("A session-start greeting authored by the configured session model.")
+@extension("x-ms-foundry-meta", PromptVoiceAgentRequiredPreview)
+model LlmGeneratedVoiceGreetingConfig extends VoiceGreetingConfig {
+  type: VoiceGreetingType.llm_generated;
+
+  @doc("The non-empty prompt that guides the opening response. Supports template substitution via `structured_inputs`.")
+  @minLength(1)
+  prompt: string;
+
+  @doc("Optional non-empty deterministic text spoken if generation fails before output starts. Supports template substitution via `structured_inputs`.")
+  @minLength(1)
+  fallback_text?: string;
+
+  @doc("Whether the opening response may use configured session tools. Defaults to `none`.")
+  tool_choice?: VoiceGreetingToolChoice = VoiceGreetingToolChoice.none;
+}
+
+@doc("Tool-selection policy for an LLM-generated session-start greeting.")
+@extension("x-ms-foundry-meta", PromptVoiceAgentRequiredPreview)
+union VoiceGreetingToolChoice {
+  none: "none",
+  auto: "auto",
+  required: "required",
 }
 
 @doc("A Voice Live built-in control (system) tool that acts on the live session itself, e.g. ending the call. Executed natively by Voice Live; no customer code or external auth.")


### PR DESCRIPTION
Define template and LLM-generated greeting configurations, including fallback text and tool-selection policy, and regenerate the Foundry OpenAPI artifacts.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
