### PR TITLE
AKS: promote EntraId SSH access to 2026-06-01 GA

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -521,7 +521,7 @@ union AgentPoolSSHAccess {
   /**
    * SSH to node with EntraId integration. More information can be found under https://aka.ms/aks/ssh/aad
    */
-  @added(Versions.v2026_06_02_preview)
+  @added(Versions.v2026_06_01)
   EntraId: "EntraId",
 }
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
@@ -4961,7 +4961,8 @@
       "description": "SSH access method of an agent pool.",
       "enum": [
         "LocalUser",
-        "Disabled"
+        "Disabled",
+        "EntraId"
       ],
       "x-ms-enum": {
         "name": "AgentPoolSSHAccess",
@@ -4976,6 +4977,11 @@
             "name": "Disabled",
             "value": "Disabled",
             "description": "SSH service will be turned off on the node."
+          },
+          {
+            "name": "EntraId",
+            "value": "EntraId",
+            "description": "SSH to node with EntraId integration. More information can be found under https://aka.ms/aks/ssh/aad"
           }
         ]
       }


### PR DESCRIPTION
Promote the EntraId value of AgentPoolSSHAccess from @added(Versions.v2026_06_02_preview) to @added(Versions.v2026_06_01) so the EntraId SSH access mode surfaces in the 2026-06-01 stable swagger. Regenerated stable/2026-06-01/managedClusters.json.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
