### PR TITLE
ContentSafety: provenance route prefix on ContentProvenanceClient in client.tsp

### DIFF
--- a/specification/cognitiveservices/ContentSafety/client.tsp
+++ b/specification/cognitiveservices/ContentSafety/client.tsp
@@ -21,6 +21,7 @@ interface ContentSafetyClient {
   name: "ContentProvenanceClient",
   service: ContentSafety,
 })
+@TypeSpec.Http.route("/provenance")
 interface ContentProvenanceClient {
   detect is ContentSafety.ContentProvenanceOperations.detect;
   getOperationStatus is ContentSafety.ContentProvenanceOperations.getOperationStatus;


### PR DESCRIPTION
Fixes the `/provenance` route prefix being dropped from **generated SDK clients** for the Content Provenance operations added in `2026-07-01-preview` (#45038).

**This is a client-generation fix only. `contentsafety.json` is byte-for-byte unchanged** — verified by recompiling with this change applied (`git status` stays clean). No API contract change, no new API version.

## Problem

`routes.tsp` declares the prefix on the **interface**:

```tsp
@route("/provenance")
interface ContentProvenanceOperations {
  getOperationStatus is ProvenanceResourceOps.ResourceRead<ProvenanceDetectOperation>;

  @route(":detect")
  detect is Azure.Core.LongRunningRpcOperation<...>;
}
```

`client.tsp` re-declares those operations under a `@client` interface that carried no `@route`, so the client emitters never applied the `/provenance` prefix. The OpenAPI emitter composes routes at the original declaration site, which is why the checked-in swagger is correct and this went unnoticed.

Result — every generated SDK called the wrong URL:

| | generated | expected |
|---|---|---|
| detect | `/contentsafety:detect` | `/contentsafety/provenance:detect` |
| status | `/contentsafety/operations/{operationId}` | `/contentsafety/provenance/operations/{operationId}` |

Confirmed in .NET ([`ContentProvenanceClient.RestClient.cs#L27-L28`](https://github.com/Azure/azure-sdk-for-net/blob/7d6aef7a37744da9f3e99f5e053d6aff5d061987/sdk/contentsafety/Azure.AI.ContentSafety/src/Generated/ContentProvenanceClient.RestClient.cs#L27-L28)), Python ([`_operations.py#L151`](https://github.com/Azure/azure-sdk-for-python/blob/d61b096d74a20c5308853e0ac80f1455c90ade66/sdk/contentsafety/azure-ai-contentsafety/azure/ai/contentsafety/_operations/_operations.py#L151)) and JavaScript ([`operations.ts#L71`](https://github.com/Azure/azure-sdk-for-js/blob/f65d907d1fc74521e9268a77392995d38ee9431b/sdk/contentsafety/ai-content-safety-rest/src/contentProvenance/api/operations.ts#L71)).

## Verification

Reproduced and fixed locally with the same emitter version the SDK pipeline used (`@azure-tools/typespec-python@0.63.3`, from the SDK PR's `_metadata.json`):

```
before:  _url = ":detect"                     after:  _url = "/provenance:detect"
before:  _url = "/operations/{operationId}"   after:  _url = "/provenance/operations/{operationId}"
```

Only 2 of 36 generated files change (`_operations.py` and `apiview-properties.json`, the latter with an identical `CrossLanguageDefinitionId` set). All other operation paths are byte-identical.

Note: this cannot be reproduced with the autorest emitter — it resolves routes from the service definition and ignores the `@client` overlay, emitting the correct path either way. A client emitter is required.

## Impact

Only the provenance operations are affected. `analyzeText` / `analyzeImage` / `shieldPrompt` / `detectTextProtectedMaterial` use absolute operation-level `@route`s, and `TextBlocklists` derives paths from the resource model — both are self-contained and survive the `client.tsp` re-declaration. Verified against the shipped SDKs on `main`, which have correct paths.

The four open SDK PRs for `2026-07-01-preview` will be regenerated once this merges.
