### PR TITLE
Add scheduledEvents schema for 2026-06-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/examples/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/examples/readme.md
@@ -1,0 +1,3 @@
+# AKS Scheduled Events Examples
+
+This folder is reserved for AKS scheduled events examples.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
@@ -1,0 +1,119 @@
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+
+using Azure.ResourceManager;
+using TypeSpec.Versioning;
+using TypeSpec.OpenAPI;
+
+/**
+ * The Container Service Scheduled Events data model.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "This project intentionally emits a schema-only proxy resource contract for Azure Resource Notifications with no customer-callable ARM operations."
+@armProviderNamespace
+@service(#{ title: "ContainerServiceClient" })
+@versioned(Versions)
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+namespace Microsoft.ContainerService;
+
+/**
+ * The available API versions.
+ */
+enum Versions {
+  /**
+   * The 2026-06-01 API version.
+   */
+  v2026_06_01: "2026-06-01",
+}
+
+/**
+ * Scheduled event.
+ */
+model ScheduledEvent
+  is Azure.ResourceManager.ProxyResource<ScheduledEventProperties> {
+  ...ResourceNameParameter<
+    Resource = ScheduledEvent,
+    KeyName = "scheduledEventName",
+    SegmentName = "scheduledEvents",
+    NamePattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+  >;
+}
+
+@@doc(ScheduledEvent.properties, "Properties for the event.");
+
+/**
+ * Properties for a scheduled event.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Preserves the existing scheduledEvents notification contract; this materialized notification data model does not include provisioningState."
+model ScheduledEventProperties {
+  /**
+   * The description of the event.
+   */
+  description?: string;
+
+  /**
+   * The event id of the event.
+   */
+  eventId?: string;
+
+  /**
+   * The source of the event.
+   */
+  eventSource?: string;
+
+  /**
+   * The status of the event.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserves the existing scheduledEvents swagger x-ms-enum metadata."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeps the enum inline to preserve the existing scheduledEvents swagger shape."
+  @extension("x-ms-enum", #{ name: "eventStatus", modelAsString: true })
+  eventStatus?:
+    | "Scheduled"
+    | "Started"
+    | "Completed"
+    | "Cancelled"
+    | "Failed"
+    | string;
+
+  /**
+   * The details of the event.
+   */
+  eventDetails?: string;
+
+  /**
+   * The time of the event is scheduled to start.
+   */
+  scheduledTime?: utcDateTime;
+
+  /**
+   * The time the event actually started.
+   */
+  startTime?: utcDateTime;
+
+  /**
+   * The last time the state of the event was updated.
+   */
+  lastUpdateTime?: utcDateTime;
+
+  /**
+   * The list of resources impacted by the event.
+   */
+  resources?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.ContainerService/managedClusters";
+    },
+    {
+      type: "Microsoft.ContainerService/managedClusters/agentPools";
+    }
+  ]>[];
+
+  /**
+   * The resource type of the event.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserves the existing scheduledEvents swagger x-ms-enum metadata."
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeps the enum inline to preserve the existing scheduledEvents swagger shape."
+  @extension("x-ms-enum", #{ name: "ResourceType", modelAsString: true })
+  resourceType?: "ManagedCluster" | "AgentPool" | string;
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
@@ -2,11 +2,9 @@ import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
-import "@typespec/openapi";
 
 using Azure.ResourceManager;
 using TypeSpec.Versioning;
-using TypeSpec.OpenAPI;
 
 /**
  * The Container Service Scheduled Events data model.
@@ -44,6 +42,48 @@ model ScheduledEvent
 @@doc(ScheduledEvent.properties, "Properties for the event.");
 
 /**
+ * The status of the event.
+ */
+union EventStatus {
+  string,
+  /**
+   * The event is scheduled.
+   */
+  Scheduled: "Scheduled",
+  /**
+   * The event has started.
+   */
+  Started: "Started",
+  /**
+   * The event completed.
+   */
+  Completed: "Completed",
+  /**
+   * The event was cancelled.
+   */
+  Cancelled: "Cancelled",
+  /**
+   * The event failed.
+   */
+  Failed: "Failed",
+}
+
+/**
+ * The resource type of the event.
+ */
+union ResourceType {
+  string,
+  /**
+   * The event applies to a managed cluster.
+   */
+  ManagedCluster: "ManagedCluster",
+  /**
+   * The event applies to an agent pool.
+   */
+  AgentPool: "AgentPool",
+}
+
+/**
  * Properties for a scheduled event.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Preserves the existing scheduledEvents notification contract; this materialized notification data model does not include provisioningState."
@@ -66,16 +106,7 @@ model ScheduledEventProperties {
   /**
    * The status of the event.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserves the existing scheduledEvents swagger x-ms-enum metadata."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeps the enum inline to preserve the existing scheduledEvents swagger shape."
-  @extension("x-ms-enum", #{ name: "eventStatus", modelAsString: true })
-  eventStatus?:
-    | "Scheduled"
-    | "Started"
-    | "Completed"
-    | "Cancelled"
-    | "Failed"
-    | string;
+  eventStatus?: EventStatus;
 
   /**
    * The details of the event.
@@ -83,7 +114,7 @@ model ScheduledEventProperties {
   eventDetails?: string;
 
   /**
-   * The time of the event is scheduled to start.
+   * The time the event is scheduled to start.
    */
   scheduledTime?: utcDateTime;
 
