### PR TITLE
Address APIView naming feedback for BulkActions generated SDK

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -474,3 +474,10 @@ namespace Microsoft.Compute;
 );
 @@clientName(OccurrenceResource, "OccurrenceResourceMetadata", "csharp");
 @@clientName(OccurrenceExtensionResource, "OccurrenceExtension", "csharp");
+
+// APIView naming feedback: give the generic single-word resource/model/enum
+// names an RP/domain prefix so they are self-descriptive in .NET IntelliSense.
+@@clientName(Occurrence, "ScheduledActionOccurrence", "csharp");
+@@clientName(DelayRequest.delay, "delayTo", "csharp");
+@@clientName(Mode, "ProxyAgentMode", "csharp");
+@@clientName(Modes, "ImdsAccessControlMode", "csharp");


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider.
  - [x] Update existing version for a new feature. (Revising a preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing OpenAPI spec to TypeSpec spec.
  - [ ] Other.

### Details

Addresses the automated **APIView naming** findings raised on the BulkActions generated SDK. All fixes are **C#/SDK-only** (`@@clientName` renames in `client.tsp`) with **no wire/swagger impact** — the generated OpenAPI JSON is unchanged.

| # | Rule | Change | File |
|---|------|--------|------|
| 1 | RESNAME001 | `Occurrence` resource trio &rarr; `ScheduledActionOccurrence` (avoids ambiguous single-word resource name) | `client.tsp` |
| 2 | DATE001 | `DelayRequest.delay` &rarr; `delayTo` (date/time property naming) | `client.tsp` |
| 3 | Contextual | `Mode` &rarr; `ProxyAgentMode` | `client.tsp` |
| 4 | Contextual | `Modes` &rarr; `ImdsAccessControlMode` | `client.tsp` |

#### Intentionally NOT changed (TYPE001 findings)

Two `TYPE001` findings suggested changing `string` properties to `armResourceIdentifier`:
- `ApiEntityReference.id` (surfaces as `DataDisk.SourceResourceId`)
- `EncryptionIdentity.userAssignedIdentityResourceId`

These are **won't-fix**:
- These models are **reused from the virtual machine profile as defined today for Compute** — we are not redefining the shared models here.
- Switching `string` &rarr; `armResourceIdentifier` emits `"format": "arm-id"` in swagger, a **wire-visible breaking change**.
- The other language SDKs for this release (JS, Java, Go, Python) are **already released** against the current shape; changing now would break existing consumers and diverge across languages.

### Validation

- `tsp compile --warn-as-error` — PASS
- Full `tsv` (FolderStructure &rarr; LinterRuleset &rarr; Compile &rarr; Format) — PASS
- Regenerated swagger diff is **empty** (renames are C#-only), confirming no OpenAPI/wire change.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the Resource Provider guidelines.
- [x] A release plan has been created (35410).
