### PR TITLE
Add inspect_ai grader type and BenchmarkName enum

### DIFF
--- a/specification/ai-foundry/cspell.yaml
+++ b/specification/ai-foundry/cspell.yaml
@@ -74,6 +74,14 @@ overrides:
     - '**/specification/ai-foundry/data-plane/Foundry/preview'
     words:
     - gleu # Evaluation metric
+    - gpqa # Graduate-level Google-Proof Q&A benchmark
+    - bbeh # BIG-Bench Extra Hard benchmark
+    - musr # Multi-step reasoning benchmark
+    - chembench # Chemistry reasoning benchmark
+    - aime # American Invitational Mathematics Examination
+    - ifeval # Instruction-Following Evaluation benchmark
+    - inspectai # inspect_ai evaluation framework
+    - telecom # Telecommunications domain benchmark
   # Audio/realtime related terms
   - filename:
     - '**/specification/ai-foundry/data-plane/Foundry/src/agents'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29923,7 +29923,7 @@
             "description": "Data schema scenario, always `benchmark` for benchmark evaluations."
           },
           "benchmark_name": {
-            "type": "string",
+            "$ref": "#/components/schemas/BenchmarkName",
             "description": "The name of the benchmark specification."
           },
           "benchmark_version": {
@@ -31229,6 +31229,30 @@
           }
         },
         "description": "A base class for connection credentials"
+      },
+      "BenchmarkName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "builtin.gpqa_diamond",
+              "builtin.bbeh",
+              "builtin.bigbenchhard",
+              "builtin.frontierscience",
+              "builtin.ifeval",
+              "builtin.musr",
+              "builtin.truthful_qa",
+              "builtin.inspect_ai.aime2025",
+              "builtin.inspect_ai.browse_comp",
+              "builtin.inspect_ai.chembench",
+              "builtin.inspect_ai.tau2_telecom"
+            ]
+          }
+        ],
+        "description": "The set of available benchmark specifications."
       },
       "BingCustomSearchConfiguration": {
         "type": "object",
@@ -32765,6 +32789,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -34275,6 +34302,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -34365,6 +34395,32 @@
           }
         ],
         "description": "Represents a CSV data source for evaluation runs."
+      },
+      "EvalGraderInspectAI": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "task_name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "inspect_ai"
+            ],
+            "description": "The object type, which is always `inspect_ai`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the benchmark."
+          },
+          "task_name": {
+            "type": "string",
+            "description": "The inspect_ai task module path (e.g., `inspect_evals/aime2025`)."
+          }
+        },
+        "description": "Grader inspect_ai definition for inspect_ai benchmark evaluators."
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40449,7 +40449,7 @@ components:
             - benchmark_preview
           description: Data schema scenario, always `benchmark` for benchmark evaluations.
         benchmark_name:
-          type: string
+          $ref: '#/components/schemas/BenchmarkName'
           description: The name of the benchmark specification.
         benchmark_version:
           type: string
@@ -41364,6 +41364,23 @@ components:
           None: '#/components/schemas/NoAuthenticationCredentials'
           AgenticIdentityToken_Preview: '#/components/schemas/AgenticIdentityPreviewCredentials'
       description: A base class for connection credentials
+    BenchmarkName:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - builtin.gpqa_diamond
+            - builtin.bbeh
+            - builtin.bigbenchhard
+            - builtin.frontierscience
+            - builtin.ifeval
+            - builtin.musr
+            - builtin.truthful_qa
+            - builtin.inspect_ai.aime2025
+            - builtin.inspect_ai.browse_comp
+            - builtin.inspect_ai.chembench
+            - builtin.inspect_ai.tau2_telecom
+      description: The set of available benchmark specifications.
     BingCustomSearchConfiguration:
       type: object
       required:
