### PR TITLE
Set release plan based on the latest API version

### DIFF
--- a/eng/tools/release-plan/src/pr-comment.ts
+++ b/eng/tools/release-plan/src/pr-comment.ts
@@ -112,5 +112,8 @@ export function buildReleaseplanCommentBody(params: CommentBodyParams): string {
   body += `| **API Version** | \`${apiVersion}\` |\n`;
   body += `| **TypeSpec Project** | \`${tspProjectPath}\` |\n`;
 
+  body += `\n> **Note:** The SDK will be generated based on API version \`${apiVersion}\`. `;
+  body += `This is the final API version detected from the changes in this pull request.\n`;
+
   return body;
 }

--- a/eng/tools/release-plan/src/typespec-project.ts
+++ b/eng/tools/release-plan/src/typespec-project.ts
@@ -27,8 +27,7 @@ export const FOLDER_MIGRATION_LABEL = "FolderMigrationV2";
  * @param params.repo Repository name
  * @param params.workspace Absolute path to workspace root
  * @param params.octokit Octokit instance for GitHub API calls
- * @returns TypeSpec project info with path and API version, or null if no spec changes, no projects found, or multiple projects found
- * @throws Error if no API version detected in project
+ * @returns TypeSpec project info with path and API version, or null if no spec changes, no projects found, multiple projects found, or no API version detected
  */
 export async function getTypeSpecProjectInfoFromPr(params: {
   prNumber: number;
@@ -72,7 +71,10 @@ export async function getTypeSpecProjectInfoFromPr(params: {
   );
 
   if (versionResult.apiVersions.length === 0) {
-    throw new Error("No API version found in modified files or TypeSpec project path/content.");
+    console.log(
+      "No API version detected in modified files or TypeSpec project. Skipping release plan creation.",
+    );
+    return null;
   }
 
   return {
@@ -172,7 +174,10 @@ export async function getTypeSpecProjectInfoFromCommit(params: {
   );
 
   if (versionResult.apiVersions.length === 0) {
-    throw new Error("No API version found in modified files or TypeSpec project path/content.");
+    console.log(
+      "No API version detected in modified files or TypeSpec project. Skipping release plan creation.",
+    );
+    return { projectInfo: null, hasNewApiVersionLabel: false };
   }
 
   return {
@@ -368,7 +373,7 @@ export function findTspConfigDir(relativeFilePath: string, workspace: string): s
  * @param changedFiles Array of changed file paths
  * @param tspProjectPath Relative path to TypeSpec project
  * @param workspace Absolute path to workspace root
- * @returns Object containing sorted API versions (latest first) and preview flag
+ * @returns Object containing sorted API versions (latest first) and a preview flag derived from the final (latest) API version
  */
 export function detectApiVersions(
   changedFiles: string[],
@@ -377,16 +382,12 @@ export function detectApiVersions(
 ): { apiVersions: string[]; isPreview: boolean } {
   const apiVersionPattern = /(\d{4}-\d{2}-\d{2}(?:-preview)?)/g;
   const versions = new Set<string>();
-  let isPreview = false;
 
   for (const file of changedFiles) {
     const matches = file.match(apiVersionPattern);
     if (matches) {
       for (const version of matches) {
         versions.add(version);
-        if (version.endsWith("-preview")) {
-          isPreview = true;
-        }
       }
     }
   }
@@ -394,13 +395,17 @@ export function detectApiVersions(
   if (versions.size === 0) {
     for (const version of collectApiVersionsFromMainTsp(tspProjectPath, workspace)) {
       versions.add(version);
-      if (version.endsWith("-preview")) {
-        isPreview = true;
-      }
     }
   }
 
   const apiVersions = [...versions].sort(compareApiVersionsDesc);
+
+  // The release type (Public Preview vs GA) is decided solely by the final
+  // (latest) API version detected, not by whether any version in the change
+  // set happens to be a preview. apiVersions[0] is the latest version because
+  // the list is sorted in descending order.
+  const isPreview = apiVersions.length > 0 && apiVersions[0].endsWith("-preview");
+
   return { apiVersions, isPreview };
 }
 

--- a/eng/tools/release-plan/test/pr-comment.test.ts
+++ b/eng/tools/release-plan/test/pr-comment.test.ts
@@ -23,6 +23,7 @@ describe("PR comment creation", () => {
     expect(body).toContain("123");
     expect(body).toContain("2025-06-01-preview");
     expect(body).toContain("specification/foo/Contoso.Service");
+    expect(body).toContain("The SDK will be generated based on API version `2025-06-01-preview`");
   });
 
   it("builds comment body without link", () => {

--- a/eng/tools/release-plan/test/typespec-project.test.ts
+++ b/eng/tools/release-plan/test/typespec-project.test.ts
@@ -236,7 +236,11 @@ describe("TypeSpec project detection edge cases", () => {
     expect(result.apiVersions).toContain("2025-05-01");
     expect(result.apiVersions).toContain("2025-06-01-preview");
     expect(result.apiVersions).toContain("2026-01-01");
-    expect(result.isPreview).toBe(true);
+    // Release type is decided by the final (latest) version. The latest here is
+    // the GA version 2026-01-01, so isPreview must be false even though a
+    // preview version is present in the change set.
+    expect(result.apiVersions[0]).toBe("2026-01-01");
+    expect(result.isPreview).toBe(false);
   });
 
   it("returns null for invalid API version format", () => {


### PR DESCRIPTION

Currently automation marks release plan type as preview if any of the changed files is for preview version. This is incorrect. Release plan type should be derived based on the on the final API version detected from the changes in this PR to avoid creating incorrect release plan type when a spec PR contains changes in old preview version and adds a new stable version.