### PR TITLE
Add PlatformValidation service group to Microsoft.PlatformValidation ARM lease

### DIFF
--- a/.github/arm-leases/platformvalidation/Microsoft.PlatformValidation/PlatformValidation/lease.yaml
+++ b/.github/arm-leases/platformvalidation/Microsoft.PlatformValidation/PlatformValidation/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.PlatformValidation
+  startdate: 2026-07-29
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds an ARM lease for **Microsoft.PlatformValidation** (service group **PlatformValidation**) per `.github/arm-leases/README.md`.

- Path: `.github/arm-leases/platformvalidation/Microsoft.PlatformValidation/PlatformValidation/lease.yaml`
- Resource provider: `Microsoft.PlatformValidation`
- Start date: 2026-07-29
- Duration: P180D
- Reviewer: @vikeshi26