@@ -42477,6 +42494,7 @@ components:
               - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
               - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
               - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+              - $ref: '#/components/schemas/EvalGraderInspectAI'
           description: A list of graders for all eval runs in this group. Graders can reference variables in the data source using double curly braces notation, like `{{item.variable_name}}`. To reference the model's output, use the `sample` namespace (ie, `{{sample.output_text}}`).
         properties:
           type: object
@@ -43529,6 +43547,7 @@ components:
               - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
               - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
               - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+              - $ref: '#/components/schemas/EvalGraderInspectAI'
           description: A list of testing criteria.
         created_at:
           type: integer
@@ -43624,6 +43643,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a CSV data source for evaluation runs.
+    EvalGraderInspectAI:
+      type: object
+      required:
+        - type
+        - name
+        - task_name
+      properties:
+        type:
+          type: string
+          enum:
+            - inspect_ai
+          description: The object type, which is always `inspect_ai`.
+        name:
+          type: string
+          description: The display name of the benchmark.
+        task_name:
+          type: string
+          description: The inspect_ai task module path (e.g., `inspect_evals/aime2025`).
+      description: Grader inspect_ai definition for inspect_ai benchmark evaluators.
     EvalResult:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -33183,7 +33183,7 @@
             "description": "Data schema scenario, always `benchmark` for benchmark evaluations."
           },
           "benchmark_name": {
-            "type": "string",
+            "$ref": "#/components/schemas/BenchmarkName",
             "description": "The name of the benchmark specification."
           },
           "benchmark_version": {
@@ -34489,6 +34489,30 @@
           }
         },
         "description": "A base class for connection credentials"
+      },
+      "BenchmarkName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "builtin.gpqa_diamond",
+              "builtin.bbeh",
+              "builtin.bigbenchhard",
+              "builtin.frontierscience",
+              "builtin.ifeval",
+              "builtin.musr",
+              "builtin.truthful_qa",
+              "builtin.inspect_ai.aime2025",
+              "builtin.inspect_ai.browse_comp",
+              "builtin.inspect_ai.chembench",
+              "builtin.inspect_ai.tau2_telecom"
+            ]
+          }
+        ],
+        "description": "The set of available benchmark specifications."
       },
       "BingCustomSearchConfiguration": {
         "type": "object",
@@ -36172,6 +36196,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -37773,6 +37800,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -37863,6 +37893,32 @@
           }
         ],
         "description": "Represents a CSV data source for evaluation runs."
+      },
+      "EvalGraderInspectAI": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "task_name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "inspect_ai"
+            ],
+            "description": "The object type, which is always `inspect_ai`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the benchmark."
+          },
+          "task_name": {
+            "type": "string",
+            "description": "The inspect_ai task module path (e.g., `inspect_evals/aime2025`)."
+          }
+        },
+        "description": "Grader inspect_ai definition for inspect_ai benchmark evaluators."
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42637,7 +42637,7 @@ components:
             - benchmark_preview
           description: Data schema scenario, always `benchmark` for benchmark evaluations.
         benchmark_name:
-          type: string
+          $ref: '#/components/schemas/BenchmarkName'
           description: The name of the benchmark specification.
         benchmark_version:
           type: string
@@ -43552,6 +43552,23 @@ components:
           None: '#/components/schemas/NoAuthenticationCredentials'
           AgenticIdentityToken_Preview: '#/components/schemas/AgenticIdentityPreviewCredentials'
       description: A base class for connection credentials
+    BenchmarkName:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - builtin.gpqa_diamond
+            - builtin.bbeh
+            - builtin.bigbenchhard
+            - builtin.frontierscience
+            - builtin.ifeval
+            - builtin.musr
+            - builtin.truthful_qa
+            - builtin.inspect_ai.aime2025
+            - builtin.inspect_ai.browse_comp
+            - builtin.inspect_ai.chembench
+            - builtin.inspect_ai.tau2_telecom
+      description: The set of available benchmark specifications.
     BingCustomSearchConfiguration:
       type: object
       required:
