### PR TITLE
Add AgentExtensions task storage TypeSpec

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -4,6 +4,7 @@ import "./src/voice-agents/routes.tsp";
 import "./src/agents-session-files/routes.tsp";
 import "./src/agents-invocations/routes.tsp";
 import "./src/agents-invocations_ws/routes.tsp";
+import "./src/agentserver-persistence/routes.tsp";
 import "./src/common/custom-types.tsp";
 import "./src/common/service.tsp";
 import "./src/connections/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -15,6 +15,9 @@
       "name": "Voice Agent Versions"
     },
     {
+      "name": "AgentServer Task Storage"
+    },
+    {
       "name": "Responses Root",
       "description": "Responses"
     },
@@ -26494,6 +26497,623 @@
         }
       }
     },
+    "/tasks": {
+      "post": {
+        "operationId": "createAgentServerTask",
+        "summary": "Create a task",
+        "description": "Creates a durable task record.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Stable lease owner. Must be supplied together with `lease_instance_id` and\n`lease_duration_seconds`. Lease parameters are query parameters, never body fields.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_instance_id",
+            "in": "query",
+            "required": false,
+            "description": "Ephemeral worker instance id. Must be supplied together with `lease_owner`\nand `lease_duration_seconds`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_duration_seconds",
+            "in": "query",
+            "required": false,
+            "description": "Lease duration in seconds. `0` force-expires the current lease; otherwise\nvalues are bounded by the task-storage service.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentServerTaskCreateRequest"
+              }
+            }
+          },
+          "description": "Task creation body."
+        },
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "listAgentServerTasks",
+        "summary": "List tasks",
+        "description": "Lists durable task records that match the supplied filters.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "query",
+            "required": false,
+            "description": "Filter by agent name.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "description": "Filter by session id.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by task status.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentServerTaskStatus"
+            },
+            "explode": false
+          },
+          {
+            "name": "has_error",
+            "in": "query",
+            "required": false,
+            "description": "Filter by whether the task has a recorded error.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_expired",
+            "in": "query",
+            "required": false,
+            "description": "Filter by whether the current lease is expired.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Filter by lease owner.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Tag equality filters in `key:value` form. Repeat for AND filtering.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": false
+          },
+          {
+            "name": "source_type",
+            "in": "query",
+            "required": false,
+            "description": "Filter by source type, for example `routine_action_delivery`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "Cursor for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of records to return. Default 20, maximum 100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentServerTaskListOrder",
+              "default": "desc"
+            },
+            "explode": false
+          },
+          {
+            "name": "omit_attachment_values",
+            "in": "query",
+            "required": false,
+            "description": "When true, omit attachment values from returned task records.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskListResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      }
+    },
+    "/tasks/{task_id}": {
+      "get": {
+        "operationId": "getAgentServerTask",
+        "summary": "Get a task",
+        "description": "Retrieves a durable task record by id.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "patch": {
+        "operationId": "patchAgentServerTask",
+        "summary": "Patch a task",
+        "description": "Patches a durable task record, including status, payload, tags, attachments, and lease operations.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Stable lease owner. Must be supplied together with `lease_instance_id` and\n`lease_duration_seconds`. Lease parameters are query parameters, never body fields.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_instance_id",
+            "in": "query",
+            "required": false,
+            "description": "Ephemeral worker instance id. Must be supplied together with `lease_owner`\nand `lease_duration_seconds`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_duration_seconds",
+            "in": "query",
+            "required": false,
+            "description": "Lease duration in seconds. `0` force-expires the current lease; otherwise\nvalues are bounded by the task-storage service.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "description": "Optimistic-concurrency precondition for patch/delete operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "description": "Arbitrary JSON patch document. Supported top-level fields include status,\npayload, tags, attachments, error, and suspension_reason."
+        },
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "deleteAgentServerTask",
+        "summary": "Delete a task",
+        "description": "Deletes a durable task record.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "description": "Optimistic-concurrency precondition for patch/delete operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "Force deletion of a non-terminal task and release any active lease. Defaults to false.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      }
+    },
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
@@ -29318,6 +29938,432 @@
             "type": "string",
             "description": "The version identifier of the agent."
           }
+        }
+      },
+      "AgentServerTaskCreateRequest": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "session_id",
+          "title"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional caller-supplied task identifier. If omitted, the provider generates one."
+          },
+          "agent_name": {
+            "type": "string",
+            "description": "Agent scope that owns this task."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Session scope that owns this task."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Human-readable title."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Optional human-readable description."
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentServerTaskStatus",
+            "description": "Initial task status. Defaults to `pending`.",
+            "default": "pending"
+          },
+          "payload": {
+            "description": "Initial arbitrary JSON task payload."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Initial string tags."
+          },
+          "source": {
+            "$ref": "#/components/schemas/AgentServerTaskSource",
+            "description": "Source/provenance metadata that identifies the task producer."
+          },
+          "attachments": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Initial JSON-serializable attachment values keyed by attachment name."
+          }
+        },
+        "description": "Request body for creating an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskError": {
+        "type": "object",
+        "required": [
+          "type",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Error type discriminator, such as `timeout` or `retries_exhausted`."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "code": {
+            "type": "string",
+            "description": "Optional machine-readable error code. Defaults to `error` when omitted by the caller.",
+            "default": "error"
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Structured error persisted on a task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskLease": {
+        "type": "object",
+        "required": [
+          "owner",
+          "instance_id",
+          "generation",
+          "expires_at",
+          "expiry_count"
+        ],
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Stable lease owner, typically scoped to the agent and session."
+          },
+          "instance_id": {
+            "type": "string",
+            "description": "Ephemeral worker instance identifier."
+          },
+          "generation": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Fencing generation. Increments whenever a different instance re-acquires the lease.",
+            "default": 0
+          },
+          "expires_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant after which the lease is expired."
+          },
+          "expiry_count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of times ownership changed via expiry.",
+            "default": 0
+          }
+        },
+        "description": "Lease details on an AgentServer durable task record.\nThe lease is the optimistic ownership/fencing token for a single worker instance.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskListOrder": {
+        "type": "string",
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "AgentServerTaskListResponse": {
+        "type": "object",
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ],
+            "description": "Object discriminator. Always `list`."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentServerTaskRecord"
+            },
+            "description": "Page of matching task records."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "First task id represented in this page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more records are available."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "Cursor to pass as `after` for the next page when `has_more` is true."
+          }
+        },
+        "description": "Cursor-paged list response for AgentServer durable task records.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskRecord": {
+        "type": "object",
+        "required": [
+          "object",
+          "id",
+          "agent_name",
+          "session_id",
+          "status",
+          "title",
+          "description",
+          "lease",
+          "payload",
+          "tags",
+          "source",
+          "attachments",
+          "error",
+          "suspension_reason",
+          "created_at",
+          "updated_at",
+          "started_at",
+          "completed_at",
+          "etag"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "task"
+            ],
+            "description": "Envelope discriminator. Always `task`."
+          },
+          "id": {
+            "type": "string",
+            "description": "Stable task identifier."
+          },
+          "agent_name": {
+            "type": "string",
+            "description": "Agent scope that owns this task."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Session scope that owns this task."
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentServerTaskStatus",
+            "description": "Current task status."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Human-readable title."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description."
+          },
+          "lease": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskLease"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Active lease details, or null when no lease is held."
+          },
+          "payload": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Arbitrary JSON payload used by the agent as task input or mutable task state."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "object",
+                "unevaluatedProperties": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "String tags associated with this task."
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Source/provenance metadata that identifies the task producer."
+          },
+          "attachments": {
+            "anyOf": [
+              {
+                "type": "object",
+                "unevaluatedProperties": {}
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "JSON-serializable attachment values keyed by attachment name."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskError"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Structured terminal error details."
+          },
+          "suspension_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "maxLength": 256,
+            "description": "Reason the task was suspended."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC last-update timestamp."
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 UTC timestamp of the first transition to `in_progress`, or null."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 UTC completion timestamp, or null."
+          },
+          "etag": {
+            "type": "string",
+            "description": "Optimistic-concurrency token."
+          }
+        },
+        "description": "Client-facing representation of an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Source system or producer type."
+          },
+          "routine_name": {
+            "type": "string",
+            "description": "Routine name that produced the task, when applicable."
+          },
+          "routine_run_id": {
+            "type": "string",
+            "description": "Routine run identifier that produced the task, when available."
+          },
+          "dispatch_id": {
+            "type": "string",
+            "description": "Dispatch identifier associated with the source event."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Correlation identifier for the source action that created the task."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant when the source object was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant when the source object was last updated."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Provenance and recovery-routing metadata for an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "suspended",
+              "completed"
+            ]
+          }
+        ],
+        "description": "Status values persisted on an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
         }
       },
       "AgentSessionResource": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -6,6 +6,7 @@ tags:
   - name: Agent Conversations
   - name: Voice Agents
   - name: Voice Agent Versions
