### PR TITLE
Shorten TypeSpec suppressions source line column and clarify testing status

### DIFF
--- a/.github/workflows/src/typespec-suppressions/suppressions-comment.js
+++ b/.github/workflows/src/typespec-suppressions/suppressions-comment.js
@@ -186,6 +186,20 @@ function escapeHtml(value) {
 }
 
 /**
+ * Inserts `<wbr>` break opportunities after path separators so long, unbroken
+ * strings (rule names and source paths, which contain no spaces) can wrap
+ * within their table cell instead of forcing the column wide. GitHub's HTML
+ * sanitizer allows `<wbr>`, and it renders as a zero-width break hint. The input
+ * is HTML-escaped first so the inserted markup is the only HTML in the result.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function withWrapPoints(value) {
+  return escapeHtml(value).replaceAll("/", "/<wbr>");
+}
+
+/**
  * @param {string} filePath
  * @returns {string}
  */
@@ -221,7 +235,7 @@ function pluralize(count, singular, plural = `${singular}s`) {
  * @returns {string}
  */
 function renderRuleLabel(suppression) {
-  const label = `<code>${escapeHtml(suppression.ruleName)}</code>`;
+  const label = `<code>${withWrapPoints(suppression.ruleName)}</code>`;
   const documentationUrl = suppression.ruleMetadata?.documentationUrl;
   return documentationUrl ? `<a href="${documentationUrl}">${label}</a>` : label;
 }
@@ -242,7 +256,7 @@ function renderSourceLink(owner, repo, head_sha, suppression) {
     suppression.sourceFile,
     suppression.location.line,
   );
-  return `<a href="${sourceUrl}">${escapeHtml(sourceLabel)}</a>`;
+  return `<a href="${sourceUrl}">${withWrapPoints(sourceLabel)}</a>`;
 }
 
 /**
@@ -340,7 +354,9 @@ export function renderSuppressionsCommentBody(
   const changedSuppressions = reported.changedSuppressions ?? [];
 
   const statusCell = isApproved ? "✅" : "❌";
-  const approvalState = isApproved ? "✅ Approved" : "❌ Approval required";
+  const approvalState = isApproved
+    ? "✅ Approval label applied"
+    : "⚠️ Approval label not applied (not required during testing)";
 
   const totalCount = newSuppressions.length + changedSuppressions.length;
 
@@ -351,7 +367,7 @@ export function renderSuppressionsCommentBody(
     "",
     `**Status:** ${summaryParts.join(" — ")}`,
     "",
-    "⚠️ This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue; reviewers should approve only when there is a clear, compelling justification and no reasonable alternative. Review each linked rule and source location, then apply <code>Approved-TypeSpecSuppression</code> only if every justification is acceptable. The <strong>Status</strong> column shows ✅ once the label is applied and ❌ while approval is pending.",
+    "⚠️ <strong>This check is currently in testing mode and is non-blocking</strong> — it will not prevent this PR from merging, and applying the <code>Approved-TypeSpecSuppression</code> label is <strong>not currently required</strong>. This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue. The list below is surfaced for visibility and feedback while the check is being validated; the <strong>Status</strong> column shows ✅ once the label is applied and ❌ while it is not.",
     "",
   ];
 

--- a/.github/workflows/src/typespec-suppressions/suppressions-comment.js
+++ b/.github/workflows/src/typespec-suppressions/suppressions-comment.js
@@ -345,8 +345,8 @@ export function renderSuppressionsCommentBody(
 
   const statusCell = isApproved ? "✅" : "❌";
   const approvalState = isApproved
-    ? "✅ Approval label applied"
-    : "⚠️ Approval label not applied (not required during testing)";
+    ? "✅ Approved"
+    : "❌ Approval required (currently under testing, review NOT enforced)";
 
   const totalCount = newSuppressions.length + changedSuppressions.length;
 
@@ -357,7 +357,7 @@ export function renderSuppressionsCommentBody(
     "",
     `**Status:** ${summaryParts.join(" — ")}`,
     "",
-    "⚠️ <strong>This check is currently in testing mode and is non-blocking</strong> — it will not prevent this PR from merging, and applying the <code>Approved-TypeSpecSuppression</code> label is <strong>not currently required</strong>. This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue. The list below is surfaced for visibility and feedback while the check is being validated; the <strong>Status</strong> column shows ✅ once the label is applied and ❌ while it is not.",
+    "⚠️ <strong>This check is currently in testing mode and is non-blocking</strong> — it will not prevent this PR from merging. This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue; reviewers should approve only when there is a clear, compelling justification and no reasonable alternative. Review each linked rule and source location, then apply <code>Approved-TypeSpecSuppression</code> only if every justification is acceptable. The <strong>Status</strong> column shows ✅ once the label is applied and ❌ while approval is pending.",
     "",
   ];
 

--- a/.github/workflows/src/typespec-suppressions/suppressions-comment.js
+++ b/.github/workflows/src/typespec-suppressions/suppressions-comment.js
@@ -186,25 +186,15 @@ function escapeHtml(value) {
 }
 
 /**
- * Inserts `<wbr>` break opportunities after path separators so long, unbroken
- * strings (rule names and source paths, which contain no spaces) can wrap
- * within their table cell instead of forcing the column wide. GitHub's HTML
- * sanitizer allows `<wbr>`, and it renders as a zero-width break hint. The input
- * is HTML-escaped first so the inserted markup is the only HTML in the result.
+ * Returns the file name (basename) of a path, e.g. `.../main.tsp` -> `main.tsp`.
+ * The full path is preserved in the link's href; only the visible label is
+ * shortened so the Source column stays narrow and readable.
  *
- * @param {string} value
- * @returns {string}
- */
-function withWrapPoints(value) {
-  return escapeHtml(value).replaceAll("/", "/<wbr>");
-}
-
-/**
  * @param {string} filePath
  * @returns {string}
  */
