### PR TITLE
[AI Foundry][Data Plane] Add session_configuration.idle_timeout_seconds to HostedAgentDefinition

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38541,6 +38541,15 @@
           "telemetry_config": {
             "$ref": "#/components/schemas/TelemetryConfig",
             "description": "Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
+          },
+          "session_configuration": {
+            "$ref": "#/components/schemas/SessionConfiguration",
+            "description": "Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.",
+            "examples": [
+              {
+                "idle_timeout_seconds": 300
+              }
+            ]
           }
         },
         "allOf": [
@@ -80569,6 +80578,23 @@
             "VoiceAgents=V1Preview"
           ]
         }
+      },
+      "SessionConfiguration": {
+        "type": "object",
+        "properties": {
+          "idle_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 300,
+            "maximum": 3600,
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "examples": [
+              300
+            ],
+            "default": 900
+          }
+        },
+        "description": "Session defaults applied to sessions created for a hosted agent version."
       },
       "SessionDirectoryEntry": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -34149,6 +34149,15 @@
           "telemetry_config": {
             "$ref": "#/components/schemas/TelemetryConfig",
             "description": "Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
+          },
+          "session_configuration": {
+            "$ref": "#/components/schemas/SessionConfiguration",
+            "description": "Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.",
+            "examples": [
+              {
+                "idle_timeout_seconds": 300
+              }
+            ]
           }
         },
         "allOf": [
@@ -75819,6 +75828,23 @@
             "Schedules=V1Preview"
           ]
         }
+      },
+      "SessionConfiguration": {
+        "type": "object",
+        "properties": {
+          "idle_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 300,
+            "maximum": 3600,
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "examples": [
+              300
+            ],
+            "default": 900
+          }
+        },
+        "description": "Session defaults applied to sessions created for a hosted agent version."
       },
       "SessionDirectoryEntry": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -43647,6 +43647,11 @@ components:
         telemetry_config:
           $ref: '#/components/schemas/TelemetryConfig'
           description: Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
+        session_configuration:
+          $ref: '#/components/schemas/SessionConfiguration'
+          description: Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.
+          examples:
+            - idle_timeout_seconds: 300
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
@@ -73783,6 +73788,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    SessionConfiguration:
+      type: object
+      properties:
+        idle_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 300
+          maximum: 3600
+          description: |-
+            The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            (inclusive).
+          examples:
+            - 300
+          default: 900
+      description: Session defaults applied to sessions created for a hosted agent version.
     SessionDirectoryEntry:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46746,6 +46746,11 @@ components:
         telemetry_config:
           $ref: '#/components/schemas/TelemetryConfig'
           description: Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
+        session_configuration:
+          $ref: '#/components/schemas/SessionConfiguration'
+          description: Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.
+          examples:
+            - idle_timeout_seconds: 300
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
@@ -77113,6 +77118,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    SessionConfiguration:
+      type: object
+      properties:
+        idle_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 300
+          maximum: 3600
+          description: |-
+            The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            (inclusive).
+          examples:
+            - 300
+          default: 900
+      description: Session defaults applied to sessions created for a hosted agent version.
     SessionDirectoryEntry:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -42817,6 +42817,15 @@
           "telemetry_config": {
             "$ref": "#/components/schemas/TelemetryConfig",
             "description": "Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
+          },
+          "session_configuration": {
+            "$ref": "#/components/schemas/SessionConfiguration",
+            "description": "Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.",
+            "examples": [
+              {
+                "idle_timeout_seconds": 300
+              }
+            ]
           }
         },
         "allOf": [
@@ -85123,6 +85132,23 @@
             "VoiceAgents=V1Preview"
           ]
         }
+      },
+      "SessionConfiguration": {
+        "type": "object",
+        "properties": {
+          "idle_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 300,
+            "maximum": 3600,
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "examples": [
+              300
+            ],
+            "default": 900
+          }
+        },
+        "description": "Session defaults applied to sessions created for a hosted agent version."
       },
       "SessionDirectoryEntry": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -38429,6 +38429,15 @@
           "telemetry_config": {
             "$ref": "#/components/schemas/TelemetryConfig",
             "description": "Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
+          },
+          "session_configuration": {
+            "$ref": "#/components/schemas/SessionConfiguration",
+            "description": "Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.",
+            "examples": [
+              {
+                "idle_timeout_seconds": 300
+              }
+            ]
           }
         },
         "allOf": [
@@ -80377,6 +80386,23 @@
             "Schedules=V1Preview"
           ]
         }
+      },
+      "SessionConfiguration": {
+        "type": "object",
+        "properties": {
+          "idle_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 300,
+            "maximum": 3600,
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "examples": [
+              300
+            ],
+            "default": 900
+          }
+        },
+        "description": "Session defaults applied to sessions created for a hosted agent version."
       },
       "SessionDirectoryEntry": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49686,6 +49686,11 @@ components:
         telemetry_config:
           $ref: '#/components/schemas/TelemetryConfig'
           description: Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
