### PR TITLE
fix: status workflow never triggers due to incorrect branches filter

### DIFF
--- a/.github/workflows/package-name-approval-status.yaml
+++ b/.github/workflows/package-name-approval-status.yaml
@@ -4,8 +4,6 @@ on:
   workflow_run:
     workflows: ["Package Name Approval - Analyze Code"]
     types: [completed]
-    branches:
-      - main
 
 permissions:
   actions: read


### PR DESCRIPTION
## Fix

Remove `branches: - main` from the `workflow_run` trigger in `package-name-approval-status.yaml`.

## Problem

The status workflow has never executed since being added. The `branches` filter on a `workflow_run` trigger filters by the branch the triggering workflow **ran on** (the PR head branch), not the PR's target branch. Since PR head branches are never named `main`, this filter silently blocks all executions.

This means package name approval labels, comments, and commit statuses are never posted on PRs.

## Why the filter is unnecessary

The code workflow (`package-name-approval-code.yaml`) already has:

`yaml
on:
  pull_request:
    branches:
      - main
    paths:
      - "specification/**/tspconfig.yaml"
`

This correctly limits it to PRs targeting main with tspconfig changes. Since the status workflow only fires when the code workflow completes, there is no scenario where the status workflow runs for non-main PRs.

Additionally, `post-results.js` already handles missing artifacts gracefully (returns null and exits) as a safety net.
