### PR TITLE
Update BenchmarkName union with current benchmark specifications

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -112,23 +112,26 @@ union BenchmarkName {
   /** FrontierScience — frontier scientific reasoning. */
   builtinFrontierScience: "builtin.frontierscience",
 
+  /** IFEval — instruction-following evaluation. */
+  builtinIFEval: "builtin.ifeval",
+
   /** MuSR — multi-step reasoning. */
   builtinMuSR: "builtin.musr",
 
   /** TruthfulQA — truthfulness evaluation. */
   builtinTruthfulQA: "builtin.truthful_qa",
 
-  /** GPQA Diamond via inspect_ai framework. */
-  builtinInspectAIGPQADiamond: "builtin.inspect_ai.gpqa_diamond",
+  /** AIME 2025 via inspect_ai framework. */
+  builtinInspectAIAIME2025: "builtin.inspect_ai.aime2025",
 
-  /** ChemBench via inspect_ai framework. */
+  /** BrowseComp via inspect_ai framework — web browsing agent benchmark. */
+  builtinInspectAIBrowseComp: "builtin.inspect_ai.browse_comp",
+
+  /** ChemBench via inspect_ai framework — chemistry reasoning. */
   builtinInspectAIChemBench: "builtin.inspect_ai.chembench",
 
-  /** AIME 2025 via inspect_ai framework. */
-  builtinInspectAIAIME2025: "builtin.inspect_ai.aime_2025",
-
-  /** MuSR via inspect_ai framework. */
-  builtinInspectAIMuSR: "builtin.inspect_ai.musr",
+  /** Tau2-Bench Telecom via inspect_ai framework — dual-agent telecom benchmark. */
+  builtinInspectAITau2Telecom: "builtin.inspect_ai.tau2_telecom",
 }
 
 /** Data source configuration for benchmark evaluations. */


### PR DESCRIPTION
## Summary

Updates the `BenchmarkName` union to match the current set of deployed benchmarks in the azureml registry.

## Changes

| Action | Benchmark | Reason |
|--------|-----------|--------|
| **Fix** | `builtin.inspect_ai.aime_2025` → `builtin.inspect_ai.aime2025` | Underscore was incorrect; actual asset name has no underscore |
| **Remove** | `builtin.inspect_ai.gpqa_diamond` | Does not exist in registry |
| **Remove** | `builtin.inspect_ai.musr` | Does not exist in registry |
| **Add** | `builtin.ifeval` | IFEval — instruction-following evaluation (newly released) |
| **Add** | `builtin.inspect_ai.browse_comp` | BrowseComp — web browsing agent benchmark (newly released) |
| **Add** | `builtin.inspect_ai.tau2_telecom` | Tau2-Bench Telecom — dual-agent telecom benchmark (newly released) |

## Verification

All 11 benchmark names verified against deployed assets in `azureml-assets` repo: https://github.com/Azure/azureml-assets/tree/main/assets/benchmarkspecs/builtin