### PR TITLE
[BlobAccessPoint] Add blobAccessPointConfiguration to blob container properties

### DIFF
--- a/specification/storage/Storage.Management/examples/2026-06-01/BlobContainersPutBlobAccessPointConfiguration.json
+++ b/specification/storage/Storage.Management/examples/2026-06-01/BlobContainersPutBlobAccessPointConfiguration.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-06-01",
+    "blobContainer": {
+      "properties": {
+        "blobAccessPointConfiguration": {
+          "blobAccessPointConfigurationName": "myAccessPointConfig",
+          "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "containerName": "container6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "blobAccessPointConfiguration": {
+            "blobAccessPointConfigurationName": "myAccessPointConfig",
+            "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "blobAccessPointConfiguration": {
+            "blobAccessPointConfigurationName": "myAccessPointConfig",
+            "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithBlobAccessPointConfiguration"
+}

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1631,7 +1631,7 @@ model BlobAccessPointConfigurationConnection {
   /**
    * Name of the Blob Access Point Configuration to connect to.
    */
-  blobAccessPointConfigurationName: string;
+  blobAccessPointConfigurationName?: string;
 
   /**
    * System-generated unique identifier of the Blob Access Point Configuration to connect to. If not provided on create, the service looks up and persists the current unique id.

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1615,6 +1615,28 @@ model ContainerProperties {
    * Enable NFSv3 all squash on blob container.
    */
   enableNfsV3AllSquash?: boolean;
+
+  /**
+   * Configuration that attaches this container to a Blob Access Point. If set, the container is a read-only virtual container whose read/list requests are forwarded to the connected backing data store. Cannot be changed, removed, or added after container creation.
+   */
+  @added(Versions.v2026_06_01)
+  blobAccessPointConfiguration?: BlobAccessPointConfigurationConnection;
+}
+
+/**
+ * Blob Access Point configuration associated with a blob container.
+ */
+@added(Versions.v2026_06_01)
+model BlobAccessPointConfigurationConnection {
+  /**
+   * Name of the Blob Access Point Configuration to connect to.
+   */
+  blobAccessPointConfigurationName: string;
+
+  /**
+   * System-generated unique identifier of the Blob Access Point Configuration to connect to. If not provided on create, the service looks up and persists the current unique id.
+   */
+  blobAccessPointConfigurationUniqueId?: string;
 }
 
 /**

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/examples/BlobContainersPutBlobAccessPointConfiguration.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/examples/BlobContainersPutBlobAccessPointConfiguration.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-06-01",
+    "blobContainer": {
+      "properties": {
+        "blobAccessPointConfiguration": {
+          "blobAccessPointConfigurationName": "myAccessPointConfig",
+          "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "containerName": "container6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "blobAccessPointConfiguration": {
+            "blobAccessPointConfigurationName": "myAccessPointConfig",
+            "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "blobAccessPointConfiguration": {
+            "blobAccessPointConfigurationName": "myAccessPointConfig",
+            "blobAccessPointConfigurationUniqueId": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithBlobAccessPointConfiguration"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json
@@ -2261,6 +2261,9 @@
           }
         },
         "x-ms-examples": {
+          "PutContainerWithBlobAccessPointConfiguration": {
+            "$ref": "./examples/BlobContainersPutBlobAccessPointConfiguration.json"
+          },
           "PutContainerWithDefaultEncryptionScope": {
             "$ref": "./examples/BlobContainersPutDefaultEncryptionScope.json"
           },
@@ -9355,6 +9358,23 @@
         "directoryServiceOptions"
       ]
     },
+    "BlobAccessPointConfigurationConnection": {
+      "type": "object",
+      "description": "Blob Access Point configuration associated with a blob container.",
+      "properties": {
+        "blobAccessPointConfigurationName": {
+          "type": "string",
+          "description": "Name of the Blob Access Point Configuration to connect to."
+        },
+        "blobAccessPointConfigurationUniqueId": {
+          "type": "string",
+          "description": "System-generated unique identifier of the Blob Access Point Configuration to connect to. If not provided on create, the service looks up and persists the current unique id."
+        }
+      },
+      "required": [
+        "blobAccessPointConfigurationName"
+      ]
+    },
     "BlobContainer": {
       "type": "object",
       "description": "Properties of the blob container, including Id, resource name, resource type, Etag.",
@@ -9992,6 +10012,10 @@
         "enableNfsV3AllSquash": {
           "type": "boolean",
           "description": "Enable NFSv3 all squash on blob container."
+        },
+        "blobAccessPointConfiguration": {
+          "$ref": "#/definitions/BlobAccessPointConfigurationConnection",
+          "description": "Configuration that attaches this container to a Blob Access Point. If set, the container is a read-only virtual container whose read/list requests are forwarded to the connected backing data store. Cannot be changed, removed, or added after container creation."
         }
       }
     },

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json
@@ -9370,10 +9370,7 @@
           "type": "string",
           "description": "System-generated unique identifier of the Blob Access Point Configuration to connect to. If not provided on create, the service looks up and persists the current unique id."
         }
-      },
-      "required": [
-        "blobAccessPointConfigurationName"
-      ]
+      }
     },
     "BlobContainer": {
       "type": "object",


### PR DESCRIPTION
## Summary
Adds the read-only container → Blob Access Point Configuration attachment to `ContainerProperties`
in the consolidated **2026-06-01** Microsoft.Storage spec:
- `blobAccessPointConfiguration` property on `ContainerProperties`
- `BlobAccessPointConfigurationConnection` model (`blobAccessPointConfigurationName` required,
  `blobAccessPointConfigurationUniqueId` optional)
- a `PutContainer` example

Both are gated to `2026-06-01` via `@added(Versions.v2026_06_01)`. Separate from the
`StorageConnectors` ARM resource, which is unchanged. Targets `storagecontextcache-mgmt` so it
consolidates before merging to `main`.

## TypeSpec-first
Hand-authored in `Storage.Management/models.tsp` (+ source example under
`Storage.Management/examples/2026-06-01/`); the `2026-06-01` `openapi.json` and its example were
**regenerated**, not hand-edited.

## Commands used to generate the swagger
​```
npm ci
npx tsp compile specification/storage/Storage.Management
npx tsv specification/storage/Storage.Management
npx tsp format specification/storage/Storage.Management
​```

## Validation
- `tsp compile` succeeds; `tsv` clean; `tsp format` reports no changes.
- `oav validate-example` and `oav validate-spec` both pass.

## Files
- `Storage.Management/models.tsp` (source)
- `Storage.Management/examples/2026-06-01/BlobContainersPutBlobAccessPointConfiguration.json` (source example)
- `resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json` (generated)
- `resource-manager/Microsoft.Storage/stable/2026-06-01/examples/BlobContainersPutBlobAccessPointConfiguration.json` (emitted)