### PR TITLE
Prepare main for C# model naming lint rules

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7620,6 +7620,7 @@ model EdgeMachineHostNetwork {
   /**
    * Optional parameter required only for 3 Nodes Switchless deployments. This allows users to specify IPs and Mask for Storage NICs when Network ATC is not assigning the IPs for storage automatically.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   enableStorageAutoIp?: boolean = false;
 }
@@ -7809,6 +7810,7 @@ model EdgeMachineStorageNetwork {
 /**
  * The StorageAdapter physical nodes reported for the edge machine.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model EdgeMachineStorageAdapterIpInfo {
   /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/recurringScheduledActions.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/recurringScheduledActions.tsp
@@ -383,6 +383,7 @@ model ScheduledActionResource {
 
 @@identifiers(ResourceListResponse.value, #[]);
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-07-06-preview`)
 model ResourceListResponse is Azure.Core.Page<ScheduledActionResource>;
 
@@ -529,6 +530,7 @@ model ScheduledActionsExtensionProperties {
   resourceNotificationSettings?: Array<NotificationProperties>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-07-06-preview`)
 @doc("The response from scheduled action resource requests, which contains the status of each resource")
 model ScheduledActionResourceOperationResponse {
@@ -626,6 +628,7 @@ model OccurrenceResource is ScheduledActionResource {
 
 @@identifiers(OccurrenceResourceListResponse.value, #[]);
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-07-06-preview`)
 model OccurrenceResourceListResponse is Azure.Core.Page<OccurrenceResource>;
 

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -4499,6 +4499,7 @@ model VirtualMachineScaleSetExtensionUpdate extends SubResourceReadOnly {
 /**
  * Response after calling a manual recovery walk
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RecoveryWalkResponse {
   /**
    * Whether the recovery walk was performed
@@ -6318,6 +6319,7 @@ model VirtualMachineExtensionUpdateProperties {
 /**
  * Specifies the input for attaching and detaching a list of managed data disks.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AttachDetachDataDisksRequest {
   /**
    * The list of managed data disks to be attached.

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -1356,6 +1356,7 @@ model UefiKeySignatures {
   /**
    * The database of UEFI keys for this image version.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @identifiers(#[])
   db?: UefiKey[];
 

--- a/specification/connectedcache/ConnectedCache.Management/models.tsp
+++ b/specification/connectedcache/ConnectedCache.Management/models.tsp
@@ -786,46 +786,55 @@ model AdditionalCacheNodeProperties {
   @visibility(Lifecycle.Read)
   tlsStatus?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system edition of the cache node host machine")
   @visibility(Lifecycle.Read)
   hostOsEdition?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system version of the cache node host machine")
   @visibility(Lifecycle.Read)
   hostOsVersion?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system build of the cache node host machine")
   @visibility(Lifecycle.Read)
   hostOsBuild?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system edition of the WSL Linux distribution used to run the cache node on Windows host machines")
   @visibility(Lifecycle.Read)
   distroOsEditionWsl?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system version of the WSL Linux distribution used to run the cache node on Windows host machines")
   @visibility(Lifecycle.Read)
   distroOsVersionWsl?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system build of the WSL Linux distribution used to run the cache node on Windows host machines")
   @visibility(Lifecycle.Read)
   distroOsBuildWsl?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system edition of container used to run the cache node")
   @visibility(Lifecycle.Read)
   containerOsEdition?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system version of the container used to run the cache node")
   @visibility(Lifecycle.Read)
   containerOsVersion?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_06_01)
   @doc("Operating system build of the container used to run the cache node")
   @visibility(Lifecycle.Read)

--- a/specification/education/resource-manager/Microsoft.Education/Education/JoinRequestDetails.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/JoinRequestDetails.tsp
@@ -12,6 +12,7 @@ namespace Microsoft.Education;
 /**
  * join requests.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @parentResource(LabDetails)
 model JoinRequestDetails
   is Azure.ResourceManager.ProxyResource<JoinRequestProperties> {

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActionGroupsApi/models.tsp
@@ -631,6 +631,7 @@ model EnableRequest {
   receiverName: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @error
 model ArmConflictErrorResponse {

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActivityLogAlertsApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/ActivityLogAlertsApi/models.tsp
@@ -169,6 +169,7 @@ model AzureResource {
 /**
  * The error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ActivityLogAlertErrorResponse {
   /**

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/AutoScaleApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/AutoScaleApi/models.tsp
@@ -688,6 +688,7 @@ model Resource {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model AutoscaleErrorResponse {
   /**

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/MetricAlertApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/MetricAlertApi/models.tsp
@@ -343,6 +343,7 @@ model Resource {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MetricAlertErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/MetricBaselinesApi/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/MetricBaselinesApi/models.tsp
@@ -37,6 +37,7 @@ union BaselineSensitivity {
 /**
  * A list of metric baselines.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MetricBaselinesResponse {
   /**
    * The list of metric baselines.
@@ -188,6 +189,7 @@ model BaselineMetadata {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MetricBaselinesErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/TenantActionGroups/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/TenantActionGroups/models.tsp
@@ -163,6 +163,7 @@ model TenantNotificationRequestBody {
 /**
  * The details of the test notification results.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TestNotificationDetailsResponse {
   /**
    * The context info

--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/NetworkInterfaceIPConfiguration.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/NetworkInterfaceIPConfiguration.tsp
@@ -25,6 +25,7 @@ model NetworkInterfaceIPConfiguration extends SubResourceModel {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   properties?: NetworkInterfaceIPConfigurationPropertiesFormat;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("ipConfigurationName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/CustomIpPrefix.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/CustomIpPrefix.tsp
@@ -24,6 +24,7 @@ namespace Microsoft.Network;
 model CustomIpPrefix extends Common.Resource {
   properties?: CustomIpPrefixPropertiesFormat;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("customIpPrefixName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/HubIpConfiguration.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/HubIpConfiguration.tsp
@@ -29,6 +29,7 @@ model HubIpConfiguration extends SubResourceModel {
   /**
    * The name of the resource that is unique within a resource group. This name can be used to access the resource.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("ipConfigName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/IpAllocation.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/IpAllocation.tsp
@@ -24,6 +24,7 @@ namespace Microsoft.Network;
 model IpAllocation extends Common.Resource {
   properties?: IpAllocationPropertiesFormat;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("ipAllocationName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/IpGroup.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/IpGroup.tsp
@@ -24,6 +24,7 @@ namespace Microsoft.Network;
 model IpGroup extends Common.Resource {
   properties?: IpGroupPropertiesFormat;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("ipGroupsName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/PublicIPAddress.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/PublicIPAddress.tsp
@@ -44,6 +44,7 @@ alias PublicIPAddressOps = Azure.ResourceManager.Legacy.LegacyOperations<
     networkInterfaceName: string;
 
     /** The name of the IP configuration. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("ipconfigurations")
     @key
@@ -51,6 +52,7 @@ alias PublicIPAddressOps = Azure.ResourceManager.Legacy.LegacyOperations<
   },
   {
     /** The name of the public IP Address. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("publicipaddresses")
     @key
@@ -111,6 +113,7 @@ alias PublicIPAddressOperationGroupOps = Azure.ResourceManager.Legacy.LegacyOper
   },
   {
     /** The name of the public IP address. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("publicIPAddresses")
     @key

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/PublicIPPrefix.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/PublicIPPrefix.tsp
@@ -24,6 +24,7 @@ namespace Microsoft.Network;
 model PublicIPPrefix extends Common.Resource {
   properties?: PublicIPPrefixPropertiesFormat;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @path
   @key("publicIpPrefixName")

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualNetwork.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualNetwork.tsp
@@ -93,6 +93,7 @@ interface VirtualNetworks {
       /**
        * The private IP address to be verified.
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("ipAddress")
       ipAddress: string;
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/VpnGateway.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/VpnGateway.tsp
@@ -165,6 +165,7 @@ interface VpnGateways {
       /**
        * VpnGateway ipConfigurationId to specify the gateway instance.
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("ipConfigurationId")
       ipConfigurationId?: string;
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -7285,6 +7285,7 @@ model ApplicationGatewayBackendSettingsPropertiesFormat {
   /**
    * Whether to send Proxy Protocol header to backend servers over TCP or TLS protocols. Default value is false.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   enableL4ClientIpPreservation?: boolean;
 
   /**
@@ -8347,6 +8348,7 @@ model ApplicationGatewayPrivateLinkIpConfiguration extends SubResource {
 /**
  * Properties of an application gateway private link IP configuration.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
 model ApplicationGatewayPrivateLinkIpConfigurationProperties {
@@ -10302,6 +10304,7 @@ model BastionActiveSession {
   /**
    * The IP Address of the target.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   targetIpAddress?: string;
 
@@ -10408,6 +10411,7 @@ model SwapResourceListResult {
 /**
  * Custom IP prefix properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model CustomIpPrefixPropertiesFormat {
@@ -12969,6 +12973,7 @@ model CommonResource {
 /**
  * Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 @summary("Error response")
 model CommonErrorResponse {
@@ -13272,6 +13277,7 @@ model CommonProxyResource extends CommonResource {}
 /**
  * Properties of the IpAllocation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
@@ -13325,6 +13331,7 @@ model IpAllocationPropertiesFormat {
 /**
  * The IpGroups property information.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model IpGroupPropertiesFormat {
@@ -13405,6 +13412,7 @@ model QueryInboundNatRulePortMappingRequest {
   /**
    * NetworkInterfaceIPConfiguration set in load balancer backend address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipConfiguration?: SubResource;
 
   /**
@@ -15120,6 +15128,7 @@ model ContainerNetworkInterfaceIpConfiguration {
 /**
  * Properties of the container network interface IP configuration.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model ContainerNetworkInterfaceIpConfigurationPropertiesFormat {
@@ -15218,6 +15227,7 @@ model SecurityPerimeterSystemData {
 /**
  * Update tags request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.networkSecurityPerimeter)
 model UpdateTagsRequest {
@@ -16449,6 +16459,7 @@ model InboundSecurityRules {
 /**
  * The error object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.networkWatcher)
 @error
@@ -17930,6 +17941,7 @@ model NetworkConfigurationDiagnosticProfile {
 /**
  * Results of network configuration diagnostic on the target resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.networkWatcher)
 model NetworkConfigurationDiagnosticResponse {
@@ -18961,6 +18973,7 @@ model PrivateDnsZoneGroupListResult is Azure.Core.Page<PrivateDnsZoneGroup>;
 /**
  * Request body of the CheckPrivateLinkServiceVisibility API service call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model CheckPrivateLinkServiceVisibilityRequest {
@@ -19145,6 +19158,7 @@ model PublicIPPrefixPropertiesFormat {
 /**
  * Reference to a public IP address.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model ReferencedPublicIpAddress {
@@ -21996,6 +22010,7 @@ model VpnClientConnectionHealthDetail {
 /**
  * List of p2s vpn connections to be disconnected.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
@@ -23900,6 +23915,7 @@ model P2SVpnProfileParameters {
 /**
  * Vpn Profile Response for package generation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
 model VpnProfileResponse {
@@ -23946,6 +23962,7 @@ model P2SVpnConnectionHealth {
 /**
  * VpnServerConfigurations list associated with VirtualWan Response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
 model VpnServerConfigurationsResponse {
@@ -24376,6 +24393,7 @@ model HubIPConfigurationPropertiesFormat {
 /**
  * VirtualHubIpConfigurations list.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
 model ListVirtualHubIpConfigurationResults
@@ -26279,6 +26297,7 @@ model ServiceGatewayUpdateServicesRequest {
 /**
  * Properties of the service gateway services request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.serviceGateway)
 model ServiceGatewayServiceRequest {
@@ -26348,6 +26367,7 @@ model GetServiceGatewayAddressLocationsResult
 /**
  * Properties of the service gateway address location.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.serviceGateway)
 model ServiceGatewayAddressLocationResponse {
@@ -26460,6 +26480,7 @@ model VirtualNetworkApplianceIpConfiguration extends SubResource {
 /**
  * Properties of virtual network appliance IP configuration.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetworkAppliance)
 model VirtualNetworkApplianceIpConfigurationProperties {

--- a/specification/network/resource-manager/Microsoft.Network/Network/Vmss/NetworkInterfaceIPConfiguration.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Vmss/NetworkInterfaceIPConfiguration.tsp
@@ -53,6 +53,7 @@ interface NetworkInterfaceIPConfigurations {
       @key
       networkInterfaceName: string;
 
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @path
       @key

--- a/specification/network/resource-manager/Microsoft.Network/Network/Vmss/PublicIPAddress.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Vmss/PublicIPAddress.tsp
@@ -51,11 +51,13 @@ interface PublicIPAddresses {
       @key
       networkInterfaceName: string;
 
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @path
       @key
       ipConfigurationName: string;
 
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @path
       @key
@@ -97,6 +99,7 @@ interface PublicIPAddresses {
       @key
       networkInterfaceName: string;
 
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @path
       @key

--- a/specification/purestorage/PureStorage.Block.Management/main.tsp
+++ b/specification/purestorage/PureStorage.Block.Management/main.tsp
@@ -304,6 +304,7 @@ model PlatformConsoleSubnet {
   @doc("Azure resource ID of the subnet")
   id: Azure.Core.armResourceIdentifier;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Management IP address assigned to the subnet (system-populated)")
   @visibility(Lifecycle.Read)
   managementIpAddress?: string;
@@ -1214,6 +1215,7 @@ model ConnectionParametersResponse {
   iscsi: IscsiConnectionParameters;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 @doc("Request to overwrite all volumes in a volume group from a snapshot")
 model VolumeGroupOverwriteRequest {
@@ -1224,6 +1226,7 @@ model VolumeGroupOverwriteRequest {
   sourceVolumeGroupResourceId: Azure.Core.armResourceIdentifier;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 @doc("Request to overwrite a volume's content from another volume or a snapshot")
 model VolumeOverwriteRequest {
@@ -1515,6 +1518,7 @@ interface RecoverableVolumeGroups {
   delete is ArmResourceDeleteWithoutOkAsync<RecoverableVolumeGroup>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is the correct casing for Software as a Service"
 @added(Versions.v2026_03_01_preview)
 @doc("SaaS guid for Activate SaaS Resource")
@@ -1526,6 +1530,7 @@ model ActivateSaaSRequest {
   publisherId?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Response model extending ProxyResource for consistency with Azure patterns"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is the correct casing for Software as a Service"
 @added(Versions.v2026_03_01_preview)
@@ -1536,6 +1541,7 @@ model SaaSResourceDetailsResponse
   saasId?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is the correct casing for Software as a Service"
 @added(Versions.v2026_03_01_preview)
 @doc("SaaS details for linking to a reservation.")
@@ -1545,6 +1551,7 @@ model LinkSaaSRequest {
   saaSResourceId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is the correct casing for Software as a Service"
 @added(Versions.v2026_03_01_preview)
 @doc("Response of get latest linked SaaS resource operation.")
@@ -1685,6 +1692,7 @@ model VolumeGroupSnapshotPostListResult {
   totalCount?: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 @doc("Request payload for listing volume group snapshots")
 model VolumeGroupSnapshotListRequest {

--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/ResourceGraphApi/models.tsp
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/ResourceGraphApi/models.tsp
@@ -139,6 +139,7 @@ model QueryRequest {
 /**
  * The options for query evaluation
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QueryRequestOptions {
   /**
    * Continuation token for pagination, capturing the next page size and offset, as well as the context of the query.
@@ -177,6 +178,7 @@ model QueryRequestOptions {
 /**
  * A request to compute additional statistics (facets) over the query results.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FacetRequest {
   /**
    * The column or list of columns to summarize by
@@ -192,6 +194,7 @@ model FacetRequest {
 /**
  * The options for facet evaluation
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FacetRequestOptions {
   /**
    * The column name or query expression to sort on. Defaults to count if not present.

--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/ResourceHistory/models.tsp
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/ResourceHistory/models.tsp
@@ -15,6 +15,7 @@ alias DateTimeInterval = ResourceGraphCommon.DateTimeInterval;
 /**
  * Describes a history request to be executed.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourcesHistoryRequest {
   /**
    * Azure subscriptions against which to execute the query.
@@ -40,6 +41,7 @@ model ResourcesHistoryRequest {
 /**
  * The options for history request evaluation
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourcesHistoryRequestOptions {
   /**
    * The time interval used to fetch history.

--- a/specification/storage/data-plane/BlobStorage/Common/models.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/models.tsp
@@ -468,6 +468,7 @@ model SignedIdentifier {
 }
 
 /** The result of the Find Blobs by Tags API. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model FilteredBlobResponse {
   /** The service endpoint. */


### PR DESCRIPTION
## Summary

Adds targeted suppressions for existing `csharp-model-suffix` and `csharp-use-standard-acronyms` violations in declarations that were added to `main` after the `typespec-next` staging branch was created.

- Preserves the existing generated C# SDK API surface.
- Contains 75 suppression directives across 28 TypeSpec files.
- Complements #44762, which fixes the violations already present on `typespec-next`.
- Together, the two PRs eliminate all C# naming diagnostics observed when `typespec-next` CI temporarily merges `main`.
- Does not change package manifests or generated OpenAPI/JSON.

Related linter PR: Azure/typespec-azure#4867
Related staging PR: #44762