### PR TITLE
Add Nishanth-MS as EventGrid CODEOWNERS reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,8 +131,8 @@
 /specification/domainservices/ @jihochang
 
 # PRLabel: %Event Grid
-/specification/eventgrid/resource-manager/ @shankarsama @Kishp01 @a-hamad
-/specification/eventgrid/ @Kishp01 @shankarsama @rajeshka
+/specification/eventgrid/resource-manager/ @shankarsama @Kishp01 @a-hamad @Nishanth-MS
+/specification/eventgrid/ @Kishp01 @shankarsama @rajeshka @Nishanth-MS
 
 # PRLabel: %Event Hubs
 /specification/eventhub/ @v-ajnava @dsouzaarun @damodaravadhani


### PR DESCRIPTION
Adds `@Nishanth-MS` as a code owner / required reviewer for EventGrid specs.

### Change
Added `@Nishanth-MS` to both EventGrid entries in `.github/CODEOWNERS`:
- `/specification/eventgrid/resource-manager/` (control plane)
- `/specification/eventgrid/` (all EventGrid, incl. data plane)

### Verification
`Nishanth-MS` is confirmed:
- A public member of the Azure org (satisfies CODEOWNERS linting)
- Has `write` permission on the repository (eligible for review requests)

### Note
GitHub CODEOWNERS uses last-match-wins, so for control-plane PRs the effective owner line is `/specification/eventgrid/` (the later entry). `@Nishanth-MS` was added to that line as well, so they will be requested on control-plane PRs.