### PR TITLE
Add Foundry trace PII redaction option

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -30477,7 +30477,7 @@
           "mapping": {
             "simple_qna": "#/components/schemas/SimpleQnADataGenerationJobOptions",
             "traces": "#/components/schemas/TracesDataGenerationJobOptions",
-            "task_generation": "#/components/schemas/TaskGenerationDataGenerationJobOptions",
+            "simulation_seed": "#/components/schemas/SimulationSeedDataGenerationJobOptions",
             "tool_use": "#/components/schemas/ToolUseFineTuningDataGenerationJobOptions"
           }
         },
@@ -30674,7 +30674,7 @@
               "simple_qna",
               "traces",
               "tool_use",
-              "task_generation"
+              "simulation_seed"
             ]
           }
         ],
@@ -76554,7 +76554,7 @@
         },
         "description": "Base class for targets with discriminator support."
       },
-      "TaskGenerationDataGenerationJobOptions": {
+      "SimulationSeedDataGenerationJobOptions": {
         "type": "object",
         "required": [
           "type"
@@ -76563,9 +76563,9 @@
           "type": {
             "type": "string",
             "enum": [
-              "task_generation"
+              "simulation_seed"
             ],
-            "description": "The data generation job type, which is TaskGeneration for this model."
+            "description": "The data generation job type, which is SimulationSeed for this model."
           }
         },
         "allOf": [
@@ -76573,7 +76573,7 @@
             "$ref": "#/components/schemas/DataGenerationJobOptions"
           }
         ],
-        "description": "The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "description": "The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "DataGenerationJobs=V1Preview"
@@ -77310,6 +77310,11 @@
               "traces"
             ],
             "description": "The data generation job type, which is Traces for this model."
+          },
+          "pii_redaction": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -77311,10 +77311,10 @@
             ],
             "description": "The data generation job type, which is Traces for this model."
           },
-          "pii_redaction": {
+          "redact_private_content": {
             "type": "boolean",
             "default": true,
-            "description": "Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction."
+            "description": "Whether to redact private content from traces. When omitted or set to true, private content is redacted. Set to false to opt out of redaction."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -74845,10 +74845,10 @@ components:
           enum:
             - traces
           description: The data generation job type, which is Traces for this model.
-        pii_redaction:
+        redact_private_content:
           type: boolean
           default: true
-          description: Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.
+          description: Whether to redact private content from traces. When omitted or set to true, private content is redacted. Set to false to opt out of redaction.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
       description: The options for a data generation job with Traces type.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40875,7 +40875,7 @@ components:
         mapping:
           simple_qna: '#/components/schemas/SimpleQnADataGenerationJobOptions'
           traces: '#/components/schemas/TracesDataGenerationJobOptions'
-          task_generation: '#/components/schemas/TaskGenerationDataGenerationJobOptions'
+          simulation_seed: '#/components/schemas/SimulationSeedDataGenerationJobOptions'
           tool_use: '#/components/schemas/ToolUseFineTuningDataGenerationJobOptions'
       description: Options for managing data generation jobs.
       x-ms-foundry-meta:
@@ -41003,7 +41003,7 @@ components:
             - simple_qna
             - traces
             - tool_use
-            - task_generation
+            - simulation_seed
       description: The supported data generation job types.
       x-ms-foundry-meta:
         conditional_previews:
@@ -74315,7 +74315,7 @@ components:
           azure_ai_model: '#/components/schemas/AzureAIModelTargetUpdate'
           azure_ai_agent: '#/components/schemas/AzureAIAgentTargetUpdate'
       description: Base class for targets with discriminator support.
-    TaskGenerationDataGenerationJobOptions:
+    SimulationSeedDataGenerationJobOptions:
       type: object
       required:
         - type
@@ -74323,11 +74323,11 @@ components:
         type:
           type: string
           enum:
-            - task_generation
-          description: The data generation job type, which is TaskGeneration for this model.
+            - simulation_seed
+          description: The data generation job type, which is SimulationSeed for this model.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
-      description: The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      description: The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview
@@ -74845,6 +74845,10 @@ components:
           enum:
             - traces
           description: The data generation job type, which is Traces for this model.
+        pii_redaction:
+          type: boolean
+          default: true
+          description: Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
       description: The options for a data generation job with Traces type.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -33914,7 +33914,7 @@
           "mapping": {
             "simple_qna": "#/components/schemas/SimpleQnADataGenerationJobOptions",
             "traces": "#/components/schemas/TracesDataGenerationJobOptions",
-            "task_generation": "#/components/schemas/TaskGenerationDataGenerationJobOptions",
+            "simulation_seed": "#/components/schemas/SimulationSeedDataGenerationJobOptions",
             "tool_use": "#/components/schemas/ToolUseFineTuningDataGenerationJobOptions"
           }
         },
@@ -34111,7 +34111,7 @@
               "simple_qna",
               "traces",
               "tool_use",
-              "task_generation"
+              "simulation_seed"
             ]
           }
         ],
@@ -81138,7 +81138,7 @@
         },
         "description": "Base class for targets with discriminator support."
       },
-      "TaskGenerationDataGenerationJobOptions": {
+      "SimulationSeedDataGenerationJobOptions": {
         "type": "object",
         "required": [
           "type"
@@ -81147,9 +81147,9 @@
           "type": {
             "type": "string",
             "enum": [
-              "task_generation"
+              "simulation_seed"
             ],
-            "description": "The data generation job type, which is TaskGeneration for this model."
+            "description": "The data generation job type, which is SimulationSeed for this model."
           }
         },
         "allOf": [
@@ -81157,7 +81157,7 @@
             "$ref": "#/components/schemas/DataGenerationJobOptions"
           }
         ],
-        "description": "The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
+        "description": "The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "DataGenerationJobs=V1Preview"
@@ -81896,6 +81896,11 @@
               "traces"
             ],
             "description": "The data generation job type, which is Traces for this model."