+        session_configuration:
+          $ref: '#/components/schemas/SessionConfiguration'
+          description: Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.
+          examples:
+            - idle_timeout_seconds: 300
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
@@ -80250,6 +80255,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    SessionConfiguration:
+      type: object
+      properties:
+        idle_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 300
+          maximum: 3600
+          description: |-
+            The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            (inclusive).
+          examples:
+            - 300
+          default: 900
+      description: Session defaults applied to sessions created for a hosted agent version.
     SessionDirectoryEntry:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -46593,6 +46593,11 @@ components:
         telemetry_config:
           $ref: '#/components/schemas/TelemetryConfig'
           description: Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
+        session_configuration:
+          $ref: '#/components/schemas/SessionConfiguration'
+          description: Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.
+          examples:
+            - idle_timeout_seconds: 300
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
@@ -76926,6 +76931,22 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    SessionConfiguration:
+      type: object
+      properties:
+        idle_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 300
+          maximum: 3600
+          description: |-
+            The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            (inclusive).
+          examples:
+            - 300
+          default: 900
+      description: Session defaults applied to sessions created for a hosted agent version.
     SessionDirectoryEntry:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -370,6 +370,19 @@ model ContainerConfiguration {
   image: string;
 }
 
+@doc("Session defaults applied to sessions created for a hosted agent version.")
+model SessionConfiguration {
+  @doc("""
+    The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+    unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+    (inclusive).
+    """)
+  @minValue(300)
+  @maxValue(3600)
+  @example(300)
+  idle_timeout_seconds?: int32 = 900;
+}
+
 @doc("Code-based deployment configuration for a hosted agent.")
 model CodeConfiguration {
   @doc("The runtime identifier for code execution (e.g., 'python_3_11', 'python_3_12', 'python_3_13').")
@@ -459,6 +472,10 @@ model HostedAgentDefinition extends AgentDefinition {
 
   @doc("Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.")
   telemetry_config?: TelemetryConfig;
+
+  @doc("Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.")
+  @example(#{ idle_timeout_seconds: 300 })
+  session_configuration?: SessionConfiguration;
 }
 
 @doc("The container app agent definition.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -393,6 +393,19 @@ model ContainerConfiguration {
   registry_connection_id?: string;
 }
 
+@doc("Session defaults applied to sessions created for a hosted agent version.")
+model SessionConfiguration {
+  @doc("""
+    The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
+    unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+    (inclusive).
+    """)
+  @minValue(300)
+  @maxValue(3600)
+  @example(300)
+  idle_timeout_seconds?: int32 = 900;
+}
+
 @doc("Code-based deployment configuration for a hosted agent.")
 model CodeConfiguration {
   @doc("The runtime identifier for code execution (e.g., 'python_3_11', 'python_3_12', 'python_3_13').")
@@ -482,6 +495,10 @@ model HostedAgentDefinition extends AgentDefinition {
 
   @doc("Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.")
   telemetry_config?: TelemetryConfig;
+
+  @doc("Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.")
+  @example(#{ idle_timeout_seconds: 300 })
+  session_configuration?: SessionConfiguration;
 }
 
 @doc("The container app agent definition.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -400,10 +400,11 @@ model SessionConfiguration {
     unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
     (inclusive).
     """)
-  @minValue(300)
-  @maxValue(3600)
-  @example(300)
-  idle_timeout_seconds?: int32 = 900;
+  @minValue(duration.fromISO("PT300S"))
+  @maxValue(duration.fromISO("PT3600S"))
+  @example(duration.fromISO("PT300S"))
+  @encode(DurationKnownEncoding.seconds, int32)
+  idle_timeout_seconds?: duration = duration.fromISO("PT900S");
 }
 
 @doc("Code-based deployment configuration for a hosted agent.")
@@ -497,7 +498,7 @@ model HostedAgentDefinition extends AgentDefinition {
   telemetry_config?: TelemetryConfig;
 
   @doc("Optional session defaults (for example, the idle timeout) applied to sessions created for this agent version.")
-  @example(#{ idle_timeout_seconds: 300 })
+  @example(#{ idle_timeout_seconds: duration.fromISO("PT300S") })
   session_configuration?: SessionConfiguration;
 }
 


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

## Summary

Model the optional `session_configuration.idle_timeout_seconds` field on `HostedAgentDefinition` in TypeSpec so the service-side hand-written customization can be removed once regenerated. Ungated, so it applies to both `v1` and `virtual-public-preview`. `idle_timeout_seconds` is `int32`, range `[60, 3600]`, defaulting to the 900s server default when unset. Additive, non-breaking change.

## API Info: The Basics

Is this review for (select one):

- [ ] a private preview
- [x] a public preview
- [ ] GA release

### Change Scope

* Updated paths:
  * `specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp` — new `SessionConfiguration` model + optional `HostedAgentDefinition.session_configuration` property
  * Regenerated OpenAPI3 outputs for `v1` and `virtual-public-preview` (`.json` + `.yaml`)