### PR TITLE
AKS: add NAT Gateway BYOIP fields to 2026-06-01 GA

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -2807,7 +2807,7 @@ model ManagedClusterNATGatewayProfile {
    * Desired outbound IP Prefix resources for the managed NAT Gateway. Only compatible with NAT Gateway V2.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
-  @added(Versions.v2026_06_02_preview)
+  @added(Versions.v2026_06_01)
   outboundIPPrefixes?: {
     /**
      * A list of public IP prefix resources.
@@ -2824,7 +2824,7 @@ model ManagedClusterNATGatewayProfile {
    * Desired outbound IP resources for the managed NAT Gateway.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
-  @added(Versions.v2026_06_02_preview)
+  @added(Versions.v2026_06_01)
   outboundIPs?: {
     /**
      * A list of public IP resources.
@@ -2860,7 +2860,7 @@ model ManagedClusterManagedOutboundIPProfile {
    * The desired number of IPv6 outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive).
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
-  @added(Versions.v2026_06_02_preview)
+  @added(Versions.v2026_06_01)
   @maxValue(16)
   @minValue(1)
   countIPv6?: int32;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
@@ -8095,6 +8095,13 @@
           "default": 1,
           "minimum": 1,
           "maximum": 16
+        },
+        "countIPv6": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The desired number of IPv6 outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive).",
+          "minimum": 1,
+          "maximum": 16
         }
       }
     },
@@ -8127,6 +8134,50 @@
             "$ref": "#/definitions/ResourceReference"
           },
           "readOnly": true
+        },
+        "outboundIPPrefixes": {
+          "type": "object",
+          "description": "Desired outbound IP Prefix resources for the managed NAT Gateway. Only compatible with NAT Gateway V2.",
+          "properties": {
+            "publicIPPrefixes": {
+              "type": "array",
+              "description": "A list of public IP prefix resources.",
+              "items": {
+                "type": "string",
+                "format": "arm-id",
+                "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+                "x-ms-arm-id-details": {
+                  "allowedResources": [
+                    {
+                      "type": "Microsoft.Network/publicIPPrefixes"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "outboundIPs": {
+          "type": "object",
+          "description": "Desired outbound IP resources for the managed NAT Gateway.",
+          "properties": {
+            "publicIPs": {
+              "type": "array",
+              "description": "A list of public IP resources.",
+              "items": {
+                "type": "string",
+                "format": "arm-id",
+                "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+                "x-ms-arm-id-details": {
+                  "allowedResources": [
+                    {
+                      "type": "Microsoft.Network/publicIPAddresses"
+                    }
+                  ]
+                }
+              }
+            }
+          }
         },
         "idleTimeoutInMinutes": {
           "type": "integer",


### PR DESCRIPTION
Follow-up to #45002. The NAT Gateway V2 GA surface was published with natGatewayProfile.sku, but three fields from the approved API proposal were still scoped to the preview only.

Move to @added(Versions.v2026_06_01):
  - natGatewayProfile.outboundIPs
  - natGatewayProfile.outboundIPPrefixes
  - managedOutboundIPProfile.countIPv6

All three are already implemented and served on the GA version by the AKS resource provider, so the GA spec was under-reporting the real surface.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