+  - name: AgentServer Task Storage
   - name: Responses Root
     description: Responses
   - name: Responses
@@ -38056,6 +38057,433 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - Skills=V1Preview
+  /tasks:
+    post:
+      operationId: createAgentServerTask
+      summary: Create a task
+      description: Creates a durable task record.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: lease_owner
+          in: query
+          required: false
+          description: |-
+            Stable lease owner. Must be supplied together with `lease_instance_id` and
+            `lease_duration_seconds`. Lease parameters are query parameters, never body fields.
+          schema:
+            type: string
+          explode: false
+        - name: lease_instance_id
+          in: query
+          required: false
+          description: |-
+            Ephemeral worker instance id. Must be supplied together with `lease_owner`
+            and `lease_duration_seconds`.
+          schema:
+            type: string
+          explode: false
+        - name: lease_duration_seconds
+          in: query
+          required: false
+          description: |-
+            Lease duration in seconds. `0` force-expires the current lease; otherwise
+            values are bounded by the task-storage service.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentServerTaskCreateRequest'
+        description: Task creation body.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    get:
+      operationId: listAgentServerTasks
+      summary: List tasks
+      description: Lists durable task records that match the supplied filters.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: agent_name
+          in: query
+          required: false
+          description: Filter by agent name.
+          schema:
+            type: string
+          explode: false
+        - name: session_id
+          in: query
+          required: false
+          description: Filter by session id.
+          schema:
+            type: string
+          explode: false
+        - name: status
+          in: query
+          required: false
+          description: Filter by task status.
+          schema:
+            $ref: '#/components/schemas/AgentServerTaskStatus'
+          explode: false
+        - name: has_error
+          in: query
+          required: false
+          description: Filter by whether the task has a recorded error.
+          schema:
+            type: boolean
+          explode: false
+        - name: lease_expired
+          in: query
+          required: false
+          description: Filter by whether the current lease is expired.
+          schema:
+            type: boolean
+          explode: false
+        - name: lease_owner
+          in: query
+          required: false
+          description: Filter by lease owner.
+          schema:
+            type: string
+          explode: false
+        - name: tag
+          in: query
+          required: false
+          description: Tag equality filters in `key:value` form. Repeat for AND filtering.
+          schema:
+            type: array
+            items:
+              type: string
+          explode: false
+        - name: source_type
+          in: query
+          required: false
+          description: Filter by source type, for example `routine_action_delivery`.
+          schema:
+            type: string
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: Cursor for the next page.
+          schema:
+            type: string
+          explode: false
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of records to return. Default 20, maximum 100.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: Sort order.
+          schema:
+            $ref: '#/components/schemas/AgentServerTaskListOrder'
+            default: desc
+          explode: false
+        - name: omit_attachment_values
+          in: query
+          required: false
+          description: When true, omit attachment values from returned task records.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskListResponse'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+  /tasks/{task_id}:
+    get:
+      operationId: getAgentServerTask
+      summary: Get a task
+      description: Retrieves a durable task record by id.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    patch:
+      operationId: patchAgentServerTask
+      summary: Patch a task
+      description: Patches a durable task record, including status, payload, tags, attachments, and lease operations.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: lease_owner
+          in: query
+          required: false
+          description: |-
+            Stable lease owner. Must be supplied together with `lease_instance_id` and
+            `lease_duration_seconds`. Lease parameters are query parameters, never body fields.
+          schema:
+            type: string
+          explode: false
+        - name: lease_instance_id
+          in: query
+          required: false
+          description: |-
+            Ephemeral worker instance id. Must be supplied together with `lease_owner`
+            and `lease_duration_seconds`.
+          schema:
+            type: string
+          explode: false
+        - name: lease_duration_seconds
+          in: query
+          required: false
+          description: |-
+            Lease duration in seconds. `0` force-expires the current lease; otherwise
+            values are bounded by the task-storage service.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: If-Match
+          in: header
+          required: false
+          description: Optimistic-concurrency precondition for patch/delete operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {}
+        description: |-
+          Arbitrary JSON patch document. Supported top-level fields include status,
+          payload, tags, attachments, error, and suspension_reason.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    delete:
+      operationId: deleteAgentServerTask
+      summary: Delete a task
+      description: Deletes a durable task record.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: If-Match
+          in: header
+          required: false
+          description: Optimistic-concurrency precondition for patch/delete operations.
+          schema:
+            type: string
+        - name: force
+          in: query
+          required: false
+          description: Force deletion of a non-terminal task and release any active lease. Defaults to false.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
   /toolboxes:
     get:
       operationId: listToolboxes
