### PR TITLE
Reapply "Add getAgentInvocationAsyncApiSpec{Json,Yaml} operations" (re-submit of #44416 after review-gate discussion)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4304,6 +4304,149 @@
         ]
       }
     },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "unevaluatedProperties": {}
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4307,6 +4307,149 @@
         ]
       }
     },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "unevaluatedProperties": {}
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4310,6 +4310,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "summary": "Get an agent invocation AsyncAPI spec (JSON)",
         "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification.\nPublishing is optional; when published, JSON and YAML representations may be served as\nseparately stored artifacts.",
         "parameters": [
           {
@@ -4382,6 +4383,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "summary": "Get an agent invocation AsyncAPI spec (YAML)",
         "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification, or if only\na JSON representation is published for that version.",
         "parameters": [
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4310,7 +4310,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
-        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification.\nPublishing is optional; when published, JSON and YAML representations may be served as\nseparately stored artifacts.",
         "parameters": [
           {
             "name": "agent_name",
@@ -4382,7 +4382,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
-        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification, or if only\na JSON representation is published for that version.",
         "parameters": [
           {
             "name": "agent_name",
@@ -4419,7 +4419,8 @@
             "content": {
               "application/yaml": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "unevaluatedProperties": {}
                 }
               }
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2978,6 +2978,106 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Versions
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      description: |-
+        Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
+        invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
+        companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
+        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
+        optional; when published, both JSON and YAML representations are available.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                unevaluatedProperties: {}
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      description: |-
+        Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
+        invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
+        extension is authoritative for the returned content type (no `Accept` negotiation).
+        Returns 404 if the agent does not publish an AsyncAPI specification.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/yaml:
+              schema:
+                type: string
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2979,6 +2979,106 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Versions
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      description: |-
+        Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
+        invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
+        companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
+        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
+        optional; when published, both JSON and YAML representations are available.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                unevaluatedProperties: {}
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      description: |-
+        Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
+        invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
+        extension is authoritative for the returned content type (no `Accept` negotiation).
+        Returns 404 if the agent does not publish an AsyncAPI specification.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/yaml:
+              schema:
+                type: string
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2982,6 +2982,7 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      summary: Get an agent invocation AsyncAPI spec (JSON)
       description: |-
         Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
         invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
@@ -3039,6 +3040,7 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
     get:
       operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      summary: Get an agent invocation AsyncAPI spec (YAML)
       description: |-
         Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
         invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2986,8 +2986,14 @@ paths:
         Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
         invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
         companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
-        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
-        optional; when published, both JSON and YAML representations are available.
+
+        Before serving the document, the service performs baseline validation checks including
+        document size limits, external reference restrictions, and structural validity checks.
+        Validation failures return 400.
+
+        Returns 404 if the agent version does not publish an AsyncAPI specification.
+        Publishing is optional; when published, JSON and YAML representations may be served as
+        separately stored artifacts.
       parameters:
         - name: agent_name
           in: path
@@ -3037,7 +3043,13 @@ paths:
         Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
         invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
         extension is authoritative for the returned content type (no `Accept` negotiation).
-        Returns 404 if the agent does not publish an AsyncAPI specification.
+
+        Before serving the document, the service performs baseline validation checks including
+        document size limits, external reference restrictions, and structural validity checks.
+        Validation failures return 400.
+
+        Returns 404 if the agent version does not publish an AsyncAPI specification, or if only
+        a JSON representation is published for that version.
       parameters:
         - name: agent_name
           in: path

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -3076,7 +3076,8 @@ paths:
           content:
             application/yaml:
               schema:
-                type: string
+                type: object
+                unevaluatedProperties: {}
         4XX:
           description: Client error
           content:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5341,6 +5341,149 @@
         }
       }
     },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "unevaluatedProperties": {}
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5344,6 +5344,149 @@
         }
       }
     },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "unevaluatedProperties": {}
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
+    "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
+      "get": {
+        "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "parameters": [
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations"
+        ]
+      }
+    },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5347,6 +5347,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
+        "summary": "Get an agent invocation AsyncAPI spec (JSON)",
         "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification.\nPublishing is optional; when published, JSON and YAML representations may be served as\nseparately stored artifacts.",
         "parameters": [
           {
@@ -5419,6 +5420,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
+        "summary": "Get an agent invocation AsyncAPI spec (YAML)",
         "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification, or if only\na JSON representation is published for that version.",
         "parameters": [
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5347,7 +5347,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecJson",
-        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\nReturns 404 if the agent does not publish an AsyncAPI specification. Publishing is\noptional; when published, both JSON and YAML representations are available.",
+        "description": "Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven\ninvocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the\ncompanion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification.\nPublishing is optional; when published, JSON and YAML representations may be served as\nseparately stored artifacts.",
         "parameters": [
           {
             "name": "agent_name",
@@ -5419,7 +5419,7 @@
     "/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationAsyncApiSpecYaml",
-        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\nReturns 404 if the agent does not publish an AsyncAPI specification.",
+        "description": "Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven\ninvocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path\nextension is authoritative for the returned content type (no `Accept` negotiation).\n\nBefore serving the document, the service performs baseline validation checks including\ndocument size limits, external reference restrictions, and structural validity checks.\nValidation failures return 400.\n\nReturns 404 if the agent version does not publish an AsyncAPI specification, or if only\na JSON representation is published for that version.",
         "parameters": [
           {
             "name": "agent_name",
@@ -5456,7 +5456,8 @@
             "content": {
               "application/yaml": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "unevaluatedProperties": {}
                 }
               }
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3690,6 +3690,106 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - ContainerAgents=V1Preview
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      description: |-
+        Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
+        invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
+        companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
+        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
+        optional; when published, both JSON and YAML representations are available.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                unevaluatedProperties: {}
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      description: |-
+        Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
+        invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
+        extension is authoritative for the returned content type (no `Accept` negotiation).
+        Returns 404 if the agent does not publish an AsyncAPI specification.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/yaml:
+              schema:
+                type: string
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3691,6 +3691,106 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - ContainerAgents=V1Preview
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      description: |-
+        Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
+        invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
+        companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
+        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
+        optional; when published, both JSON and YAML representations are available.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                unevaluatedProperties: {}
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
+  /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
+    get:
+      operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      description: |-
+        Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
+        invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
+        extension is authoritative for the returned content type (no `Accept` negotiation).
+        Returns 404 if the agent does not publish an AsyncAPI specification.
+      parameters:
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_version
+          in: path
+          required: true
+          description: The version of the agent.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/yaml:
+              schema:
+                type: string
+        4XX:
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        5XX:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agent Invocations
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3694,6 +3694,7 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationAsyncApiSpecJson
+      summary: Get an agent invocation AsyncAPI spec (JSON)
       description: |-
         Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
         invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
@@ -3751,6 +3752,7 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml:
     get:
       operationId: AgentInvocations_getAgentInvocationAsyncApiSpecYaml
+      summary: Get an agent invocation AsyncAPI spec (YAML)
       description: |-
         Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
         invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3788,7 +3788,8 @@ paths:
           content:
             application/yaml:
               schema:
-                type: string
+                type: object
+                unevaluatedProperties: {}
         4XX:
           description: Client error
           content:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3698,8 +3698,14 @@ paths:
         Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
         invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
         companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
-        Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
-        optional; when published, both JSON and YAML representations are available.
+
+        Before serving the document, the service performs baseline validation checks including
+        document size limits, external reference restrictions, and structural validity checks.
+        Validation failures return 400.
+
+        Returns 404 if the agent version does not publish an AsyncAPI specification.
+        Publishing is optional; when published, JSON and YAML representations may be served as
+        separately stored artifacts.
       parameters:
         - name: agent_name
           in: path
@@ -3749,7 +3755,13 @@ paths:
         Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
         invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
         extension is authoritative for the returned content type (no `Accept` negotiation).
-        Returns 404 if the agent does not publish an AsyncAPI specification.
+
+        Before serving the document, the service performs baseline validation checks including
+        document size limits, external reference restrictions, and structural validity checks.
+        Validation failures return 400.
+
+        Returns 404 if the agent version does not publish an AsyncAPI specification, or if only
+        a JSON representation is published for that version.
       parameters:
         - name: agent_name
           in: path

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -31,6 +31,51 @@ interface AgentInvocations {
   >;
 
   /**
+   * Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
+   * invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
+   * companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
+   * Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
+   * optional; when published, both JSON and YAML representations are available.
+   */
+  @get
+  @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json")
+  getAgentInvocationAsyncApiSpecJson is FoundryDataPlaneOperation<
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The version of the agent. */
+      @path agent_version: string;
+    },
+    {
+      @header contentType: "application/json";
+      @body spec: Record<unknown>;
+    }
+  >;
+
+  /**
+   * Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
+   * invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
+   * extension is authoritative for the returned content type (no `Accept` negotiation).
+   * Returns 404 if the agent does not publish an AsyncAPI specification.
+   */
+  @get
+  @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml")
+  getAgentInvocationAsyncApiSpecYaml is FoundryDataPlaneOperation<
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The version of the agent. */
+      @path agent_version: string;
+    },
+    {
+      @header contentType: "application/yaml";
+      @body spec: string;
+    }
+  >;
+
+  /**
    * Creates an invocation for the specified agent version.
    */
   @summary("Create an agent invocation")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -6,6 +6,14 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
+/**
+ * An AsyncAPI document, as defined by the AsyncAPI Specification (https://www.asyncapi.com/).
+ * The document is a structured object whose shape is owned by the AsyncAPI specification and is
+ * therefore not modeled here. Serialization format (JSON or YAML) is selected by the request path
+ * and is conveyed by the `content-type` response header; it does not change the body type.
+ */
+alias AsyncApiDocument = Record<unknown>;
+
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations")
 interface AgentInvocations {
@@ -55,7 +63,9 @@ interface AgentInvocations {
     },
     {
       @header contentType: "application/json";
-      @body spec: Record<unknown>;
+
+      /** The AsyncAPI document, serialized as JSON. */
+      @body spec: AsyncApiDocument;
     }
   >;
 
@@ -83,7 +93,9 @@ interface AgentInvocations {
     },
     {
       @header contentType: "application/yaml";
-      @body spec: string;
+
+      /** The AsyncAPI document, serialized as YAML. */
+      @body spec: AsyncApiDocument;
     }
   >;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -51,6 +51,7 @@ interface AgentInvocations {
    * Publishing is optional; when published, JSON and YAML representations may be served as
    * separately stored artifacts.
    */
+  @summary("Get an agent invocation AsyncAPI spec (JSON)")
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json")
   getAgentInvocationAsyncApiSpecJson is FoundryDataPlaneOperation<
@@ -62,6 +63,7 @@ interface AgentInvocations {
       @path agent_version: string;
     },
     {
+      /** The content type of the response body. */
       @header contentType: "application/json";
 
       /** The AsyncAPI document, serialized as JSON. */
@@ -81,6 +83,7 @@ interface AgentInvocations {
    * Returns 404 if the agent version does not publish an AsyncAPI specification, or if only
    * a JSON representation is published for that version.
    */
+  @summary("Get an agent invocation AsyncAPI spec (YAML)")
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml")
   getAgentInvocationAsyncApiSpecYaml is FoundryDataPlaneOperation<
@@ -92,6 +95,7 @@ interface AgentInvocations {
       @path agent_version: string;
     },
     {
+      /** The content type of the response body. */
       @header contentType: "application/yaml";
 
       /** The AsyncAPI document, serialized as YAML. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -34,8 +34,14 @@ interface AgentInvocations {
    * Retrieves the AsyncAPI (JSON) specification for an agent version's event-driven
    * invocation contract (e.g. the `invocations_ws` WebSocket protocol). AsyncAPI is the
    * companion to OpenAPI for streaming/bidirectional surfaces that OpenAPI cannot express.
-   * Returns 404 if the agent does not publish an AsyncAPI specification. Publishing is
-   * optional; when published, both JSON and YAML representations are available.
+   *
+   * Before serving the document, the service performs baseline validation checks including
+   * document size limits, external reference restrictions, and structural validity checks.
+   * Validation failures return 400.
+   *
+   * Returns 404 if the agent version does not publish an AsyncAPI specification.
+   * Publishing is optional; when published, JSON and YAML representations may be served as
+   * separately stored artifacts.
    */
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.json")
@@ -57,7 +63,13 @@ interface AgentInvocations {
    * Retrieves the AsyncAPI (YAML) specification for an agent version's event-driven
    * invocation contract. Companion to `getAgentInvocationAsyncApiSpecJson`; the path
    * extension is authoritative for the returned content type (no `Accept` negotiation).
-   * Returns 404 if the agent does not publish an AsyncAPI specification.
+   *
+   * Before serving the document, the service performs baseline validation checks including
+   * document size limits, external reference restrictions, and structural validity checks.
+   * Validation failures return 400.
+   *
+   * Returns 404 if the agent version does not publish an AsyncAPI specification, or if only
+   * a JSON representation is published for that version.
    */
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/invocations/docs/asyncapi.yaml")


### PR DESCRIPTION
## Summary

Re-submits the AsyncAPI docs endpoint TypeSpec change originally landed in #44416, then reverted in #44835 to satisfy the experience/product review gate flagged by @jsquire-ms / @travisez13.

This PR reapplies the same change on top of the latest `feature/foundry-release`.

## Why re-submit now

Since the revert, the AsyncAPI direction has been reviewed by the OpenAPI SME and stewardship board:

- **@vincentbiret** (OpenAPI SME) confirmed AsyncAPI is the best way to represent WS today; the recommended pattern is documenting the WS init in OpenAPI and the rest of the WS flow in AsyncAPI — which is exactly what these endpoints enable.
- **@travisez13** shared this alignment with the Azure REST API board thread; no objection has been raised in the review window.
- Tooling gaps around TypeSpec → AsyncAPI emission remain (tracked in microsoft/typespec#2463) but do not block the discovery endpoint itself.

## What this does

- Adds `getAgentInvocationAsyncApiSpecJson` — `GET .../invocations/docs/asyncapi.json`
- Adds `getAgentInvocationAsyncApiSpecYaml` — `GET .../invocations/docs/asyncapi.yaml`
- Regenerates the openapi3 `v1` and `virtual-public-preview` artifacts to keep TSP source and OpenAPI in sync.

Net: 531 insertions across 5 files — exact inverse of the revert in #44835.

## Related

- Original PR: #44416
- Revert: #44835
- Feature spec (contract prose): coreai-microsoft/foundrysdk_specs#209
- Work item: AB#5407708