### PR TITLE
resources/deployments: change C# emitter namespace to Azure.ResourceManager.Resources.Deployments

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -13,7 +13,7 @@ options:
     examples-dir: "{project-root}/examples"
   "@azure-typespec/http-client-csharp-mgmt":
     package-name: "Azure.ResourceManager.Resources.Deployments"
-    namespace: "Azure.ResourceManager.Resources"
+    namespace: "Azure.ResourceManager.Resources.Deployments"
     emitter-output-dir: "{output-dir}/sdk/resources/{package-name}"
     enable-wire-path-attribute: true
   "@azure-tools/typespec-python":


### PR DESCRIPTION
## Overview

Updates `specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml` so the `@azure-typespec/http-client-csharp-mgmt` emitter's `namespace` option is `Azure.ResourceManager.Resources.Deployments` (matches `package-name`) instead of `Azure.ResourceManager.Resources`.

This keeps the emitted SDK's root namespace aligned with the package name and prevents type collisions with the sibling `Azure.ResourceManager.Resources` package (both packages previously exposed types like `AzureResourceManagerResourcesContext` in `Azure.ResourceManager.Resources.Models`).

## Related

- SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/61573

## Change scope

- Only `tspconfig.yaml` is modified — a single-line namespace value change for the `@azure-typespec/http-client-csharp-mgmt` emitter.
- No `.tsp` files, examples, or API surface are touched.
- Other language emitter options are untouched.