@@ -40021,6 +40449,298 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentServerTaskCreateRequest:
+      type: object
+      required:
+        - agent_name
+        - session_id
+        - title
+      properties:
+        id:
+          type: string
+          description: Optional caller-supplied task identifier. If omitted, the provider generates one.
+        agent_name:
+          type: string
+          description: Agent scope that owns this task.
+        session_id:
+          type: string
+          description: Session scope that owns this task.
+        title:
+          type: string
+          maxLength: 256
+          description: Human-readable title.
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional human-readable description.
+        status:
+          $ref: '#/components/schemas/AgentServerTaskStatus'
+          description: Initial task status. Defaults to `pending`.
+          default: pending
+        payload:
+          description: Initial arbitrary JSON task payload.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Initial string tags.
+        source:
+          $ref: '#/components/schemas/AgentServerTaskSource'
+          description: Source/provenance metadata that identifies the task producer.
+        attachments:
+          type: object
+          unevaluatedProperties: {}
+          description: Initial JSON-serializable attachment values keyed by attachment name.
+      description: Request body for creating an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskError:
+      type: object
+      required:
+        - type
+        - message
+      properties:
+        type:
+          type: string
+          description: Error type discriminator, such as `timeout` or `retries_exhausted`.
+        message:
+          type: string
+          description: Human-readable error message.
+        code:
+          type: string
+          description: Optional machine-readable error code. Defaults to `error` when omitted by the caller.
+          default: error
+      unevaluatedProperties: {}
+      description: Structured error persisted on a task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskLease:
+      type: object
+      required:
+        - owner
+        - instance_id
+        - generation
+        - expires_at
+        - expiry_count
+      properties:
+        owner:
+          type: string
+          description: Stable lease owner, typically scoped to the agent and session.
+        instance_id:
+          type: string
+          description: Ephemeral worker instance identifier.
+        generation:
+          type: integer
+          format: int32
+          description: Fencing generation. Increments whenever a different instance re-acquires the lease.
+          default: 0
+        expires_at:
+          type: string
+          description: ISO 8601 UTC instant after which the lease is expired.
+        expiry_count:
+          type: integer
+          format: int32
+          description: Number of times ownership changed via expiry.
+          default: 0
+      description: |-
+        Lease details on an AgentServer durable task record.
+        The lease is the optimistic ownership/fencing token for a single worker instance.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskListOrder:
+      type: string
+      enum:
+        - asc
+        - desc
+    AgentServerTaskListResponse:
+      type: object
+      required:
+        - object
+        - data
+        - has_more
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object discriminator. Always `list`.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentServerTaskRecord'
+          description: Page of matching task records.
+        first_id:
+          type: string
+          description: First task id represented in this page.
+        has_more:
+          type: boolean
+          description: Whether more records are available.
+        last_id:
+          type: string
+          description: Cursor to pass as `after` for the next page when `has_more` is true.
+      description: Cursor-paged list response for AgentServer durable task records.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskRecord:
+      type: object
+      required:
+        - object
+        - id
+        - agent_name
+        - session_id
+        - status
+        - title
+        - description
+        - lease
+        - payload
+        - tags
+        - source
+        - attachments
+        - error
+        - suspension_reason
+        - created_at
+        - updated_at
+        - started_at
+        - completed_at
+        - etag
+      properties:
+        object:
+          type: string
+          enum:
+            - task
+          description: Envelope discriminator. Always `task`.
+        id:
+          type: string
+          description: Stable task identifier.
+        agent_name:
+          type: string
+          description: Agent scope that owns this task.
+        session_id:
+          type: string
+          description: Session scope that owns this task.
+        status:
+          $ref: '#/components/schemas/AgentServerTaskStatus'
+          description: Current task status.
+        title:
+          type: string
+          maxLength: 256
+          description: Human-readable title.
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          maxLength: 1024
+          description: Optional human-readable description.
+        lease:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskLease'
+            - type: 'null'
+          description: Active lease details, or null when no lease is held.
+        payload:
+          anyOf:
+            - {}
+            - type: 'null'
+          description: Arbitrary JSON payload used by the agent as task input or mutable task state.
+        tags:
+          anyOf:
+            - type: object
+              unevaluatedProperties:
+                type: string
+            - type: 'null'
+          description: String tags associated with this task.
+        source:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskSource'
+            - type: 'null'
+          description: Source/provenance metadata that identifies the task producer.
+        attachments:
+          anyOf:
+            - type: object
+              unevaluatedProperties: {}
+            - type: 'null'
+          description: JSON-serializable attachment values keyed by attachment name.
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskError'
+            - type: 'null'
+          description: Structured terminal error details.
+        suspension_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          maxLength: 256
+          description: Reason the task was suspended.
+        created_at:
+          type: string
+          description: ISO 8601 UTC creation timestamp.
+        updated_at:
+          type: string
+          description: ISO 8601 UTC last-update timestamp.
+        started_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: ISO 8601 UTC timestamp of the first transition to `in_progress`, or null.
+        completed_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: ISO 8601 UTC completion timestamp, or null.
+        etag:
+          type: string
+          description: Optimistic-concurrency token.
+      description: Client-facing representation of an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: Source system or producer type.
+        routine_name:
+          type: string
+          description: Routine name that produced the task, when applicable.
+        routine_run_id:
+          type: string
+          description: Routine run identifier that produced the task, when available.
+        dispatch_id:
+          type: string
+          description: Dispatch identifier associated with the source event.
+        action_correlation_id:
+          type: string
+          description: Correlation identifier for the source action that created the task.
+        created_at:
+          type: string
+          description: ISO 8601 UTC instant when the source object was created.
+        updated_at:
+          type: string
+          description: ISO 8601 UTC instant when the source object was last updated.
+      unevaluatedProperties: {}
+      description: Provenance and recovery-routing metadata for an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - pending
+            - in_progress
+            - suspended
+            - completed
+      description: Status values persisted on an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
     AgentSessionResource:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15,6 +15,9 @@
       "name": "Voice Agent Versions"
     },
     {
+      "name": "AgentServer Task Storage"
+    },
+    {
       "name": "EvaluationSuiteGenerationJobs"
     },
     {
@@ -29300,6 +29303,623 @@
         }
       }
     },