@@ -112,8 +143,5 @@ model ScheduledEventProperties {
   /**
    * The resource type of the event.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserves the existing scheduledEvents swagger x-ms-enum metadata."
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeps the enum inline to preserve the existing scheduledEvents swagger shape."
-  @extension("x-ms-enum", #{ name: "ResourceType", modelAsString: true })
-  resourceType?: "ManagedCluster" | "AgentPool" | string;
+  resourceType?: ResourceType;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
@@ -9,7 +9,7 @@ using TypeSpec.Versioning;
 /**
  * The Container Service Scheduled Events data model.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "This project intentionally emits a schema-only proxy resource contract for Azure Resource Notifications with no customer-callable ARM operations."
+#suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "This sibling project intentionally emits the schema-only Azure Resource Notifications / Azure Resource Graph / Event Grid contract for Microsoft.ContainerService/managedClusters/scheduledEvents. The contract is consumed as notification and resource graph payload schema and has no customer-callable ARM operations."
 @armProviderNamespace
 @service(#{ title: "ContainerServiceClient" })
 @versioned(Versions)
@@ -27,7 +27,7 @@ enum Versions {
 }
 
 /**
- * Scheduled event.
+ * Scheduled event for a managed cluster. ARM resource type: Microsoft.ContainerService/managedClusters/scheduledEvents.
  */
 model ScheduledEvent
   is Azure.ResourceManager.ProxyResource<ScheduledEventProperties> {
@@ -39,7 +39,7 @@ model ScheduledEvent
   >;
 }
 
-@@doc(ScheduledEvent.properties, "Properties for the event.");
+@@doc(ScheduledEvent.properties, "Properties for the scheduled event.");
 
 /**
  * The status of the event.
@@ -74,9 +74,9 @@ union EventStatus {
 }
 
 /**
- * The resource type of the event.
+ * The kind of resource impacted by the scheduled event.
  */
-union ResourceType {
+union ScheduledEventResourceType {
   string,
 
   /**
@@ -92,31 +92,33 @@ union ResourceType {
 
 /**
  * Properties for a scheduled event.
+ *
+ * Timestamp property names intentionally preserve the existing wire contract; all timestamp values are UTC date-time values.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Preserves the existing scheduledEvents notification contract; this materialized notification data model does not include provisioningState."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "This type is a read-only notification payload with no ARM create or update operations, so it has no provisioning lifecycle and no provisioningState to report."
 model ScheduledEventProperties {
   /**
-   * The description of the event.
+   * Human-readable summary of the scheduled event.
    */
   description?: string;
 
   /**
-   * The event id of the event.
+   * Unique ID of the scheduled event, represented as a GUID string.
    */
   eventId?: string;
 
   /**
-   * The source of the event.
+   * AKS component or workflow that raised the scheduled event.
    */
   eventSource?: string;
 
   /**
-   * The status of the event.
+   * Current lifecycle state of the scheduled event.
    */
   eventStatus?: EventStatus;
 
   /**
-   * The details of the event.
+   * Free-form human-readable details about why the event was raised or what it represents.
    */
   eventDetails?: string;
 
@@ -148,7 +150,7 @@ model ScheduledEventProperties {
   ]>[];
 
   /**
-   * The resource type of the event.
+   * Whether the event applies to the managed cluster itself or to one of its agent pools.
    */
-  resourceType?: ResourceType;
+  resourceType?: ScheduledEventResourceType;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/main.tsp
@@ -46,22 +46,27 @@ model ScheduledEvent
  */
 union EventStatus {
   string,
+
   /**
    * The event is scheduled.
    */
   Scheduled: "Scheduled",
+
   /**
    * The event has started.
    */
   Started: "Started",
+
   /**
    * The event completed.
    */
   Completed: "Completed",
+
   /**
    * The event was cancelled.
    */
   Cancelled: "Cancelled",
+
   /**
    * The event failed.
    */
@@ -73,10 +78,12 @@ union EventStatus {
  */
 union ResourceType {
   string,
+
   /**
    * The event applies to a managed cluster.
    */
   ManagedCluster: "ManagedCluster",
+
   /**
    * The event applies to an agent pool.
    */

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/readme.md
@@ -1,0 +1,23 @@
+# AKS Scheduled Events
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for AKS scheduled events.
+
+``` yaml
+openapi-type: arm
+tag: package-2026-06
+suppressions:
+  - code: OperationsAPIImplementation
+    from: scheduledEvents.json
+    reason: scheduledEvents is a schema-only Azure Resource Notifications contract and intentionally does not define customer-callable ARM operations.
+```
+
+### Tag: package-2026-06
+
+These settings apply only when `--tag=package-2026-06` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-06'
+input-file:
+  - stable/2026-06-01/scheduledEvents.json
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/readme.md
@@ -4,13 +4,15 @@
 
 This is the AutoRest configuration file for AKS scheduled events.
 
+The emitted schema describes the Azure Resource Notifications / Azure Resource Graph / Event Grid payload for ARM resource type `Microsoft.ContainerService/managedClusters/scheduledEvents`. It is intentionally not a customer-callable AKS RP operation surface.
+
 ``` yaml
 openapi-type: arm
 tag: package-2026-06
 suppressions:
   - code: OperationsAPIImplementation
     from: scheduledEvents.json
-    reason: scheduledEvents is a schema-only Azure Resource Notifications contract and intentionally does not define customer-callable ARM operations.
+    reason: scheduledEvents is a schema-only Azure Resource Notifications / Azure Resource Graph / Event Grid contract for Microsoft.ContainerService/managedClusters/scheduledEvents and intentionally does not define customer-callable ARM operations.
 ```
 
 ### Tag: package-2026-06

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/service.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/service.yaml
@@ -1,0 +1,5 @@
+versions:
+  - version: 2026-06-01
+    source: typespec
+    swagger-files:
+      - stable/2026-06-01/scheduledEvents.json

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
@@ -1,0 +1,13 @@
+# AKS Scheduled Events 2026-06-01
+
+> see https://aka.ms/autorest
+
+This folder contains the generated OpenAPI schema for the `2026-06-01` AKS scheduled events Azure Resource Notifications / Azure Resource Graph / Event Grid contract.
+
+The AutoRest configuration for this schema lives in `../../readme.md`.
+
+``` yaml
+openapi-type: arm
+input-file:
+  - scheduledEvents.json
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
@@ -9,6 +9,10 @@ The AutoRest configuration for this schema lives in `../../readme.md`.
 ``` yaml
 openapi-type: arm
 tag: package-2026-06
+suppressions:
+  - code: OperationsAPIImplementation
+    from: scheduledEvents.json
+    reason: scheduledEvents is a schema-only Azure Resource Notifications / Azure Resource Graph / Event Grid contract for Microsoft.ContainerService/managedClusters/scheduledEvents and intentionally does not define customer-callable ARM operations.
 ```
 
 ### Tag: package-2026-06

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/readme.md
@@ -8,6 +8,14 @@ The AutoRest configuration for this schema lives in `../../readme.md`.
 
 ``` yaml
 openapi-type: arm
+tag: package-2026-06
+```
+
+### Tag: package-2026-06
+
+These settings apply only when `--tag=package-2026-06` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-06'
 input-file:
   - scheduledEvents.json
 ```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
@@ -83,37 +83,13 @@
         ]
       }
     },
-    "ResourceType": {
-      "type": "string",
-      "description": "The resource type of the event.",
-      "enum": [
-        "ManagedCluster",
-        "AgentPool"
-      ],
-      "x-ms-enum": {
-        "name": "ResourceType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "ManagedCluster",
-            "value": "ManagedCluster",
-            "description": "The event applies to a managed cluster."
-          },
-          {
-            "name": "AgentPool",
-            "value": "AgentPool",
-            "description": "The event applies to an agent pool."
-          }
-        ]
-      }
-    },
     "ScheduledEvent": {
       "type": "object",
-      "description": "Scheduled event.",
+      "description": "Scheduled event for a managed cluster. ARM resource type: Microsoft.ContainerService/managedClusters/scheduledEvents.",
       "properties": {
         "properties": {
           "$ref": "#/definitions/ScheduledEventProperties",
-          "description": "Properties for the event."
+          "description": "Properties for the scheduled event."
         }
       },
       "allOf": [
@@ -124,27 +100,27 @@
     },
     "ScheduledEventProperties": {
       "type": "object",
-      "description": "Properties for a scheduled event.",
+      "description": "Properties for a scheduled event.\n\nTimestamp property names intentionally preserve the existing wire contract; all timestamp values are UTC date-time values.",
       "properties": {
         "description": {
           "type": "string",
-          "description": "The description of the event."
+          "description": "Human-readable summary of the scheduled event."
         },
         "eventId": {
           "type": "string",
-          "description": "The event id of the event."
+          "description": "Unique ID of the scheduled event, represented as a GUID string."
         },
         "eventSource": {
           "type": "string",
-          "description": "The source of the event."
+          "description": "AKS component or workflow that raised the scheduled event."
         },
         "eventStatus": {
           "$ref": "#/definitions/EventStatus",
-          "description": "The status of the event."
+          "description": "Current lifecycle state of the scheduled event."
         },
         "eventDetails": {
           "type": "string",
-          "description": "The details of the event."
+          "description": "Free-form human-readable details about why the event was raised or what it represents."
         },
         "scheduledTime": {
           "type": "string",
@@ -181,9 +157,33 @@
           }
         },
         "resourceType": {
-          "$ref": "#/definitions/ResourceType",
-          "description": "The resource type of the event."
+          "$ref": "#/definitions/ScheduledEventResourceType",
+          "description": "Whether the event applies to the managed cluster itself or to one of its agent pools."
         }
+      }
+    },
+    "ScheduledEventResourceType": {
+      "type": "string",
+      "description": "The kind of resource impacted by the scheduled event.",
+      "enum": [
+        "ManagedCluster",
+        "AgentPool"
+      ],
+      "x-ms-enum": {
+        "name": "ScheduledEventResourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ManagedCluster",
+            "value": "ManagedCluster",
+            "description": "The event applies to a managed cluster."
+          },
+          {
+            "name": "AgentPool",
+            "value": "AgentPool",
+            "description": "The event applies to an agent pool."
+          }
+        ]
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
@@ -41,6 +41,72 @@
   "tags": [],
   "paths": {},
   "definitions": {
+    "EventStatus": {
+      "type": "string",
+      "description": "The status of the event.",
+      "enum": [
+        "Scheduled",
+        "Started",
+        "Completed",
+        "Cancelled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "EventStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Scheduled",
+            "value": "Scheduled",
+            "description": "The event is scheduled."
+          },
+          {
+            "name": "Started",
+            "value": "Started",
+            "description": "The event has started."
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "The event completed."
+          },
+          {
+            "name": "Cancelled",
+            "value": "Cancelled",
+            "description": "The event was cancelled."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The event failed."
+          }
+        ]
+      }
+    },
+    "ResourceType": {
+      "type": "string",
+      "description": "The resource type of the event.",
+      "enum": [
+        "ManagedCluster",
+        "AgentPool"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ManagedCluster",
+            "value": "ManagedCluster",
+            "description": "The event applies to a managed cluster."
+          },
+          {
+            "name": "AgentPool",
+            "value": "AgentPool",
+            "description": "The event applies to an agent pool."
+          }
+        ]
+      }
+    },
     "ScheduledEvent": {
       "type": "object",
       "description": "Scheduled event.",
@@ -73,19 +139,8 @@
           "description": "The source of the event."
         },
         "eventStatus": {
-          "type": "string",
-          "description": "The status of the event.",
-          "enum": [
-            "Scheduled",
-            "Started",
-            "Completed",
-            "Cancelled",
-            "Failed"
-          ],
-          "x-ms-enum": {
-            "name": "eventStatus",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EventStatus",
+          "description": "The status of the event."
         },
         "eventDetails": {
           "type": "string",
@@ -94,7 +149,7 @@
         "scheduledTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The time of the event is scheduled to start."
+          "description": "The time the event is scheduled to start."
         },
         "startTime": {
           "type": "string",
@@ -126,16 +181,8 @@
           }
         },
         "resourceType": {
-          "type": "string",
-          "description": "The resource type of the event.",
-          "enum": [
-            "ManagedCluster",
-            "AgentPool"
-          ],
-          "x-ms-enum": {
-            "name": "ResourceType",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/ResourceType",
+          "description": "The resource type of the event."
         }
       }
     }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/stable/2026-06-01/scheduledEvents.json
