### PR TITLE
[Test] Exercise TypeSpec Suppressions workflow

### DIFF
--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -16,6 +16,7 @@ using Azure.Core;
 namespace Azure.Contoso.WidgetManager;
 
 @doc("Versions info.")
+#suppress "@azure-tools/typespec-azure-core/no-enum" "test: checked rule suppression with justification for workflow validation"
 enum Versions {
   @doc("The 2022-11-01-preview version.")
   v2022_11_01_Preview: "2022-11-01-preview",
@@ -26,15 +27,18 @@ enum Versions {
 
 @doc("A widget.")
 @resource("widgets")
+#suppress "@azure-tools/typespec-azure-core/casing-style" "test: unchecked rule suppression with justification (not in check-rules.json)"
 model WidgetSuite {
   @key("widgetName")
   @doc("The widget name.")
   @visibility(Lifecycle.Read)
   name: string;
 
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "test: checked rule suppression with justification for workflow validation"
   @doc("The ID of the widget's manufacturer.")
   manufacturerId: string;
 
+  #suppress "@azure-tools/typespec-azure-core/use-extensible-enum"
   @doc("The faked shared model.")
   sharedModel?: FakedSharedModel;
 }

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -9,6 +9,9 @@ linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"
     - "@azure-tools/typespec-azure-rulesets/client-sdk"
+  disable:
+    "@azure-tools/typespec-azure-core/no-openapi": "test: checked config suppression with justification for workflow validation"
+    "@azure-tools/typespec-azure-core/require-key-visibility": "test: unchecked config suppression with justification (not in check-rules.json)"
 options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"


### PR DESCRIPTION
## Purpose

**Test PR — do not merge.** Exercises the `TypeSpec Suppressions` CI workflow by adding a mix of lint suppressions to the `Contoso.WidgetManager` project.

## Suppressions added

Inline ( + "main.tsp" + ):
| Rule | In check-rules.json? | Justification |
|------|----------------------|---------------|
| `@azure-tools/typespec-azure-core/no-enum` | ✅ checked | ✅ yes |
| `@azure-tools/typespec-azure-core/documentation-required` | ✅ checked | ✅ yes |
| `@azure-tools/typespec-azure-core/casing-style` | ❌ unchecked | ✅ yes |
| `@azure-tools/typespec-azure-core/use-extensible-enum` | ✅ checked | ❌ **no justification** |

Config ( + "	spconfig.yaml" +  `linter.disable`):
| Rule | In check-rules.json? | Justification |
|------|----------------------|---------------|
| `@azure-tools/typespec-azure-core/no-openapi` | ✅ checked | ✅ yes |
| `@azure-tools/typespec-azure-core/require-key-visibility` | ❌ unchecked | ✅ yes |

## Expected workflow behavior

- Detects all 6 new suppressions across inline + config sources.
- Flags the `use-extensible-enum` suppression as **missing justification**.
- Gating/approval focuses on the checked rules; unchecked rules are reported for visibility only.