### PR TITLE
Add 2026-07-30-preview with ephemeral type compatibility check for Managed DevOps Pools

### DIFF
--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-03-preview/EphemeralTypeCompatibility_Check.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-03-preview/EphemeralTypeCompatibility_Check.json
@@ -1,0 +1,41 @@
+{
+  "title": "EphemeralTypeCompatibility_Check",
+  "operationId": "EphemeralTypeCompatibility_Check",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "location": "eastus",
+    "api-version": "2026-07-03-preview",
+    "body": {
+      "sku": {
+        "name": "Standard_D4ads_v5"
+      },
+      "imageVersionResourceIds": [
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/images/providers/Microsoft.Compute/galleries/gallery/images/ubuntu-24.04/versions/latest",
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0"
+      ]
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "imageVersionResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/images/providers/Microsoft.Compute/galleries/gallery/images/ubuntu-24.04/versions/latest",
+            "availableEphemeralTypes": [
+              "Automatic",
+              "CacheDisk",
+              "ResourceDisk"
+            ]
+          },
+          {
+            "imageVersionResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0",
+            "error": {
+              "code": "ImageNotFound",
+              "message": "The image version '/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0' was not found."
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/CreateOrUpdatePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/CreateOrUpdatePool.json
@@ -1,0 +1,182 @@
+{
+  "title": "Pools_CreateOrUpdate",
+  "operationId": "Pools_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "provisioningState": "Succeeded",
+        "maximumConcurrency": 10,
+        "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+        "organizationProfile": {
+          "kind": "AzureDevOps",
+          "description": "Managed by Managed DevOps Pools",
+          "updateDescription": true,
+          "organizations": [
+            {
+              "url": "https://mseng.visualstudio.com",
+              "openAccess": true
+            }
+          ]
+        },
+        "agentProfile": {
+          "kind": "Stateless"
+        },
+        "fabricProfile": {
+          "kind": "Vmss",
+          "sku": {
+            "name": "Standard_D4ads_v5"
+          },
+          "images": [
+            {
+              "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+              "ephemeralType": "NVMeDisk",
+              "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+              "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+              "provisioningScriptShouldRestart": true,
+              "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+            }
+          ],
+          "osProfile": {
+            "secretsManagementSettings": {
+              "certificateStoreName": "Root",
+              "observedCertificates": [
+                "https://abc.vault.azure.net/secrets/one"
+              ],
+              "keyExportable": false
+            }
+          },
+          "networkProfile": {
+            "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+            "staticIpAddressCount": 2
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    },
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/CreateOrUpdatePool_InstanceMix.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/CreateOrUpdatePool_InstanceMix.json
@@ -1,0 +1,206 @@
+{
+  "title": "Pools_CreateOrUpdate_InstanceMix",
+  "operationId": "Pools_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "provisioningState": "Succeeded",
+        "maximumConcurrency": 10,
+        "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+        "organizationProfile": {
+          "kind": "AzureDevOps",
+          "description": "Managed by Managed DevOps Pools",
+          "updateDescription": true,
+          "organizations": [
+            {
+              "url": "https://mseng.visualstudio.com",
+              "openAccess": true
+            }
+          ]
+        },
+        "agentProfile": {
+          "kind": "Stateless"
+        },
+        "fabricProfile": {
+          "kind": "Vmss",
+          "sku": {
+            "name": "Mix",
+            "vmSizes": [
+              {
+                "name": "Standard_E2ads_v5"
+              },
+              {
+                "name": "Standard_D2ads_v5"
+              }
+            ]
+          },
+          "images": [
+            {
+              "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+              "ephemeralType": "Automatic",
+              "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+              "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+              "provisioningScriptShouldRestart": true,
+              "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+            }
+          ],
+          "osProfile": {
+            "secretsManagementSettings": {
+              "certificateStoreName": "Root",
+              "observedCertificates": [
+                "https://abc.vault.azure.net/secrets/one"
+              ],
+              "keyExportable": false
+            }
+          },
+          "networkProfile": {
+            "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+            "staticIpAddressCount": 2
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Mix",
+              "vmSizes": [
+                {
+                  "name": "Standard_E2ads_v5"
+                },
+                {
+                  "name": "Standard_D2ads_v5"
+                }
+              ]
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    },
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Mix",
+              "vmSizes": [
+                {
+                  "name": "Standard_E2ads_v5"
+                },
+                {
+                  "name": "Standard_D2ads_v5"
+                }
+              ]
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/DeletePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/DeletePool.json
@@ -1,0 +1,18 @@
+{
+  "title": "Pools_Delete",
+  "operationId": "Pools_Delete",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/EphemeralTypeCompatibility_Check.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/EphemeralTypeCompatibility_Check.json
@@ -4,7 +4,7 @@
   "parameters": {
     "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
     "location": "eastus",
-    "api-version": "2026-07-03-preview",
+    "api-version": "2026-07-30-preview",
     "body": {
       "sku": {
         "name": "Standard_D4ads_v5"

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/GetPool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/GetPool.json
@@ -1,0 +1,49 @@
+{
+  "title": "Pools_Get",
+  "operationId": "Pools_Get",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true
+              }
+            ]
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ImageVersions_ListByImage.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ImageVersions_ListByImage.json
@@ -1,0 +1,27 @@
+{
+  "title": "ImageVersions_ListByImage",
+  "operationId": "ImageVersions_ListByImage",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "imageName": "windows-2022"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/images/windows-2022/versions/2024.0417.0",
+            "name": "2024.0417.0"
+          },
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/images/windows-2022/versions/2024.0417.1",
+            "name": "2024.0417.1"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListOperations.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListOperations.json
@@ -1,0 +1,12 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-07-30-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListPoolsBySubscription.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListPoolsBySubscription.json
@@ -1,0 +1,20 @@
+{
+  "title": "Pools_ListBySubscription",
+  "operationId": "Pools_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/aoiresourceGroupName/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListPoolsBySubscriptionAndResourceGroup.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ListPoolsBySubscriptionAndResourceGroup.json
@@ -1,0 +1,21 @@
+{
+  "title": "Pools_ListByResourceGroup",
+  "operationId": "Pools_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Pools_CheckNameAvailability.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Pools_CheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "title": "Pools_CheckNameAvailability",
+  "operationId": "Pools_CheckNameAvailability",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "api-version": "2026-07-30-preview",
+    "body": {
+      "name": "mydevopspool",
+      "type": "Microsoft.DevOpsInfrastructure/pools"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "available": "Unavailable",
+        "message": "Managed DevOps pool mydevopspool is already in use. Please choose a pool name that has not been taken.",
+        "name": "mydevopspool",
+        "reason": "AlreadyExists"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Pools_DeleteResources.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Pools_DeleteResources.json
@@ -1,0 +1,19 @@
+{
+  "title": "Pools_DeleteResources",
+  "operationId": "Pools_DeleteResources",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "poolName": "my-dev-ops-pool",
+    "body": {
+      "resourceIds": [
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-dev-ops-pool/resources/dd8cc705c_0",
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-dev-ops-pool/resources/dd8cc705c_1"
+      ]
+    }
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ResourceDetails_ListByPool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/ResourceDetails_ListByPool.json
@@ -1,0 +1,37 @@
+{
+  "title": "ResourceDetails_ListByPool",
+  "operationId": "ResourceDetails_ListByPool",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "poolName": "my-dev-ops-pool"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-devops-pool/resources/my-dev-ops-pool:04dcde21-626e-5a7e-8659-ce12f9284b29:dd8cc705c_0",
+            "name": "dd8cc705c000000",
+            "properties": {
+              "image": "my-image",
+              "imageVersion": "4.0.0",
+              "status": "Ready"
+            }
+          },
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-devops-pool/resources/my-dev-ops-pool:04dcde21-626e-5a7e-8659-ce12f9284b29:dd8cc705c_1",
+            "name": "dd8cc705c000001",
+            "properties": {
+              "image": "my-image",
+              "imageVersion": "4.0.0",
+              "status": "Allocated"
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Sku_ListByLocation.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/Sku_ListByLocation.json
@@ -1,0 +1,278 @@
+{
+  "title": "Sku_ListByLocation",
+  "operationId": "Sku_ListByLocation",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "locationName": "eastus"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "resourceType": "virtualMachines",
+              "tier": "Basic",
+              "size": "A0",
+              "family": "basicAFamily",
+              "locations": [
+                "eastus"
+              ],
+              "locationInfo": [
+                {
+                  "location": "eastus",
+                  "zones": [],
+                  "zoneDetails": []
+                }
+              ],
+              "capabilities": [
+                {
+                  "name": "MaxResourceVolumeMB",
+                  "value": "20480"
+                },
+                {
+                  "name": "OSVhdSizeMB",
+                  "value": "1047552"
+                },
+                {
+                  "name": "vCPUs",
+                  "value": "1"
+                },
+                {
+                  "name": "MemoryPreservingMaintenanceSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "HyperVGenerations",
+                  "value": "V1"
+                },
+                {
+                  "name": "MemoryGB",
+                  "value": "0.75"
+                },
+                {
+                  "name": "MaxDataDiskCount",
+                  "value": "1"
+                },
+                {
+                  "name": "CpuArchitectureType",
+                  "value": "x64"
+                },
+                {
+                  "name": "LowPriorityCapable",
+                  "value": "False"
+                },
+                {
+                  "name": "PremiumIO",
+                  "value": "False"
+                },
+                {
+                  "name": "VMDeploymentTypes",
+                  "value": "IaaS"
+                },
+                {
+                  "name": "vCPUsAvailable",
+                  "value": "1"
+                },
+                {
+                  "name": "ACUs",
+                  "value": "50"
+                },
+                {
+                  "name": "vCPUsPerCore",
+                  "value": "1"
+                },
+                {
+                  "name": "EphemeralOSDiskSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "EncryptionAtHostSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "CapacityReservationSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "AcceleratedNetworkingEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "RdmaEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "MaxNetworkInterfaces",
+                  "value": "2"
+                }
+              ],
+              "restrictions": [
+                {
+                  "type": "Location",
+                  "values": [
+                    "eastus"
+                  ],
+                  "restrictionInfo": {
+                    "locations": [
+                      "eastus"
+                    ]
+                  },
+                  "reasonCode": "NotAvailableForSubscription"
+                },
+                {
+                  "type": "Zone",
+                  "values": [
+                    "eastus"
+                  ],
+                  "restrictionInfo": {
+                    "locations": [
+                      "eastus"
+                    ],
+                    "zones": [
+                      "1",
+                      "2",
+                      "3"
+                    ]
+                  },
+                  "reasonCode": "NotAvailableForSubscription"
+                }
+              ]
+            },
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/providers/Microsoft.DevOpsInfrastructure/locations/eastus/skus/Basic_A0",
+            "name": "Basic_A0"
+          },
+          {
+            "properties": {
+              "resourceType": "virtualMachines",
+              "tier": "Standard",
+              "size": "A2_v2",
+              "family": "standardAv2Family",
+              "locations": [
+                "eastus"
+              ],
+              "locationInfo": [
+                {
+                  "location": "eastus",
+                  "zones": [
+                    "1",
+                    "2",
+                    "3"
+                  ],
+                  "zoneDetails": []
+                }
+              ],
+              "capabilities": [
+                {
+                  "name": "MaxResourceVolumeMB",
+                  "value": "20480"
+                },
+                {
+                  "name": "OSVhdSizeMB",
+                  "value": "1047552"
+                },
+                {
+                  "name": "vCPUs",
+                  "value": "2"
+                },
+                {
+                  "name": "MemoryPreservingMaintenanceSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "HyperVGenerations",
+                  "value": "V1"
+                },
+                {
+                  "name": "MemoryGB",
+                  "value": "4"
+                },
+                {
+                  "name": "MaxDataDiskCount",
+                  "value": "4"
+                },
+                {
+                  "name": "CpuArchitectureType",
+                  "value": "x64"
+                },
+                {
+                  "name": "LowPriorityCapable",
+                  "value": "True"
+                },
+                {
+                  "name": "PremiumIO",
+                  "value": "False"
+                },
+                {
+                  "name": "VMDeploymentTypes",
+                  "value": "PaaS,IaaS"
+                },
+                {
+                  "name": "vCPUsAvailable",
+                  "value": "2"
+                },
+                {
+                  "name": "ACUs",
+                  "value": "100"
+                },
+                {
+                  "name": "vCPUsPerCore",
+                  "value": "1"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedIOPS",
+                  "value": "2000"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedReadBytesPerSecond",
+                  "value": "41943040"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+                  "value": "20971520"
+                },
+                {
+                  "name": "UncachedDiskIOPS",
+                  "value": "3200"
+                },
+                {
+                  "name": "UncachedDiskBytesPerSecond",
+                  "value": "48000000"
+                },
+                {
+                  "name": "EphemeralOSDiskSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "EncryptionAtHostSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "CapacityReservationSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "AcceleratedNetworkingEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "RdmaEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "MaxNetworkInterfaces",
+                  "value": "2"
+                }
+              ],
+              "restrictions": []
+            },
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/providers/Microsoft.DevOpsInfrastructure/locations/eastus/skus/Standard_A2_v2",
+            "name": "Standard_A2_v2"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/SubscriptionUsages_Usages.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/SubscriptionUsages_Usages.json
@@ -1,0 +1,38 @@
+{
+  "title": "SubscriptionUsages_Usages",
+  "operationId": "SubscriptionUsages_Usages",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "location": "eastus",
+    "api-version": "2026-07-30-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/providers/Microsoft.DevOpsInfrastructure/Usages/standardDADSv5Family",
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 212,
+            "name": {
+              "value": "standardDADSv5Family",
+              "localizedValue": "Standard DADSv5 Family vCPUs (PME VMSS)"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/providers/Microsoft.DevOpsInfrastructure/Usages/standardDPLDSv5Family",
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "standardDPLDSv5Family",
+              "localizedValue": "Standard DPLDSv5 Family vCPUs (PME VMSS)"
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/UpdatePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/examples/2026-07-30-preview/UpdatePool.json
@@ -1,0 +1,23 @@
+{
+  "title": "Pools_Update",
+  "operationId": "Pools_Update",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "properties": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/main.tsp
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/main.tsp
@@ -39,6 +39,10 @@ enum Versions {
   /** 2026-07-03-preview version */
   @armCommonTypesVersion(CommonTypes.Versions.v6)
   v2026_07_03_preview: "2026-07-03-preview",
+
+  /** 2026-07-30-preview version */
+  @armCommonTypesVersion(CommonTypes.Versions.v6)
+  v2026_07_30_preview: "2026-07-30-preview",
 }
 
 model Pool is TrackedResource<PoolProperties> {
@@ -868,7 +872,7 @@ model QuotaName {
 }
 
 @doc("The agent size or sizes an ephemeral type compatibility check is evaluated against. This mirrors the SKU shape a pool already uses, so a caller can pass the SKU it is about to save without reshaping it.")
-@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)
 model EphemeralTypeCompatibilitySku {
   @doc("The Azure SKU name of the machines in the pool. Use \"Mix\" together with vmSizes for an instance mix pool.")
   name: string;
@@ -879,7 +883,7 @@ model EphemeralTypeCompatibilitySku {
 }
 
 @doc("Asks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes.")
-@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)
 model EphemeralTypeCompatibilityRequest {
   @doc("The agent size or sizes to evaluate against.")
   sku: EphemeralTypeCompatibilitySku;
@@ -891,7 +895,7 @@ model EphemeralTypeCompatibilityRequest {
 }
 
 @doc("The compatibility result for a single requested image version. This contains either availableEphemeralTypes or error, never both, so that one image version failing to evaluate does not discard the results for the others.")
-@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)
 model EphemeralTypeCompatibilityResult {
   @doc("The resource id of the image version this result is for, echoed from the request.")
   imageVersionResourceId: string;
@@ -904,14 +908,14 @@ model EphemeralTypeCompatibilityResult {
 }
 
 @doc("The per-image-version results of an ephemeral type compatibility check.")
-@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)
 model EphemeralTypeCompatibilityListResult {
   @doc("The per-image-version results, in the order the image versions were requested.")
   @identifiers(#["imageVersionResourceId"])
   value: EphemeralTypeCompatibilityResult[];
 }
 
-@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)
 @armResourceOperations
 interface EphemeralTypeCompatibility {
   @action("checkEphemeralTypeCompatibility")

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/main.tsp
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/main.tsp
@@ -867,6 +867,69 @@ model QuotaName {
   localizedValue?: string;
 }
 
+@doc("The agent size or sizes an ephemeral type compatibility check is evaluated against. This mirrors the SKU shape a pool already uses, so a caller can pass the SKU it is about to save without reshaping it.")
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+model EphemeralTypeCompatibilitySku {
+  @doc("The Azure SKU name of the machines in the pool. Use \"Mix\" together with vmSizes for an instance mix pool.")
+  name: string;
+
+  @doc("Specifies VM sizes for instance-mix allocation. An explicit placement is only reported as available when every one of these sizes supports it.")
+  @identifiers(#["name"])
+  vmSizes?: VmSize[];
+}
+
+@doc("Asks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes.")
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+model EphemeralTypeCompatibilityRequest {
+  @doc("The agent size or sizes to evaluate against.")
+  sku: EphemeralTypeCompatibilitySku;
+
+  @doc("The resource ids of the image versions to evaluate. A version of 'latest' is resolved by the service.")
+  @minItems(1)
+  @maxItems(50)
+  imageVersionResourceIds: string[];
+}
+
+@doc("The compatibility result for a single requested image version. This contains either availableEphemeralTypes or error, never both, so that one image version failing to evaluate does not discard the results for the others.")
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+model EphemeralTypeCompatibilityResult {
+  @doc("The resource id of the image version this result is for, echoed from the request.")
+  imageVersionResourceId: string;
+
+  @doc("The ephemeral types that can be used for this image version on the requested agent sizes. Automatic is always included when the image version was evaluated successfully.")
+  availableEphemeralTypes?: EphemeralType[];
+
+  @doc("The reason this image version could not be evaluated.")
+  error?: Azure.ResourceManager.CommonTypes.ErrorDetail;
+}
+
+@doc("The per-image-version results of an ephemeral type compatibility check.")
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+model EphemeralTypeCompatibilityListResult {
+  @doc("The per-image-version results, in the order the image versions were requested.")
+  @identifiers(#["imageVersionResourceId"])
+  value: EphemeralTypeCompatibilityResult[];
+}
+
+@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_03_preview)
+@armResourceOperations
+interface EphemeralTypeCompatibility {
+  @action("checkEphemeralTypeCompatibility")
+  @armProviderNameValue
+  @post
+  @doc("Checks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes. A syntactically valid request returns 200 even when individual image versions fail to evaluate, so that one unreadable image version does not discard the results for the others. Those image versions carry an error instead of a list of available ephemeral types.")
+  check(
+    ...SubscriptionIdParameter,
+    ...Azure.ResourceManager.Foundations.DefaultProviderNamespace,
+    ...LocationResourceParameter,
+    ...ApiVersionParameter,
+
+    @doc("The ephemeral type compatibility request.")
+    @bodyRoot
+    body: EphemeralTypeCompatibilityRequest,
+  ): ArmResponse<EphemeralTypeCompatibilityListResult> | ErrorResponse;
+}
+
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "No ProvisioningState"
 #suppress "@azure-tools/typespec-azure-resource-manager/missing-property" "No Identity"
 @doc("An image resource.")

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-03-preview/devopsinfrastructure.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-03-preview/devopsinfrastructure.json
@@ -54,6 +54,9 @@
       "name": "SubscriptionUsages"
     },
     {
+      "name": "EphemeralTypeCompatibility"
+    },
+    {
       "name": "ImageVersions"
     }
   ],
@@ -135,6 +138,54 @@
         "x-ms-examples": {
           "Pools_CheckNameAvailability": {
             "$ref": "./examples/Pools_CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DevOpsInfrastructure/locations/{location}/checkEphemeralTypeCompatibility": {
+      "post": {
+        "operationId": "EphemeralTypeCompatibility_Check",
+        "tags": [
+          "EphemeralTypeCompatibility"
+        ],
+        "description": "Checks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes. A syntactically valid request returns 200 even when individual image versions fail to evaluate, so that one unreadable image version does not discard the results for the others. Those image versions carry an error instead of a list of available ephemeral types.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The ephemeral type compatibility request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EphemeralTypeCompatibilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EphemeralTypeCompatibilityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EphemeralTypeCompatibility_Check": {
+            "$ref": "./examples/EphemeralTypeCompatibility_Check.json"
           }
         }
       }
@@ -1124,6 +1175,95 @@
           }
         ]
       }
+    },
+    "EphemeralTypeCompatibilityListResult": {
+      "type": "object",
+      "description": "The per-image-version results of an ephemeral type compatibility check.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The per-image-version results, in the order the image versions were requested.",
+          "items": {
+            "$ref": "#/definitions/EphemeralTypeCompatibilityResult"
+          },
+          "x-ms-identifiers": [
+            "imageVersionResourceId"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EphemeralTypeCompatibilityRequest": {
+      "type": "object",
+      "description": "Asks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/EphemeralTypeCompatibilitySku",
+          "description": "The agent size or sizes to evaluate against."
+        },
+        "imageVersionResourceIds": {
+          "type": "array",
+          "description": "The resource ids of the image versions to evaluate. A version of 'latest' is resolved by the service.",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "sku",
+        "imageVersionResourceIds"
+      ]
+    },
+    "EphemeralTypeCompatibilityResult": {
+      "type": "object",
+      "description": "The compatibility result for a single requested image version. This contains either availableEphemeralTypes or error, never both, so that one image version failing to evaluate does not discard the results for the others.",
+      "properties": {
+        "imageVersionResourceId": {
+          "type": "string",
+          "description": "The resource id of the image version this result is for, echoed from the request."
+        },
+        "availableEphemeralTypes": {
+          "type": "array",
+          "description": "The ephemeral types that can be used for this image version on the requested agent sizes. Automatic is always included when the image version was evaluated successfully.",
+          "items": {
+            "$ref": "#/definitions/EphemeralType"
+          }
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "The reason this image version could not be evaluated."
+        }
+      },
+      "required": [
+        "imageVersionResourceId"
+      ]
+    },
+    "EphemeralTypeCompatibilitySku": {
+      "type": "object",
+      "description": "The agent size or sizes an ephemeral type compatibility check is evaluated against. This mirrors the SKU shape a pool already uses, so a caller can pass the SKU it is about to save without reshaping it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Azure SKU name of the machines in the pool. Use \"Mix\" together with vmSizes for an instance mix pool."
+        },
+        "vmSizes": {
+          "type": "array",
+          "description": "Specifies VM sizes for instance-mix allocation. An explicit placement is only reported as available when every one of these sizes supports it.",
+          "items": {
+            "$ref": "#/definitions/VmSize"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ]
     },
     "FabricProfile": {
       "type": "object",

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-03-preview/examples/EphemeralTypeCompatibility_Check.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-03-preview/examples/EphemeralTypeCompatibility_Check.json
@@ -1,0 +1,41 @@
+{
+  "title": "EphemeralTypeCompatibility_Check",
+  "operationId": "EphemeralTypeCompatibility_Check",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "location": "eastus",
+    "api-version": "2026-07-03-preview",
+    "body": {
+      "sku": {
+        "name": "Standard_D4ads_v5"
+      },
+      "imageVersionResourceIds": [
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/images/providers/Microsoft.Compute/galleries/gallery/images/ubuntu-24.04/versions/latest",
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0"
+      ]
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "imageVersionResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/images/providers/Microsoft.Compute/galleries/gallery/images/ubuntu-24.04/versions/latest",
+            "availableEphemeralTypes": [
+              "Automatic",
+              "CacheDisk",
+              "ResourceDisk"
+            ]
+          },
+          {
+            "imageVersionResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0",
+            "error": {
+              "code": "ImageNotFound",
+              "message": "The image version '/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/private-images/providers/Microsoft.Compute/galleries/gallery/images/windows-2022/versions/1.0.0' was not found."
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/devopsinfrastructure.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/devopsinfrastructure.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Managed DevOps Infrastructure",
-    "version": "2026-07-03-preview",
+    "version": "2026-07-30-preview",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"
@@ -52,6 +52,9 @@
     },
     {
       "name": "SubscriptionUsages"
+    },
+    {
+      "name": "EphemeralTypeCompatibility"
     },
     {
       "name": "ImageVersions"
@@ -135,6 +138,54 @@
         "x-ms-examples": {
           "Pools_CheckNameAvailability": {
             "$ref": "./examples/Pools_CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DevOpsInfrastructure/locations/{location}/checkEphemeralTypeCompatibility": {
+      "post": {
+        "operationId": "EphemeralTypeCompatibility_Check",
+        "tags": [
+          "EphemeralTypeCompatibility"
+        ],
+        "description": "Checks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes. A syntactically valid request returns 200 even when individual image versions fail to evaluate, so that one unreadable image version does not discard the results for the others. Those image versions carry an error instead of a list of available ephemeral types.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The ephemeral type compatibility request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EphemeralTypeCompatibilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EphemeralTypeCompatibilityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EphemeralTypeCompatibility_Check": {
+            "$ref": "./examples/EphemeralTypeCompatibility_Check.json"
           }
         }
       }
@@ -1124,6 +1175,95 @@
           }
         ]
       }
+    },
+    "EphemeralTypeCompatibilityListResult": {
+      "type": "object",
+      "description": "The per-image-version results of an ephemeral type compatibility check.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The per-image-version results, in the order the image versions were requested.",
+          "items": {
+            "$ref": "#/definitions/EphemeralTypeCompatibilityResult"
+          },
+          "x-ms-identifiers": [
+            "imageVersionResourceId"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EphemeralTypeCompatibilityRequest": {
+      "type": "object",
+      "description": "Asks which ephemeral OS disk placements can be used for a set of image versions on a set of agent sizes.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/EphemeralTypeCompatibilitySku",
+          "description": "The agent size or sizes to evaluate against."
+        },
+        "imageVersionResourceIds": {
+          "type": "array",
+          "description": "The resource ids of the image versions to evaluate. A version of 'latest' is resolved by the service.",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "sku",
+        "imageVersionResourceIds"
+      ]
+    },
+    "EphemeralTypeCompatibilityResult": {
+      "type": "object",
+      "description": "The compatibility result for a single requested image version. This contains either availableEphemeralTypes or error, never both, so that one image version failing to evaluate does not discard the results for the others.",
+      "properties": {
+        "imageVersionResourceId": {
+          "type": "string",
+          "description": "The resource id of the image version this result is for, echoed from the request."
+        },
+        "availableEphemeralTypes": {
+          "type": "array",
+          "description": "The ephemeral types that can be used for this image version on the requested agent sizes. Automatic is always included when the image version was evaluated successfully.",
+          "items": {
+            "$ref": "#/definitions/EphemeralType"
+          }
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "The reason this image version could not be evaluated."
+        }
+      },
+      "required": [
+        "imageVersionResourceId"
+      ]
+    },
+    "EphemeralTypeCompatibilitySku": {
+      "type": "object",
+      "description": "The agent size or sizes an ephemeral type compatibility check is evaluated against. This mirrors the SKU shape a pool already uses, so a caller can pass the SKU it is about to save without reshaping it.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Azure SKU name of the machines in the pool. Use \"Mix\" together with vmSizes for an instance mix pool."
+        },
+        "vmSizes": {
+          "type": "array",
+          "description": "Specifies VM sizes for instance-mix allocation. An explicit placement is only reported as available when every one of these sizes supports it.",
+          "items": {
+            "$ref": "#/definitions/VmSize"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ]
     },
     "FabricProfile": {
       "type": "object",

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/CreateOrUpdatePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/CreateOrUpdatePool.json
@@ -1,0 +1,182 @@
+{
+  "title": "Pools_CreateOrUpdate",
+  "operationId": "Pools_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "provisioningState": "Succeeded",
+        "maximumConcurrency": 10,
+        "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+        "organizationProfile": {
+          "kind": "AzureDevOps",
+          "description": "Managed by Managed DevOps Pools",
+          "updateDescription": true,
+          "organizations": [
+            {
+              "url": "https://mseng.visualstudio.com",
+              "openAccess": true
+            }
+          ]
+        },
+        "agentProfile": {
+          "kind": "Stateless"
+        },
+        "fabricProfile": {
+          "kind": "Vmss",
+          "sku": {
+            "name": "Standard_D4ads_v5"
+          },
+          "images": [
+            {
+              "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+              "ephemeralType": "NVMeDisk",
+              "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+              "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+              "provisioningScriptShouldRestart": true,
+              "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+            }
+          ],
+          "osProfile": {
+            "secretsManagementSettings": {
+              "certificateStoreName": "Root",
+              "observedCertificates": [
+                "https://abc.vault.azure.net/secrets/one"
+              ],
+              "keyExportable": false
+            }
+          },
+          "networkProfile": {
+            "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+            "staticIpAddressCount": 2
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    },
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/CreateOrUpdatePool_InstanceMix.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/CreateOrUpdatePool_InstanceMix.json
@@ -1,0 +1,206 @@
+{
+  "title": "Pools_CreateOrUpdate_InstanceMix",
+  "operationId": "Pools_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "provisioningState": "Succeeded",
+        "maximumConcurrency": 10,
+        "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+        "organizationProfile": {
+          "kind": "AzureDevOps",
+          "description": "Managed by Managed DevOps Pools",
+          "updateDescription": true,
+          "organizations": [
+            {
+              "url": "https://mseng.visualstudio.com",
+              "openAccess": true
+            }
+          ]
+        },
+        "agentProfile": {
+          "kind": "Stateless"
+        },
+        "fabricProfile": {
+          "kind": "Vmss",
+          "sku": {
+            "name": "Mix",
+            "vmSizes": [
+              {
+                "name": "Standard_E2ads_v5"
+              },
+              {
+                "name": "Standard_D2ads_v5"
+              }
+            ]
+          },
+          "images": [
+            {
+              "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+              "ephemeralType": "Automatic",
+              "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+              "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+              "provisioningScriptShouldRestart": true,
+              "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+            }
+          ],
+          "osProfile": {
+            "secretsManagementSettings": {
+              "certificateStoreName": "Root",
+              "observedCertificates": [
+                "https://abc.vault.azure.net/secrets/one"
+              ],
+              "keyExportable": false
+            }
+          },
+          "networkProfile": {
+            "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+            "staticIpAddressCount": 2
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Mix",
+              "vmSizes": [
+                {
+                  "name": "Standard_E2ads_v5"
+                },
+                {
+                  "name": "Standard_D2ads_v5"
+                }
+              ]
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    },
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Mix",
+              "vmSizes": [
+                {
+                  "name": "Standard_E2ads_v5"
+                },
+                {
+                  "name": "Standard_D2ads_v5"
+                }
+              ]
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true,
+                "provisioningScriptStorageAccountResourceId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/provisioningscriptsa",
+                "provisioningScriptManagedIdentityClientId": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "provisioningScriptShouldRestart": true,
+                "provisioningScriptEntryPoint": "scripts/setup-agent.ps1"
+              }
+            ],
+            "osProfile": {
+              "secretsManagementSettings": {
+                "certificateStoreName": "Root",
+                "observedCertificates": [
+                  "https://abc.vault.azure.net/secrets/one"
+                ],
+                "keyExportable": false
+              }
+            },
+            "networkProfile": {
+              "subnetId": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+              "staticIpAddressCount": 2,
+              "ipAddresses": [
+                "1.1.1.1",
+                "2.2.2.2"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/DeletePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/DeletePool.json
@@ -1,0 +1,18 @@
+{
+  "title": "Pools_Delete",
+  "operationId": "Pools_Delete",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/EphemeralTypeCompatibility_Check.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/EphemeralTypeCompatibility_Check.json
@@ -4,7 +4,7 @@
   "parameters": {
     "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
     "location": "eastus",
-    "api-version": "2026-07-03-preview",
+    "api-version": "2026-07-30-preview",
     "body": {
       "sku": {
         "name": "Standard_D4ads_v5"

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/GetPool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/GetPool.json
@@ -1,0 +1,49 @@
+{
+  "title": "Pools_Get",
+  "operationId": "Pools_Get",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "maximumConcurrency": 10,
+          "devCenterProjectResourceId": "/subscriptions/222e81d0-cf38-4dab-baa5-289bf16baaa4/resourceGroups/rg-1es-devcenter/providers/Microsoft.DevCenter/projects/1ES",
+          "organizationProfile": {
+            "kind": "AzureDevOps",
+            "description": "Managed by Managed DevOps Pools",
+            "updateDescription": true,
+            "organizations": [
+              {
+                "url": "https://mseng.visualstudio.com"
+              }
+            ]
+          },
+          "agentProfile": {
+            "kind": "Stateless"
+          },
+          "fabricProfile": {
+            "kind": "Vmss",
+            "sku": {
+              "name": "Standard_D4ads_v5"
+            },
+            "images": [
+              {
+                "resourceId": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+                "ephemeralType": "Automatic",
+                "isEphemeral": true
+              }
+            ]
+          }
+        },
+        "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+        "location": "eastus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ImageVersions_ListByImage.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ImageVersions_ListByImage.json
@@ -1,0 +1,27 @@
+{
+  "title": "ImageVersions_ListByImage",
+  "operationId": "ImageVersions_ListByImage",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "imageName": "windows-2022"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/images/windows-2022/versions/2024.0417.0",
+            "name": "2024.0417.0"
+          },
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/images/windows-2022/versions/2024.0417.1",
+            "name": "2024.0417.1"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListOperations.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListOperations.json
@@ -1,0 +1,12 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-07-30-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListPoolsBySubscription.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListPoolsBySubscription.json
@@ -1,0 +1,20 @@
+{
+  "title": "Pools_ListBySubscription",
+  "operationId": "Pools_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/aoiresourceGroupName/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListPoolsBySubscriptionAndResourceGroup.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ListPoolsBySubscriptionAndResourceGroup.json
@@ -1,0 +1,21 @@
+{
+  "title": "Pools_ListByResourceGroup",
+  "operationId": "Pools_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/rg/providers/Microsoft.DevOpsInfrastructure/Pools/pool",
+            "location": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Pools_CheckNameAvailability.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Pools_CheckNameAvailability.json
@@ -1,0 +1,22 @@
+{
+  "title": "Pools_CheckNameAvailability",
+  "operationId": "Pools_CheckNameAvailability",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "api-version": "2026-07-30-preview",
+    "body": {
+      "name": "mydevopspool",
+      "type": "Microsoft.DevOpsInfrastructure/pools"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "available": "Unavailable",
+        "message": "Managed DevOps pool mydevopspool is already in use. Please choose a pool name that has not been taken.",
+        "name": "mydevopspool",
+        "reason": "AlreadyExists"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Pools_DeleteResources.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Pools_DeleteResources.json
@@ -1,0 +1,19 @@
+{
+  "title": "Pools_DeleteResources",
+  "operationId": "Pools_DeleteResources",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "poolName": "my-dev-ops-pool",
+    "body": {
+      "resourceIds": [
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-dev-ops-pool/resources/dd8cc705c_0",
+        "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-dev-ops-pool/resources/dd8cc705c_1"
+      ]
+    }
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ResourceDetails_ListByPool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/ResourceDetails_ListByPool.json
@@ -1,0 +1,37 @@
+{
+  "title": "ResourceDetails_ListByPool",
+  "operationId": "ResourceDetails_ListByPool",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "my-resource-group",
+    "poolName": "my-dev-ops-pool"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-devops-pool/resources/my-dev-ops-pool:04dcde21-626e-5a7e-8659-ce12f9284b29:dd8cc705c_0",
+            "name": "dd8cc705c000000",
+            "properties": {
+              "image": "my-image",
+              "imageVersion": "4.0.0",
+              "status": "Ready"
+            }
+          },
+          {
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/resourceGroups/my-resource-group/providers/Microsoft.DevOpsInfrastructure/pools/my-devops-pool/resources/my-dev-ops-pool:04dcde21-626e-5a7e-8659-ce12f9284b29:dd8cc705c_1",
+            "name": "dd8cc705c000001",
+            "properties": {
+              "image": "my-image",
+              "imageVersion": "4.0.0",
+              "status": "Allocated"
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Sku_ListByLocation.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/Sku_ListByLocation.json
@@ -1,0 +1,278 @@
+{
+  "title": "Sku_ListByLocation",
+  "operationId": "Sku_ListByLocation",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "locationName": "eastus"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "resourceType": "virtualMachines",
+              "tier": "Basic",
+              "size": "A0",
+              "family": "basicAFamily",
+              "locations": [
+                "eastus"
+              ],
+              "locationInfo": [
+                {
+                  "location": "eastus",
+                  "zones": [],
+                  "zoneDetails": []
+                }
+              ],
+              "capabilities": [
+                {
+                  "name": "MaxResourceVolumeMB",
+                  "value": "20480"
+                },
+                {
+                  "name": "OSVhdSizeMB",
+                  "value": "1047552"
+                },
+                {
+                  "name": "vCPUs",
+                  "value": "1"
+                },
+                {
+                  "name": "MemoryPreservingMaintenanceSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "HyperVGenerations",
+                  "value": "V1"
+                },
+                {
+                  "name": "MemoryGB",
+                  "value": "0.75"
+                },
+                {
+                  "name": "MaxDataDiskCount",
+                  "value": "1"
+                },
+                {
+                  "name": "CpuArchitectureType",
+                  "value": "x64"
+                },
+                {
+                  "name": "LowPriorityCapable",
+                  "value": "False"
+                },
+                {
+                  "name": "PremiumIO",
+                  "value": "False"
+                },
+                {
+                  "name": "VMDeploymentTypes",
+                  "value": "IaaS"
+                },
+                {
+                  "name": "vCPUsAvailable",
+                  "value": "1"
+                },
+                {
+                  "name": "ACUs",
+                  "value": "50"
+                },
+                {
+                  "name": "vCPUsPerCore",
+                  "value": "1"
+                },
+                {
+                  "name": "EphemeralOSDiskSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "EncryptionAtHostSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "CapacityReservationSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "AcceleratedNetworkingEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "RdmaEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "MaxNetworkInterfaces",
+                  "value": "2"
+                }
+              ],
+              "restrictions": [
+                {
+                  "type": "Location",
+                  "values": [
+                    "eastus"
+                  ],
+                  "restrictionInfo": {
+                    "locations": [
+                      "eastus"
+                    ]
+                  },
+                  "reasonCode": "NotAvailableForSubscription"
+                },
+                {
+                  "type": "Zone",
+                  "values": [
+                    "eastus"
+                  ],
+                  "restrictionInfo": {
+                    "locations": [
+                      "eastus"
+                    ],
+                    "zones": [
+                      "1",
+                      "2",
+                      "3"
+                    ]
+                  },
+                  "reasonCode": "NotAvailableForSubscription"
+                }
+              ]
+            },
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/providers/Microsoft.DevOpsInfrastructure/locations/eastus/skus/Basic_A0",
+            "name": "Basic_A0"
+          },
+          {
+            "properties": {
+              "resourceType": "virtualMachines",
+              "tier": "Standard",
+              "size": "A2_v2",
+              "family": "standardAv2Family",
+              "locations": [
+                "eastus"
+              ],
+              "locationInfo": [
+                {
+                  "location": "eastus",
+                  "zones": [
+                    "1",
+                    "2",
+                    "3"
+                  ],
+                  "zoneDetails": []
+                }
+              ],
+              "capabilities": [
+                {
+                  "name": "MaxResourceVolumeMB",
+                  "value": "20480"
+                },
+                {
+                  "name": "OSVhdSizeMB",
+                  "value": "1047552"
+                },
+                {
+                  "name": "vCPUs",
+                  "value": "2"
+                },
+                {
+                  "name": "MemoryPreservingMaintenanceSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "HyperVGenerations",
+                  "value": "V1"
+                },
+                {
+                  "name": "MemoryGB",
+                  "value": "4"
+                },
+                {
+                  "name": "MaxDataDiskCount",
+                  "value": "4"
+                },
+                {
+                  "name": "CpuArchitectureType",
+                  "value": "x64"
+                },
+                {
+                  "name": "LowPriorityCapable",
+                  "value": "True"
+                },
+                {
+                  "name": "PremiumIO",
+                  "value": "False"
+                },
+                {
+                  "name": "VMDeploymentTypes",
+                  "value": "PaaS,IaaS"
+                },
+                {
+                  "name": "vCPUsAvailable",
+                  "value": "2"
+                },
+                {
+                  "name": "ACUs",
+                  "value": "100"
+                },
+                {
+                  "name": "vCPUsPerCore",
+                  "value": "1"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedIOPS",
+                  "value": "2000"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedReadBytesPerSecond",
+                  "value": "41943040"
+                },
+                {
+                  "name": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+                  "value": "20971520"
+                },
+                {
+                  "name": "UncachedDiskIOPS",
+                  "value": "3200"
+                },
+                {
+                  "name": "UncachedDiskBytesPerSecond",
+                  "value": "48000000"
+                },
+                {
+                  "name": "EphemeralOSDiskSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "EncryptionAtHostSupported",
+                  "value": "False"
+                },
+                {
+                  "name": "CapacityReservationSupported",
+                  "value": "True"
+                },
+                {
+                  "name": "AcceleratedNetworkingEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "RdmaEnabled",
+                  "value": "False"
+                },
+                {
+                  "name": "MaxNetworkInterfaces",
+                  "value": "2"
+                }
+              ],
+              "restrictions": []
+            },
+            "id": "/subscriptions/a2e95d27-c161-4b61-bda4-11512c14c2c2/providers/Microsoft.DevOpsInfrastructure/locations/eastus/skus/Standard_A2_v2",
+            "name": "Standard_A2_v2"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/SubscriptionUsages_Usages.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/SubscriptionUsages_Usages.json
@@ -1,0 +1,38 @@
+{
+  "title": "SubscriptionUsages_Usages",
+  "operationId": "SubscriptionUsages_Usages",
+  "parameters": {
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "location": "eastus",
+    "api-version": "2026-07-30-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/providers/Microsoft.DevOpsInfrastructure/Usages/standardDADSv5Family",
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 212,
+            "name": {
+              "value": "standardDADSv5Family",
+              "localizedValue": "Standard DADSv5 Family vCPUs (PME VMSS)"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/providers/Microsoft.DevOpsInfrastructure/Usages/standardDPLDSv5Family",
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "standardDPLDSv5Family",
+              "localizedValue": "Standard DPLDSv5 Family vCPUs (PME VMSS)"
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/UpdatePool.json
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/preview/2026-07-30-preview/examples/UpdatePool.json
@@ -1,0 +1,23 @@
+{
+  "title": "Pools_Update",
+  "operationId": "Pools_Update",
+  "parameters": {
+    "api-version": "2026-07-30-preview",
+    "subscriptionId": "a2e95d27-c161-4b61-bda4-11512c14c2c2",
+    "resourceGroupName": "rg",
+    "poolName": "pool",
+    "properties": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus"
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/readme.md
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/readme.md
@@ -27,12 +27,21 @@ These are the global settings for the devopsinfrastructure.
 ```yaml
 openapi-type: arm
 openapi-subtype: providerHub
-tag: package-preview-2026-07-03
+tag: package-preview-2026-07-30
 ```
 
 ``` yaml
 modelerfour:
   flatten-models: false
+```
+
+### Tag: package-preview-2026-07-30
+
+These settings apply only when `--tag=package-preview-2026-07-30` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-07-30'
+input-file:
+  - preview/2026-07-30-preview/devopsinfrastructure.json
 ```
 
 ### Tag: package-preview-2026-07-03


### PR DESCRIPTION
## Summary

Cuts the `2026-07-30-preview` api-version for `Microsoft.DevOpsInfrastructure` and adds
`EphemeralTypeCompatibility_Check` to it.

```
POST /subscriptions/{subscriptionId}/providers/Microsoft.DevOpsInfrastructure/locations/{location}/checkEphemeralTypeCompatibility
```

Managed DevOps Pools already accepts a per-image `ephemeralType`, but a caller has no way to
discover which placements a given image version can actually use on a given agent size. Today the
only way to find out is to save the pool and see what provisioning decides. This lets the Azure
Portal offer only the placements that will actually be honoured, without duplicating the service's
image-size and SKU capability rules and drifting from provisioning behaviour.

## Versioning

This originally added the operation to `2026-07-03-preview`. The versioning check correctly flagged
that: `2026-07-03-preview` is already merged to `main`, so it is considered shipped regardless of
whether any resource provider serves it yet. The change now cuts a new `2026-07-30-preview` instead,
and `2026-07-03-preview` is restored byte for byte to its state on `main`.

`2026-07-30-preview` inherits every existing operation plus `NVMeDisk` on the `EphemeralType` enum
(added in #44406), and adds the one new operation. Everything new is gated with
`@added(Microsoft.DevOpsInfrastructure.Versions.v2026_07_30_preview)`. Generated with
`tsp compile`; no previously released version is modified.

## Design notes

**Subscription and location scoped, not pool scoped.** The pool create experience needs the answer
before a pool resource exists.

**The request mirrors the SKU shape a pool already uses** (`name`, plus `vmSizes` for an instance
mix), so a caller can pass the SKU it is about to save without reshaping it. For an instance mix, an
explicit placement is only reported as available when every VM size supports it.

**Images are identified by resource id**, since MDP pools reference images that way. A version of
`latest` is resolved by the service.

**Partial failure is a success.** A syntactically valid request returns 200 even when individual
image versions fail to evaluate. Each result carries either `availableEphemeralTypes` or `error`,
never both, so one unreadable image does not discard the results for the others. Non-2xx is reserved
for failures that prevent evaluating the request as a whole, such as a malformed body or an agent
size that is not available in the location. The example shows both outcomes in one response.

## Consuming change

The resource provider implementation is a separate change in the internal ResourceManagement repo
and will not ship ahead of this spec, since ProviderHub routes `Microsoft.DevOpsInfrastructure`
against the published folder here.