@@ -1,0 +1,144 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "version": "2026-06-01",
+    "description": "The Container Service Scheduled Events data model.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [],
+  "paths": {},
+  "definitions": {
+    "ScheduledEvent": {
+      "type": "object",
+      "description": "Scheduled event.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScheduledEventProperties",
+          "description": "Properties for the event."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ScheduledEventProperties": {
+      "type": "object",
+      "description": "Properties for a scheduled event.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description of the event."
+        },
+        "eventId": {
+          "type": "string",
+          "description": "The event id of the event."
+        },
+        "eventSource": {
+          "type": "string",
+          "description": "The source of the event."
+        },
+        "eventStatus": {
+          "type": "string",
+          "description": "The status of the event.",
+          "enum": [
+            "Scheduled",
+            "Started",
+            "Completed",
+            "Cancelled",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "eventStatus",
+            "modelAsString": true
+          }
+        },
+        "eventDetails": {
+          "type": "string",
+          "description": "The details of the event."
+        },
+        "scheduledTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time of the event is scheduled to start."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the event actually started."
+        },
+        "lastUpdateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The last time the state of the event was updated."
+        },
+        "resources": {
+          "type": "array",
+          "description": "The list of resources impacted by the event.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.ContainerService/managedClusters"
+                },
+                {
+                  "type": "Microsoft.ContainerService/managedClusters/agentPools"
+                }
+              ]
+            }
+          }
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "The resource type of the event.",
+          "enum": [
+            "ManagedCluster",
+            "AgentPool"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceType",
+            "modelAsString": true
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/suppressions.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/suppressions.yaml
@@ -1,0 +1,5 @@
+- tool: TypeSpecValidation
+  path: tspconfig.yaml
+  reason: This project intentionally emits a schema-only ARN/ARG contract and must not generate SDK packages.
+  rules:
+    - SdkTspConfigValidation

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/suppressions.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/suppressions.yaml
@@ -1,5 +1,5 @@
 - tool: TypeSpecValidation
   path: tspconfig.yaml
-  reason: This project intentionally emits a schema-only ARN/ARG contract and must not generate SDK packages.
+  reason: This project intentionally emits a schema-only Azure Resource Notifications / Azure Resource Graph contract and must not generate SDK packages.
   rules:
     - SdkTspConfigValidation

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/tspconfig.yaml
@@ -7,12 +7,10 @@ options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "resource-manager"
     omit-unreachable-types: false
-    use-read-only-status-schema: true
     emitter-output-dir: "{project-root}"
     output-file: "{version-status}/{version}/scheduledEvents.json"
     examples-dir: "{project-root}/examples"
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
-    emit-lro-options: "all"
 
 linter:
   extends:

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents/tspconfig.yaml
@@ -1,0 +1,19 @@
+parameters:
+  "service-dir":
+    default: "sdk/containerservice"
+emit:
+  - "@azure-tools/typespec-autorest"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "resource-manager"
+    omit-unreachable-types: false
+    use-read-only-status-schema: true
+    emitter-output-dir: "{project-root}"
+    output-file: "{version-status}/{version}/scheduledEvents.json"
+    examples-dir: "{project-root}/examples"
+    arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+    emit-lro-options: "all"
+
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary

This is the main-targeting ARM review PR requested in https://github.com/Azure/azure-rest-api-specs/pull/44951#pullrequestreview-4783055202.

It adds a sibling TypeSpec project for the AKS `managedClusters/scheduledEvents` Azure Resource Notifications / ARG contract. The project emits a standalone `scheduledEvents.json` for `2026-06-01` with:

- `paths: {}` because this is a schema-only notification contract, not a customer-callable ARM API surface.
- `ScheduledEvent` / `ScheduledEventProperties` matching the existing `2023-11-02-preview` contract shape.
- No SDK emitters configured, because no SDK should be generated for this schema-only contract.

The release-branch PR remains open at #44951 for the `dev-containerservice-Microsoft.ContainerService-2026-06` branch.

Related API proposal approval: https://github.com/azure-management-and-platforms/aks-handbook/pull/208

## Validation

- `npx tsv specification/containerservice/resource-manager/Microsoft.ContainerService/aksscheduledevents`
- Local `lint-diff` against `main` completed with no must-fix rows.
