### PR TITLE
Fix Java service-dir for containerservicepreparedimgspec tspconfig

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
@@ -17,7 +17,7 @@ options:
     namespace: "Azure.ResourceManager.ContainerServicePreparedImgSpec"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-java":
-    service-dir: "sdk/containerservice"
+    service-dir: "sdk/containerservicepreparedimgspec"
     namespace: "com.azure.resourcemanager.containerservicepreparedimgspec"
     package-dir: "azure-resourcemanager-containerservicepreparedimgspec"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservicepreparedimgspec"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
@@ -23,6 +23,9 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservicepreparedimgspec"
     service-name: "Container Service Prepared Image Specification"
     flavor: azure
+    rename-model:
+      PreparedImageSpecificationListResult: PreparedImgSpecListResult
+      PreparedImageSpecificationVersionListResult: PreparedImgSpecVersionListResult
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerservicepreparedimgspec"
     package-dir: "armcontainerservicepreparedimgspec"


### PR DESCRIPTION
The @azure-tools/typespec-java emitter's service-dir in the preparedimagespecification tspconfig was set to sdk/containerservice, which placed the generated Java package under sdk/containerservice/azure-resourcemanager-containerservicepreparedimgspec.

It should be sdk/containerservicepreparedimgspec to match the top-level default service-dir parameter and keep the package under its own service directory (sdk/containerservicepreparedimgspec/azure-resourcemanager-containerservicepreparedimgspec).