### PR TITLE
Prefix Container Registry Tasks C# model names with service context

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/client.tsp
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/client.tsp
@@ -31,22 +31,34 @@ using Microsoft.ContainerRegistry;
   "ContainerRegistryTaskBaseImageTriggerUpdateContent",
   "csharp"
 );
-@@clientName(DockerBuildRequest, "DockerBuildContent", "csharp");
+@@clientName(
+  DockerBuildRequest,
+  "ContainerRegistryDockerBuildContent",
+  "csharp"
+);
 @@clientName(
   DockerBuildStepUpdateParameters,
-  "DockerBuildStepUpdateContent",
+  "ContainerRegistryDockerBuildStepUpdateContent",
   "csharp"
 );
-@@clientName(EncodedTaskRunRequest, "EncodedTaskRunContent", "csharp");
+@@clientName(
+  EncodedTaskRunRequest,
+  "ContainerRegistryEncodedTaskRunContent",
+  "csharp"
+);
 @@clientName(
   EncodedTaskStepUpdateParameters,
-  "EncodedTaskStepUpdateContent",
+  "ContainerRegistryEncodedTaskStepUpdateContent",
   "csharp"
 );
-@@clientName(FileTaskRunRequest, "FileTaskRunContent", "csharp");
+@@clientName(
+  FileTaskRunRequest,
+  "ContainerRegistryFileTaskRunContent",
+  "csharp"
+);
 @@clientName(
   FileTaskStepUpdateParameters,
-  "FileTaskStepUpdateContent",
+  "ContainerRegistryFileTaskStepUpdateContent",
   "csharp"
 );
 @@clientName(
@@ -54,7 +66,7 @@ using Microsoft.ContainerRegistry;
   "ContainerRegistryTaskPlatformUpdateContent",
   "csharp"
 );
-@@clientName(RunRequest, "RunContent", "csharp");
+@@clientName(RunRequest, "ContainerRegistryRunContent", "csharp");
 @@clientName(
   SourceTriggerUpdateParameters,
   "ContainerRegistryTaskSourceTriggerUpdateContent",
@@ -70,8 +82,12 @@ using Microsoft.ContainerRegistry;
   "ContainerRegistryTaskSourceUploadResult",
   "csharp"
 );
-@@clientName(TaskRunRequest, "TaskRunContent", "csharp");
-@@clientName(TaskStepUpdateParameters, "TaskStepUpdateContent", "csharp");
+@@clientName(TaskRunRequest, "ContainerRegistryTaskRunContent", "csharp");
+@@clientName(
+  TaskStepUpdateParameters,
+  "ContainerRegistryTaskStepUpdateContent",
+  "csharp"
+);
 @@clientName(
   TimerTriggerUpdateParameters,
   "ContainerRegistryTaskTimerTriggerUpdateContent",
@@ -264,6 +280,21 @@ using Microsoft.ContainerRegistry;
 @@clientName(
   ResourceIdentityType,
   "ContainerRegistryTaskResourceIdentityType",
+  "csharp"
+);
+
+// C# client naming: prefix step, status and request models with service context
+@@clientName(
+  TaskStepProperties,
+  "ContainerRegistryTaskStepProperties",
+  "csharp"
+);
+@@clientName(DockerBuildStep, "ContainerRegistryDockerBuildStep", "csharp");
+@@clientName(EncodedTaskStep, "ContainerRegistryEncodedTaskStep", "csharp");
+@@clientName(FileTaskStep, "ContainerRegistryFileTaskStep", "csharp");
+@@clientName(
+  AgentPoolQueueStatus,
+  "ContainerRegistryAgentPoolQueueStatus",
   "csharp"
 );
 


### PR DESCRIPTION
## Summary

Exhaustive **C#-only naming review** for `Microsoft.ContainerRegistry/RegistryTasks`. Follow-up to #44717, which established the resource-family names (`ContainerRegistryAgentPool`, `ContainerRegistryRun`, `ContainerRegistryTask`, `ContainerRegistryTaskRun`); this PR completes the pass over the remaining model types.

All **82** public types of the generated management library (`Azure.ResourceManager.ContainerRegistry.Tasks`) were reviewed against the .NET management-plane naming guidelines. **14** generic/unscoped types were flagged and renamed via `@@clientName(..., "csharp")` decorators in `client.tsp`.

Only `client.tsp` changes. No `main.tsp`, `models.tsp` or `tspconfig.yaml` edit, no wire-format change, and **no impact on any language other than C#**.

## Why

Names such as `RunContent`, `DockerBuildStep`, `TaskStepProperties` and `AgentPoolQueueStatus` are not understandable in IntelliSense without namespace context. They also diverged from the equivalent types **already shipped in `Azure.ResourceManager.ContainerRegistry`**, from which the Registry Tasks APIs are being split out. The new names match those shipped names wherever an equivalent type exists, so users moving to the dedicated Tasks package keep familiar type names.

## Renames (C# only)

| TypeSpec model | Old C# name | New C# name |
| --- | --- | --- |
| `RunRequest` | `RunContent` | `ContainerRegistryRunContent` |
| `DockerBuildRequest` | `DockerBuildContent` | `ContainerRegistryDockerBuildContent` |
| `FileTaskRunRequest` | `FileTaskRunContent` | `ContainerRegistryFileTaskRunContent` |
| `EncodedTaskRunRequest` | `EncodedTaskRunContent` | `ContainerRegistryEncodedTaskRunContent` |
| `TaskRunRequest` | `TaskRunContent` | `ContainerRegistryTaskRunContent` |
| `TaskStepProperties` | `TaskStepProperties` | `ContainerRegistryTaskStepProperties` |
| `DockerBuildStep` | `DockerBuildStep` | `ContainerRegistryDockerBuildStep` |
| `FileTaskStep` | `FileTaskStep` | `ContainerRegistryFileTaskStep` |
| `EncodedTaskStep` | `EncodedTaskStep` | `ContainerRegistryEncodedTaskStep` |
| `TaskStepUpdateParameters` | `TaskStepUpdateContent` | `ContainerRegistryTaskStepUpdateContent` |
| `DockerBuildStepUpdateParameters` | `DockerBuildStepUpdateContent` | `ContainerRegistryDockerBuildStepUpdateContent` |
| `FileTaskStepUpdateParameters` | `FileTaskStepUpdateContent` | `ContainerRegistryFileTaskStepUpdateContent` |
| `EncodedTaskStepUpdateParameters` | `EncodedTaskStepUpdateContent` | `ContainerRegistryEncodedTaskStepUpdateContent` |
| `AgentPoolQueueStatus` | `AgentPoolQueueStatus` | `ContainerRegistryAgentPoolQueueStatus` |

The remaining 68 public types already carried the `ContainerRegistry` service prefix or are generator infrastructure types (model factory, extensions, mockable extensions, serialization context) and were left unchanged.

## Dependent SDK PRs

- Management: https://github.com/Azure/azure-sdk-for-net/pull/61576
- Provisioning: https://github.com/Azure/azure-sdk-for-net/pull/61055

Both currently pin `tsp-location.yaml` to this branch's commit on the `ArcturusZhang/azure-rest-api-specs` fork; the pins move to `Azure/azure-rest-api-specs` once this PR merges.

## Validation

- `npx tsp compile . --no-emit` completes successfully; every decorator target is a real `model` declaration in `models.tsp` (no aliases).
- `npx tsp format client.tsp` applied.
- Both dependent SDK packages regenerate, build and pass their tests against this commit.