+    "/tasks": {
+      "post": {
+        "operationId": "createAgentServerTask",
+        "summary": "Create a task",
+        "description": "Creates a durable task record.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Stable lease owner. Must be supplied together with `lease_instance_id` and\n`lease_duration_seconds`. Lease parameters are query parameters, never body fields.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_instance_id",
+            "in": "query",
+            "required": false,
+            "description": "Ephemeral worker instance id. Must be supplied together with `lease_owner`\nand `lease_duration_seconds`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_duration_seconds",
+            "in": "query",
+            "required": false,
+            "description": "Lease duration in seconds. `0` force-expires the current lease; otherwise\nvalues are bounded by the task-storage service.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentServerTaskCreateRequest"
+              }
+            }
+          },
+          "description": "Task creation body."
+        },
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "listAgentServerTasks",
+        "summary": "List tasks",
+        "description": "Lists durable task records that match the supplied filters.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "query",
+            "required": false,
+            "description": "Filter by agent name.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "description": "Filter by session id.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by task status.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentServerTaskStatus"
+            },
+            "explode": false
+          },
+          {
+            "name": "has_error",
+            "in": "query",
+            "required": false,
+            "description": "Filter by whether the task has a recorded error.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_expired",
+            "in": "query",
+            "required": false,
+            "description": "Filter by whether the current lease is expired.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Filter by lease owner.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Tag equality filters in `key:value` form. Repeat for AND filtering.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": false
+          },
+          {
+            "name": "source_type",
+            "in": "query",
+            "required": false,
+            "description": "Filter by source type, for example `routine_action_delivery`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "Cursor for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of records to return. Default 20, maximum 100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentServerTaskListOrder",
+              "default": "desc"
+            },
+            "explode": false
+          },
+          {
+            "name": "omit_attachment_values",
+            "in": "query",
+            "required": false,
+            "description": "When true, omit attachment values from returned task records.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskListResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      }
+    },
+    "/tasks/{task_id}": {
+      "get": {
+        "operationId": "getAgentServerTask",
+        "summary": "Get a task",
+        "description": "Retrieves a durable task record by id.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "patch": {
+        "operationId": "patchAgentServerTask",
+        "summary": "Patch a task",
+        "description": "Patches a durable task record, including status, payload, tags, attachments, and lease operations.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lease_owner",
+            "in": "query",
+            "required": false,
+            "description": "Stable lease owner. Must be supplied together with `lease_instance_id` and\n`lease_duration_seconds`. Lease parameters are query parameters, never body fields.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_instance_id",
+            "in": "query",
+            "required": false,
+            "description": "Ephemeral worker instance id. Must be supplied together with `lease_owner`\nand `lease_duration_seconds`.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "lease_duration_seconds",
+            "in": "query",
+            "required": false,
+            "description": "Lease duration in seconds. `0` force-expires the current lease; otherwise\nvalues are bounded by the task-storage service.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "description": "Optimistic-concurrency precondition for patch/delete operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentServerTaskRecord"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "description": "Arbitrary JSON patch document. Supported top-level fields include status,\npayload, tags, attachments, error, and suspension_reason."
+        },
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "deleteAgentServerTask",
+        "summary": "Delete a task",
+        "description": "Deletes a durable task record.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "description": "Optimistic-concurrency precondition for patch/delete operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "Force deletion of a non-terminal task and release any active lease. Defaults to false.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentServer Task Storage"
+        ],
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence",
+          "required_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      }
+    },
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
@@ -32548,6 +33168,432 @@
             "type": "string",
             "description": "The version identifier of the agent."
           }
+        }
+      },
+      "AgentServerTaskCreateRequest": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "session_id",
+          "title"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional caller-supplied task identifier. If omitted, the provider generates one."
+          },
+          "agent_name": {
+            "type": "string",
+            "description": "Agent scope that owns this task."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Session scope that owns this task."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Human-readable title."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Optional human-readable description."
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentServerTaskStatus",
+            "description": "Initial task status. Defaults to `pending`.",
+            "default": "pending"
+          },
+          "payload": {
+            "description": "Initial arbitrary JSON task payload."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Initial string tags."
+          },
+          "source": {
+            "$ref": "#/components/schemas/AgentServerTaskSource",
+            "description": "Source/provenance metadata that identifies the task producer."
+          },
+          "attachments": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Initial JSON-serializable attachment values keyed by attachment name."
+          }
+        },
+        "description": "Request body for creating an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskError": {
+        "type": "object",
+        "required": [
+          "type",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Error type discriminator, such as `timeout` or `retries_exhausted`."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "code": {
+            "type": "string",
+            "description": "Optional machine-readable error code. Defaults to `error` when omitted by the caller.",
+            "default": "error"
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Structured error persisted on a task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskLease": {
+        "type": "object",
+        "required": [
+          "owner",
+          "instance_id",
+          "generation",
+          "expires_at",
+          "expiry_count"
+        ],
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Stable lease owner, typically scoped to the agent and session."
+          },
+          "instance_id": {
+            "type": "string",
+            "description": "Ephemeral worker instance identifier."
+          },
+          "generation": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Fencing generation. Increments whenever a different instance re-acquires the lease.",
+            "default": 0
+          },
+          "expires_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant after which the lease is expired."
+          },
+          "expiry_count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of times ownership changed via expiry.",
+            "default": 0
+          }
+        },
+        "description": "Lease details on an AgentServer durable task record.\nThe lease is the optimistic ownership/fencing token for a single worker instance.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskListOrder": {
+        "type": "string",
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "AgentServerTaskListResponse": {
+        "type": "object",
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ],
+            "description": "Object discriminator. Always `list`."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentServerTaskRecord"
+            },
+            "description": "Page of matching task records."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "First task id represented in this page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more records are available."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "Cursor to pass as `after` for the next page when `has_more` is true."
+          }
+        },
+        "description": "Cursor-paged list response for AgentServer durable task records.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskRecord": {
+        "type": "object",
+        "required": [
+          "object",
+          "id",
+          "agent_name",
+          "session_id",
+          "status",
+          "title",
+          "description",
+          "lease",
+          "payload",
+          "tags",
+          "source",
+          "attachments",
+          "error",
+          "suspension_reason",
+          "created_at",
+          "updated_at",
+          "started_at",
+          "completed_at",
+          "etag"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "task"
+            ],
+            "description": "Envelope discriminator. Always `task`."
+          },
+          "id": {
+            "type": "string",
+            "description": "Stable task identifier."
+          },
+          "agent_name": {
+            "type": "string",
+            "description": "Agent scope that owns this task."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Session scope that owns this task."
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentServerTaskStatus",
+            "description": "Current task status."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Human-readable title."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description."
+          },
+          "lease": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskLease"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Active lease details, or null when no lease is held."
+          },
+          "payload": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Arbitrary JSON payload used by the agent as task input or mutable task state."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "object",
+                "unevaluatedProperties": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "String tags associated with this task."
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Source/provenance metadata that identifies the task producer."
+          },
+          "attachments": {
+            "anyOf": [
+              {
+                "type": "object",
+                "unevaluatedProperties": {}
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "JSON-serializable attachment values keyed by attachment name."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentServerTaskError"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Structured terminal error details."
+          },
+          "suspension_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "maxLength": 256,
+            "description": "Reason the task was suspended."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC last-update timestamp."
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 UTC timestamp of the first transition to `in_progress`, or null."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 UTC completion timestamp, or null."
+          },
+          "etag": {
+            "type": "string",
+            "description": "Optimistic-concurrency token."
+          }
+        },
+        "description": "Client-facing representation of an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Source system or producer type."
+          },
+          "routine_name": {
+            "type": "string",
+            "description": "Routine name that produced the task, when applicable."
+          },
+          "routine_run_id": {
+            "type": "string",
+            "description": "Routine run identifier that produced the task, when available."
+          },
+          "dispatch_id": {
+            "type": "string",
+            "description": "Dispatch identifier associated with the source event."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Correlation identifier for the source action that created the task."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant when the source object was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 UTC instant when the source object was last updated."
+          }
+        },
+        "unevaluatedProperties": {},
+        "description": "Provenance and recovery-routing metadata for an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
+        }
+      },
+      "AgentServerTaskStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "suspended",
+              "completed"
+            ]
+          }
+        ],
+        "description": "Status values persisted on an AgentServer durable task record.",
+        "x-ms-foundry-meta": {
+          "contract": "agentserver-persistence",
+          "usage": "cross-language-sdk-persistence"
         }
       },
       "AgentSessionResource": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -6,6 +6,7 @@ tags:
   - name: Agent Conversations
   - name: Voice Agents
   - name: Voice Agent Versions
