### PR TITLE
Fix Java service-dir to match package name for 3 mgmt libraries

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/tspconfig.yaml
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/tspconfig.yaml
@@ -21,6 +21,7 @@ options:
     generate-sample: true
     flavor: azure
   "@azure-tools/typespec-java":
+    service-dir: sdk/resiliencemanagement
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-resiliencemanagement"
     namespace: com.azure.resourcemanager.resiliencemanagement
     service-name: Resilience Management

--- a/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/tspconfig.yaml
+++ b/specification/billingtrust/resource-manager/Microsoft.BillingTrust/BillingTrust/tspconfig.yaml
@@ -21,6 +21,7 @@ options:
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
+    service-dir: "sdk/billing"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-billing-trust"
     namespace: "com.azure.resourcemanager.billing.trust"
     service-name: "BillingTrust"

--- a/specification/portalservices/CopilotSettings.Management/tspconfig.yaml
+++ b/specification/portalservices/CopilotSettings.Management/tspconfig.yaml
@@ -18,6 +18,7 @@ options:
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
+    service-dir: "sdk/portalservicescopilot"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-portalservicescopilot"
     namespace: "com.azure.resourcemanager.portalservicescopilot"
     service-name: "Portal Services Copilot"


### PR DESCRIPTION
Aligns the `@azure-tools/typespec-java` service-dir with the Java package name for 3 management libraries, so the generated SDK lands in a service folder matching `azure-resourcemanager-<name>` (same fix pattern as #45098).

| tspconfig | old service-dir (inherited default) | new Java service-dir |
|---|---|---|
| `azureresiliencemanagement/.../AzureResilienceManagement` | `sdk/azureresiliencemanagement` | `sdk/resiliencemanagement` |
| `billingtrust/.../BillingTrust` | `sdk/billingtrust` | `sdk/billing-trust` |
| `portalservices/CopilotSettings.Management` | `sdk/portalservices` | `sdk/portalservicescopilot` |

The Java emitter previously had no explicit `service-dir` and inherited the `parameters` default (which matches the other languages' folders but not the Java package name).

### Related
- Corresponding SDK move PR: Azure/azure-sdk-for-java (to follow)