-function getPathSegment(filePath) {
-  return filePath.split("/").slice(-4).join("/");
+function getFileName(filePath) {
+  return filePath.split("/").pop() || filePath;
 }
 
 /**
@@ -235,7 +225,7 @@ function pluralize(count, singular, plural = `${singular}s`) {
  * @returns {string}
  */
 function renderRuleLabel(suppression) {
-  const label = `<code>${withWrapPoints(suppression.ruleName)}</code>`;
+  const label = `<code>${escapeHtml(suppression.ruleName)}</code>`;
   const documentationUrl = suppression.ruleMetadata?.documentationUrl;
   return documentationUrl ? `<a href="${documentationUrl}">${label}</a>` : label;
 }
@@ -248,7 +238,7 @@ function renderRuleLabel(suppression) {
  * @returns {string}
  */
 function renderSourceLink(owner, repo, head_sha, suppression) {
-  const sourceLabel = `${getPathSegment(suppression.sourceFile)}#L${suppression.location.line}`;
+  const sourceLabel = `${getFileName(suppression.sourceFile)}#L${suppression.location.line}`;
   const sourceUrl = getBlobLineLink(
     owner,
     repo,
@@ -256,7 +246,7 @@ function renderSourceLink(owner, repo, head_sha, suppression) {
     suppression.sourceFile,
     suppression.location.line,
   );
-  return `<a href="${sourceUrl}">${withWrapPoints(sourceLabel)}</a>`;
+  return `<a href="${sourceUrl}">${escapeHtml(sourceLabel)}</a>`;
 }
 
 /**

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -81,7 +81,9 @@ describe("renderSuppressionsCommentBody", () => {
 
     expect(body).toContain("## TypeSpec suppressions requiring review");
     expect(body).toContain("Suppressions are strongly discouraged");
-    expect(body).toContain("❌ Approval required — 1 suppression");
+    expect(body).toContain(
+      "⚠️ Approval label not applied (not required during testing) — 1 suppression",
+    );
   });
 
   it("reflects approval status in the heading and status cells", () => {
@@ -106,14 +108,14 @@ describe("renderSuppressionsCommentBody", () => {
       ...options,
       isApproved: false,
     });
-    expect(pending).toContain("❌ Approval required");
+    expect(pending).toContain("⚠️ Approval label not applied");
     expect(pending).toContain('<td align="center">❌</td>');
 
     const approved = renderSuppressionsCommentBody(report, {
       ...options,
       isApproved: true,
     });
-    expect(approved).toContain("✅ Approved");
+    expect(approved).toContain("✅ Approval label applied");
     expect(approved).toContain('<td align="center">✅</td>');
   });
 });
@@ -201,7 +203,9 @@ describe("buildSuppressionsComment", async () => {
       );
       expect(body).toContain("Suppressions are strongly discouraged");
       expect(body).toContain("https://aka.ms/tsp-suppress/feedback");
-      expect(body).toContain("❌ Approval required — 2 suppressions");
+      expect(body).toContain(
+        "⚠️ Approval label not applied (not required during testing) — 2 suppressions",
+      );
     },
   );
 
@@ -275,7 +279,7 @@ describe("buildSuppressionsComment", async () => {
         "abc123",
         [],
       );
-      expect(pending).toContain("❌ Approval required");
+      expect(pending).toContain("⚠️ Approval label not applied");
       expect(pending).toContain('<td align="center">❌</td>');
 
       const approved = await buildSuppressionsComment(
@@ -286,7 +290,7 @@ describe("buildSuppressionsComment", async () => {
         "abc123",
         ["Approved-TypeSpecSuppression"],
       );
-      expect(approved).toContain("✅ Approved");
+      expect(approved).toContain("✅ Approval label applied");
       expect(approved).toContain('<td align="center">✅</td>');
     },
   );

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -84,6 +84,10 @@ describe("renderSuppressionsCommentBody", () => {
     expect(body).toContain(
       "⚠️ Approval label not applied (not required during testing) — 1 suppression",
     );
+    // Source link text is the file name + line only (full path stays in the href).
+    expect(body).toContain(
+      '<a href="https://github.com/test-owner/test-repo/blob/abc123/specification/demo/main.tsp#L12">main.tsp#L12</a>',
+    );
   });
 
   it("reflects approval status in the heading and status cells", () => {

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -82,7 +82,7 @@ describe("renderSuppressionsCommentBody", () => {
     expect(body).toContain("## TypeSpec suppressions requiring review");
     expect(body).toContain("Suppressions are strongly discouraged");
     expect(body).toContain(
-      "⚠️ Approval label not applied (not required during testing) — 1 suppression",
+      "❌ Approval required (currently under testing, review NOT enforced) — 1 suppression",
     );
     // Source link text is the file name + line only (full path stays in the href).
     expect(body).toContain(
@@ -112,14 +112,16 @@ describe("renderSuppressionsCommentBody", () => {
       ...options,
       isApproved: false,
     });
-    expect(pending).toContain("⚠️ Approval label not applied");
+    expect(pending).toContain(
+      "❌ Approval required (currently under testing, review NOT enforced)",
+    );
     expect(pending).toContain('<td align="center">❌</td>');
 
     const approved = renderSuppressionsCommentBody(report, {
       ...options,
       isApproved: true,
     });
-    expect(approved).toContain("✅ Approval label applied");
+    expect(approved).toContain("✅ Approved");
     expect(approved).toContain('<td align="center">✅</td>');
   });
 });
@@ -208,7 +210,7 @@ describe("buildSuppressionsComment", async () => {
       expect(body).toContain("Suppressions are strongly discouraged");
       expect(body).toContain("https://aka.ms/tsp-suppress/feedback");
       expect(body).toContain(
-        "⚠️ Approval label not applied (not required during testing) — 2 suppressions",
+        "❌ Approval required (currently under testing, review NOT enforced) — 2 suppressions",
       );
     },
   );
@@ -283,7 +285,9 @@ describe("buildSuppressionsComment", async () => {
         "abc123",
         [],
       );
-      expect(pending).toContain("⚠️ Approval label not applied");
+      expect(pending).toContain(
+        "❌ Approval required (currently under testing, review NOT enforced)",
+      );
       expect(pending).toContain('<td align="center">❌</td>');
 
       const approved = await buildSuppressionsComment(
@@ -294,7 +298,7 @@ describe("buildSuppressionsComment", async () => {
         "abc123",
         ["Approved-TypeSpecSuppression"],
       );
-      expect(approved).toContain("✅ Approval label applied");
+      expect(approved).toContain("✅ Approved");
       expect(approved).toContain('<td align="center">✅</td>');
     },
   );


### PR DESCRIPTION
## Purpose

Improves the readability of the **TypeSpec Suppressions Review** PR comment and clarifies its testing status. Rendering lives in `.github/workflows/src/typespec-suppressions/suppressions-comment.js`.

## Changes

**1. Shorten the Source column**
- The **Source** link now shows only the **file name + line** (e.g. `main.tsp#L37`) instead of the full spec path. The complete path is preserved in the link's `href`, so click-through is unchanged — only the visible label is shortened, keeping the column narrow and readable.

**2. Clarify testing / non-blocking status**
- The comment message now states up front that the check is **in testing mode and non-blocking** (it will not prevent the PR from merging), while retaining the reviewer guidance to approve only with a clear justification.
- The status summary reads `❌ Approval required (currently under testing, review NOT enforced)` while pending, and `✅ Approved` once the `Approved-TypeSpecSuppression` label is applied. The ✅/❌ Status column indicator is retained.

## Validation
- Verified end-to-end on a draft test PR (fork) where the base branch carries this code, so the `pull_request_target` comment job renders the updated output: the Source column shows `main.tsp#L19` and the testing/non-blocking message appears.
- Updated assertions in `suppressions-comment.test.js`; `npm run test -- typespec-suppressions` passes and prettier is clean.