+  - name: AgentServer Task Storage
   - name: EvaluationSuiteGenerationJobs
   - name: Responses Root
     description: Responses
@@ -39914,6 +39915,433 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - Skills=V1Preview
+  /tasks:
+    post:
+      operationId: createAgentServerTask
+      summary: Create a task
+      description: Creates a durable task record.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: lease_owner
+          in: query
+          required: false
+          description: |-
+            Stable lease owner. Must be supplied together with `lease_instance_id` and
+            `lease_duration_seconds`. Lease parameters are query parameters, never body fields.
+          schema:
+            type: string
+          explode: false
+        - name: lease_instance_id
+          in: query
+          required: false
+          description: |-
+            Ephemeral worker instance id. Must be supplied together with `lease_owner`
+            and `lease_duration_seconds`.
+          schema:
+            type: string
+          explode: false
+        - name: lease_duration_seconds
+          in: query
+          required: false
+          description: |-
+            Lease duration in seconds. `0` force-expires the current lease; otherwise
+            values are bounded by the task-storage service.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentServerTaskCreateRequest'
+        description: Task creation body.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    get:
+      operationId: listAgentServerTasks
+      summary: List tasks
+      description: Lists durable task records that match the supplied filters.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: agent_name
+          in: query
+          required: false
+          description: Filter by agent name.
+          schema:
+            type: string
+          explode: false
+        - name: session_id
+          in: query
+          required: false
+          description: Filter by session id.
+          schema:
+            type: string
+          explode: false
+        - name: status
+          in: query
+          required: false
+          description: Filter by task status.
+          schema:
+            $ref: '#/components/schemas/AgentServerTaskStatus'
+          explode: false
+        - name: has_error
+          in: query
+          required: false
+          description: Filter by whether the task has a recorded error.
+          schema:
+            type: boolean
+          explode: false
+        - name: lease_expired
+          in: query
+          required: false
+          description: Filter by whether the current lease is expired.
+          schema:
+            type: boolean
+          explode: false
+        - name: lease_owner
+          in: query
+          required: false
+          description: Filter by lease owner.
+          schema:
+            type: string
+          explode: false
+        - name: tag
+          in: query
+          required: false
+          description: Tag equality filters in `key:value` form. Repeat for AND filtering.
+          schema:
+            type: array
+            items:
+              type: string
+          explode: false
+        - name: source_type
+          in: query
+          required: false
+          description: Filter by source type, for example `routine_action_delivery`.
+          schema:
+            type: string
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: Cursor for the next page.
+          schema:
+            type: string
+          explode: false
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of records to return. Default 20, maximum 100.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: Sort order.
+          schema:
+            $ref: '#/components/schemas/AgentServerTaskListOrder'
+            default: desc
+          explode: false
+        - name: omit_attachment_values
+          in: query
+          required: false
+          description: When true, omit attachment values from returned task records.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskListResponse'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+  /tasks/{task_id}:
+    get:
+      operationId: getAgentServerTask
+      summary: Get a task
+      description: Retrieves a durable task record by id.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    patch:
+      operationId: patchAgentServerTask
+      summary: Patch a task
+      description: Patches a durable task record, including status, payload, tags, attachments, and lease operations.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: lease_owner
+          in: query
+          required: false
+          description: |-
+            Stable lease owner. Must be supplied together with `lease_instance_id` and
+            `lease_duration_seconds`. Lease parameters are query parameters, never body fields.
+          schema:
+            type: string
+          explode: false
+        - name: lease_instance_id
+          in: query
+          required: false
+          description: |-
+            Ephemeral worker instance id. Must be supplied together with `lease_owner`
+            and `lease_duration_seconds`.
+          schema:
+            type: string
+          explode: false
+        - name: lease_duration_seconds
+          in: query
+          required: false
+          description: |-
+            Lease duration in seconds. `0` force-expires the current lease; otherwise
+            values are bounded by the task-storage service.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: If-Match
+          in: header
+          required: false
+          description: Optimistic-concurrency precondition for patch/delete operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentServerTaskRecord'
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {}
+        description: |-
+          Arbitrary JSON patch document. Supported top-level fields include status,
+          payload, tags, attachments, error, and suspension_reason.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
+    delete:
+      operationId: deleteAgentServerTask
+      summary: Delete a task
+      description: Deletes a durable task record.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Routines=V1Preview
+        - name: task_id
+          in: path
+          required: true
+          description: The task id.
+          schema:
+            type: string
+        - name: If-Match
+          in: header
+          required: false
+          description: Optimistic-concurrency precondition for patch/delete operations.
+          schema:
+            type: string
+        - name: force
+          in: query
+          required: false
+          description: Force deletion of a non-terminal task and release any active lease. Defaults to false.
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentServer Task Storage
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+        required_previews:
+          - Routines=V1Preview
   /toolboxes:
     get:
       operationId: listToolboxes