@@ -44766,6 +44783,7 @@ components:
               - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
               - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
               - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+              - $ref: '#/components/schemas/EvalGraderInspectAI'
           description: A list of graders for all eval runs in this group. Graders can reference variables in the data source using double curly braces notation, like `{{item.variable_name}}`. To reference the model's output, use the `sample` namespace (ie, `{{sample.output_text}}`).
         properties:
           type: object
@@ -45884,6 +45902,7 @@ components:
               - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
               - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
               - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+              - $ref: '#/components/schemas/EvalGraderInspectAI'
           description: A list of testing criteria.
         created_at:
           type: integer
@@ -45979,6 +45998,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a CSV data source for evaluation runs.
+    EvalGraderInspectAI:
+      type: object
+      required:
+        - type
+        - name
+        - task_name
+      properties:
+        type:
+          type: string
+          enum:
+            - inspect_ai
+          description: The object type, which is always `inspect_ai`.
+        name:
+          type: string
+          description: The display name of the benchmark.
+        task_name:
+          type: string
+          description: The inspect_ai task module path (e.g., `inspect_evals/aime2025`).
+      description: Grader inspect_ai definition for inspect_ai benchmark evaluators.
     EvalResult:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -73,6 +73,18 @@ model TestingCriterionAzureAIEvaluator {
   ...GraderAzureAIEvaluator;
 }
 
+/** Grader inspect_ai definition for inspect_ai benchmark evaluators. */
+model EvalGraderInspectAI {
+  /** The object type, which is always `inspect_ai`. */
+  type: "inspect_ai";
+
+  /** The display name of the benchmark. */
+  name: string;
+
+  /** The inspect_ai task module path (e.g., `inspect_evals/aime2025`). */
+  task_name: string;
+}
+
 /** Base class for run data sources with discriminator support. */
 @discriminator("type")
 model DataSourceConfig {
@@ -99,13 +111,51 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
     | "benchmark_preview";
 }
 
+/** The set of available benchmark specifications. */
+union BenchmarkName {
+  string,
+
+  /** GPQA Diamond — graduate-level science reasoning. */
+  builtinGPQADiamond: "builtin.gpqa_diamond",
+
+  /** BBEH — BIG-Bench Extra Hard. */
+  builtinBBEH: "builtin.bbeh",
+
+  /** BIG-Bench Hard — challenging BIG-Bench tasks. */
+  builtinBigBenchHard: "builtin.bigbenchhard",
+
+  /** FrontierScience — frontier scientific reasoning. */
+  builtinFrontierScience: "builtin.frontierscience",
+
+  /** IFEval — instruction-following evaluation. */
+  builtinIFEval: "builtin.ifeval",
+
+  /** MuSR — multi-step reasoning. */
+  builtinMuSR: "builtin.musr",
+
+  /** TruthfulQA — truthfulness evaluation. */
+  builtinTruthfulQA: "builtin.truthful_qa",
+
+  /** AIME 2025 via inspect_ai framework. */
+  builtinInspectAIAIME2025: "builtin.inspect_ai.aime2025",
+
+  /** BrowseComp via inspect_ai framework — web browsing agent benchmark. */
+  builtinInspectAIBrowseComp: "builtin.inspect_ai.browse_comp",
+
+  /** ChemBench via inspect_ai framework — chemistry reasoning. */
+  builtinInspectAIChemBench: "builtin.inspect_ai.chembench",
+
+  /** Tau2-Bench Telecom via inspect_ai framework — dual-agent telecom benchmark. */
+  builtinInspectAITau2Telecom: "builtin.inspect_ai.tau2_telecom",
+}
+
 /** Data source configuration for benchmark evaluations. */
 model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
   /** Data schema scenario, always `benchmark` for benchmark evaluations. */
   scenario: "benchmark_preview";
 
   /** The name of the benchmark specification. */
