### PR TITLE
Suppress csharp-no-type-name-conflict (AZC0034) in remaining TypeSpec specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,17 +15,17 @@
         "@azure-tools/typespec-azure-core": "0.70.0",
         "@azure-tools/typespec-azure-portal-core": "0.70.0",
         "@azure-tools/typespec-azure-resource-manager": "0.70.0",
-        "@azure-tools/typespec-azure-rulesets": "0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "https://pkg.pr.new/@azure-tools/typespec-azure-rulesets@dbb030f",
         "@azure-tools/typespec-client-generator-cli": "0.33.1",
-        "@azure-tools/typespec-client-generator-core": "0.70.0",
+        "@azure-tools/typespec-client-generator-core": "https://pkg.pr.new/@azure-tools/typespec-client-generator-core@dbb030f",
         "@azure-tools/typespec-liftr-base": "0.13.0",
-        "@azure-tools/typespec-metadata": "0.2.1",
+        "@azure-tools/typespec-metadata": "0.3.0-dev.2",
         "@azure/avocado": "0.11.0",
         "@azure/oad": "0.12.4",
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-core": "1.0.7",
         "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
-        "@typespec/compiler": "1.14.0",
+        "@typespec/compiler": "https://pkg.pr.new/@typespec/compiler@f614bf9",
         "@typespec/events": "0.84.0",
         "@typespec/http": "1.14.0",
         "@typespec/openapi": "1.14.0",
@@ -145,6 +145,38 @@
       },
       "engines": {
         "node": ">=24.14.1"
+      }
+    },
+    "eng/tools/node_modules/@typespec/compiler": {
+      "version": "1.14.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/compiler/-/compiler-1.14.0.tgz",
+      "integrity": "sha1-2FXCBu7K+j54eOf0JVthKC8FP0Y=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@inquirer/prompts": "^8.4.1",
+        "ajv": "^8.18.0",
+        "change-case": "^5.4.4",
+        "env-paths": "^4.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "mustache": "^4.2.0",
+        "picocolors": "^1.1.1",
+        "prettier": "^3.8.1",
+        "semver": "^7.7.4",
+        "tar": "^7.5.13",
+        "temporal-polyfill": "^1.0.1",
+        "vscode-languageserver": "^10.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "yaml": "^2.8.3",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "tsp": "cmd/tsp.js",
+        "tsp-server": "cmd/tsp-server.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "eng/tools/node_modules/ajv": {
@@ -1186,18 +1218,18 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.70.0.tgz",
-      "integrity": "sha512-Uxxl/18oryDwk2S+aYx6cIqiyjmoMeFDGmjuQ72a+aw6u8mZjgahMxNsY0ShvGLSchjsDqsVGaUlazXGXakVrw==",
+      "version": "0.71.0-pr.4910.2126",
+      "resolved": "https://pkg.pr.new/@azure-tools/typespec-azure-rulesets@dbb030f",
+      "integrity": "sha512-3It8kRUs9+90KXf8NVx1g2fXwvhwOnCh/uUaGouFsOzEEl32oO/+GMksKWLlWXLxqjq2XNalzylaCCxBd4nUNg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-pr.4910.2126",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0 || >= 0.71.0-pr.4910.2126",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0 || >= 0.71.0-pr.4910.2126",
         "@typespec/compiler": "^1.14.0"
       }
     },
@@ -1231,9 +1263,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.70.0.tgz",
-      "integrity": "sha512-8yxOYJfID3wp3FLQYNIa3kbmR5YLWjYtpB+i4u66quHTTQWWANHV1/o9f8xymAf+8fO9jbLo5tw1JerumxISWg==",
+      "version": "0.71.0-pr.4910.2126",
+      "resolved": "https://pkg.pr.new/@azure-tools/typespec-client-generator-core@dbb030f",
+      "integrity": "sha512-c6JrdvMJNgrdU8Mgj1bEA5wN0nwWw/4z7MMr4Xg7RrBGIHyvHbbuAFAQX/ERcGCeR5YGEJ/ZDa4AxVzgSzpBbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1245,7 +1277,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-pr.4910.2126",
         "@typespec/compiler": "^1.14.0",
         "@typespec/events": "^0.84.0",
         "@typespec/http": "^1.14.0",
@@ -1264,9 +1296,9 @@
       "dev": true
     },
     "node_modules/@azure-tools/typespec-metadata": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-metadata/-/typespec-metadata-0.2.1.tgz",
-      "integrity": "sha1-wkamri9UtANGQudu/TYnyT4ni2A=",
+      "version": "0.3.0-dev.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure-tools/typespec-metadata/-/typespec-metadata-0.3.0-dev.2.tgz",
+      "integrity": "sha1-BoQ10h93sCTHSjmDpQ+9u7Bn+q4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1276,7 +1308,10 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-dev.3",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0 || >= 0.71.0-dev.8",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/versioning": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-migration-validation": {
@@ -5289,9 +5324,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.14.0.tgz",
-      "integrity": "sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==",
+      "version": "1.15.0-pr.11221.3360",
+      "resolved": "https://pkg.pr.new/@typespec/compiler@f614bf9",
+      "integrity": "sha512-yrRPHQjAS9TzkGoMKsH+80lLHlWSdhqOE9E7mTkaV49dZrCHWtyVxryr4hR9lh+KbliS8xgJDFjkVJ3geWcsgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
     "@azure-tools/typespec-azure-core": "0.70.0",
     "@azure-tools/typespec-azure-portal-core": "0.70.0",
     "@azure-tools/typespec-azure-resource-manager": "0.70.0",
