### PR TITLE
Add x-ms-mutability to create-only Service Bus entity properties

### DIFF
--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/models.tsp
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/models.tsp
@@ -1521,11 +1521,13 @@ model SBQueueProperties {
   /**
    * A value indicating if this queue requires duplicate detection.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   requiresDuplicateDetection?: boolean;
 
   /**
    * A value that indicates whether the queue supports the concept of sessions.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   requiresSession?: boolean;
 
   /**
@@ -1566,6 +1568,7 @@ model SBQueueProperties {
   /**
    * A value that indicates whether the queue is to be partitioned across multiple message brokers.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   enablePartitioning?: boolean;
 
   /**
@@ -1687,6 +1690,7 @@ model SBTopicProperties {
   /**
    * Value indicating if this topic requires duplicate detection.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   requiresDuplicateDetection?: boolean;
 
   /**
@@ -1717,6 +1721,7 @@ model SBTopicProperties {
   /**
    * Value that indicates whether the topic to be partitioned across multiple message brokers is enabled.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   enablePartitioning?: boolean;
 
   /**
@@ -1899,6 +1904,7 @@ model SBSubscriptionProperties {
   /**
    * Value indicating if a subscription supports the concept of sessions.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   requiresSession?: boolean;
 
   /**
@@ -1954,6 +1960,7 @@ model SBSubscriptionProperties {
   /**
    * Value that indicates whether the subscription has an affinity to the client id.
    */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   isClientAffine?: boolean;
 
   /**

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/servicebus.json
@@ -6606,11 +6606,19 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "A value indicating if this queue requires duplicate detection."
+          "description": "A value indicating if this queue requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue supports the concept of sessions."
+          "description": "A value that indicates whether the queue supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6646,7 +6654,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers."
+          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",
@@ -6770,7 +6782,11 @@
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "Value indicating if a subscription supports the concept of sessions."
+          "description": "Value indicating if a subscription supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6818,7 +6834,11 @@
         },
         "isClientAffine": {
           "type": "boolean",
-          "description": "Value that indicates whether the subscription has an affinity to the client id."
+          "description": "Value that indicates whether the subscription has an affinity to the client id.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "userMetadata": {
           "type": "string",
@@ -6928,7 +6948,11 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "Value indicating if this topic requires duplicate detection."
+          "description": "Value indicating if this topic requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "duplicateDetectionHistoryTimeWindow": {
           "type": "string",
@@ -6954,7 +6978,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled."
+          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2026-07-01-preview/servicebus.json
@@ -6637,11 +6637,19 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "A value indicating if this queue requires duplicate detection."
+          "description": "A value indicating if this queue requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue supports the concept of sessions."
+          "description": "A value that indicates whether the queue supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6677,7 +6685,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers."
+          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",
@@ -6801,7 +6813,11 @@
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "Value indicating if a subscription supports the concept of sessions."
+          "description": "Value indicating if a subscription supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6849,7 +6865,11 @@
         },
         "isClientAffine": {
           "type": "boolean",
-          "description": "Value that indicates whether the subscription has an affinity to the client id."
+          "description": "Value that indicates whether the subscription has an affinity to the client id.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "userMetadata": {
           "type": "string",
@@ -6959,7 +6979,11 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "Value indicating if this topic requires duplicate detection."
+          "description": "Value indicating if this topic requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "duplicateDetectionHistoryTimeWindow": {
           "type": "string",
@@ -6985,7 +7009,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled."
+          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/servicebus.json
@@ -6637,11 +6637,19 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "A value indicating if this queue requires duplicate detection."
+          "description": "A value indicating if this queue requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue supports the concept of sessions."
+          "description": "A value that indicates whether the queue supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6677,7 +6685,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers."
+          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",
@@ -6801,7 +6813,11 @@
         },
         "requiresSession": {
           "type": "boolean",
-          "description": "Value indicating if a subscription supports the concept of sessions."
+          "description": "Value indicating if a subscription supports the concept of sessions.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "defaultMessageTimeToLive": {
           "type": "string",
@@ -6849,7 +6865,11 @@
         },
         "isClientAffine": {
           "type": "boolean",
-          "description": "Value that indicates whether the subscription has an affinity to the client id."
+          "description": "Value that indicates whether the subscription has an affinity to the client id.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "userMetadata": {
           "type": "string",
@@ -6959,7 +6979,11 @@
         },
         "requiresDuplicateDetection": {
           "type": "boolean",
-          "description": "Value indicating if this topic requires duplicate detection."
+          "description": "Value indicating if this topic requires duplicate detection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "duplicateDetectionHistoryTimeWindow": {
           "type": "string",
@@ -6985,7 +7009,11 @@
         },
         "enablePartitioning": {
           "type": "boolean",
-          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled."
+          "description": "Value that indicates whether the topic to be partitioned across multiple message brokers is enabled.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "enableExpress": {
           "type": "boolean",


### PR DESCRIPTION
Fixes #16679

`requiresDuplicateDetection`, `requiresSession`, `enablePartitioning` and `isClientAffine` are create-only on Service Bus queues, topics and subscriptions. ARM rejects any PUT that changes one on an existing entity, but the spec declared them as freely mutable, so every downstream generator that needs the fact has had to hand-maintain it.

This adds `@visibility(Lifecycle.Read, Lifecycle.Create)` to the seven affected property/model pairs, matching the annotation `SBNamespaceProperties.zoneRedundant` already carries in the same file.

## Properties changed

| Model | Property |
|-------|----------|
| `SBQueueProperties` | `requiresDuplicateDetection`, `requiresSession`, `enablePartitioning` |
| `SBTopicProperties` | `requiresDuplicateDetection`, `enablePartitioning` |
| `SBSubscriptionProperties` | `requiresSession`, `isClientAffine` |

The issue asks for three properties on Topic and Queue. That list needed two corrections: `SBTopicProperties.requiresSession` does not exist, since topics have no sessions, and two create-only properties on `SBSubscriptionProperties` are missing from it.

## Validation

Every property was verified against live ARM on both Standard and Premium, in both directions, using a dedicated entity per case. All seven are rejected with `MessagingGatewayBadRequest` / `SubCode=40000`.

Every other writable boolean on the three models was probed as a control and is genuinely mutable, which is what makes the positive results meaningful rather than an artifact of the harness.

`enableExpress` is deliberately **not** annotated. It flips freely in both directions on Standard and is rejected only under a cross-property condition with duplicate detection, plus a separate Premium SKU guard. That is a conditional constraint, not immutability, and annotating it would introduce a new inaccuracy.

## Regeneration

`models.tsp` is shared, and the `Versions` enum emits three api-versions, so all three regenerate. A JSON tree deep-diff of each against `main` shows 0 removed keys, 0 changed values, and 0 unrelated additions. Legacy api-versions are not emitted from TypeSpec and are untouched.

`tsp compile` passes with zero warnings and `tsp format` leaves the edit unchanged.

## Impact on generated code

`x-ms-mutability` is [documented as codegen-only](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-mutability) and does not alter the wire payload. `zoneRedundant` serves as a natural experiment: it already carries this annotation and remains settable and serialized in all five management SDKs.

**One consequence worth calling out for review.** Pulumi derives `replaceOnChanges` from this extension. Once the annotation lands, changing `requiresSession` or `isClientAffine` on an existing subscription becomes a replace, meaning delete and recreate, which for a Service Bus subscription means losing its messages. That is correct behaviour, since ARM rejects the in-place update today and the practical alternative is a failed apply, but it is a behaviour change on a GA api-version and should be a conscious call rather than a side effect.

Pulumi and Terraform both hand-maintain this fact today, and both transcriptions are incomplete exactly where the spec is silent: Pulumi has no Subscription entry at all, and Terraform does not mark the client-affine property as forcing replacement.
