### PR TITLE
Fix .NET emitter-output-dir in aimanager tspconfig

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
     flavor: azure
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ContainerServiceAIManager"
-    emitter-output-dir: "{output-dir}/sdk/aimanager/{namespace}"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerserviceaimanager"
     namespace: "com.azure.resourcemanager.containerserviceaimanager"


### PR DESCRIPTION
Fixed .NET `emitter-output-dir` to `{output-dir}/{service-dir}/{namespace}` so it uses `service-dir` like the other languages.
