### PR TITLE
containerservice: make cluster secrets write-only

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -2146,6 +2146,7 @@ model ManagedClusterWindowsProfile {
   adminUsername: string;
 
   @secret
+  @visibility(Lifecycle.Create, Lifecycle.Update)
   @doc("Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"")
   adminPassword?: string;
 
@@ -2199,6 +2200,7 @@ model ManagedClusterServicePrincipalProfile {
    * The secret password associated with the service principal in plain text.
    */
   @secret
+  @visibility(Lifecycle.Create, Lifecycle.Update)
   secret?: string;
 }
 
@@ -2983,6 +2985,7 @@ model ManagedClusterAADProfile {
    * (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.
    */
   @secret
+  @visibility(Lifecycle.Create, Lifecycle.Update)
   serverAppSecret?: string;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-02-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-02-02-preview/managedClusters.json
@@ -10006,6 +10006,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -12227,6 +12231,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -12461,6 +12469,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-02-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-02-02-preview/managedClusters.json
@@ -10006,10 +10006,6 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
-          "x-ms-mutability": [
-            "update",
-            "create"
-          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -12231,10 +12227,6 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
-          "x-ms-mutability": [
-            "update",
-            "create"
-          ],
           "x-ms-secret": true
         }
       },
@@ -12469,10 +12461,6 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
-          "x-ms-mutability": [
-            "update",
-            "create"
-          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -11459,6 +11459,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -13718,6 +13722,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -13948,6 +13956,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
@@ -6409,6 +6409,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8122,6 +8126,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -8265,6 +8273,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
@@ -6465,6 +6465,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8182,6 +8186,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -8325,6 +8333,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
@@ -6489,6 +6489,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8296,6 +8300,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -8449,6 +8457,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
@@ -6499,6 +6499,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8310,6 +8314,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -8463,6 +8471,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
@@ -6983,6 +6983,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8807,6 +8811,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -8960,6 +8968,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
@@ -7006,6 +7006,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -8874,6 +8878,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -9027,6 +9035,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
@@ -7068,6 +7068,10 @@
           "type": "string",
           "format": "password",
           "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "tenantID": {
@@ -9102,6 +9106,10 @@
           "type": "string",
           "format": "password",
           "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         }
       },
@@ -9255,6 +9263,10 @@
           "type": "string",
           "format": "password",
           "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
           "x-ms-secret": true
         },
         "licenseType": {


### PR DESCRIPTION
## Summary
- mark AKS administrator, service-principal, and legacy AAD secrets as create/update-only
- regenerate every API version on `dev-containerservice-Microsoft.ContainerService-2026-06` with `x-ms-mutability: [update, create]`
- preserve reset AAD and reset service-principal request bodies

## Why
`@secret` emits `x-ms-secret`, but it does not remove read visibility. The affected credentials remained readable in Managed Cluster GET/LIST response schemas. This change makes them write-only while keeping existing write operations supported.

## SDK impact
Generated SDKs should continue accepting these values in create/update inputs and stop exposing or populating them in response models. APIView review is required because some languages may surface this as an input/output model-shape change.

## Validation
- `npm ci` with Node 24.18.0
- `npx tsp compile .`
- `npx tsv specification/containerservice/resource-manager/Microsoft.ContainerService/aks`
- Swagger LintDiff against `dev-containerservice-Microsoft.ContainerService-2026-06`
- verified all eight generated versions emit `x-ms-secret: true` and create/update-only mutability
- verified reset AAD and reset service-principal POST bodies still reference their request models