### PR TITLE
ContainerService: fix .NET BootstrapAzureConfig naming conflict in client.tsp

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -6,6 +6,11 @@ using Azure.ClientGenerator.Core.Legacy;
 using Azure.Core;
 using Microsoft.ContainerService;
 
+// Fix .NET code generation naming conflict: BootstrapAzureConfig has both an internal
+// BootstrapTokenInfo property and a flattened public string property that both resolve
+// to "BootstrapToken". Renaming the backing property avoids the CS0102 duplicate error.
+@@clientName(BootstrapAzureConfig.bootstrapToken, "BootstrapTokenDetail", "csharp");
+
 @@clientName(Microsoft.ContainerService.IPFamily, "IpFamily", "javascript");
 
 // Java specific renaming for backward compatibility

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -9,7 +9,11 @@ using Microsoft.ContainerService;
 // Fix .NET code generation naming conflict: BootstrapAzureConfig has both an internal
 // BootstrapTokenInfo property and a flattened public string property that both resolve
 // to "BootstrapToken". Renaming the backing property avoids the CS0102 duplicate error.
-@@clientName(BootstrapAzureConfig.bootstrapToken, "BootstrapTokenDetail", "csharp");
+@@clientName(
+  BootstrapAzureConfig.bootstrapToken,
+  "BootstrapTokenDetail",
+  "csharp"
+);
 
 @@clientName(Microsoft.ContainerService.IPFamily, "IpFamily", "javascript");
 


### PR DESCRIPTION
## Problem

The .NET SDK generation for `2026-05-02-preview` fails with compilation error `CS0102`:

```
error CS0102: The type 'BootstrapAzureConfig' already contains a definition for 'BootstrapToken'
```

The .NET emitter generates:
1. An `internal BootstrapTokenInfo BootstrapToken { get; }` backing property (for the `bootstrapToken` JSON field)
2. A `public string BootstrapToken` flattened convenience property (for `bootstrapToken.token`)

Both resolve to the same C# member name `BootstrapToken`, causing a duplicate member error.

Compare with `targetCluster` which works correctly:
- `internal BootstrapTargetCluster TargetCluster` → flattened to `public ResourceIdentifier TargetClusterResourceId` (different names ✅)

## Fix

Add `@@clientName(BootstrapAzureConfig.bootstrapToken, "BootstrapTokenDetail", "csharp")` in `client.tsp` to rename the internal backing property, avoiding the collision with the flattened public accessor.

## Impact

- Only affects .NET SDK generation (scoped to `csharp` target)
- No API surface change for consumers (the internal property is not public)