### PR TITLE
Rename BulkActions DelayRequest.delay client name to scheduleAt

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -478,6 +478,6 @@ namespace Microsoft.Compute;
 // APIView naming feedback: give the generic single-word resource/model/enum
 // names an RP/domain prefix so they are self-descriptive in .NET IntelliSense.
 @@clientName(Occurrence, "ScheduledActionOccurrence", "csharp");
-@@clientName(DelayRequest.delay, "delayTo", "csharp");
+@@clientName(DelayRequest.delay, "scheduleAt", "csharp");
 @@clientName(Mode, "ProxyAgentMode", "csharp");
 @@clientName(Modes, "ImdsAccessControlMode", "csharp");


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider.
  - [x] Update existing version for a new feature. (Revising a preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing OpenAPI spec to TypeSpec spec.
  - [ ] Other.

### Details

Renames the **C#/SDK-only** client name for `DelayRequest.delay` from `delayTo` to `scheduleAt` (generates the `.NET` property `ScheduleAt`).

This is a `@@clientName(..., "csharp")` override in `client.tsp` only. **No wire/swagger impact** &mdash; the generated OpenAPI JSON is unchanged, and other language SDKs are unaffected.

| Rule | Change | File |
|------|--------|------|
| DATE001 (naming) | `DelayRequest.delay` C# name `delayTo` &rarr; `scheduleAt` | `client.tsp` |

Follow-up to Azure/azure-rest-api-specs#45121, which introduced the `delayTo` name; this adjusts it to `scheduleAt` per reviewer preference.

### Validation

- `tsp compile --warn-as-error` &mdash; PASS
- Regenerated swagger diff is **empty** (client-name change is C#-only).

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the Resource Provider guidelines.
- [x] A release plan has been created (35410).