+          },
+          "pii_redaction": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -81897,10 +81897,10 @@
             ],
             "description": "The data generation job type, which is Traces for this model."
           },
-          "pii_redaction": {
+          "redact_private_content": {
             "type": "boolean",
             "default": true,
-            "description": "Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction."
+            "description": "Whether to redact private content from traces. When omitted or set to true, private content is redacted. Set to false to opt out of redaction."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -43193,7 +43193,7 @@ components:
         mapping:
           simple_qna: '#/components/schemas/SimpleQnADataGenerationJobOptions'
           traces: '#/components/schemas/TracesDataGenerationJobOptions'
-          task_generation: '#/components/schemas/TaskGenerationDataGenerationJobOptions'
+          simulation_seed: '#/components/schemas/SimulationSeedDataGenerationJobOptions'
           tool_use: '#/components/schemas/ToolUseFineTuningDataGenerationJobOptions'
       description: Options for managing data generation jobs.
       x-ms-foundry-meta:
@@ -43321,7 +43321,7 @@ components:
             - simple_qna
             - traces
             - tool_use
-            - task_generation
+            - simulation_seed
       description: The supported data generation job types.
       x-ms-foundry-meta:
         conditional_previews:
@@ -77475,7 +77475,7 @@ components:
           azure_ai_model: '#/components/schemas/AzureAIModelTargetUpdate'
           azure_ai_agent: '#/components/schemas/AzureAIAgentTargetUpdate'
       description: Base class for targets with discriminator support.
-    TaskGenerationDataGenerationJobOptions:
+    SimulationSeedDataGenerationJobOptions:
       type: object
       required:
         - type
@@ -77483,11 +77483,11 @@ components:
         type:
           type: string
           enum:
-            - task_generation
-          description: The data generation job type, which is TaskGeneration for this model.
+            - simulation_seed
+          description: The data generation job type, which is SimulationSeed for this model.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
-      description: The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
+      description: The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.
       x-ms-foundry-meta:
         conditional_previews:
           - DataGenerationJobs=V1Preview
@@ -78007,6 +78007,10 @@ components:
           enum:
             - traces
           description: The data generation job type, which is Traces for this model.
+        pii_redaction:
+          type: boolean
+          default: true
+          description: Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
       description: The options for a data generation job with Traces type.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -78007,10 +78007,10 @@ components:
           enum:
             - traces
           description: The data generation job type, which is Traces for this model.
-        pii_redaction:
+        redact_private_content:
           type: boolean
           default: true
-          description: Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.
+          description: Whether to redact private content from traces. When omitted or set to true, private content is redacted. Set to false to opt out of redaction.
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOptions'
       description: The options for a data generation job with Traces type.

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -25,8 +25,8 @@ union DataGenerationJobType {
   @doc("Tool calling conversation between user and agent.")
   tool_use: "tool_use",
 
-  @doc("Task generation for evaluation scenarios.")
-  task_generation: "task_generation",
+  @doc("Simulation seed for evaluation scenarios.")
+  simulation_seed: "simulation_seed",
 }
 
 @doc("LLM model options for data generation jobs.")
@@ -223,13 +223,16 @@ model SimpleQnADataGenerationJobOptions extends DataGenerationJobOptions {
 model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
   @doc("The data generation job type, which is Traces for this model.")
   type: "traces";
+
+  @doc("Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.")
+  pii_redaction?: boolean = true;
 }
 
-@doc("The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
+@doc("The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
-model TaskGenerationDataGenerationJobOptions extends DataGenerationJobOptions {
-  @doc("The data generation job type, which is TaskGeneration for this model.")
-  type: "task_generation";
+model SimulationSeedDataGenerationJobOptions extends DataGenerationJobOptions {
+  @doc("The data generation job type, which is SimulationSeed for this model.")
+  type: "simulation_seed";
 }
 
 @doc("The options for a data generation job with ToolUse type. Used only for fine-tuning scenarios.")

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -224,8 +224,8 @@ model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
   @doc("The data generation job type, which is Traces for this model.")
   type: "traces";
 
-  @doc("Whether to redact personally identifiable information from traces. When omitted or set to true, PII is redacted. Set to false to opt out of redaction.")
-  pii_redaction?: boolean = true;
+  @doc("Whether to redact private content from traces. When omitted or set to true, private content is redacted. Set to false to opt out of redaction.")
+  redact_private_content?: boolean = true;
 }
 
 @doc("The options for a simulation seed data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -232,7 +232,7 @@ model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model SimulationSeedDataGenerationJobOptions extends DataGenerationJobOptions {
   @doc("The data generation job type, which is SimulationSeed for this model.")
-  type: "simulation_seed";
+  type: DataGenerationJobType.simulation_seed;
 }
 
 @doc("The options for a data generation job with ToolUse type. Used only for fine-tuning scenarios.")


### PR DESCRIPTION
## Summary
- Add optional `pii_redaction` boolean to trace data generation options only, defaulting to enabled when omitted.
- Rename the task generation data generation mode to `simulation_seed`.
- Update generated Foundry OpenAPI JSON/YAML outputs for `v1` and `virtual-public-preview`.

## Validation
- `azsdk_run_typespec_validation` succeeded for `specification/ai-foundry/data-plane/Foundry`.
- Focused OpenAPI checks confirmed `pii_redaction` is trace-only and `simulation_seed` replaces `task_generation`.