### PR TITLE
Add BenchmarkName union with all current benchmark specifications

### DIFF
--- a/specification/ai-foundry/cspell.yaml
+++ b/specification/ai-foundry/cspell.yaml
@@ -74,6 +74,14 @@ overrides:
     - '**/specification/ai-foundry/data-plane/Foundry/preview'
     words:
     - gleu # Evaluation metric
+    - gpqa # Graduate-level Google-Proof Q&A benchmark
+    - bbeh # BIG-Bench Extra Hard benchmark
+    - musr # Multi-step reasoning benchmark
+    - chembench # Chemistry reasoning benchmark
+    - aime # American Invitational Mathematics Examination
+    - ifeval # Instruction-Following Evaluation benchmark
+    - inspectai # inspect_ai evaluation framework
+    - telecom # Telecommunications domain benchmark
   # Audio/realtime related terms
   - filename:
     - '**/specification/ai-foundry/data-plane/Foundry/src/agents'

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -99,13 +99,51 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
     | "benchmark_preview";
 }
 
+/** The set of available benchmark specifications. */
+union BenchmarkName {
+  string,
+
+  /** GPQA Diamond — graduate-level science reasoning. */
+  builtinGPQADiamond: "builtin.gpqa_diamond",
+
+  /** BBEH — BIG-Bench Extra Hard. */
+  builtinBBEH: "builtin.bbeh",
+
+  /** BIG-Bench Hard — challenging BIG-Bench tasks. */
+  builtinBigBenchHard: "builtin.bigbenchhard",
+
+  /** FrontierScience — frontier scientific reasoning. */
+  builtinFrontierScience: "builtin.frontierscience",
+
+  /** IFEval — instruction-following evaluation. */
+  builtinIFEval: "builtin.ifeval",
+
+  /** MuSR — multi-step reasoning. */
+  builtinMuSR: "builtin.musr",
+
+  /** TruthfulQA — truthfulness evaluation. */
+  builtinTruthfulQA: "builtin.truthful_qa",
+
+  /** AIME 2025 via inspect_ai framework. */
+  builtinInspectAIAIME2025: "builtin.inspect_ai.aime2025",
+
+  /** BrowseComp via inspect_ai framework — web browsing agent benchmark. */
+  builtinInspectAIBrowseComp: "builtin.inspect_ai.browse_comp",
+
+  /** ChemBench via inspect_ai framework — chemistry reasoning. */
+  builtinInspectAIChemBench: "builtin.inspect_ai.chembench",
+
+  /** Tau2-Bench Telecom via inspect_ai framework — dual-agent telecom benchmark. */
+  builtinInspectAITau2Telecom: "builtin.inspect_ai.tau2_telecom",
+}
+
 /** Data source configuration for benchmark evaluations. */
 model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
   /** Data schema scenario, always `benchmark` for benchmark evaluations. */
   scenario: "benchmark_preview";
 
   /** The name of the benchmark specification. */
-  benchmark_name: string;
+  benchmark_name: BenchmarkName;
 
   /** The version of the benchmark specification (e.g., '0.1'). Latest version if not specified. */
   benchmark_version?: string;


### PR DESCRIPTION
## Summary

Adds a typed `BenchmarkName` union for the `benchmark_name` field in `AzureAIBenchmarkDataSourceConfig`, providing IntelliSense/autocomplete for all currently available benchmarks while still accepting arbitrary strings for forward compatibility.

## Benchmarks Added

| Name | Description |
|------|-------------|
| `builtin.gpqa_diamond` | Graduate-level science reasoning |
| `builtin.bbeh` | BIG-Bench Extra Hard |
| `builtin.bigbenchhard` | Challenging BIG-Bench tasks |
| `builtin.frontierscience` | Frontier scientific reasoning |
| `builtin.ifeval` | Instruction-following evaluation |
| `builtin.musr` | Multi-step reasoning |
| `builtin.truthful_qa` | Truthfulness evaluation |
| `builtin.inspect_ai.aime2025` | AIME 2025 (inspect_ai) |
| `builtin.inspect_ai.browse_comp` | Web browsing agent benchmark (inspect_ai) |
| `builtin.inspect_ai.chembench` | Chemistry reasoning (inspect_ai) |
| `builtin.inspect_ai.tau2_telecom` | Dual-agent telecom benchmark (inspect_ai) |

## Notes

- The union uses `string` as the first member, allowing any string value (forward-compatible with future benchmarks)
- Previous PR #41983 had `builtin.inspect_ai.aime_2025` (with underscore) — corrected to `builtin.inspect_ai.aime2025` (no underscore) matching the actual asset name
- Removed `builtin.inspect_ai.gpqa_diamond` and `builtin.inspect_ai.musr` from the old PR as those benchmarks don't exist in the registry
- Added cspell dictionary entries for benchmark-related terms