### PR TITLE
Sync .github/skills directory with azure-sdk-tools for PR 16603

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -4,7 +4,7 @@ license: MIT
 metadata:
   version: "1.0.0"
   distribution: shared
-description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan, azure-sdk-mcp:azsdk_link_namespace_approval_issue.'
+description: 'Manage Azure SDK release plans and associated SDK PRs. **UTILITY SKILL**. USE FOR: "prepare a release plan", "plan the next SDK release", "create release plan for my package", "get or update release plan", "update API spec or SDK details in release plan", "abandon release plan", "link SDK PR", "namespace approval", "check release plan status". DO NOT USE FOR: SDK generation, pipeline troubleshooting, API review. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan, azure-sdk-mcp:azsdk_link_namespace_approval_issue.'
 compatibility: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
 ---
 
@@ -14,8 +14,8 @@ This skill creates, gets, updates, abandons, and links SDK PRs to release plan w
 
 ## Triggers
 
-USE FOR: create release plan, get release plan, update release plan, update API spec in release plan, update SDK details in release plan, abandon release plan, link SDK PR to plan, namespace approval, check release plan status
-WHEN: "create release plan", "get release plan", "update release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status"
+USE FOR: prepare release plan, create release plan, get release plan, update release plan, update API spec in release plan, update SDK details in release plan, abandon release plan, link SDK PR to plan, namespace approval, check release plan status
+WHEN: "prepare a release plan", "plan the next SDK release", "create release plan for my package", "create a release plan for my new Azure SDK service", "help me prepare a release plan for my new Azure SDK package", "create release plan", "get release plan", "update release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status"
 DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback
 
 ## Rules
@@ -57,15 +57,12 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 3. **Gather Info** — Collect required details from the user. See [details](references/release-plan-details.md):
    - Target release month/year (format: "Month YYYY", e.g. "June 2026"). Do NOT use formats like "2026-06" or "06/2026" — these are invalid.
    - API release type: Value must be one of the following: "Private Preview", "Public Preview", or "GA"
-   - SDK release type: Value must be "beta" or "stable" — always ask the user explicitly
    - Spec PR URL (optional)
    - Service Tree ID (GUID) — optional if previously created
    - Product Tree ID (GUID) — optional if previously created
-4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan` with the collected parameters including `sdkReleaseType`. Use `forceCreateReleasePlan: true` only if an existing release plan was found for a different API release type.
+4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan` with the collected parameters. Use `forceCreateReleasePlan: true` only if an existing release plan was found for a different API release type.
 5. **Namespace** — For first management plane releases, link namespace approval issue using `azure-sdk-mcp:azsdk_link_namespace_approval_issue`.
 
-> **IMPORTANT**: Do NOT default the API release type value as the SDK release type. These are separate fields — always ask the user explicitly for the SDK release type.
->
 > **IMPORTANT**: Do NOT update an existing release plan to change its API release type. If a release plan exists for a different API release type, force-create a new one instead.
 
 **Tool**: `azure-sdk-mcp:azsdk_create_release_plan`


### PR DESCRIPTION
Manual catch-up sync of azsdk-common-prepare-release-plan/SKILL.md to match azure-sdk-tools main (this repo's copy of azsdk-common-generate-sdk-locally/SKILL.md was already current). This file had drifted from an unsynced azure-sdk-tools PR (#16325). This unblocks the automated patch-based sync-skills validation on Azure/azure-sdk-tools#16603, which fails via git am because of this pre-existing content divergence across all downstream repos.