@@ -42189,6 +42617,298 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentServerTaskCreateRequest:
+      type: object
+      required:
+        - agent_name
+        - session_id
+        - title
+      properties:
+        id:
+          type: string
+          description: Optional caller-supplied task identifier. If omitted, the provider generates one.
+        agent_name:
+          type: string
+          description: Agent scope that owns this task.
+        session_id:
+          type: string
+          description: Session scope that owns this task.
+        title:
+          type: string
+          maxLength: 256
+          description: Human-readable title.
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional human-readable description.
+        status:
+          $ref: '#/components/schemas/AgentServerTaskStatus'
+          description: Initial task status. Defaults to `pending`.
+          default: pending
+        payload:
+          description: Initial arbitrary JSON task payload.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Initial string tags.
+        source:
+          $ref: '#/components/schemas/AgentServerTaskSource'
+          description: Source/provenance metadata that identifies the task producer.
+        attachments:
+          type: object
+          unevaluatedProperties: {}
+          description: Initial JSON-serializable attachment values keyed by attachment name.
+      description: Request body for creating an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskError:
+      type: object
+      required:
+        - type
+        - message
+      properties:
+        type:
+          type: string
+          description: Error type discriminator, such as `timeout` or `retries_exhausted`.
+        message:
+          type: string
+          description: Human-readable error message.
+        code:
+          type: string
+          description: Optional machine-readable error code. Defaults to `error` when omitted by the caller.
+          default: error
+      unevaluatedProperties: {}
+      description: Structured error persisted on a task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskLease:
+      type: object
+      required:
+        - owner
+        - instance_id
+        - generation
+        - expires_at
+        - expiry_count
+      properties:
+        owner:
+          type: string
+          description: Stable lease owner, typically scoped to the agent and session.
+        instance_id:
+          type: string
+          description: Ephemeral worker instance identifier.
+        generation:
+          type: integer
+          format: int32
+          description: Fencing generation. Increments whenever a different instance re-acquires the lease.
+          default: 0
+        expires_at:
+          type: string
+          description: ISO 8601 UTC instant after which the lease is expired.
+        expiry_count:
+          type: integer
+          format: int32
+          description: Number of times ownership changed via expiry.
+          default: 0
+      description: |-
+        Lease details on an AgentServer durable task record.
+        The lease is the optimistic ownership/fencing token for a single worker instance.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskListOrder:
+      type: string
+      enum:
+        - asc
+        - desc
+    AgentServerTaskListResponse:
+      type: object
+      required:
+        - object
+        - data
+        - has_more
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object discriminator. Always `list`.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentServerTaskRecord'
+          description: Page of matching task records.
+        first_id:
+          type: string
+          description: First task id represented in this page.
+        has_more:
+          type: boolean
+          description: Whether more records are available.
+        last_id:
+          type: string
+          description: Cursor to pass as `after` for the next page when `has_more` is true.
+      description: Cursor-paged list response for AgentServer durable task records.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskRecord:
+      type: object
+      required:
+        - object
+        - id
+        - agent_name
+        - session_id
+        - status
+        - title
+        - description
+        - lease
+        - payload
+        - tags
+        - source
+        - attachments
+        - error
+        - suspension_reason
+        - created_at
+        - updated_at
+        - started_at
+        - completed_at
+        - etag
+      properties:
+        object:
+          type: string
+          enum:
+            - task
+          description: Envelope discriminator. Always `task`.
+        id:
+          type: string
+          description: Stable task identifier.
+        agent_name:
+          type: string
+          description: Agent scope that owns this task.
+        session_id:
+          type: string
+          description: Session scope that owns this task.
+        status:
+          $ref: '#/components/schemas/AgentServerTaskStatus'
+          description: Current task status.
+        title:
+          type: string
+          maxLength: 256
+          description: Human-readable title.
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          maxLength: 1024
+          description: Optional human-readable description.
+        lease:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskLease'
+            - type: 'null'
+          description: Active lease details, or null when no lease is held.
+        payload:
+          anyOf:
+            - {}
+            - type: 'null'
+          description: Arbitrary JSON payload used by the agent as task input or mutable task state.
+        tags:
+          anyOf:
+            - type: object
+              unevaluatedProperties:
+                type: string
+            - type: 'null'
+          description: String tags associated with this task.
+        source:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskSource'
+            - type: 'null'
+          description: Source/provenance metadata that identifies the task producer.
+        attachments:
+          anyOf:
+            - type: object
+              unevaluatedProperties: {}
+            - type: 'null'
+          description: JSON-serializable attachment values keyed by attachment name.
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/AgentServerTaskError'
+            - type: 'null'
+          description: Structured terminal error details.
+        suspension_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          maxLength: 256
+          description: Reason the task was suspended.
+        created_at:
+          type: string
+          description: ISO 8601 UTC creation timestamp.
+        updated_at:
+          type: string
+          description: ISO 8601 UTC last-update timestamp.
+        started_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: ISO 8601 UTC timestamp of the first transition to `in_progress`, or null.
+        completed_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: ISO 8601 UTC completion timestamp, or null.
+        etag:
+          type: string
+          description: Optimistic-concurrency token.
+      description: Client-facing representation of an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskSource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: Source system or producer type.
+        routine_name:
+          type: string
+          description: Routine name that produced the task, when applicable.
+        routine_run_id:
+          type: string
+          description: Routine run identifier that produced the task, when available.
+        dispatch_id:
+          type: string
+          description: Dispatch identifier associated with the source event.
+        action_correlation_id:
+          type: string
+          description: Correlation identifier for the source action that created the task.
+        created_at:
+          type: string
+          description: ISO 8601 UTC instant when the source object was created.
+        updated_at:
+          type: string
+          description: ISO 8601 UTC instant when the source object was last updated.
+      unevaluatedProperties: {}
+      description: Provenance and recovery-routing metadata for an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
+    AgentServerTaskStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - pending
+            - in_progress
+            - suspended
+            - completed
+      description: Status values persisted on an AgentServer durable task record.
+      x-ms-foundry-meta:
+        contract: agentserver-persistence
+        usage: cross-language-sdk-persistence
     AgentSessionResource:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agentserver-persistence/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agentserver-persistence/models.tsp
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using TypeSpec.OpenAPI;
+using Azure.Core;
+
+namespace Azure.AI.Projects;
+
+const AgentServerPersistenceContract = #{
+  contract: "agentserver-persistence",
+  usage: "cross-language-sdk-persistence",
+};
+
+const AgentServerPersistenceRequiredPreviews = #{
+  contract: "agentserver-persistence",
+  usage: "cross-language-sdk-persistence",
+  required_previews: #[FoundryFeaturesOptInKeys.routines_v1_preview],
+};
+
+// ---------------------------------------------------------------------------
+// AgentServer Core durable task persistence contract
+// ---------------------------------------------------------------------------
+
+/** Status values persisted on an AgentServer durable task record. */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+union AgentServerTaskStatus {
+  string,
+  pending: "pending",
+  inProgress: "in_progress",
+  suspended: "suspended",
+  completed: "completed",
+}
+
+/**
+ * Lease details on an AgentServer durable task record.
+ * The lease is the optimistic ownership/fencing token for a single worker instance.
+ */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskLease {
+  /** Stable lease owner, typically scoped to the agent and session. */
+  owner: string;
+
+  /** Ephemeral worker instance identifier. */
+  instance_id: string;
+
+  /** Fencing generation. Increments whenever a different instance re-acquires the lease. */
+  generation: int32 = 0;
+
+  /** ISO 8601 UTC instant after which the lease is expired. */
+  expires_at: string;
+
+  /** Number of times ownership changed via expiry. */
+  expiry_count: int32 = 0;
+}
+
+/**
+ * Provenance and recovery-routing metadata for an AgentServer durable task record.
+ */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskSource {
+  /** Source system or producer type. */
+  type: string;
+
+  /** Routine name that produced the task, when applicable. */
+  routine_name?: string;
+
+  /** Routine run identifier that produced the task, when available. */
+  routine_run_id?: string;
+
+  /** Dispatch identifier associated with the source event. */
+  dispatch_id?: string;
+
+  /** Correlation identifier for the source action that created the task. */
+  action_correlation_id?: string;
+
+  /** ISO 8601 UTC instant when the source object was created. */
+  created_at?: string;
+
+  /** ISO 8601 UTC instant when the source object was last updated. */
+  updated_at?: string;
+
+  /** Forward-compatible source extension fields. */
+  ...Record<unknown>;
+}
+
+/**
+ * Client-facing representation of an AgentServer durable task record.
+ */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskRecord {
+  /** Envelope discriminator. Always `task`. */
+  object: "task";
+
+  /** Stable task identifier. */
+  id: string;
+
+  /** Agent scope that owns this task. */
+  agent_name: string;
+
+  /** Session scope that owns this task. */
+  session_id: string;
+
+  /** Current task status. */
+  status: AgentServerTaskStatus;
+
+  /** Human-readable title. */
+  @maxLength(256)
+  title: string;
+
+  /** Optional human-readable description. */
+  @maxLength(1024)
+  description: string | null;
+
+  /** Active lease details, or null when no lease is held. */
+  lease: AgentServerTaskLease | null;
+
+  /** Arbitrary JSON payload used by the agent as task input or mutable task state. */
+  payload: unknown | null;
+
+  /** String tags associated with this task. */
+  tags: Record<string> | null;
+
+  /** Source/provenance metadata that identifies the task producer. */
+  source: AgentServerTaskSource | null;
+
+  /** JSON-serializable attachment values keyed by attachment name. */
+  attachments: Record<unknown> | null;
+
+  /** Structured terminal error details. */
+  error: AgentServerTaskError | null;
+
+  /** Reason the task was suspended. */
+  @maxLength(256)
+  suspension_reason: string | null;
+
+  /** ISO 8601 UTC creation timestamp. */
+  created_at: string;
+
+  /** ISO 8601 UTC last-update timestamp. */
+  updated_at: string;
+
+  /** ISO 8601 UTC timestamp of the first transition to `in_progress`, or null. */
+  started_at: string | null;
+
+  /** ISO 8601 UTC completion timestamp, or null. */
+  completed_at: string | null;
+
+  /** Optimistic-concurrency token. */
+  etag: string;
+}
+
+/** Request body for creating an AgentServer durable task record. */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskCreateRequest {
+  /** Optional caller-supplied task identifier. If omitted, the provider generates one. */
+  id?: string;
+
+  /** Agent scope that owns this task. */
+  agent_name: string;
+
+  /** Session scope that owns this task. */
+  session_id: string;
+
+  /** Human-readable title. */
+  @maxLength(256)
+  title: string;
+
+  /** Optional human-readable description. */
+  @maxLength(1024)
+  description?: string;
+
+  /** Initial task status. Defaults to `pending`. */
+  status?: AgentServerTaskStatus = AgentServerTaskStatus.pending;
+
+  /** Initial arbitrary JSON task payload. */
+  payload?: unknown;
+
+  /** Initial string tags. */
+  tags?: Record<string>;
+
+  /** Source/provenance metadata that identifies the task producer. */
+  source?: AgentServerTaskSource;
+
+  /** Initial JSON-serializable attachment values keyed by attachment name. */
+  attachments?: Record<unknown>;
+}
+
+/** Structured error persisted on a task record. */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskError {
+  /** Error type discriminator, such as `timeout` or `retries_exhausted`. */
+  type: string;
+
+  /** Human-readable error message. */
+  message: string;
+
+  /** Optional machine-readable error code. Defaults to `error` when omitted by the caller. */
+  code?: string = "error";
+
+  /** Additional structured error fields. */
+  ...Record<unknown>;
+}
+
+/** Cursor-paged list response for AgentServer durable task records. */
+@extension("x-ms-foundry-meta", AgentServerPersistenceContract)
+model AgentServerTaskListResponse {
+  /** Object discriminator. Always `list`. */
+  object: "list";
+
+  /** Page of matching task records. */
+  @pageItems
+  data: AgentServerTaskRecord[];
+
+  /** First task id represented in this page. */
+  first_id?: string;
+
+  /** Whether more records are available. */
+  has_more: boolean;
+
+  /** Cursor to pass as `after` for the next page when `has_more` is true. */
+  @continuationToken
+  last_id?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agentserver-persistence/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agentserver-persistence/routes.tsp
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "../common/models.tsp";
+import "../common/servicepatterns.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using Azure.Core;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// AgentServer Core task-storage wire operations
+//
+// These are the REST operations used by the Python and .NET resilient-task
+// providers. SDK runtime methods such as RunAsync/StartAsync/GetActiveRunAsync
+// are language-specific ergonomics layered above this storage contract and are
+// intentionally not modeled as REST operations.
+// ---------------------------------------------------------------------------
+
+alias AgentServerTaskLeaseQueryParameters = {
+  /**
+   * Stable lease owner. Must be supplied together with `lease_instance_id` and
+   * `lease_duration_seconds`. Lease parameters are query parameters, never body fields.
+   */
+  @query lease_owner?: string;
+
+  /**
+   * Ephemeral worker instance id. Must be supplied together with `lease_owner`
+   * and `lease_duration_seconds`.
+   */
+  @query lease_instance_id?: string;
+
+  /**
+   * Lease duration in seconds. `0` force-expires the current lease; otherwise
+   * values are bounded by the task-storage service.
+   */
+  @query lease_duration_seconds?: int32;
+};
+
+alias AgentServerTaskIdPathParameter = {
+  /** The task id. */
+  @path task_id: string;
+};
+
+alias AgentServerTaskIfMatchHeader = {
+  /** Optimistic-concurrency precondition for patch/delete operations. */
+  @header("If-Match") if_match?: string;
+};
+
+alias CreateAgentServerTaskRequest = {
+  ...AgentServerTaskLeaseQueryParameters;
+
+  /** Task creation body. */
+  @body body: AgentServerTaskCreateRequest;
+};
+
+alias GetAgentServerTaskRequest = {
+  ...AgentServerTaskIdPathParameter;
+};
+
+alias PatchAgentServerTaskRequest = {
+  ...AgentServerTaskIdPathParameter;
+  ...AgentServerTaskLeaseQueryParameters;
+  ...AgentServerTaskIfMatchHeader;
+
+  /**
+   * Arbitrary JSON patch document. Supported top-level fields include status,
+   * payload, tags, attachments, error, and suspension_reason.
+   */
+  @body body: unknown;
+};
+
+alias DeleteAgentServerTaskRequest = {
+  ...AgentServerTaskIdPathParameter;
+  ...AgentServerTaskIfMatchHeader;
+
+  /** Force deletion of a non-terminal task and release any active lease. Defaults to false. */
+  @query force?: boolean = false;
+};
+
+union AgentServerTaskListOrder {
+  ascent: "asc",
+  descent: "desc",
+}
+
+alias ListAgentServerTasksRequest = {
+  /** Filter by agent name. */
+  @query agent_name?: string;
+
+  /** Filter by session id. */
+  @query session_id?: string;
+
+  /** Filter by task status. */
+  @query status?: AgentServerTaskStatus;
+
+  /** Filter by whether the task has a recorded error. */
+  @query has_error?: boolean;
+
+  /** Filter by whether the current lease is expired. */
+  @query lease_expired?: boolean;
+
+  /** Filter by lease owner. */
+  @query lease_owner?: string;
+
+  /** Tag equality filters in `key:value` form. Repeat for AND filtering. */
+  @query tag?: string[];
+
+  /** Filter by source type, for example `routine_action_delivery`. */
+  @query source_type?: string;
+
+  /** Cursor for the next page. */
+  @query after?: string;
+
+  /** Maximum number of records to return. Default 20, maximum 100. */
+  @query limit?: int32 = 20;
+
+  /** Sort order. */
+  @query order?: AgentServerTaskListOrder = AgentServerTaskListOrder.descent;
+
+  /** When true, omit attachment values from returned task records. */
+  @query omit_attachment_values?: boolean = false;
+};
+
+@tag("AgentServer Task Storage")
+interface AgentServerTaskStorage {
+  /** Creates a durable task record. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "internal SDK storage protocol"
+  @summary("Create a task")
+  @operationId("createAgentServerTask")
+  @post
+  @route("/tasks")
+  @extension("x-ms-foundry-meta", AgentServerPersistenceRequiredPreviews)
+  createAgentServerTask is FoundryDataPlaneRequiredPreviewOperation<
+    FoundryFeaturesOptInKeys.routines_v1_preview,
+    CreateAgentServerTaskRequest,
+    ResourceCreatedResponse<AgentServerTaskRecord>
+  >;
+
+  /** Retrieves a durable task record by id. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "internal SDK storage protocol"
+  @summary("Get a task")
+  @operationId("getAgentServerTask")
+  @get
+  @route("/tasks/{task_id}")
+  @extension("x-ms-foundry-meta", AgentServerPersistenceRequiredPreviews)
+  getAgentServerTask is FoundryDataPlaneRequiredPreviewOperation<
+    FoundryFeaturesOptInKeys.routines_v1_preview,
+    GetAgentServerTaskRequest,
+    AgentServerTaskRecord
+  >;
+
+  /** Patches a durable task record, including status, payload, tags, attachments, and lease operations. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "internal SDK storage protocol"
+  @summary("Patch a task")
+  @operationId("patchAgentServerTask")
+  @patch
+  @route("/tasks/{task_id}")
+  @extension("x-ms-foundry-meta", AgentServerPersistenceRequiredPreviews)
+  patchAgentServerTask is FoundryDataPlaneRequiredPreviewOperation<
+    FoundryFeaturesOptInKeys.routines_v1_preview,
+    PatchAgentServerTaskRequest,
+    AgentServerTaskRecord
+  >;
+
+  /** Deletes a durable task record. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "internal SDK storage protocol"
+  @summary("Delete a task")
+  @operationId("deleteAgentServerTask")
+  @delete
+  @route("/tasks/{task_id}")
+  @extension("x-ms-foundry-meta", AgentServerPersistenceRequiredPreviews)
+  deleteAgentServerTask is FoundryDataPlaneRequiredPreviewOperation<
+    FoundryFeaturesOptInKeys.routines_v1_preview,
+    DeleteAgentServerTaskRequest,
+    NoContentResponse
+  >;
+
+  /** Lists durable task records that match the supplied filters. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "internal SDK storage protocol"
+  @summary("List tasks")
+  @operationId("listAgentServerTasks")
+  @get
+  @list
+  @route("/tasks")
+  @extension("x-ms-foundry-meta", AgentServerPersistenceRequiredPreviews)
+  listAgentServerTasks is FoundryDataPlaneRequiredPreviewOperation<
+    FoundryFeaturesOptInKeys.routines_v1_preview,
+    ListAgentServerTasksRequest,
+    AgentServerTaskListResponse
+  >;
+}


### PR DESCRIPTION
## Summary

Adds the Foundry TypeSpec contract for the AgentExtensions task-storage API, aligned with the latest Vienna implementation.

The task resource envelope is modeled, while arbitrary task payloads, attachment values, and PATCH documents remain untyped JSON so generated SDKs preserve raw `BinaryData`/request-content handling.

## Added

- `src/agentserver-persistence/models.tsp`
- `src/agentserver-persistence/routes.tsp`
- `POST /tasks`
- `GET /tasks/{task_id}`
- `PATCH /tasks/{task_id}`
- `DELETE /tasks/{task_id}`
- `GET /tasks`

## Vienna alignment

- Removed SDK-private response recovery payload models.
- Removed unsupported task dependencies and delete cascade.
- Kept `payload` and attachment values opaque.
- Kept the PATCH body as arbitrary JSON.
- Aligned source metadata and public lease fields with AgentExtensions.
- Made task status forward-compatible.

## Validation

The Foundry project and all SDK TypeSpec entrypoints compile with warnings treated as errors.