-  benchmark_name: string;
+  benchmark_name: BenchmarkName;
 
   /** The version of the benchmark specification (e.g., '0.1'). Latest version if not specified. */
   benchmark_version?: string;
@@ -129,7 +179,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
     | AzureAIBenchmarkDataSourceConfig
 );
 
-/** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
+/** Adding Azure AI Evaluator and inspect_ai types to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
@@ -141,7 +191,8 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
     | OpenAI.EvalGraderTextSimilarity
     | OpenAI.EvalGraderPython
     | OpenAI.EvalGraderScoreModel
-    | TestingCriterionAzureAIEvaluator)[]
+    | TestingCriterionAzureAIEvaluator
+    | EvalGraderInspectAI)[]
 );
 
 model Eval is OpenAI.Eval {
@@ -177,7 +228,7 @@ model Eval is OpenAI.Eval {
     | AzureAIBenchmarkDataSourceConfig
 );
 
-/** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
+/** Adding Azure AI Evaluator and inspect_ai types to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
@@ -189,7 +240,8 @@ model Eval is OpenAI.Eval {
     | OpenAI.EvalGraderTextSimilarity
     | OpenAI.EvalGraderPython
     | OpenAI.EvalGraderScoreModel
-    | TestingCriterionAzureAIEvaluator)[]
+    | TestingCriterionAzureAIEvaluator
+    | EvalGraderInspectAI)[]
 );
 model CreateEvalRequest is OpenAI.CreateEvalRequest {
   /**


### PR DESCRIPTION
## Summary

Ports changes from PR #41983 (merged to `feature/foundry-staging`) to `feature/foundry-release` with corrections to benchmark names.

## Changes

### 1. `EvalGraderInspectAI` model
New grader type (`type: "inspect_ai"`) with `name` and `task_name` fields. The inspect_ai grader is auto-populated server-side from the BenchmarkSpec; it appears in API responses when reading back eval group `testing_criteria`.

### 2. Added `EvalGraderInspectAI` to testing_criteria unions
Added to both `Eval.testing_criteria` and `CreateEvalRequest.testing_criteria` (mirrors `EvalGraderAzureAIEvaluator` pattern).

### 3. `BenchmarkName` union
Replaces `benchmark_name: string` with a typed enum. Includes `string` as base type for forward compatibility.

| Benchmark | Description |
|-----------|-------------|
| `builtin.gpqa_diamond` | Graduate-level science reasoning |
| `builtin.bbeh` | BIG-Bench Extra Hard |
| `builtin.bigbenchhard` | Challenging BIG-Bench tasks |
| `builtin.frontierscience` | Frontier scientific reasoning |
| `builtin.ifeval` | Instruction-following evaluation |
| `builtin.musr` | Multi-step reasoning |
| `builtin.truthful_qa` | Truthfulness evaluation |
| `builtin.inspect_ai.aime2025` | AIME 2025 (inspect_ai) |
| `builtin.inspect_ai.browse_comp` | Web browsing agent benchmark (inspect_ai) |
| `builtin.inspect_ai.chembench` | Chemistry reasoning (inspect_ai) |
| `builtin.inspect_ai.tau2_telecom` | Dual-agent telecom benchmark (inspect_ai) |

### Corrections from PR #41983
- **Fix**: `builtin.inspect_ai.aime_2025` → `builtin.inspect_ai.aime2025` (no underscore)
- **Remove**: `builtin.inspect_ai.gpqa_diamond`, `builtin.inspect_ai.musr` (don't exist in registry)
- **Add**: `builtin.ifeval`, `builtin.inspect_ai.browse_comp`, `builtin.inspect_ai.tau2_telecom`

## Context

- Original PR: #41983 (merged to feature/foundry-staging)
- Spec PR: https://github.com/coreai-microsoft/foundrysdk_specs/pull/37
- All benchmark names verified against deployed assets: https://github.com/Azure/azureml-assets/tree/main/assets/benchmarkspecs/builtin