-    "@azure-tools/typespec-azure-rulesets": "0.70.0",
+    "@azure-tools/typespec-azure-rulesets": "https://pkg.pr.new/@azure-tools/typespec-azure-rulesets@dbb030f",
     "@azure-tools/typespec-client-generator-cli": "0.33.1",
-    "@azure-tools/typespec-client-generator-core": "0.70.0",
+    "@azure-tools/typespec-client-generator-core": "https://pkg.pr.new/@azure-tools/typespec-client-generator-core@dbb030f",
     "@azure-tools/typespec-liftr-base": "0.13.0",
-    "@azure-tools/typespec-metadata": "0.2.1",
+    "@azure-tools/typespec-metadata": "0.3.0-dev.2",
     "@azure/avocado": "0.11.0",
     "@azure/oad": "0.12.4",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-core": "1.0.7",
     "@microsoft.azure/openapi-validator-rulesets": "2.2.6",
-    "@typespec/compiler": "1.14.0",
+    "@typespec/compiler": "https://pkg.pr.new/@typespec/compiler@f614bf9",
     "@typespec/events": "0.84.0",
     "@typespec/http": "1.14.0",
     "@typespec/openapi": "1.14.0",
@@ -42,7 +42,11 @@
     "js-yaml@^4.0.0": "^4.3.0",
     "lodash": "^4.18.1",
     "minimatch@^3.0.0": "^3.1.5",
-    "superagent": "^10.2.3"
+    "superagent": "^10.2.3",
+    "@azure-tools/typespec-autorest": {
+      "@azure-tools/typespec-client-generator-core": "https://pkg.pr.new/@azure-tools/typespec-client-generator-core@dbb030f"
+    },
+    "@typespec/compiler": "https://pkg.pr.new/@typespec/compiler@f614bf9"
   },
   "engines": {
     "node": ">=24.14.1"

--- a/specification/computeschedule/ComputeSchedule.Management/common.tsp
+++ b/specification/computeschedule/ComputeSchedule.Management/common.tsp
@@ -30,6 +30,7 @@ model KeyVaultSecretReference {
 /**
  * The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine scale set.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-enum" "For backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2026-04-15-preview`)
 enum ResourceIdentityType {
@@ -102,6 +103,7 @@ union ZonePlacementPolicyType {
 /**
  * Describes the user-defined constraints for resource hardware placement.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2026-04-15-preview`)
 model Placement {
   /**

--- a/specification/computeschedule/ComputeSchedule.Management/scheduledactionmodels.tsp
+++ b/specification/computeschedule/ComputeSchedule.Management/scheduledactionmodels.tsp
@@ -193,6 +193,7 @@ model ScheduledActionResourceOperationResponse {
   resourcesStatuses: Array<ResourceStatus>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2025-04-15-preview`)
 @doc("The scheduled action resource")
 model ScheduledAction is TrackedResource<ScheduledActionProperties> {

--- a/specification/datadog/Datadog.Management/models.tsp
+++ b/specification/datadog/Datadog.Management/models.tsp
@@ -456,6 +456,7 @@ model MonitoredResource {
 /**
  * A Microsoft.Datadog REST API operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 model OperationResult {
   /**
    * Operation name, i.e., {provider}/{resource}/{operation}.

--- a/specification/sphere/Sphere.Management/models.tsp
+++ b/specification/sphere/Sphere.Management/models.tsp
@@ -309,6 +309,7 @@ model CatalogProperties {
 /**
  * Common fields that are returned in the response for all Azure Resource Manager resources
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 model Resource {
   /**
    * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}

--- a/specification/storageactions/StorageAction.Management/models.tsp
+++ b/specification/storageactions/StorageAction.Management/models.tsp
@@ -342,6 +342,7 @@ model ElseCondition {
 /**
  * Common fields that are returned in the response for all Azure Resource Manager resources
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-type-name-conflict" "Name kept for backward compatibility"
 model Resource {
   /**
    * Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"


### PR DESCRIPTION
## Summary

This PR adds suppress directives for csharp-no-type-name-conflict (AZC0034) violations in TypeSpec projects not covered by PR #44995.

## Changes

Updated package.json to use the same preview packages as PR #44995 (pkg.pr.new builds at dbb030f/f614bf9) to surface the new lint rule, then ran tsp compile --no-emit across all 106 TypeSpec projects with C# emitter configured (not already covered by #44995) to find remaining violations.

Suppressed violations in:
- computeschedule/ComputeSchedule.Management/common.tsp: ResourceIdentityType, Placement
- computeschedule/ComputeSchedule.Management/scheduledactionmodels.tsp: ScheduledAction
- datadog/Datadog.Management/models.tsp: OperationResult
- sphere/Sphere.Management/models.tsp: Resource
- storageactions/StorageAction.Management/models.tsp: Resource

This is a companion to PR #44995 which covers the remaining projects not handled there.