### PR TITLE
ContainerService: fix .NET SDK type naming (SUFFIX003, SUFFIX006) in client.tsp

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -15,6 +15,12 @@ using Microsoft.ContainerService;
   "csharp"
 );
 
+// .NET SDK naming: "Request" suffix is reserved for HTTP pipeline types.
+@@clientName(ListBootstrapDataRequest, "ListBootstrapDataContent", "csharp");
+
+// .NET SDK naming: "Data" suffix is reserved for ResourceData/TrackedResourceData types.
+@@clientName(PoolBootstrapData, "PoolBootstrapInfo", "csharp");
+
 @@clientName(Microsoft.ContainerService.IPFamily, "IpFamily", "javascript");
 
 // Java specific renaming for backward compatibility


### PR DESCRIPTION
## Changes

Add \@@clientName\ entries for .NET SDK naming convention compliance:

- \ListBootstrapDataRequest\ → \ListBootstrapDataContent\ (SUFFIX003: \Request\ suffix is reserved for HTTP pipeline types)
- \PoolBootstrapData\ → \PoolBootstrapInfo\ (SUFFIX006: \Data\ suffix is reserved for \ResourceData\/\TrackedResourceData\ types)

## Context

These were flagged by the mgmt-review bot on [Azure/azure-sdk-for-net#61433](https://github.com/Azure/azure-sdk-for-net/pull/61433) as blocking findings.
