### PR TITLE
Rename BulkActions models ending in Resource (C# clientName)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -291,7 +291,8 @@ namespace Microsoft.Compute;
 // ARMCOMMON001: avoid redefining the ARM-framework "ResourceType"; use a domain-scoped name.
 @@clientName(ResourceType, "ScheduledActionsResourceType", "csharp");
 // ARMCOMMON001: avoid redefining the ARM-framework "SubResource"; use a domain-scoped name.
-@@clientName(SubResource, "ComputeBulkActionsSubResource", "csharp");
+// Suffix avoids ending in "Resource", which is reserved for ArmResource-derived types.
+@@clientName(SubResource, "ComputeBulkActionsSubResourceInfo", "csharp");
 // Contextual naming: "Language" is too generic and collides across packages.
 @@clientName(Language, "ScheduledActionLanguage", "csharp");
 // Contextual naming: scope the generic "ProvisioningState" to its operation.
@@ -463,3 +464,13 @@ namespace Microsoft.Compute;
   "csharp"
 );
 @@clientName(ResourcePatchRequest, "ResourcePatchRequestContent", "csharp");
+
+// Model types must not end in "Resource" (reserved for ArmResource-derived classes);
+// these plain models collide with the ScheduledAction/Occurrence ARM resource classes.
+@@clientName(
+  ScheduledActionResource,
+  "ScheduledActionResourceMetadata",
+  "csharp"
+);
+@@clientName(OccurrenceResource, "OccurrenceResourceMetadata", "csharp");
+@@clientName(OccurrenceExtensionResource, "OccurrenceExtension", "csharp");


### PR DESCRIPTION
### Details

C#-only `@@clientName` renames for four BulkActions model types whose generated names end in `Resource`. The .NET SDK reserves the `Resource` suffix for `ArmResource`-derived classes (enforced by `InheritanceCheckTests.ValidateInheritanceForResourceAndCollectionSuffix`), and two of these plain models (`ScheduledActionResource`, `OccurrenceResource`) collide in simple name with the actual ARM resource classes.

Renames (csharp scope only, no swagger impact):

| TypeSpec model | Old C# name | New C# name |
|---|---|---|
| `SubResource` | `ComputeBulkActionsSubResource` | `ComputeBulkActionsSubResourceInfo` |
| `ScheduledActionResource` | `ScheduledActionResource` | `ScheduledActionResourceMetadata` |
| `OccurrenceResource` | `OccurrenceResource` | `OccurrenceResourceMetadata` |
| `OccurrenceExtensionResource` | `OccurrenceExtensionResource` | `OccurrenceExtension` |

These are naming-only client changes scoped to `csharp`; the OpenAPI/swagger output is unaffected. Related to release plan 35410 (.NET SDK PR Azure/azure-sdk-for-net#61492).