### PR TITLE
Suppress remaining csharp-model-suffix and csharp-use-standard-acronyms violations

### DIFF
--- a/specification/advisor/resource-manager/Microsoft.Advisor/Advisor/models.tsp
+++ b/specification/advisor/resource-manager/Microsoft.Advisor/Advisor/models.tsp
@@ -409,6 +409,7 @@ model ARMErrorResponseBody {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ArmErrorResponse {
   /**
    * ARM error response body.
@@ -417,6 +418,7 @@ model ArmErrorResponse {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmDefaultErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -424,6 +426,7 @@ model ArmDefaultErrorResponse {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ArmNotFoundResponse is ArmDefaultErrorResponse {
   ...Response<404>;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -178,6 +178,7 @@ model OptimizationAgentDefinition {
   tools?: Record<unknown>[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Tuning knobs and run-mode for an optimization job.")
 @extension("x-ms-foundry-meta", AgentOptimizationRequiredPreviews)
 model OptimizationOptions {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -66,6 +66,7 @@ alias DeleteSessionFileParams = {
 // Response models
 // ---------------------------------------------------------------------------
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response from uploading a file to a session sandbox.")
 model SessionFileWriteResponse {
   @doc("The path where the file was written, relative to the session home directory.")
@@ -92,6 +93,7 @@ model SessionDirectoryEntry {
   modified_time: utcDateTime;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SessionDirectoryListResponse {
   /** The first ID represented in this list. */
   first_id?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -15,6 +15,7 @@ const AllConditionalAgentDefinitionPreviews = #{
   ],
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateAgentVersionRequest {
   ...MetadataPropertyForRequest;
 
@@ -39,6 +40,7 @@ model CreateAgentVersionRequest {
   draft?: boolean = false;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateAgentVersionFromManifestRequest {
   ...MetadataPropertyForRequest;
 
@@ -53,6 +55,7 @@ model CreateAgentVersionFromManifestRequest {
   parameter_values: Record<unknown>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateAgentFromManifestRequest {
   @doc("""
     The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
@@ -66,10 +69,12 @@ model CreateAgentFromManifestRequest {
   ...CreateAgentVersionFromManifestRequest;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateAgentFromManifestRequest {
   ...CreateAgentVersionFromManifestRequest;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @extension("x-ms-foundry-meta", AllConditionalAgentDefinitionPreviews)
 model CreateAgentRequest {
   @doc("""
@@ -93,11 +98,13 @@ model CreateAgentRequest {
   agent_card?: AgentCard;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @extension("x-ms-foundry-meta", AllConditionalAgentDefinitionPreviews)
 model UpdateAgentRequest {
   ...OmitProperties<CreateAgentVersionRequest, "draft">;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PatchAgentRequest {
   @doc("The endpoint configuration for the agent")
   agent_endpoint?: AgentEndpointConfig;
@@ -332,6 +339,7 @@ model PromptAgentDefinition extends AgentDefinition {
 /**
  * Configuration options for a text response from the model. Can be plain text or structured JSON data.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PromptAgentDefinitionTextOptions {
   format?: OpenAI.TextResponseFormatConfiguration;
 }
@@ -491,6 +499,7 @@ alias ListAgentQueryParameters = {
   ...CommonPageQueryParameters;
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A deleted agent Object")
 model DeleteAgentResponse {
   @doc("The object type. Always 'agent.deleted'.")
@@ -503,6 +512,7 @@ model DeleteAgentResponse {
   deleted: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A deleted agent version Object")
 model DeleteAgentVersionResponse {
   @doc("The object type. Always 'agent.version.deleted'.")
@@ -793,6 +803,7 @@ model CreateAgentFromCodeContent {
  * can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
  * of the content-type label.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DownloadAgentCodeResponse {
   @doc("The media type of the returned package content.")
   @header("Content-Type")
@@ -902,6 +913,7 @@ model AgentSessionResource {
 // ── Session Request Models ──────────────────────────────
 
 /** Request body for creating a new agent session. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request to create a new agent session.")
 model CreateAgentSessionRequest {
   /** Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted. */

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -7,6 +7,7 @@ using TypeSpec.Http;
 using TypeSpec.Versioning;
 
 /** Error response for API failures. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ApiErrorResponse {
   error: ApiError;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -168,6 +168,7 @@ op FoundryDataPlaneRequiredPreviewOperation<
 // Pagination
 // ============================================================================
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The response data for a requested list of items.")
 model AgentsPagedResult<T> {
   /** The requested list of items. */

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -29,6 +29,7 @@ union DataGenerationJobType {
   task_generation: "task_generation",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("LLM model options for data generation jobs.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model DataGenerationModelOptions {
@@ -55,6 +56,7 @@ model DataGenerationJobInputs {
   output_options?: DataGenerationJobOutputOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Output options for data generation job.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model DataGenerationJobOutputOptions {
@@ -189,6 +191,7 @@ union DataGenerationJobScenario {
   evaluation: "evaluation",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Options for managing data generation jobs.")
 @discriminator("type")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
@@ -208,6 +211,7 @@ model DataGenerationJobOptions {
   model_options?: DataGenerationModelOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The options for a data generation job with SimpleQnA type.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model SimpleQnADataGenerationJobOptions extends DataGenerationJobOptions {
@@ -218,6 +222,7 @@ model SimpleQnADataGenerationJobOptions extends DataGenerationJobOptions {
   question_types?: SimpleQnAFineTuningQuestionType[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The options for a data generation job with Traces type.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
@@ -232,6 +237,7 @@ model TaskGenerationDataGenerationJobOptions extends DataGenerationJobOptions {
   type: "task_generation";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The options for a data generation job with ToolUse type. Used only for fine-tuning scenarios.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model ToolUseFineTuningDataGenerationJobOptions

--- a/specification/ai-foundry/data-plane/Foundry/src/datasets/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/datasets/models.tsp
@@ -73,6 +73,7 @@ union PendingUploadCredentialType {
   sas: "SAS",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents a request for a pending upload.")
 model PendingUploadRequest {
   @doc("If PendingUploadId is not provided, a random GUID will be used.")
@@ -85,6 +86,7 @@ model PendingUploadRequest {
   pendingUploadType: PendingUploadType.BlobReference;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents the response for a pending upload request")
 model PendingUploadResponse {
   @doc("Container-level read, write, list SAS.")
@@ -112,6 +114,7 @@ model BlobReference {
   credential: SasCredential;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents a reference to a blob for consumption")
 model AssetCredentialResponse {
   @doc("Credential info to access the storage account.")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -177,6 +177,7 @@ model EvaluationSuiteVersion {
 // Run API models
 // ---------------------------------------------------------------------------
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body for running an evaluation from a suite.")
 @extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)
 model EvaluationSuiteRunRequest {
@@ -190,6 +191,7 @@ model EvaluationSuiteRunRequest {
   evaluation_level?: EvaluationLevel;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response from running an evaluation suite.")
 @extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)
 model EvaluationSuiteRunResponse {
@@ -330,6 +332,7 @@ model EvaluationSuiteGenerationJobInputs {
   evaluation_level?: EvaluationLevel;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Options for dataset generation within an evaluation suite generation job.")
 @extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)
 model EvaluationSuiteDataGenerationOptions {

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluations/models.tsp
@@ -93,6 +93,7 @@ model AgentEvaluationRedactionConfiguration {
   redactScoreProperties?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Evaluation request for agent run.")
 @removed(Versions.v1)
 model AgentEvaluationRequest {

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -459,6 +459,7 @@ model EvaluatorVersion {
   ...AssetBase;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[FoundryFeaturesOptInKeys.evaluations_v1_preview] }

--- a/specification/ai-foundry/data-plane/Foundry/src/insights/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/insights/models.tsp
@@ -45,6 +45,7 @@ model InsightModelConfiguration {
   modelDeploymentName: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request of the insights report.")
 @discriminator("type")
 @extension("x-ms-foundry-meta", InsightsRequiredPreviews)
@@ -53,6 +54,7 @@ model InsightRequest {
   type: InsightType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Insights on set of Evaluation Results")
 @extension("x-ms-foundry-meta", InsightsRequiredPreviews)
 model EvaluationRunClusterInsightRequest extends InsightRequest {
@@ -69,6 +71,7 @@ model EvaluationRunClusterInsightRequest extends InsightRequest {
   modelConfiguration?: InsightModelConfiguration;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Insights on set of Agent Evaluation Results")
 @extension("x-ms-foundry-meta", InsightsRequiredPreviews)
 model AgentClusterInsightRequest extends InsightRequest {
@@ -82,6 +85,7 @@ model AgentClusterInsightRequest extends InsightRequest {
   modelConfiguration?: InsightModelConfiguration;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Evaluation Comparison Request")
 @extension("x-ms-foundry-meta", InsightsRequiredPreviews)
 model EvaluationComparisonInsightRequest extends InsightRequest {

--- a/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
@@ -8,6 +8,7 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateOrUpdateManagedAgentIdentityBlueprintRequest {
   @doc("""
     The unique name that identifies the managed agent identity blueprint.

--- a/specification/ai-foundry/data-plane/Foundry/src/memory-stores/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/memory-stores/models.tsp
@@ -48,6 +48,7 @@ model MemoryStoreObject {
   definition: MemoryStoreDefinition;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model DeleteMemoryStoreResponse {
   @doc("The object type. Always 'memory_store.deleted'.")
@@ -96,6 +97,7 @@ model MemoryStoreDefaultDefinition extends MemoryStoreDefinition {
   options?: MemoryStoreDefaultOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Default memory store configurations.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model MemoryStoreDefaultOptions {
@@ -142,6 +144,7 @@ union MemoryStoreUpdateStatus {
   superseded: "superseded",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Provides the status of a memory store update operation.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model MemoryStoreUpdateResponse {
@@ -201,6 +204,7 @@ union MemoryOperationKind {
   delete: "delete",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Memory search options.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model MemorySearchOptions {
@@ -208,6 +212,7 @@ model MemorySearchOptions {
   max_memories?: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Memory search response.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model MemoryStoreSearchResponse {
@@ -284,6 +289,7 @@ model ProceduralMemoryItem extends MemoryItem {
   kind: MemoryItemKind.procedural;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response for deleting memories from a scope.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model MemoryStoreDeleteScopeResponse {
@@ -300,6 +306,7 @@ model MemoryStoreDeleteScopeResponse {
   deleted: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response for deleting a memory item from a memory store.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 model DeleteMemoryResponse {

--- a/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
@@ -178,6 +178,7 @@ model LoraConfig {
   dropout?: float32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body for updating a model version. Only description and tags can be modified.")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model UpdateModelVersionRequest {
@@ -188,6 +189,7 @@ model UpdateModelVersionRequest {
   tags?: Record<string>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents a request for a pending upload of a model version.")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model ModelPendingUploadRequest {
@@ -201,6 +203,7 @@ model ModelPendingUploadRequest {
   pendingUploadType: PendingUploadType.TemporaryBlobReference;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents the response for a model pending upload request.")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model ModelPendingUploadResponse {
@@ -217,6 +220,7 @@ model ModelPendingUploadResponse {
   pendingUploadType: PendingUploadType.TemporaryBlobReference;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request to fetch credentials for a model asset.")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model ModelCredentialRequest {
@@ -224,6 +228,7 @@ model ModelCredentialRequest {
   blobUri: url;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Accepted response for asynchronous model version creation, with polling location.")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model CreateModelVersionAsyncResponse {

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -12,6 +12,7 @@ union EvalObjectType {
 }
 
 /** A deleted evaluation Object */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DeleteEvalResponse {
   @doc("The object type. Always 'eval.deleted'.")
   object: EvalObjectType.evalDeleted;
@@ -24,6 +25,7 @@ model DeleteEvalResponse {
 }
 
 /** A deleted evaluation run Object. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DeleteEvalRunResponse {
   @doc("The object type. Always 'eval.deleted'.")
   object?: "eval.deleted";
@@ -191,6 +193,7 @@ model Eval is OpenAI.Eval {
     | OpenAI.EvalGraderScoreModel
     | TestingCriterionAzureAIEvaluator)[]
 );
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateEvalRequest is OpenAI.CreateEvalRequest {
   /**
     Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -709,6 +712,7 @@ model EvalRun is OpenAI.EvalRun {
     | EvalRunDataSource /* RedTeamEvalRunDataSource | TargetCompletionsEvalRunDataSource | AzureAIResponsesEvalRunDataSource | TracesPreviewEvalRunDataSource | AzureAIBenchmarkPreviewEvalRunDataSource | AzureAITraceDataSourcePreviewEvalRunDataSource */
 );
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateEvalRunRequest is OpenAI.CreateEvalRunRequest {
   /**
     Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/responses/models.tsp
@@ -51,6 +51,7 @@ namespace Azure.AI.Projects {
 
   // Any fields marked with `@removed` need to be placed directly under `@@copyProperties`
   /** Azure specific fields used in the creation of "Response" object (i.e. "AgentReference") */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
   model AzureCreateResponseOptions {
     /** The agent to use for generating the response. */
     agent_reference?: AgentReference;

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -256,6 +256,7 @@ model Routine {
   updated_at?: FoundryTimestamp;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request body used to create or update a routine.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineCreateOrUpdateRequest {
@@ -301,6 +302,7 @@ model InvokeAgentInvocationsApiDispatchPayload extends RoutineDispatchPayload {
   input: unknown;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body for the public dispatch_async route.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model DispatchRoutineRequest {
@@ -308,6 +310,7 @@ model DispatchRoutineRequest {
   payload?: RoutineDispatchPayload;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Identifiers returned after a routine dispatch is queued.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model DispatchRoutineResponse {

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -173,6 +173,7 @@ alias DeleteSkillVersionRequest = {
   version: string;
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A deleted skill.")
 @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
 model DeleteSkillResponse {
@@ -186,6 +187,7 @@ model DeleteSkillResponse {
   deleted: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A deleted skill version.")
 @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
 model DeleteSkillVersionResponse {
@@ -202,6 +204,7 @@ model DeleteSkillVersionResponse {
   version: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The response body for downloading a skill package.")
 @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
 model DownloadSkillResponse {

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -369,6 +369,7 @@ alias DeleteToolboxRequest = {
   name: string;
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateToolboxRequest {
   @doc("The name of the toolbox to update.")
   @path

--- a/specification/ai/Azure.AI.Agents/files/models.tsp
+++ b/specification/ai/Azure.AI.Agents/files/models.tsp
@@ -91,6 +91,7 @@ union FilePurpose {
   vision: "vision",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The response data from a file list operation.")
 @added(Versions.v2025_05_01)
 model FileListResponse {

--- a/specification/ai/Azure.AI.Agents/messages/models.tsp
+++ b/specification/ai/Azure.AI.Agents/messages/models.tsp
@@ -112,6 +112,7 @@ model MessageImageUrlParam {
  * A single message within an agent thread,
  * as provided during that thread's creation for its initial state.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model ThreadMessageOptions {
   /**

--- a/specification/ai/Azure.AI.Agents/models.tsp
+++ b/specification/ai/Azure.AI.Agents/models.tsp
@@ -78,6 +78,7 @@ model Agent {
   ...RequiredNullableMetadata;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when creating a new agent.")
 @added(Versions.v2025_05_01)
 model CreateAgentOptions {
@@ -137,6 +138,7 @@ model CreateAgentOptions {
   ...OptionalNullableMetadata;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when modifying an existing agent.")
 @added(Versions.v2025_05_01)
 model UpdateAgentOptions {
@@ -207,6 +209,7 @@ model AgentDeletionStatus {
   object: "assistant.deleted";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when retrieving an agent.")
 @added(Versions.v2025_05_01)
 model GetAgentOptions {
@@ -215,6 +218,7 @@ model GetAgentOptions {
   assistantId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when deleting an agent.")
 @added(Versions.v2025_05_01)
 model DeleteAgentOptions {

--- a/specification/ai/Azure.AI.Agents/runs/models.tsp
+++ b/specification/ai/Azure.AI.Agents/runs/models.tsp
@@ -187,6 +187,7 @@ model RunCompletionUsage {
   totalTokens: int64;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The details used when creating a new run of an agent thread.")
 @added(Versions.v2025_05_01)
 model CreateRunOptions {
@@ -384,6 +385,7 @@ model SubmitToolApprovalDetails {
   toolCalls: RequiredToolCall[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The details used when creating and immediately running a new agent thread.")
 @added(Versions.v2025_05_01)
 model CreateAndRunThreadOptions {

--- a/specification/ai/Azure.AI.Agents/threads/models.tsp
+++ b/specification/ai/Azure.AI.Agents/threads/models.tsp
@@ -36,6 +36,7 @@ model AgentThread {
 }
 
 /** The details used to create a new agent thread. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model AgentThreadCreationOptions {
   /** The initial messages to associate with the new thread. */
@@ -54,6 +55,7 @@ model AgentThreadCreationOptions {
 }
 
 /** The details used to update an existing agent thread */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model UpdateAgentThreadOptions {
   /** The ID of the thread to modify. */

--- a/specification/ai/Azure.AI.Agents/tools/models.tsp
+++ b/specification/ai/Azure.AI.Agents/tools/models.tsp
@@ -248,6 +248,7 @@ model BrowserAutomationToolConnectionParameters {
 /**
  * Ranking options for file search.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model FileSearchRankingOptions {
   @doc("File search ranker.")

--- a/specification/ai/Azure.AI.Agents/vector_stores/common/main.tsp
+++ b/specification/ai/Azure.AI.Agents/vector_stores/common/main.tsp
@@ -7,6 +7,7 @@ using TypeSpec.Versioning;
 namespace Azure.AI.Agents;
 
 /** Options to configure a vector store static chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model VectorStoreStaticChunkingStrategyOptions {
   /** The maximum number of tokens in each chunk. The default value is 800. The minimum value is 100 and the maximum value is 4096. */
@@ -49,6 +50,7 @@ model VectorStoreAutoChunkingStrategyRequest
 }
 
 /** A statically configured chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model VectorStoreStaticChunkingStrategyRequest
   extends VectorStoreChunkingStrategyRequest {
@@ -67,6 +69,7 @@ union VectorStoreChunkingStrategyResponseType {
 }
 
 /** An abstract representation of a vector store chunking strategy configuration. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("type")
 @added(Versions.v2025_05_01)
 model VectorStoreChunkingStrategyResponse {
@@ -77,6 +80,7 @@ model VectorStoreChunkingStrategyResponse {
 /**
  * This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the chunking_strategy concept was introduced in the API.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model VectorStoreAutoChunkingStrategyResponse
   extends VectorStoreChunkingStrategyResponse {
@@ -85,6 +89,7 @@ model VectorStoreAutoChunkingStrategyResponse
 }
 
 /** A statically configured chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_05_01)
 model VectorStoreStaticChunkingStrategyResponse
   extends VectorStoreChunkingStrategyResponse {

--- a/specification/ai/Azure.AI.Agents/vector_stores/models.tsp
+++ b/specification/ai/Azure.AI.Agents/vector_stores/models.tsp
@@ -109,6 +109,7 @@ model VectorStore {
 }
 
 /** Request object for creating a vector store. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VectorStoreOptions {
   /** A list of file IDs that the vector store should use. Useful for tools like `file_search` that can access files. */
   @maxItems(500)
@@ -134,6 +135,7 @@ model VectorStoreOptions {
 }
 
 /** Request object for updating a vector store. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VectorStoreUpdateOptions {
   /** The name of the vector store. */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"

--- a/specification/ai/ContentUnderstanding/models.tsp
+++ b/specification/ai/ContentUnderstanding/models.tsp
@@ -524,6 +524,7 @@ model AnalyzeParameters {
   processingLocation?: ProcessingLocation = ProcessingLocation.global;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Analyze operation request.")
 model AnalyzeRequest {
   ...AnalyzeParameters;
@@ -574,6 +575,7 @@ model AnalysisInput {
   range?: RangeExpression;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Analyze operation request directly from binary content.")
 model AnalyzeBinaryRequest {
   ...AnalyzeParameters;
@@ -853,6 +855,7 @@ model ContentUnderstandingDefaults {
   modelDeployments: Record<string>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_11_01)
 @doc("Copy operation request.")
 model CopyRequest {
@@ -866,6 +869,7 @@ model CopyRequest {
   sourceAnalyzerId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_11_01)
 @doc("Grant copy authorization request.")
 model GrantCopyAuthorizationRequest {

--- a/specification/ai/DocumentIntelligence/models.tsp
+++ b/specification/ai/DocumentIntelligence/models.tsp
@@ -363,6 +363,7 @@ union AnalyzeOutputOption {
   "figures",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Document analysis parameters.")
 model AnalyzeDocumentRequest {
   @doc("Document URL to analyze.  Either urlSource or base64Source must be specified.")
@@ -375,6 +376,7 @@ model AnalyzeDocumentRequest {
   base64Source?: bytes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Batch document analysis parameters.")
 model AnalyzeBatchDocumentsRequest {
   @doc("""
@@ -400,6 +402,7 @@ model AnalyzeBatchDocumentsRequest {
   overwriteExisting?: boolean = false;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Error response object.")
 @error
 model DocumentIntelligenceErrorResponse {
@@ -1153,6 +1156,7 @@ model AddressValue {
   level?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body to build a new custom document model.")
 model BuildDocumentModelRequest {
   @doc("Unique document model name.")
@@ -1208,6 +1212,7 @@ model AzureBlobFileListContentSource {
   fileList: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body to create a composed document model from component document models.")
 model ComposeDocumentModelRequest {
   @doc("Unique document model name.")
@@ -1231,6 +1236,7 @@ model ComposeDocumentModelRequest {
   tags?: Record<string>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body to authorize document model copy.")
 model AuthorizeCopyRequest {
   @doc("Unique document model name.")
@@ -1273,6 +1279,7 @@ model ModelCopyAuthorization {
   expirationDateTime: utcDateTime;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body to authorize document classifier copy.")
 model AuthorizeClassifierCopyRequest {
   @doc("Unique document classifier name.")
@@ -1475,6 +1482,7 @@ model DocumentFieldSchema {
   properties?: Record<DocumentFieldSchema>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body to build a new custom document classifier.")
 model BuildDocumentClassifierRequest {
   @doc("Unique document classifier name.")
@@ -1554,6 +1562,7 @@ model DocumentClassifierDetails {
   warnings?: DocumentIntelligenceWarning[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Document classification parameters.")
 model ClassifyDocumentRequest {
   @doc("Document URL to classify.  Either urlSource or base64Source must be specified.")

--- a/specification/ai/Face/models.common.tsp
+++ b/specification/ai/Face/models.common.tsp
@@ -98,6 +98,7 @@ model BaseCollection {
   recognitionModel?: RecognitionModel;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Model for creating face collection.")
 model CreateCollectionRequest {
   ...UserDefinedFields;
@@ -124,6 +125,7 @@ model BaseFace {
   ...FaceUserData;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Query parameters for add face.")
 model AddFaceOptions {
   @doc("A face rectangle to specify the target face to be added to a person, in the format of 'targetFace=left,top,width,height'.")
@@ -142,6 +144,7 @@ model AddFaceOptions {
   userData?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Add face from stream request.")
 model AddFaceRequest is AddFaceOptions {
   @doc("The format of the HTTP payload.")
@@ -153,6 +156,7 @@ model AddFaceRequest is AddFaceOptions {
   imageContent: bytes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Add face from url request.")
 model AddFaceFromUrlRequest is AddFaceOptions {
   @clientName("uri", "csharp")
@@ -313,6 +317,7 @@ model FaceError {
   message: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FaceErrorResponse is Azure.Core.Foundations.ErrorResponseBase<FaceError>;
 
 alias BodyParameter<

--- a/specification/ai/Face/models.session.tsp
+++ b/specification/ai/Face/models.session.tsp
@@ -81,6 +81,7 @@ model LivenessSessionData {
   @doc("Whether or not to allow client to set their own 'userCorrelationId' via the Vision SDK. Default is false, and 'userCorrelationId' must be set in this request body.")
   userCorrelationIdSetInClient?: boolean;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v1_3_preview_1)
   @doc("Specify the expected IP address or CIDR block of the client that runs the liveness check.")
   expectedClientIpAddress?: string;
@@ -382,6 +383,7 @@ model LivenessSessionCommonData {
   @doc("Denotes if the abuse monitoring feature was enabled during this session.")
   isAbuseMonitoringEnabled?: HttpPart<boolean>;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v1_3_preview_1)
   @doc("The expected IP address or CIDR block of the client that runs the liveness check.")
   expectedClientIpAddress?: string;
@@ -525,6 +527,7 @@ model LivenessError {
 @added(Versions.v1_3_preview_1)
 @doc("The client information gathered during the liveness attempt.")
 model ClientInformation {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The client ip address seen during the liveness attempt.")
   ip: string;
 }
@@ -566,6 +569,7 @@ model LivenessColorDecisionTarget {
   faceRectangle: FaceRectangle;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v1_2)
 @doc("Request wrapper of liveness with verify session creation.")
 model CreateLivenessWithVerifySessionRequest {
@@ -621,6 +625,7 @@ model LivenessAbuseMonitoringSetting {
   enabled: HttpPart<boolean>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v1_3_preview_1)
 @doc("Response model for client assets access token.")
 model ClientAssetsAccessTokenResponse {

--- a/specification/ai/OpenAI.Assistants/assistants/models.tsp
+++ b/specification/ai/OpenAI.Assistants/assistants/models.tsp
@@ -83,6 +83,7 @@ model Assistant {
   ...RequiredNullableMetadata;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when creating a new assistant.")
 @added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantCreationOptions {
@@ -146,6 +147,7 @@ model AssistantCreationOptions {
   ...OptionalNullableMetadata;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request details to use when modifying an existing assistant.")
 @added(ServiceApiVersions.v2024_02_15_preview)
 model UpdateAssistantOptions {

--- a/specification/ai/OpenAI.Assistants/files/models.tsp
+++ b/specification/ai/OpenAI.Assistants/files/models.tsp
@@ -112,6 +112,7 @@ union FilePurpose {
   vision: "vision",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The response data from a file list operation.")
 @added(ServiceApiVersions.v2024_02_15_preview)
 model FileListResponse {

--- a/specification/ai/OpenAI.Assistants/messages/models.tsp
+++ b/specification/ai/OpenAI.Assistants/messages/models.tsp
@@ -8,6 +8,7 @@ namespace Azure.AI.OpenAI.Assistants;
 using TypeSpec.Versioning;
 
 /** A single message within an assistant thread, as provided during that thread's creation for its initial state. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_02_15_preview)
 model ThreadMessageOptions {
   /**

--- a/specification/ai/OpenAI.Assistants/runs/models.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/models.tsp
@@ -195,6 +195,7 @@ union RunIncludes {
   fileSearchContent: "step_details.tool_calls[*].file_search.results[*].content",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The details used when creating a new run of an assistant thread.")
 @added(ServiceApiVersions.v2024_02_15_preview)
 model CreateRunOptions {
@@ -377,6 +378,7 @@ model SubmitToolOutputsDetails {
   toolCalls: RequiredToolCall[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The details used when creating and immediately running a new assistant thread.")
 @added(ServiceApiVersions.v2024_02_15_preview)
 model CreateAndRunThreadOptions {

--- a/specification/ai/OpenAI.Assistants/threads/models.tsp
+++ b/specification/ai/OpenAI.Assistants/threads/models.tsp
@@ -37,6 +37,7 @@ model AssistantThread {
 }
 
 /** The details used to create a new assistant thread. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantThreadCreationOptions {
   /** The initial messages to associate with the new thread. */
@@ -57,6 +58,7 @@ model AssistantThreadCreationOptions {
 }
 
 /** The details used to update an existing assistant thread */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_02_15_preview)
 model UpdateAssistantThreadOptions {
   /** The ID of the thread to modify. */

--- a/specification/ai/OpenAI.Assistants/tools/tool_resources.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/tool_resources.tsp
@@ -65,6 +65,7 @@ model FileSearchToolResource {
  * type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search`
  * tool requires a list of vector store IDs.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model CreateToolResourcesOptions {
   /**
@@ -82,6 +83,7 @@ model CreateToolResourcesOptions {
 /**
  * A set of resources that will be used by the `code_interpreter` tool. Request object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model CreateCodeInterpreterToolResourceOptions {
   /** A list of file IDs made available to the `code_interpreter` tool. */
@@ -111,6 +113,7 @@ union CreateFileSearchToolResourceOptions {
 }
 
 /** File IDs associated to the vector store to be passed to the helper. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model CreateFileSearchToolResourceVectorStoreOptions {
   /** A list of file IDs to add to the vector store. There can be a maximum of 10000 files in a vector store. */
@@ -138,6 +141,7 @@ model CreateFileSearchToolResourceVectorStoreOptions {
  * For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of
  * vector store IDs.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model UpdateToolResourcesOptions {
   /**
@@ -153,6 +157,7 @@ model UpdateToolResourcesOptions {
 }
 
 /** Request object to update `code_interpreted` tool resources. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model UpdateCodeInterpreterToolResourceOptions {
   /** A list of file IDs to override the current list of the assistant. */
@@ -162,6 +167,7 @@ model UpdateCodeInterpreterToolResourceOptions {
 }
 
 /** Request object to update `file_search` tool resources. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model UpdateFileSearchToolResourceOptions {
   /** A list of vector store IDs to override the current list of the assistant. */

--- a/specification/ai/OpenAI.Assistants/vector_stores/common/main.tsp
+++ b/specification/ai/OpenAI.Assistants/vector_stores/common/main.tsp
@@ -7,6 +7,7 @@ using TypeSpec.Versioning;
 namespace Azure.AI.OpenAI.Assistants;
 
 /** Options to configure a vector store static chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreStaticChunkingStrategyOptions {
   /** The maximum number of tokens in each chunk. The default value is 800. The minimum value is 100 and the maximum value is 4096. */
@@ -32,6 +33,7 @@ union VectorStoreChunkingStrategyRequestType {
 }
 
 /** An abstract representation of a vector store chunking strategy configuration. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("type")
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreChunkingStrategyRequest {
@@ -42,6 +44,7 @@ model VectorStoreChunkingStrategyRequest {
 /**
  * The default strategy. This strategy currently uses a max_chunk_size_tokens of 800 and chunk_overlap_tokens of 400.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreAutoChunkingStrategyRequest
   extends VectorStoreChunkingStrategyRequest {
@@ -50,6 +53,7 @@ model VectorStoreAutoChunkingStrategyRequest
 }
 
 /** A statically configured chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreStaticChunkingStrategyRequest
   extends VectorStoreChunkingStrategyRequest {
@@ -69,6 +73,7 @@ union VectorStoreChunkingStrategyResponseType {
 }
 
 /** An abstract representation of a vector store chunking strategy configuration. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("type")
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreChunkingStrategyResponse {
@@ -79,6 +84,7 @@ model VectorStoreChunkingStrategyResponse {
 /**
  * This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the chunking_strategy concept was introduced in the API.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreAutoChunkingStrategyResponse
   extends VectorStoreChunkingStrategyResponse {
@@ -87,6 +93,7 @@ model VectorStoreAutoChunkingStrategyResponse
 }
 
 /** A statically configured chunking strategy. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_preview)
 model VectorStoreStaticChunkingStrategyResponse
   extends VectorStoreChunkingStrategyResponse {

--- a/specification/ai/OpenAI.Assistants/vector_stores/models.tsp
+++ b/specification/ai/OpenAI.Assistants/vector_stores/models.tsp
@@ -114,6 +114,7 @@ model VectorStore {
 }
 
 /** Request object for creating a vector store. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model VectorStoreOptions {
   /** A list of file IDs that the vector store should use. Useful for tools like `file_search` that can access files. */
@@ -137,6 +138,7 @@ model VectorStoreOptions {
 }
 
 /** Request object for updating a vector store. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_preview)
 model VectorStoreUpdateOptions {
   /** The name of the vector store. */

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -10,6 +10,7 @@ namespace VoiceLive;
 
 /** Base for session configuration shared between request and response. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style. // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(RequestUsage)
 model RequestSession {
   ...SessionBase;
@@ -138,6 +139,7 @@ union ReasoningEffort {
 
 /** Base for session configuration in the response. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(ResponseUsage)
 model ResponseSession is RequestSession {
   ...SessionBase;
@@ -666,6 +668,7 @@ union AudioInputTranscriptionModel {
 
 /** Configuration for input audio transcription. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(RequestUsage)
 model AudioInputTranscriptionOptions {
   /**
@@ -1055,6 +1058,7 @@ union AnimationOutputType {
 
 /** Configuration for animation outputs including blendshapes and visemes metadata. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(RequestUsage)
 model Animation {
   /** The name of the animation model to use. */
@@ -1179,6 +1183,7 @@ model IceServer {
 
 /** Configuration for the agent. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(RequestUsage)
 model AgentConfig {
   /** The type of agent to use. */

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -37,6 +37,7 @@ model VoiceLiveErrorDetails {
 }
 
 /** Standard error response envelope. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 @usage(ResponseUsage)
 model ErrorResponse {
@@ -203,6 +204,7 @@ model ConversationItemBase {
 
 /** The response resource. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @usage(ResponseUsage)
 model Response {
   /** The unique ID of the response. */

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertProcessingRules/models.tsp
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertProcessingRules/models.tsp
@@ -377,6 +377,7 @@ model Resource {
 /**
  * An error response from the service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertRuleRecommendations/models.tsp
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertRuleRecommendations/models.tsp
@@ -227,6 +227,7 @@ union MetricAlertsDisplayUnit {
 /**
  * List of alert rule recommendations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AlertRuleRecommendationsListResponse
   is Azure.Core.Page<AlertRuleRecommendationResource>;
 

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertsManagement/models.tsp
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/AlertsManagement/models.tsp
@@ -682,6 +682,7 @@ model ProxyResource {
 /**
  * An error response from the service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model AlertsManagementErrorResponse {
   /**
@@ -948,6 +949,7 @@ model AlertEnrichmentsList is Azure.Core.Page<AlertEnrichmentResponse>;
  * The alert's enrichments.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AlertEnrichmentResponse
   extends Azure.ResourceManager.Foundations.ProxyResource {
   /**

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
@@ -5046,6 +5046,7 @@ model FailureStatusCodeRange {
 /**
  * The response to be returned when a backend fails to respond
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BackendFailureResponse {
   /**
    * The status code of the response.

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -1974,6 +1974,7 @@ model BuildConfiguration {
   /**
    * Base OS used to build and run the app.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   baseOs?: string;
 
   /**
@@ -6705,6 +6706,7 @@ model EnvironmentVariable {
 /**
  * App Service error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**
@@ -7974,6 +7976,7 @@ model ContainerAppsBuildConfiguration {
   /**
    * Base OS used to build and run the app.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   baseOs?: string;
 
@@ -8253,6 +8256,7 @@ model PatchDetailsNewLayer {
   /**
    * The OS name and its version in the new run image for the target image.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osAndVersion?: string;
 }
 
@@ -8273,6 +8277,7 @@ model PatchDetailsOldLayer {
   /**
    * The OS name and its version in the old run image for the target image.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osAndVersion?: string;
 }
 

--- a/specification/applicationinsights/data-plane/Exporters/models.tsp
+++ b/specification/applicationinsights/data-plane/Exporters/models.tsp
@@ -260,6 +260,7 @@ model Domain {
 /**
  * Response containing the status of each telemetry item.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TrackResponse {
   /**
    * The number of items received.

--- a/specification/applicationinsights/data-plane/LiveMetrics/models.tsp
+++ b/specification/applicationinsights/data-plane/LiveMetrics/models.tsp
@@ -295,6 +295,7 @@ union DocumentType {
  * Request document type.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "Need to follow the casing style of the existing SDK contract."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model Request extends DocumentIngress {
   @doc("Telemetry type for Request.")
   DocumentType: DocumentType.Request;

--- a/specification/artifactsigning/data-plane/ArtifactSigning/main.tsp
+++ b/specification/artifactsigning/data-plane/ArtifactSigning/main.tsp
@@ -127,6 +127,7 @@ model CertificateProfileName {
   certificateProfile: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The artifact request information to be signed by the service.")
 model SigningPayloadOptions {
   @doc("The supported signature algorithm identifiers.")
@@ -154,6 +155,7 @@ model SignStatusResult {
   signingCertificate?: bytes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Signing option parameters corresponding to the account and certificate profile name.")
 model SigningOptions {
   @doc("Signing account name.")

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/Kusto/models.tsp
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/Kusto/models.tsp
@@ -3641,6 +3641,7 @@ model EventGridConnectionProperties {
 /**
  * Class representing the Kusto CosmosDb data connection properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbDataConnectionProperties {
   /**
    * The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table.

--- a/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/AzureArcData/models.tsp
+++ b/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/AzureArcData/models.tsp
@@ -2074,6 +2074,7 @@ enum FailureConditionLevel {
  * Specifies whether the availability group supports failover for database health conditions.
  */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 enum DbFailover {
   /**
    * ON
@@ -2298,6 +2299,7 @@ model K8sScheduling {
 /**
  * The kubernetes scheduling options. It describes restrictions used to help Kubernetes select appropriate nodes to host the database service
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model K8sSchedulingOptions {
   ...Record<unknown>;
 
@@ -2690,6 +2692,7 @@ model SqlServerInstanceProperties {
   /**
    * Indicates whether database master key exists in SQL Server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   dbMasterKeyExists?: boolean;
 
@@ -2906,6 +2909,7 @@ model DBMEndpoint {
   /**
    * Listener IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddress?: string;
 
@@ -2970,6 +2974,7 @@ model hostIPAddressInformation {
   /**
    * IP address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddress?: string;
 
@@ -3547,6 +3552,7 @@ model SkuRecommendationResultsAzureSqlVirtualMachineTargetSku {
   /**
    * temp db disk sizes.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @identifiers(#[])
   tempDbDiskSizes?: DiskSizes[];
 }
@@ -3854,6 +3860,7 @@ model SqlServerInstanceUpdateProperties {
   /**
    * Indicates whether database master key exists in SQL Server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   dbMasterKeyExists?: boolean;
 
@@ -4019,6 +4026,7 @@ model SqlServerInstanceUpdateProperties {
 /**
  * The Arc SQL Server instance telemetry retrieval request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceTelemetryRequest {
   /**
    * The name of the telemetry dataset to retrieve.
@@ -4056,6 +4064,7 @@ model SqlServerInstanceTelemetryRequest {
 /**
  * A section of the telemetry response for the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceTelemetryResponse {
   /**
    * The columns of the result telemetry table for the SQL Server instance.
@@ -4096,6 +4105,7 @@ model SqlServerInstanceTelemetryColumn {
 /**
  * The request for retrieving SQL best practices assessment results.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceBpaRequest {
   /**
    * The report type that needs to be fetched. If not specified, the default is AssessmentSummary.
@@ -4121,6 +4131,7 @@ model SqlServerInstanceBpaRequest {
 /**
  * A section of the SQL best practices assessment response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceBpaResponse {
   /**
    * The SQL best practices assessment response columns.
@@ -4160,6 +4171,7 @@ model SqlServerInstanceBpaColumn {
 /**
  * The response for running migration assessment on the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceRunMigrationAssessmentResponse {
   /**
    * The unique identifier of the job.
@@ -4260,6 +4272,7 @@ model SequencerAction {
 /**
  * The request for running a SQL Server Instance target recommendation job.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceRunTargetRecommendationJobRequest {
   /**
    * Controls whether the SQL Server instance resource is updated with the target recommendation details after the job completes.
@@ -4294,6 +4307,7 @@ model SqlServerInstanceRunTargetRecommendationJobRequest {
 /**
  * Represents the response of a SQL Server Instance target recommendation job execution.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceRunTargetRecommendationJobResponse {
   /**
    * Represents the current status of the target recommendation job.
@@ -4305,6 +4319,7 @@ model SqlServerInstanceRunTargetRecommendationJobResponse {
 /**
  * The request for retrieving SQL Server Instance target recommendation reports.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceTargetRecommendationReportsRequest {
   /**
    * Zero-based offset indicating where to continue reading reports in the overall list of reports. Defaults to 0 if not provided. This value must be used together with the corresponding sectionOffset to resume pagination. The reportOffset advances only after all sections of the current report have been retrieved. To retrieve subsequent pages, use the nextReportOffset and nextSectionOffset values from the previous response.
@@ -4332,6 +4347,7 @@ model SqlServerInstanceTargetRecommendationReportsRequest {
 /**
  * Represents the response containing SQL Server Instance target recommendation reports.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceTargetRecommendationReportsResponse {
   /**
    * Represents the status of the latest target recommendation job. Report records are returned only when the job status is Succeeded.
@@ -4422,6 +4438,7 @@ model SqlServerInstanceTargetRecommendationReportSection {
 /**
  * Represents the response containing the SQL Server Instance Migration Readiness report.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceMigrationReadinessReportResponse {
   /**
    * The migration readiness report as a serialized JSON string. When isCompressed is true, the value is base64-encoded GZip-compressed and must be decoded and decompressed before parsing.
@@ -4446,6 +4463,7 @@ model SqlServerInstanceMigrationReadinessReportResponse {
 /**
  * The response object for the request to run SQL best practices assessment.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceRunBestPracticesAssessmentResponse {
   /**
    * The unique identifier of the job.
@@ -4482,6 +4500,7 @@ model SqlServerInstanceRunBestPracticesAssessmentResponse {
 /**
  * The response object for the request to run migration readiness assessment.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceRunMigrationReadinessAssessmentResponse {
   /**
    * The unique identifier of the job.
@@ -4518,6 +4537,7 @@ model SqlServerInstanceRunMigrationReadinessAssessmentResponse {
 /**
  * The request for the status of the jobs running on the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceJobsStatusRequest {
   /**
    * The name of the feature to retrieve the job status for.
@@ -4533,6 +4553,7 @@ model SqlServerInstanceJobsStatusRequest {
 /**
  * The response for the status of the jobs running on the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceJobsStatusResponse {
   /**
    * The list of jobs status running on the SQL Server instance.
@@ -4580,6 +4601,7 @@ model SqlServerInstanceJobStatus {
 /**
  * The request for the jobs running on the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceJobsRequest {
   /**
    * The name of the feature to retrieve the jobs for.
@@ -4595,6 +4617,7 @@ model SqlServerInstanceJobsRequest {
 /**
  * The response for the jobs running on the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceJobsResponse {
   /**
    * The list of jobs running on the SQL Server instance.
@@ -4642,6 +4665,7 @@ model SqlServerInstanceJob {
 /**
  * The MI Link assessment request for the SQL Server instance.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceManagedInstanceLinkAssessmentRequest {
   /**
    * The Azure SQL Managed Instance resource ID to link with the SQL Server instance.
@@ -4676,12 +4700,14 @@ model SqlServerInstanceManagedInstanceLinkAssessmentRequest {
   /**
    * The IP address of the SQL Server instance.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   sqlServerIpAddress?: string;
 }
 
 /**
  * The response containing the results of the MI Link assessment.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerInstanceManagedInstanceLinkAssessmentResponse {
   /**
    * The list of the results for MI Link assessment.
@@ -5392,6 +5418,7 @@ model AvailabilityGroupInfo {
   /**
    * Specifies whether the availability group supports failover for database health conditions.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbFailover?: boolean;
 
   /**
@@ -5462,12 +5489,14 @@ model SqlAvailabilityGroupStaticIPListenerProperties {
   /**
    * IP V4 Addresses and masks for the listener.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @identifiers(#["ipAddress"])
   ipV4AddressesAndMasks?: SqlAvailabilityGroupIpV4AddressesAndMasksPropertiesItem[];
 
   /**
    * IP V6 Addresses for the listener
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipV6Addresses?: string[];
 
   /**
@@ -5477,10 +5506,12 @@ model SqlAvailabilityGroupStaticIPListenerProperties {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model SqlAvailabilityGroupIpV4AddressesAndMasksPropertiesItem {
   /**
    * IPV4 address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 
   /**
@@ -5857,6 +5888,7 @@ model AvailabilityGroupCreateUpdateConfiguration {
   /**
    * Specifies whether the availability group supports failover for database health conditions.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbFailover?: DbFailover;
 
   /**
@@ -6212,6 +6244,7 @@ model SqlServerDatabaseResourceProperties {
 /**
  * List of features that are enabled for the database
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SqlServerDatabaseResourcePropertiesDatabaseOptions {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   isAutoCloseOn?: boolean;

--- a/specification/azurelargeinstance/resource-manager/Microsoft.AzureLargeInstance/AzureLargeInstance/models.tsp
+++ b/specification/azurelargeinstance/resource-manager/Microsoft.AzureLargeInstance/AzureLargeInstance/models.tsp
@@ -366,6 +366,7 @@ model HardwareProfile {
 
 @doc("Specifies the storage settings for the Azure Large Instance disks.")
 model StorageProfile {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @removed(Versions.v2024_08_01_preview)
   @renamedFrom(Versions.v2024_08_01_preview, "nfsIpAddress")
   @doc("IP Address to connect to storage.")
@@ -407,6 +408,7 @@ model OsProfile {
   @doc("Specifies the host OS name of the Azure Large Instance.")
   computerName?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @removed(Versions.v2024_08_01_preview)
   @renamedFrom(Versions.v2024_08_01_preview, "osType")
   @doc("This property allows you to specify the type of the OS.")

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drill.models.tsp
@@ -558,6 +558,7 @@ model DrillEndRequest {
   attestationNotes: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response body of Drill actions")
 model DrillActionResponse {
   @doc("JobId of the Drill")
@@ -609,6 +610,7 @@ model IncludeOrUpdateResource {
   faultProperties?: FaultProperties;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response body of the AddOrUpdateResources API.")
 @removed(Versions.v2026_04_01_preview)
 model AddOrUpdateResourcesResponse {
@@ -828,6 +830,7 @@ model DrillResourceQualification {
   resourceQualificationDetails: ResourceQualificationDetails;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("ValidateForExecution post action response.")
 @added(Versions.v2026_03_01_preview)
 model ValidateForExecutionResponse {

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drillRun.models.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drillRun.models.tsp
@@ -123,6 +123,7 @@ model DrillRunTestFailoverCleanupRequest {
   comments?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body for TestFailoverCleanup API.")
 model DrillRunActionResponse {
   @doc("JobId of the RO job.")
@@ -140,6 +141,7 @@ model MarkAsCompleteRequest {
   drillRunStage: DrillRunSubtasks;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response body for MarkAsComplete API.")
 model MarkAsCompleteResponse {
   @doc("Matrix of Actions supported on Operations.")

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/goals/goalResource.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/goals/goalResource.tsp
@@ -64,6 +64,7 @@ model UpdateGoalResourceRequest {
   resources: GoalResource[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response model for update goal resource.")
 model UpdateGoalResourceResponse {
   @doc("List of update goal resource.")
@@ -81,6 +82,7 @@ model GoalResource is ProxyResource<GoalResourceProperties> {
   name: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response model for refresh goal resources.")
 model RefreshGoalResourcesResponse {
   @doc("Total count of resources under the goal assignment after refresh.")

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/OsImages.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/OsImages.tsp
@@ -12,6 +12,7 @@ namespace Microsoft.AzureStackHCI;
 /**
  * Represents a os image resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @parentResource(SubscriptionLocationResource)
 @added(Versions.v2026_05_01_preview)
 model OsImage is Azure.ResourceManager.ProxyResource<OsImageProperties> {

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -6623,6 +6623,7 @@ model HciRepairServerJobProperties extends ClusterJobProperties {
 /**
  * Request for Add/Remove Devices to the pool.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model ListOfDevicesRequest {
   /**
@@ -6922,6 +6923,7 @@ model ProvisioningDetails {
   /**
    * Operating system profile.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osProfile: OsProvisionProfile;
 
   /**
@@ -7242,6 +7244,7 @@ model EdgeMachineReportedProperties {
   /**
    * OS Properties for edge machine.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osProfile?: OsProfile;
 
@@ -7401,6 +7404,7 @@ model EdgeMachineNicDetail {
   /**
    * Subnet Mask of NIC
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ip4Address?: string;
 
@@ -7491,18 +7495,21 @@ model OsProfile {
   /**
    * OS type (“windows", “linux”)
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: string;
 
   /**
    * OS SKU (e.g., “ Microsoft Azure Linux ROE“, “Azure Stack HCI", "Microsoft Azure Linux 3.0")
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osSku?: string;
 
   /**
    * OS Version
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osVersion?: string;
 
@@ -8000,6 +8007,7 @@ model EdgeMachineRemoteSupportJobProperties extends EdgeMachineJobProperties {
 /**
  * Represents the properties of an Azure Linux restricted operating environment Provision Os job.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model ProvisionOsJobProperties extends EdgeMachineJobProperties {
   /**
@@ -8032,12 +8040,14 @@ model DownloadRequest {
   /**
    * Operating system profile.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osProfile: DownloadOsProfile;
 }
 
 /**
  * Represents the properties of Download Os job.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model DownloadOsJobProperties extends EdgeMachineJobProperties {
   /**
@@ -8059,6 +8069,7 @@ model DownloadOsJobProperties extends EdgeMachineJobProperties {
 /**
  * Reported Properties for Provision Os job
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model ProvisionOsReportedProperties {
   ...JobReportedProperties;
@@ -8078,6 +8089,7 @@ model ProvisioningRequest {
   /**
    * Operating system profile.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osProfile: OsProvisionProfile;
 
   /**
@@ -8252,26 +8264,31 @@ model EdgeMachineJobReportedProperties {
 /**
  * Operating system profile.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model OsProvisionProfile {
   /**
    * Name of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osName?: string;
 
   /**
    * Type of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
    * Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVersion?: string;
 
   /**
    * Location of the operating system image.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osImageLocation?: string;
 
   /**
@@ -8299,26 +8316,31 @@ model OsProvisionProfile {
 /**
  * Operating system profile.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model DownloadOsProfile {
   /**
    * Name of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osName?: string;
 
   /**
    * Type of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
    * Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVersion?: string;
 
   /**
    * Location of the operating system image.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osImageLocation?: string;
 
   /**
@@ -8513,11 +8535,13 @@ model NetworkAdapter {
   /**
    * Type of IP assignment.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAssignmentType: IpAssignmentType;
 
   /**
    * IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 
   /**
@@ -8533,6 +8557,7 @@ model NetworkAdapter {
   /**
    * IP address range.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddressRange?: IpAddressRange;
 
   /**
@@ -8582,11 +8607,13 @@ model IpAddressRange {
   /**
    * Start IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   startIp: string;
 
   /**
    * End IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   endIp: string;
 }
 
@@ -8703,6 +8730,7 @@ model ClusterJobListResult is Azure.Core.Page<ClusterJob>;
  * Represents properties of a os image resource.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "OsImage is a read-only catalog proxy resource exposing available OS images; it has no lifecycle and therefore no provisioningState."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model OsImageProperties {
   /**
@@ -9559,6 +9587,7 @@ model NetworkAdapterConfiguration {
   adapterName?: string;
 
   /** IP address. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ip4Address?: string;
 
   /** Subnet mask. */
@@ -9571,6 +9600,7 @@ model NetworkAdapterConfiguration {
   dnsServers?: string[];
 
   /** IP configuration type (Dhcp or Static). */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipInterfaceType?: IpInterfaceType;
 
   /** VLAN identifier for network segmentation. */
@@ -9592,6 +9622,7 @@ model NetworkAdapterReportedProperties {
   adapterName?: string;
 
   /** IP address. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ip4Address?: string;
 
   /** Subnet mask. */
@@ -9652,6 +9683,7 @@ model NetworkAdapterReportedProperties {
   nicStatus?: string;
 
   /** IP configuration type. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipInterfaceType?: IpInterfaceType;
 

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/models.tsp
@@ -917,6 +917,7 @@ model ExtendedLocation {
   type?: ExtendedLocationTypes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The gallery images resource patch definition.")
 model GalleryImagesUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -954,6 +955,7 @@ model LogicalNetworkProperties {
   networkType?: LogicalNetworkTypeEnum;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("DhcpOptions contains an array of DNS servers available to VMs deployed in the logical network. Standard DHCP option for a subnet overrides logical network DHCP options.")
 model LogicalNetworkPropertiesDhcpOptions {
   @doc("The list of DNS servers IP addresses.")
@@ -1336,6 +1338,7 @@ model LogicalNetworkStatusProvisioningStatus {
   status?: Status;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The logical network resource patch definition.")
 model LogicalNetworksUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -1367,6 +1370,7 @@ model VirtualNetworkAddressSpace {
   addressPrefixes: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_09_01_preview)
 @doc("DHCP options for virtual networks")
 model VirtualNetworkDhcpOptions {
@@ -1823,6 +1827,7 @@ model LoadBalancerStatusProvisioningStatus {
   status?: Status;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The virtual network subnet resource patch definition.")
 @added(Versions.v2025_09_01_preview)
 model VirtualNetworkSubnetUpdateRequest {
@@ -1909,6 +1914,7 @@ model MarketplaceGalleryImageStatusDownloadStatus {
   downloadSizeInMB?: int64;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The marketplace gallery image resource patch definition.")
 model MarketplaceGalleryImagesUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -1916,6 +1922,7 @@ model MarketplaceGalleryImagesUpdateRequest {
   tags?: Record<string>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The network interface resource patch definition.")
 model NetworkInterfacesUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -1992,6 +1999,7 @@ model StorageContainerStatusProvisioningStatus {
   status?: Status;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The storage container resource patch definition.")
 model StorageContainersUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -2211,6 +2219,7 @@ model VirtualHardDiskUploadStatus {
   errorMessage?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The virtual hard disk resource patch definition.")
 model VirtualHardDisksUpdateRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Existing api"
@@ -2646,6 +2655,7 @@ model Identity {
   type?: "SystemAssigned";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The virtual machine instance resource patch definition.")
 model VirtualMachineInstanceUpdateRequest {
   @doc("Defines the resource properties for the update.")
@@ -2826,6 +2836,7 @@ model GuestCredential {
   password?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_04_01_preview)
 @doc("The operation gracefully shuts down a virtual machine by requesting the operating system to shut down. The virtual machine can be restarted with the same provisioned resources. To force an immediate shut down, see the skipShutdown flag.")
 model PowerOffVirtualMachineOptions {

--- a/specification/batch/data-plane/Batch/java-client.tsp
+++ b/specification/batch/data-plane/Batch/java-client.tsp
@@ -11,6 +11,7 @@ using TypeSpec.Http;
 namespace JavaClient;
 
 // Get Application Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Application operation.")
 model BatchApplicationGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -38,6 +39,7 @@ op getApplicationCustomization is Azure.Batch.ReadOperation<
 
 // List Applications Operation
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Applications operation.")
 model BatchApplicationsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -62,6 +64,7 @@ op listApplicationsCustomization is Azure.Batch.ListOperation<
 );
 
 // List Pool Usage Metrics Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Pool Usage Metrics operation.")
 model BatchPoolUsageMetricsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -87,6 +90,7 @@ op listPoolUsageMetricsCustomization is Azure.Batch.ListOperation<
 );
 
 // Create Pool Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Pool operation.")
 model BatchPoolCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -109,6 +113,7 @@ op createPoolCustomization is Azure.Batch.CreateOperation<
 @@override(Azure.Batch.Pools.createPool, createPoolCustomization, "java");
 
 // List Pools Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Pools operation.")
 model BatchPoolsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -130,6 +135,7 @@ op listPoolsCustomization is Azure.Batch.ListOperation<
 @@override(Azure.Batch.Pools.listPools, listPoolsCustomization, "java");
 
 // Delete Pool Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Pool operation.")
 model BatchPoolDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -154,6 +160,7 @@ op deletePoolCustomization is Azure.Batch.DeleteOperation<
 @@override(Azure.Batch.Pools.deletePool, deletePoolCustomization, "java");
 
 // Pool Exists Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Pool Exists operation.")
 model BatchPoolExistsOptions {
   ...Azure.Batch.CommonParameters;
@@ -180,6 +187,7 @@ op poolExistsCustomization is Azure.Batch.ResourceInfoOperationWithAdditionalRes
 @@override(Azure.Batch.Pools.poolExists, poolExistsCustomization, "java");
 
 // Get Pool Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Pool operation.")
 model BatchPoolGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -205,6 +213,7 @@ op getPoolCustomization is Azure.Batch.ReadOperation<
 @@override(Azure.Batch.Pools.getPool, getPoolCustomization, "java");
 
 // Update Pool Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Update Pool operation.")
 model BatchPoolUpdateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -229,6 +238,7 @@ op updatePoolCustomization is Azure.Batch.UpdateOperation<
 @@override(Azure.Batch.Pools.updatePool, updatePoolCustomization, "java");
 
 // Disable Pool Autoscale Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Disable Pool AutoScale operation.")
 model BatchPoolDisableAutoScaleOptions {
   ...Azure.Batch.CommonParameters;
@@ -255,6 +265,7 @@ op disablePoolAutoScaleCustomization is Azure.Batch.PostOperation<
 );
 
 // Enable Pool Autoscale Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Enable Pool AutoScale operation.")
 model BatchPoolEnableAutoScaleOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -283,6 +294,7 @@ op enablePoolAutoScaleCustomization is Azure.Batch.PostOperation<
 );
 
 // Evaluate Pool Autoscale Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Evaluate Pool AutoScale operation.")
 model BatchPoolEvaluateAutoScaleOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -309,6 +321,7 @@ op evaluatePoolAutoScaleCustomization is Azure.Batch.PostOperation<
 );
 
 // Resize Pool Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Resize Pool operation.")
 model BatchPoolResizeOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -333,6 +346,7 @@ op resizePoolCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Pools.resizePool, resizePoolCustomization, "java");
 
 // Stop Pool Resize Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Stop Pool Resize operation.")
 model BatchPoolResizeStopOptions {
   ...Azure.Batch.CommonParameters;
@@ -361,6 +375,7 @@ op stopPoolResizeCustomization is Azure.Batch.PostOperation<
 );
 
 // Replace Pool Properties Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Replace Pool Properties operation.")
 model BatchPoolPropertiesReplaceOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -387,6 +402,7 @@ op replacePoolPropertiesCustomization is Azure.Batch.PostOperation<
 );
 
 // Remove Nodes Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Remove Nodes operation.")
 model BatchNodesRemoveOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -411,6 +427,7 @@ op removeNodesCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Pools.removeNodes, removeNodesCustomization, "java");
 
 // List Supported Images Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Supported Images operation.")
 model SupportedBatchImagesListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -436,6 +453,7 @@ op listSupportedImagesCustomization is Azure.Batch.ListOperation<
 );
 
 // List Pool Node Counts Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Pool Node Counts operation.")
 model BatchPoolNodeCountsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -461,6 +479,7 @@ op listPoolNodeCountsCustomization is Azure.Batch.ListOperation<
 );
 
 // Delete Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Job operation.")
 model BatchJobDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -486,6 +505,7 @@ op deleteJobCustomization is Azure.Batch.DeleteOperation<
 @@override(Azure.Batch.Jobs.deleteJob, deleteJobCustomization, "java");
 
 // Get Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Job operation.")
 model BatchJobGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -511,6 +531,7 @@ op getJobCustomization is Azure.Batch.ReadOperation<
 @@override(Azure.Batch.Jobs.getJob, getJobCustomization, "java");
 
 // Update Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Update Job operation.")
 model BatchJobUpdateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -535,6 +556,7 @@ op updateJobCustomization is Azure.Batch.UpdateOperation<
 @@override(Azure.Batch.Jobs.updateJob, updateJobCustomization, "java");
 
 // Replace Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Replace Job operation.")
 model BatchJobReplaceOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -559,6 +581,7 @@ op replaceJobCustomization is Azure.Batch.ReplaceOperation<
 @@override(Azure.Batch.Jobs.replaceJob, replaceJobCustomization, "java");
 
 // Disable Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Disable Job operation.")
 model BatchJobDisableOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -583,6 +606,7 @@ op disableJobCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Jobs.disableJob, disableJobCustomization, "java");
 
 // Enable Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Enable Job operation.")
 model BatchJobEnableOptions {
   ...Azure.Batch.CommonParameters;
@@ -607,6 +631,7 @@ op enableJobCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Jobs.enableJob, enableJobCustomization, "java");
 
 // Terminate Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Terminate Job operation.")
 model BatchJobTerminateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -632,6 +657,7 @@ op terminateJobCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Jobs.terminateJob, terminateJobCustomization, "java");
 
 // Create Job Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Job operation.")
 model BatchJobCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -654,6 +680,7 @@ op createJobCustomization is Azure.Batch.CreateOperation<
 @@override(Azure.Batch.Jobs.createJob, createJobCustomization, "java");
 
 // List Jobs Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Jobs operation.")
 model BatchJobsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -675,6 +702,7 @@ op listJobsCustomization is Azure.Batch.ListOperation<
 @@override(Azure.Batch.Jobs.listJobs, listJobsCustomization, "java");
 
 // List Jobs From Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Jobs From Schedule operation.")
 model BatchJobsFromScheduleListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -702,6 +730,7 @@ op listJobsFromScheduleCustomization is Azure.Batch.ListOperation<
 );
 
 // List Jobs Preparation and Release Task Status Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Jobs From Schedule operation.")
 model BatchJobPreparationAndReleaseTaskStatusListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -729,6 +758,7 @@ op listJobPreparationAndReleaseTaskStatusCustomization is Azure.Batch.ListOperat
 );
 
 // Get Job Task Counts Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Job Task Counts operation.")
 model BatchJobTaskCountsGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -755,6 +785,7 @@ op getJobTaskCountsCustomization is Azure.Batch.ReadOperation<
 );
 
 // Job Schedule Exists Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Job Schedule Exists operation.")
 model BatchJobScheduleExistsOptions {
   ...Azure.Batch.CommonParameters;
@@ -785,6 +816,7 @@ op jobScheduleExistsCustomization is Azure.Batch.ResourceInfoOperationWithAdditi
 );
 
 // Delete Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Job Schedule operation.")
 model BatchJobScheduleDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -814,6 +846,7 @@ op deleteJobScheduleCustomization is Azure.Batch.DeleteOperation<
 );
 
 // Get Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Job Schedule operation.")
 model BatchJobScheduleGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -843,6 +876,7 @@ op getJobScheduleCustomization is Azure.Batch.ReadOperation<
 );
 
 // Update Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Job Schedule operation.")
 model BatchJobScheduleUpdateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -871,6 +905,7 @@ op updateJobScheduleCustomization is Azure.Batch.UpdateOperation<
 );
 
 // Replace Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Replace Job Schedule operation.")
 model BatchJobScheduleReplaceOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -899,6 +934,7 @@ op replaceJobScheduleCustomization is Azure.Batch.ReplaceOperation<
 );
 
 // Disable Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Disable Job Schedule operation.")
 model BatchJobScheduleDisableOptions {
   ...Azure.Batch.CommonParameters;
@@ -927,6 +963,7 @@ op disableJobScheduleCustomization is Azure.Batch.PostOperation<
 );
 
 // Enable Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Enable Job Schedule operation.")
 model BatchJobScheduleEnableOptions {
   ...Azure.Batch.CommonParameters;
@@ -955,6 +992,7 @@ op enableJobScheduleCustomization is Azure.Batch.PostOperation<
 );
 
 // Terminate Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Terminate Job Schedule operation.")
 model BatchJobScheduleTerminateOptions {
   ...Azure.Batch.CommonParameters;
@@ -984,6 +1022,7 @@ op terminateJobScheduleCustomization is Azure.Batch.PostOperation<
 );
 
 // Create Job Schedule Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Job Schedule operation.")
 model BatchJobScheduleCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1010,6 +1049,7 @@ op createJobScheduleCustomization is Azure.Batch.CreateOperation<
 );
 
 // List Job Schedules Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Job Schedules operation.")
 model BatchJobSchedulesListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -1035,6 +1075,7 @@ op listJobSchedulesCustomization is Azure.Batch.ListOperation<
 );
 
 // Create Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Task operation.")
 model BatchTaskCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1057,6 +1098,7 @@ op createTaskCustomization is Azure.Batch.CreateOperation<
 @@override(Azure.Batch.Tasks.createTask, createTaskCustomization, "java");
 
 // List Tasks Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Tasks operation.")
 model BatchTasksListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -1080,6 +1122,7 @@ op listTasksCustomization is Azure.Batch.ListOperation<
 @@override(Azure.Batch.Tasks.listTasks, listTasksCustomization, "java");
 
 // Create Task Collection Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Task Collection operation.")
 model BatchTaskCollectionCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1106,6 +1149,7 @@ op createTaskCollectionCustomization is Azure.Batch.PostOperation<
 );
 
 // Delete Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Task operation.")
 model BatchTaskDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -1130,6 +1174,7 @@ op deleteTaskCustomization is Azure.Batch.DeleteOperation<
 @@override(Azure.Batch.Tasks.deleteTask, deleteTaskCustomization, "java");
 
 // Get Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Task operation.")
 model BatchTaskGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1155,6 +1200,7 @@ op getTaskCustomization is Azure.Batch.ReadOperation<
 @@override(Azure.Batch.Tasks.getTask, getTaskCustomization, "java");
 
 // Replace Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Replace Task operation.")
 model BatchTaskReplaceOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1179,6 +1225,7 @@ op replaceTaskCustomization is Azure.Batch.ReplaceOperation<
 @@override(Azure.Batch.Tasks.replaceTask, replaceTaskCustomization, "java");
 
 // List SubTasks Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List SubTasks operation.")
 model BatchSubTasksListOptions {
   ...Azure.Batch.CommonParameters;
@@ -1203,6 +1250,7 @@ op listSubTasksCustomization is Azure.Batch.ReadOperation<
 @@override(Azure.Batch.Tasks.listSubTasks, listSubTasksCustomization, "java");
 
 // Terminate Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Terminate Task operation.")
 model BatchTaskTerminateOptions {
   ...Azure.Batch.CommonParameters;
@@ -1227,6 +1275,7 @@ op terminateTaskCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Tasks.terminateTask, terminateTaskCustomization, "java");
 
 // Reactivate Task Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Reactivate Task operation.")
 model BatchTaskReactivateOptions {
   ...Azure.Batch.CommonParameters;
@@ -1255,6 +1304,7 @@ op reactivateTaskCustomization is Azure.Batch.PostOperation<
 );
 
 // Delete Task File Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Task File operation.")
 model BatchTaskFileDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -1282,6 +1332,7 @@ op deleteTaskFileCustomization is Azure.Batch.DeleteOperation<
 );
 
 // Get Task File Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Task File operation.")
 model BatchTaskFileGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1306,6 +1357,7 @@ op getTaskFileCustomization is Azure.Batch.FileOperation<
 @@override(Azure.Batch.Tasks.getTaskFile, getTaskFileCustomization, "java");
 
 // Get Task File Properties Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Task File Properties operation.")
 model BatchTaskFilePropertiesGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1333,6 +1385,7 @@ op getTaskFilePropertiesCustomization is Azure.Batch.HeadFileOperation<
 );
 
 // List Task Files Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Task Files operation.")
 model BatchTaskFilesListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -1356,6 +1409,7 @@ op listTaskFilesCustomization is Azure.Batch.ListOperation<
 @@override(Azure.Batch.Tasks.listTaskFiles, listTaskFilesCustomization, "java");
 
 // Create Node User Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Create Node User operation.")
 model BatchNodeUserCreateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1382,6 +1436,7 @@ op createNodeUserCustomization is Azure.Batch.CreateOperation<
 );
 
 // Delete Node User Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Node User operation.")
 model BatchNodeUserDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -1408,6 +1463,7 @@ op deleteNodeUserCustomization is Azure.Batch.DeleteOperation<
 );
 
 // Replace Node User Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Replace Node User operation.")
 model BatchNodeUserReplaceOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1434,6 +1490,7 @@ op replaceNodeUserCustomization is Azure.Batch.ReplaceOperation<
 );
 
 // Get Node Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Node operation.")
 model BatchNodeGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1457,6 +1514,7 @@ op getNodeCustomization is Azure.Batch.ReadOperation<
 @@override(Azure.Batch.Nodes.getNode, getNodeCustomization, "java");
 
 // Reboot Node Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Reboot Node operation.")
 model BatchNodeRebootOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1480,6 +1538,7 @@ op rebootNodeCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Nodes.rebootNode, rebootNodeCustomization, "java");
 
 // Start Node Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Start Node operation.")
 model BatchNodeStartOptions {
   ...Azure.Batch.CommonParameters;
@@ -1502,6 +1561,7 @@ op startNodeCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Nodes.startNode, startNodeCustomization, "java");
 
 // Deallocate Node Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Deallocate Node operation.")
 model BatchNodeDeallocateOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1529,6 +1589,7 @@ op deallocateNodeCustomization is Azure.Batch.PostOperation<
 );
 
 // Reimage Node Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Reimage Node operation.")
 model BatchNodeReimageOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1552,6 +1613,7 @@ op reimageNodeCustomization is Azure.Batch.PostOperation<
 @@override(Azure.Batch.Nodes.reimageNode, reimageNodeCustomization, "java");
 
 // Disable Node Scheduling Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Disable Node Scheduling operation.")
 model BatchNodeSchedulingDisableOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1579,6 +1641,7 @@ op disableNodeSchedulingCustomization is Azure.Batch.PostOperation<
 );
 
 // Enable Node Scheduling Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Enable Node Scheduling operation.")
 model BatchNodeSchedulingEnableOptions {
   ...Azure.Batch.CommonParameters;
@@ -1605,6 +1668,7 @@ op enableNodeSchedulingCustomization is Azure.Batch.PostOperation<
 );
 
 // Get Node Remote Login Settings Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Node Remote Login Settings operation.")
 model BatchNodeRemoteLoginSettingsGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1631,6 +1695,7 @@ op getNodeRemoteLoginSettingsCustomization is Azure.Batch.ReadOperation<
 );
 
 // Upload Node Logs Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Upload Node Logs operation.")
 model BatchNodeLogsUploadOptions {
   ...Azure.Batch.CommonJsonParameters;
@@ -1657,6 +1722,7 @@ op uploadNodeLogsCustomization is Azure.Batch.PostOperation<
 );
 
 // List Nodes Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Nodes operation.")
 model BatchNodesListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -1680,6 +1746,7 @@ op listNodesCustomization is Azure.Batch.ListOperation<
 @@override(Azure.Batch.Nodes.listNodes, listNodesCustomization, "java");
 
 // Get Node Extension Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Node Extension operation.")
 model BatchNodeExtensionGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1707,6 +1774,7 @@ op getNodeExtensionCustomization is Azure.Batch.ReadOperation<
 );
 
 // List Node Extensions Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Node Extensions operation.")
 model BatchNodeExtensionsListOptions {
   ...Azure.Batch.CommonListParameters;
@@ -1734,6 +1802,7 @@ op listNodeExtensionsCustomization is Azure.Batch.ListOperation<
 );
 
 // Delete Node File Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Delete Node File operation.")
 model BatchNodeFileDeleteOptions {
   ...Azure.Batch.CommonParameters;
@@ -1761,6 +1830,7 @@ op deleteNodeFileCustomization is Azure.Batch.DeleteOperation<
 );
 
 // Get Node File Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Node File operation.")
 model BatchNodeFileGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1785,6 +1855,7 @@ op getNodeFileCustomization is Azure.Batch.FileOperation<
 @@override(Azure.Batch.Nodes.getNodeFile, getNodeFileCustomization, "java");
 
 // Get Node File Properties Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for Get Node File Properties operation.")
 model BatchNodeFilePropertiesGetOptions {
   ...Azure.Batch.CommonParameters;
@@ -1812,6 +1883,7 @@ op getNodeFilePropertiesCustomization is Azure.Batch.HeadFileOperation<
 );
 
 // List Node Files Operation
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional parameters for List Node Files operation.")
 model BatchNodeFilesListOptions {
   ...Azure.Batch.CommonListParameters;

--- a/specification/batch/data-plane/Batch/models.tsp
+++ b/specification/batch/data-plane/Batch/models.tsp
@@ -841,6 +841,7 @@ model BatchSupportedImage {
   @doc("The reference to the Azure Virtual Machine's Marketplace Image.")
   imageReference: BatchVmImageReference;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The type of operating system (e.g. Windows or Linux) of the Image.")
   osType: OSType;
 
@@ -1231,6 +1232,7 @@ model BatchJobSchedule {
   stats?: BatchJobScheduleStatistics;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   Parameters for updating an Azure Batch Job Schedule.
   """)
@@ -1245,6 +1247,7 @@ model BatchJobScheduleUpdateOptions {
   metadata?: BatchMetadataItem[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   Parameters for creating an Azure Batch Job Schedule
   """)
@@ -1901,6 +1904,7 @@ model VirtualMachineConfiguration {
   @doc("The virtual machine extension for the pool. If specified, the extensions mentioned in this configuration will be installed on each node.")
   extensions?: VMExtension[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Settings for the operating system disk of the Virtual Machine.")
   @clientName("OsDisk")
   osDisk?: BatchOsDisk;
@@ -2025,6 +2029,7 @@ model VMExtension {
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "The names of Property types must use camelCase"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("Settings for the operating system disk of the compute node (VM).")
 model BatchOsDisk {
   @doc("Specifies the ephemeral Disk Settings for the operating system disk used by the compute node (VM).")
@@ -2074,6 +2079,7 @@ model NetworkConfiguration {
   @doc("The configuration for endpoints on Compute Nodes in the Batch Pool.")
   endpointConfiguration?: BatchPoolEndpointConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The Public IPAddress configuration for Compute Nodes in the Batch Pool.")
   @clientName("publicIpAddressConfiguration", "!go")
   publicIPAddressConfiguration?: BatchPublicIpAddressConfiguration;
@@ -2131,24 +2137,30 @@ model NetworkSecurityGroupRule {
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "The names of Property types must use camelCase"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("The public IP Address configuration of the networking configuration of a Pool.")
 model BatchPublicIpAddressConfiguration {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The provisioning type for Public IP Addresses for the Pool. The default value is BatchManaged.")
   @clientName("IpAddressProvisioningType")
   provision?: IpAddressProvisioningType;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The IP families used to specify IP versions available to the pool. IP families are used to determine single-stack or dual-stack pools. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6.")
   ipFamilies?: IPFamily[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The list of public IPs which the Batch service will use when provisioning Compute Nodes. The number of IPs specified here limits the maximum size of the Pool - 100 dedicated nodes or 100 Spot/Low-priority nodes can be allocated for each public IP. For example, a pool needing 250 dedicated VMs would need at least 3 public IPs specified. Each element of this collection is of the form: /subscriptions/{subscription}/resourceGroups/{group}/providers/Microsoft.Network/publicIPAddresses/{ip}.")
   ipAddressIds?: Azure.Core.armResourceIdentifier[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("A list of IP tags associated with the public IP addresses of the Pool. IP tags are used to categorize and filter public IP addresses for billing and management purposes.")
   ipTags?: IPTag[];
 }
 
 @doc("Contains the IP tag associated with the public IP address.")
 model IPTag {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The IP Tag type. Example: FirstPartyUsage.")
   ipTagType?: string;
 
@@ -2560,6 +2572,7 @@ model BatchJob {
   stats?: BatchJobStatistics;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for creating an Azure Batch Job.")
 model BatchJobCreateOptions {
   @doc("A string that uniquely identifies the Job within the Account. The ID can contain any combination of alphanumeric characters including hyphens and underscores, and cannot contain more than 64 characters. The ID is case-preserving and case-insensitive (that is, you may not have two IDs within an Account that differ only by case).")
@@ -2614,6 +2627,7 @@ model BatchJobCreateOptions {
   metadata?: BatchMetadataItem[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for updating an Azure Batch Job.")
 model BatchJobUpdateOptions {
   @doc("The priority of the Job. Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority. If omitted, the priority of the Job is left unchanged.")
@@ -2677,12 +2691,14 @@ model BatchJobSchedulingError {
   details?: NameValuePair[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for disabling an Azure Batch Job.")
 model BatchJobDisableOptions {
   @doc("What to do with active Tasks associated with the Job.")
   disableTasks: DisableBatchJobOption;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for terminating an Azure Batch Job.")
 model BatchJobTerminateOptions {
   @doc("The text you want to appear as the Job's TerminationReason. The default is 'UserTerminate'.")
@@ -3021,6 +3037,7 @@ model BatchPool {
   upgradePolicy?: UpgradePolicy;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for creating an Azure Batch Pool.")
 model BatchPoolCreateOptions {
   @doc("A string that uniquely identifies the Pool within the Account. The ID can contain any combination of alphanumeric characters including hyphens and underscores, and cannot contain more than 64 characters. The ID is case-preserving and case-insensitive (that is, you may not have two Pool IDs within an Account that differ only by case).")
@@ -3084,6 +3101,7 @@ model BatchPoolCreateOptions {
   upgradePolicy?: UpgradePolicy;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for replacing properties on an Azure Batch Pool.")
 model BatchPoolReplaceOptions {
   @doc("A Task to run on each Compute Node as it joins the Pool. The Task runs when the Compute Node is added to the Pool or when the Compute Node is restarted. If this element is present, it overwrites any existing StartTask. If omitted, any existing StartTask is removed from the Pool.")
@@ -3096,6 +3114,7 @@ model BatchPoolReplaceOptions {
   metadata: BatchMetadataItem[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for updating an Azure Batch Pool.")
 model BatchPoolUpdateOptions {
   @doc("The display name for the Pool. The display name need not be unique and can contain any Unicode characters up to a maximum length of 1024. This field can be updated only when the pool is empty.")
@@ -3209,6 +3228,7 @@ model BatchPoolListResult {
   `odata.nextLink`?: url;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for enabling automatic scaling on an Azure Batch Pool.")
 model BatchPoolEnableAutoScaleOptions {
   @doc("The formula for the desired number of Compute Nodes in the Pool. The default value is 15 minutes. The minimum and maximum value are 5 minutes and 168 hours respectively. If you specify a value less than 5 minutes or greater than 168 hours, the Batch service rejects the request with an invalid property value error; if you are calling the REST API directly, the HTTP status code is 400 (Bad Request). If you specify a new interval, then the existing autoscale evaluation schedule will be stopped and a new autoscale evaluation schedule will be started, with its starting time being the time when this request was issued.")
@@ -3218,12 +3238,14 @@ model BatchPoolEnableAutoScaleOptions {
   autoScaleEvaluationInterval?: duration;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for evaluating an automatic scaling formula on an Azure Batch Pool.")
 model BatchPoolEvaluateAutoScaleOptions {
   @doc("The formula for the desired number of Compute Nodes in the Pool. The formula is validated and its results calculated, but it is not applied to the Pool. To apply the formula to the Pool, 'Enable automatic scaling on a Pool'. For more information about specifying this formula, see Automatically scale Compute Nodes in an Azure Batch Pool (https://learn.microsoft.com/azure/batch/batch-automatic-scaling).")
   autoScaleFormula: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for changing the size of an Azure Batch Pool.")
 model BatchPoolResizeOptions {
   @doc("The desired number of dedicated Compute Nodes in the Pool.")
@@ -3239,6 +3261,7 @@ model BatchPoolResizeOptions {
   nodeDeallocationOption?: BatchNodeDeallocationOption;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for removing nodes from an Azure Batch Pool.")
 model BatchNodeRemoveOptions {
   @doc("A list containing the IDs of the Compute Nodes to be removed from the specified Pool. A maximum of 100 nodes may be removed per request.")
@@ -3252,6 +3275,7 @@ model BatchNodeRemoveOptions {
   nodeDeallocationOption?: BatchNodeDeallocationOption;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Options for deallocating a Compute Node.")
 model BatchNodeDeallocateOptions {
   @doc("When to deallocate the Compute Node and what to do with currently running Tasks. The default value is requeue.")
@@ -3375,6 +3399,7 @@ model BatchTask {
   applicationPackageReferences?: BatchApplicationPackageReference[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   Parameters for creating an Azure Batch Task.
   """)
@@ -3455,6 +3480,7 @@ model ExitCodeMapping {
   exitOptions: ExitOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Specifies how the Batch service responds to a particular exit condition.")
 model ExitOptions {
   @doc("An action to take on the Job containing the Task, if the Task completes with the given exit condition and the Job's onTaskFailed property is 'performExitOptionsJobAction'. The default is none for exit code 0 and terminate for all other exit conditions. If the Job's onTaskFailed property is noaction, then specifying this property returns an error and the add Task request fails with an invalid property value error; if you are calling the REST API directly, the HTTP status code is 400 (Bad Request).")
@@ -3745,6 +3771,7 @@ model UpgradePolicy {
   mode: UpgradeMode;
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "The names of Property types must use camelCase"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Configuration parameters used for performing automatic OS Upgrade. The configuration parameters used for performing automatic OS upgrade.")
   @clientName("automaticOsUpgradePolicy")
   automaticOSUpgradePolicy?: AutomaticOsUpgradePolicy;
@@ -3753,12 +3780,14 @@ model UpgradePolicy {
   rollingUpgradePolicy?: RollingUpgradePolicy;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("The configuration parameters used for performing automatic OS upgrade.")
 model AutomaticOsUpgradePolicy {
   @doc("Whether OS image rollback feature should be disabled.")
   disableAutomaticRollback?: boolean;
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "The names of Property types must use camelCase"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer version of the OS image becomes available. <br /><br /> If this is set to true for Windows based pools, [WindowsConfiguration.enableAutomaticUpdates](https://learn.microsoft.com/rest/api/batchservice/pools/create-pool#windowsconfiguration) cannot be set to true.")
   @clientName("enableAutomaticOsUpgrade")
   enableAutomaticOSUpgrade?: boolean;
@@ -3766,6 +3795,7 @@ model AutomaticOsUpgradePolicy {
   @doc("Indicates whether rolling upgrade policy should be used during Auto OS Upgrade. Auto OS Upgrade will fallback to the default policy if no policy is defined on the VMSS.")
   useRollingUpgradePolicy?: boolean;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Defer OS upgrades on the TVMs if they are running tasks.")
   osRollingUpgradeDeferral?: boolean;
 }
@@ -3794,6 +3824,7 @@ model RollingUpgradePolicy {
   rollbackFailedInstancesOnPolicyBreach?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for creating a user account for RDP or SSH access on an Azure Batch Compute Node.")
 model BatchNodeUserCreateOptions {
   @doc("The user name of the Account.")
@@ -3813,6 +3844,7 @@ model BatchNodeUserCreateOptions {
   sshPublicKey?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for updating a user account for RDP or SSH access on an Azure Batch Compute Node.")
 model BatchNodeUserUpdateOptions {
   @secret
@@ -3856,6 +3888,7 @@ model BatchNode {
   @visibility(Lifecycle.Read)
   allocationTime: utcDateTime;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The IP address that other Nodes can use to communicate with this Compute Node. Every Compute Node that is added to a Pool is assigned a unique IP address. Whenever a Compute Node is removed from a Pool, all of its local files are deleted, and the IP address is reclaimed and could be reused for new Compute Nodes.")
   @visibility(Lifecycle.Read)
   ipAddress: ipV4Address;
@@ -4002,6 +4035,7 @@ model InboundEndpoint {
   @doc("The protocol of the endpoint.")
   protocol: InboundEndpointProtocol;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The public IP address of the Compute Node.")
   @clientName("publicIpAddress")
   publicIPAddress: ipV4Address;
@@ -4039,6 +4073,7 @@ model VirtualMachineInfo {
   scaleSetVmResourceId?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for rebooting an Azure Batch Compute Node.")
 model BatchNodeRebootOptions {
   @doc("When to reboot the Compute Node and what to do with currently running Tasks. The default value is requeue.")
@@ -4046,12 +4081,14 @@ model BatchNodeRebootOptions {
   nodeRebootOption?: BatchNodeRebootKind;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for reimaging an Azure Batch Compute Node.")
 model BatchNodeReimageOptions {
   @doc("When to reimage the Compute Node and what to do with currently running Tasks. The default value is requeue.")
   nodeReimageOption?: BatchNodeReimageOption;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Parameters for disabling scheduling on an Azure Batch Compute Node.")
 model BatchNodeDisableSchedulingOptions {
   @doc("What to do with currently running Tasks when disabling Task scheduling on the Compute Node. The default value is requeue.")
@@ -4061,6 +4098,7 @@ model BatchNodeDisableSchedulingOptions {
 #suppress "@azure-tools/typespec-azure-core/casing-style" "The names of Property types must use camelCase"
 @doc("The remote login settings for a Compute Node.")
 model BatchNodeRemoteLoginSettings {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The IPv6 address used for remote login to the Compute Node.")
   @clientName("ipv6RemoteLoginIpAddress")
   ipv6RemoteLoginIPAddress?: ipV6Address;
@@ -4068,6 +4106,7 @@ model BatchNodeRemoteLoginSettings {
   @doc("The port used for remote login to the Compute Node.")
   ipv6RemoteLoginPort?: int32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The IP address used for remote login to the Compute Node.")
   @clientName("remoteLoginIpAddress")
   remoteLoginIPAddress: ipV4Address;
@@ -4076,6 +4115,7 @@ model BatchNodeRemoteLoginSettings {
   remoteLoginPort: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The Azure Batch service log files upload parameters for a Compute Node.")
 model UploadBatchServiceLogsOptions {
   @doc("The URL of the container within Azure Blob Storage to which to upload the Batch Service log file(s). If a user assigned managed identity is not being used, the URL must include a Shared Access Signature (SAS) granting write permissions to the container. The SAS duration must allow enough time for the upload to finish. The start time for SAS is optional and recommended to not be specified.")

--- a/specification/billing/resource-manager/Microsoft.Billing/Billing/BillingRequest.tsp
+++ b/specification/billing/resource-manager/Microsoft.Billing/Billing/BillingRequest.tsp
@@ -13,6 +13,7 @@ namespace Microsoft.Billing;
 /**
  * A request submitted by a user to manage billing. Users with an owner role on the scope can approve or decline these requests.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @tenantResource
 model BillingRequest
   is Azure.ResourceManager.ProxyResource<BillingRequestProperties> {

--- a/specification/billing/resource-manager/Microsoft.Billing/Billing/models.tsp
+++ b/specification/billing/resource-manager/Microsoft.Billing/Billing/models.tsp
@@ -5450,6 +5450,7 @@ model UtilizationAggregates {
 /**
  * Savings plan patch request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SavingsPlanUpdateRequest {
   /**
    * Savings plan patch request
@@ -7794,6 +7795,7 @@ model RenewPropertiesResponse {
 /**
  * The request for reservation purchase
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ReservationPurchaseRequest {
   /**
    * The name of sku
@@ -8878,6 +8880,7 @@ model RecipientTransferProperties {
 /**
  * Result of transfer validation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidateTransferListResponse {
   /**
    * The list of transfer validation results.

--- a/specification/billingbenefits/resource-manager/Microsoft.BillingBenefits/BillingBenefits/models.tsp
+++ b/specification/billingbenefits/resource-manager/Microsoft.BillingBenefits/BillingBenefits/models.tsp
@@ -1395,6 +1395,7 @@ model SavingsPlanSummaryCount {
 /**
  * Savings plan patch request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SavingsPlanUpdateRequest {
   /**
    * Savings plan patch request
@@ -1438,6 +1439,7 @@ model SavingsPlanUpdateValidateRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SavingsPlanValidateResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @identifiers(#[])
@@ -1847,6 +1849,7 @@ model Plan {
  * Discounts patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DiscountPatchRequest {
   /**
    * Discounts patch request properties
@@ -2559,6 +2562,7 @@ model MaccPatchRequestProperties {
  * Macc patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MaccPatchRequest {
   /**
    * Macc patch request properties
@@ -2580,6 +2584,7 @@ model MaccList is Azure.Core.Page<Macc>;
 /**
  * Charge shortfall request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ChargeShortfallRequest {
   /**
    * Charge shortfall request properties
@@ -2635,6 +2640,7 @@ model SellerResourceListRequestProperties {
 /**
  * List MACCs under a billing account
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SellerResourceListRequest {
   /**
    * Request properties to list maccs under a billing account
@@ -2946,6 +2952,7 @@ model CreditDimension {
  * Credit patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreditPatchRequest {
   /**
    * Resource tags
@@ -2989,6 +2996,7 @@ model CreditsList is Azure.Core.Page<Credit>;
 /**
  * Request body for the changeSponsor action on a credit.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ChangeSponsorRequest {
   /** Financial code identifying the new sponsor. This is an alphanumeric identifier assigned by the billing system, for example P20567384. */
   @example("P30000001")
@@ -3194,6 +3202,7 @@ model ConditionalCreditProperties {
  * Conditional credit patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ConditionalCreditPatchRequest {
   /**
    * Conditional credit patch request properties
@@ -3389,6 +3398,7 @@ model ContributorConditionalCreditMilestone
 /**
  * ARM not found response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmNotFoundResponse {
   ...Response<404>;
@@ -3397,6 +3407,7 @@ model ArmNotFoundResponse {
 /**
  * Request to validate any benefit.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BenefitValidateRequest {
   /**
    * Defines benefits for validation.
@@ -3419,6 +3430,7 @@ model BenefitValidateModel {
 /**
  * Benefit validate response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BenefitValidateResponse {
   /**
    * Defines benefit validation response for benefits.
@@ -3497,6 +3509,7 @@ model CreditSourceProperties {
  * Credit patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreditSourcePatchRequest {
   /**
    * Resource Tags
@@ -3789,6 +3802,7 @@ union FreeServicesStatus {
  * Free services patch request
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FreeServicesPatchRequest {
   /**
    * Free services patch request properties

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/models.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/models.tsp
@@ -3711,6 +3711,7 @@ model DeploymentVersionChange {
 /**
  * Metrics Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MetricsResponse {
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -3765,6 +3766,7 @@ model Components1Gs0LlpSchemasMetricsresponsePropertiesSeriesItemsPropertiesData
 /**
  * Rankings Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RankingsResponse {
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -3812,6 +3814,7 @@ model RankingsResponseTablesPropertiesItemsMetricsItem {
 /**
  * Continents Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ContinentsResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   continents?: ContinentsResponseContinentsItem[];
@@ -3836,6 +3839,7 @@ model ContinentsResponseCountryOrRegionsItem {
 /**
  * Resources Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourcesResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   endpoints?: ResourcesResponseEndpointsItem[];
@@ -3882,6 +3886,7 @@ model ResourcesResponseCustomDomainsItem {
 /**
  * Waf Metrics Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model WafMetricsResponse {
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -3936,6 +3941,7 @@ model Components18OrqelSchemasWafmetricsresponsePropertiesSeriesItemsPropertiesD
 /**
  * Waf Rankings Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model WafRankingsResponse {
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/certificateregistration/resource-manager/Microsoft.CertificateRegistration/CertificateRegistration/models.tsp
+++ b/specification/certificateregistration/resource-manager/Microsoft.CertificateRegistration/CertificateRegistration/models.tsp
@@ -377,6 +377,7 @@ model CertificateOrderContact {
 /**
  * App Service error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -18,6 +18,7 @@ namespace Microsoft.Chaos;
  * Location header should continue polling until a 200 response is returned.
  * The body reflects the current run state at the time of the poll.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ScenarioRunInProgressResponse {
   ...AcceptedResponse;
 

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -96,6 +96,7 @@ model MultivariateBatchDetectionResultSummary {
   setupInfo: MultivariateBatchDetectionOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Error information that the API returned.")
 @error
 model ErrorResponse {
@@ -127,6 +128,7 @@ model VariableState {
   lastTimestamp?: utcDateTime;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   Detection request for batch inference. This is an asynchronous inference that
   will need another API to get detection results.
@@ -365,6 +367,7 @@ model ModelList {
   nextLink?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request of the last detection.")
 model MultivariateLastDetectionOptions {
   @doc("""

--- a/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
@@ -49,6 +49,7 @@ union TimeGranularity {
   None: "none",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request of the entire or last anomaly detection.")
 model UnivariateDetectionOptions {
   @doc("""
@@ -242,6 +243,7 @@ model UnivariateLastDetectionResult {
   severity?: float32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request of change point detection.")
 model UnivariateChangePointDetectionOptions {
   @doc("""

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -4501,6 +4501,7 @@ model ManagedNetworkSettings {
    * Public IP address assigned to the Azure Firewall.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "'firewallPublicIpAddress' is nullable in 'ManagedNetworkSettings' for backward compatibility with existing API behavior"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   firewallPublicIpAddress?: string | null;
 
@@ -5536,6 +5537,7 @@ model RaiBlockListResult {
  * The list of Cognitive Services RaiBlocklist Items for batch add.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Empty model 'RaiBlocklistItemsBulkAddRequest' preserved for backward compatibility with existing API surface"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @identifiers(#["name"])
 model RaiBlocklistItemsBulkAddRequest is Array<RaiBlocklistItemBulkRequest>;
 
@@ -5708,6 +5710,7 @@ model RaiPolicyListResult {
  * The list of Cognitive Services RaiBlocklist Items Names.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Empty model 'RaiBlocklistItemsBulkDeleteRequest' preserved for backward compatibility with existing API surface"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RaiBlocklistItemsBulkDeleteRequest is Array<string>;
 
 /**
@@ -6085,6 +6088,7 @@ model ConnectivityEndpoints {
   /**
    * The public IP address of the compute instance.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   publicIpAddress?: string;
 

--- a/specification/cognitiveservices/ContentSafety/models.tsp
+++ b/specification/cognitiveservices/ContentSafety/models.tsp
@@ -65,6 +65,7 @@ union AnalyzeImageOutputType {
   FourSeverityLevels: "FourSeverityLevels",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The text analysis request.")
 model AnalyzeTextOptions {
   @doc("The text to be analyzed. We support a maximum of 10k Unicode characters (Unicode code points) in the text of one request.")
@@ -117,6 +118,7 @@ model TextCategoriesAnalysis {
   severity?: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The image analysis request.")
 model AnalyzeImageOptions {
   @doc("The image to be analyzed.")
@@ -196,6 +198,7 @@ model TextBlocklistItem {
   isRegex?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request to add blocklistItems to a text blocklist.")
 model AddOrUpdateTextBlocklistItemsOptions {
   @doc("Array of blocklistItems to add.")
@@ -208,12 +211,14 @@ model AddOrUpdateTextBlocklistItemsResult {
   blocklistItems: TextBlocklistItem[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request to remove blocklistItems from a text blocklist.")
 model RemoveTextBlocklistItemsOptions {
   @doc("Array of blocklistItemIds to remove.")
   blocklistItemIds: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ContentSafety.Versions.v2024_09_01)
 @doc("The request of analyzing potential direct or indirect injection attacks.")
 model ShieldPromptOptions {
@@ -248,6 +253,7 @@ model DocumentInjectionAnalysisResult {
   attackDetected: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ContentSafety.Versions.v2024_09_01)
 @doc("The request of detecting potential protected material present in the given text.")
 model DetectTextProtectedMaterialOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_speech.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_speech.tsp
@@ -58,6 +58,7 @@ union SpeechGenerationResponseFormat {
   pcm: "pcm",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A representation of the request options that control the behavior of a text-to-speech operation.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model SpeechGenerationOptions {
@@ -87,6 +88,7 @@ model SpeechGenerationOptions {
   `model`?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A representation of a response for a text-to-speech operation.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model SpeechGenerationResponse {

--- a/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_transcription.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_transcription.tsp
@@ -52,6 +52,7 @@ union AudioTranscriptionTimestampGranularity {
   segment: "segment",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The configuration information for an audio transcription request.
   """)

--- a/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_translation.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_translation.tsp
@@ -34,6 +34,7 @@ union AudioTranslationFormat {
   vtt: "vtt",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The configuration information for an audio translation request.
   """)

--- a/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/batch.tsp
@@ -38,6 +38,7 @@ model BatchErrorDatum {
 }
 
 /** Defines the request to create a batch. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_Preview)
 model BatchCreateRequest {
   /** The API endpoint used by the batch. */
@@ -57,6 +58,7 @@ model BatchCreateRequest {
 }
 
 /** The requested new batch job. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_07_01_Preview)
 model BatchCreateResponse {
   // Customization note: the status code in OpenAI is 200.

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_chat_extensions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_chat_extensions.tsp
@@ -252,6 +252,7 @@ model UserSecurityContext {
   endUserTenantId?: Azure.Core.uuid;
 
   /** Captures the original client's IP address, accepting both IPv4 and IPv6 formats. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @encodedName("application/json", "source_ip")
   sourceIp?: string;
 }

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -81,6 +81,7 @@ model ChatCompletionsJsonSchemaResponseFormat
 /**
  * Options for streaming response. Only set this when you set `stream: true`.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_09_01_Preview)
 model ChatCompletionStreamOptions {
   /**
@@ -90,6 +91,7 @@ model ChatCompletionStreamOptions {
   includeUsage?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The configuration information for a chat completions request.
   Completions support a wide variety of tasks and generate text that continues from or "completes"

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/completions_create.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/completions_create.tsp
@@ -13,6 +13,7 @@ using Azure.ClientGenerator.Core;
 
 namespace Azure.OpenAI;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The configuration information for a completions request.
   Completions support a wide variety of tasks and generate text that continues from or "completes"

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/authentication.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/authentication.tsp
@@ -37,6 +37,7 @@ union OnYourDataAuthenticationType {
   usernameAndPassword: "username_and_password",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("type")
 @doc("The authentication options for Azure OpenAI On Your Data.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
@@ -45,6 +46,7 @@ model OnYourDataAuthenticationOptions {
   type: OnYourDataAuthenticationType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using an API key.
   """)
@@ -58,6 +60,7 @@ model OnYourDataApiKeyAuthenticationOptions
   key: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using a connection string.
   """)
@@ -72,6 +75,7 @@ model OnYourDataConnectionStringAuthenticationOptions
   connectionString: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using an Elasticsearch key and key ID pair.
   """)
@@ -89,6 +93,7 @@ model OnYourDataKeyAndKeyIdAuthenticationOptions
   keyId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using an Elasticsearch encoded API key.
   """)
@@ -103,6 +108,7 @@ model OnYourDataEncodedApiKeyAuthenticationOptions
   encodedApiKey: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using a username and password.
   """)
@@ -119,6 +125,7 @@ model OnYourDataUsernameAndPasswordAuthenticationOptions
   password: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using access token.
   """)
@@ -133,6 +140,7 @@ model OnYourDataAccessTokenAuthenticationOptions
   accessToken: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using a system-assigned managed identity.
   """)
@@ -143,6 +151,7 @@ model OnYourDataSystemAssignedManagedIdentityAuthenticationOptions
   type: OnYourDataAuthenticationType.systemAssignedManagedIdentity;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The authentication options for Azure OpenAI On Your Data when using a user-assigned managed identity.
   """)

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/azure_cosmosdb_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/azure_cosmosdb_options.tsp
@@ -72,6 +72,7 @@ model AzureCosmosDBChatExtensionParameters {
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "this represents the case-sensitive wire format"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional settings to control how fields are processed when using a configured Azure Cosmos DB resource.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model AzureCosmosDBFieldMappingOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/azure_search_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/azure_search_options.tsp
@@ -70,6 +70,7 @@ model AzureSearchChatExtensionParameters {
   embeddingDependency?: OnYourDataVectorizationSource;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional settings to control how fields are processed when using a configured Azure Search resource.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model AzureSearchIndexFieldMappingOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/elasticsearch_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/elasticsearch_options.tsp
@@ -61,6 +61,7 @@ model ElasticsearchChatExtensionParameters {
   embeddingDependency?: OnYourDataVectorizationSource;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional settings to control how fields are processed when using a configured Elasticsearch® resource.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model ElasticsearchIndexFieldMappingOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/pinecone_options.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/pinecone_options.tsp
@@ -60,6 +60,7 @@ model PineconeChatExtensionParameters {
   embeddingDependency: OnYourDataVectorizationSource;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Optional settings to control how fields are processed when using a configured Pinecone resource.")
 @added(ServiceApiVersions.v2024_02_15_Preview)
 model PineconeFieldMappingOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/vector_search.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/extensions/oyd/vector_search.tsp
@@ -124,6 +124,7 @@ union OnYourDataVectorSearchAuthenticationType {
 /**
  * The authentication options for Azure OpenAI On Your Data vector search.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("type")
 @added(ServiceApiVersions.v2024_05_01_Preview)
 model OnYourDataVectorSearchAuthenticationOptions {
@@ -134,6 +135,7 @@ model OnYourDataVectorSearchAuthenticationOptions {
 /**
  * The authentication options for Azure OpenAI On Your Data when using an API key.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_Preview)
 model OnYourDataVectorSearchApiKeyAuthenticationOptions
   extends OnYourDataVectorSearchAuthenticationOptions {
@@ -147,6 +149,7 @@ model OnYourDataVectorSearchApiKeyAuthenticationOptions
 /**
  * The authentication options for Azure OpenAI On Your Data vector search when using access token.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_05_01_Preview)
 model OnYourDataVectorSearchAccessTokenAuthenticationOptions
   extends OnYourDataVectorSearchAuthenticationOptions {

--- a/specification/cognitiveservices/OpenAI.Inference/models/embeddings_create.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/embeddings_create.tsp
@@ -10,6 +10,7 @@ using Azure.ClientGenerator.Core;
 
 namespace Azure.OpenAI;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   The configuration information for an embeddings request.
   Embeddings measure the relatedness of text strings and are commonly used for search, clustering,

--- a/specification/cognitiveservices/OpenAI.Inference/models/files.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/files.tsp
@@ -107,6 +107,7 @@ union FilePurpose {
   vision: "vision",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The response data from a file list operation.")
 @added(ServiceApiVersions.v2024_07_01_Preview)
 model FileListResponse {

--- a/specification/cognitiveservices/OpenAI.Inference/models/images/images.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/images/images.tsp
@@ -103,6 +103,7 @@ union ImageGenerationResponseFormat {
   base64: "b64_json",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Represents the request data used to generate images.")
 @added(ServiceApiVersions.v2023_06_01_Preview)
 model ImageGenerationOptions {
@@ -267,6 +268,7 @@ model ImageGenerations {
 // version, but not prevent generation of models for older versions.
 
 //@lroStatus
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("A polling status update or final response payload for an image operation.")
 @added(ServiceApiVersions.v2023_06_01_Preview)
 @removed(ServiceApiVersions.v2024_02_15_Preview)

--- a/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/uploads.tsp
@@ -7,6 +7,7 @@ namespace Azure.OpenAI;
 using TypeSpec.Versioning;
 
 /** The request body of an upload creation operation. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_08_01_Preview)
 model CreateUploadRequest {
   /** The name of the file to upload. */
@@ -34,6 +35,7 @@ model CreateUploadRequest {
 }
 
 /** The multipart/form-data request body of a data part addition request for an upload. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_08_01_Preview)
 model AddUploadPartRequest {
   /** The chunk of bytes for this Part. */
@@ -41,6 +43,7 @@ model AddUploadPartRequest {
 }
 
 /** The request body of an upload completion request. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ServiceApiVersions.v2024_08_01_Preview)
 model CompleteUploadRequest {
   /** The ordered list of Part IDs. */

--- a/specification/cognitiveservices/Speech.Transcription/models.tsp
+++ b/specification/cognitiveservices/Speech.Transcription/models.tsp
@@ -53,6 +53,7 @@ model PhraseListProperties {
 }
 
 #suppress "@azure-tools/typespec-autorest/unsupported-multipart-type" "Support streaming input files"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Metadata for a transcription request.")
 model TranscriptionOptions {
   @doc("The URL of the audio to be transcribed. The audio must be shorter than 2 hours in audio duration and smaller than 250 MB in size. If both Audio and AudioUrl are provided, Audio is used.")
@@ -81,6 +82,7 @@ model TranscriptionOptions {
   phraseList?: PhraseListProperties;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The Speaker Diarization settings. Diarization settings must be specified to enable speaker diarization.")
 model TranscriptionDiarizationOptions {
   @doc("Enable speaker diarization. This is automatically set to true when maxSpeakers is specified.")

--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeConversations/models/common.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeConversations/models/common.tsp
@@ -14,6 +14,7 @@ using Azure.Core.Traits;
 namespace Language.Conversations;
 
 /** Error response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse is Azure.Core.Foundations.ErrorResponseBase<Error>;
 

--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeConversationsAuthoring/models/project.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeConversationsAuthoring/models/project.tsp
@@ -509,6 +509,7 @@ model AnalyzeConversationAuthoringProjectAzureResourceIds {
 /**
  * Represents the options for deleting a project deployment.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AnalyzeConversationAuthoringDeleteDeploymentOptions {
   /**
    * Represents the resource IDs to delete the deployment from. If not provided, the deployment will be rolled out from all the resources it is deployed to. If provided, it will delete the deployment only from the specified assigned resources, and leave it for the rest.

--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeDocuments/models/common.models.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeDocuments/models/common.models.tsp
@@ -533,6 +533,7 @@ model AzureContainerFolderDocumentLocation extends DocumentLocation {
 }
 
 /** Error response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse is Azure.Core.Foundations.ErrorResponseBase<Error>;
 

--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeText/models/common.models.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeText/models/common.models.tsp
@@ -366,6 +366,7 @@ model DocumentDetectedLanguage {
 }
 
 /** Error response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse is Azure.Core.Foundations.ErrorResponseBase<Error>;
 

--- a/specification/cognitiveservices/data-plane/LanguageQuestionAnswering/models.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageQuestionAnswering/models.tsp
@@ -260,6 +260,7 @@ union StringIndexType {
 /**
  * Parameters to query a knowledge base.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AnswersOptions {
   /**
    * Exact QnA ID to fetch from the knowledge base, this field takes priority over
@@ -388,6 +389,7 @@ model MetadataRecord {
 /**
  * To configure Answer span prediction feature.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ShortAnswerOptions {
   /**
    * Enable or disable Answer Span prediction.
@@ -586,6 +588,7 @@ model AnswerSpan {
 /**
  * Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse is Azure.Core.Foundations.ErrorResponseBase<Error>;
 
@@ -643,6 +646,7 @@ model InnerErrorModel {
 /**
  * The question and text record parameters to answer.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AnswersFromTextOptions {
   /**
    * User question to query against the given text records.

--- a/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/models.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/models.tsp
@@ -444,6 +444,7 @@ model ProjectSettings {
 /**
  * Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse is Azure.Core.Foundations.ErrorResponseBase<Error>;
 
@@ -606,6 +607,7 @@ model ExportJobResultUrl {
 /**
  * Project assets that need to be imported.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImportJobOptions {
   /**
    * Parameters needed to create the project.
@@ -640,6 +642,7 @@ model Assets {
 }
 
 /** Response payload after synonyms updated successfully. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSynonymsWithNoContentResponse {
   @doc("Status code.")
   @statusCode
@@ -922,6 +925,7 @@ model UpdateQnaSourceRecord {
 /**
  * Boolean flag used to refresh data from the Source.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RefreshSourceOptions {
   /**
    * Boolean flag used to refresh data from the Source.
@@ -930,6 +934,7 @@ model RefreshSourceOptions {
 }
 
 /** A list of QnAs to be updated. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateQnaOptions is UpdateQnaRecord[];
 
 /**
@@ -980,16 +985,19 @@ model FeedbackRecord {
 /**
  * The request has been accepted for processing, but processing has not yet completed.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AcceptedResponse is TypeSpec.Http.AcceptedResponse;
 
 /**
  * There is no content to send for this request, but the headers may be useful.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NoContentResponse is TypeSpec.Http.NoContentResponse;
 
 /**
  * Feedback recorded successfully.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AddFeedBackNoContentResponse is NoContentResponse;
 
 alias ExportJobResponse = AcceptedResponse;

--- a/specification/commerce/resource-manager/Microsoft.Commerce/Commerce/models.tsp
+++ b/specification/commerce/resource-manager/Microsoft.Commerce/Commerce/models.tsp
@@ -140,6 +140,7 @@ model UsageSample {
 /**
  * Describes the format of Error response with a wrapper object
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorObjectResponse {
   /**
@@ -151,6 +152,7 @@ model ErrorObjectResponse {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/communication/Communication.JobRouter/models.tsp
+++ b/specification/communication/Communication.JobRouter/models.tsp
@@ -638,6 +638,7 @@ model SuspendMode extends JobMatchingMode {
   kind: JobMatchingModeKind.suspend;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @access(Access.public, "python")
 @access(Access.public, "java")
 @doc("Request payload for cancelling a job.")
@@ -649,6 +650,7 @@ model CancelJobOptions {
   dispositionCode?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @access(Access.public, "python")
 @access(Access.public, "java")
 @doc("Request payload for completing jobs.")
@@ -657,6 +659,7 @@ model CompleteJobOptions {
   note?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @access(Access.public, "python")
 @access(Access.public, "java")
 @doc("Request payload for closing jobs")
@@ -689,6 +692,7 @@ model RouterJobPositionDetails {
   estimatedWaitTimeMinutes: float64;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request payload for unassigning a job.")
 model UnassignJobOptions {
   @doc("If SuspendMatching is true, then a job is not queued for re-matching with a worker.")
@@ -716,6 +720,7 @@ model AcceptJobOfferResult {
   workerId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @access(Access.public, "python")
 @access(Access.public, "java")
 @doc("Request payload for declining offers.")
@@ -875,6 +880,7 @@ model BestWorkerMode extends DistributionMode {
   kind: DistributionModeKind.bestWorker;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Encapsulates all options that can be passed as parameters for scoring rule with BestWorkerMode.")
 model ScoringRuleOptions {
   @doc("Set batch size when 'isBatchScoringEnabled' is set to true. Defaults to 20 if not configured.")
@@ -1202,6 +1208,7 @@ model WorkerWeightedAllocation {
   workerSelectors: RouterWorkerSelector[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @clientName("ReclassifyJobOptionsInternal", "java")
 @access(Access.internal)
 @doc("Request payload for reclassifying jobs.")
@@ -1212,6 +1219,7 @@ model ReclassifyJobOptions {}
 @doc("Response payload from reclassifying a job.")
 model ReclassifyJobResult {}
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("OK Response payload from reclassifying a job.")
 model ReclassifyJobResultWithOkResponse {
   @doc("Response payload from reclassifying a job.")
@@ -1228,6 +1236,7 @@ model ReclassifyJobResultWithOkResponse {
 @doc("Response payload from closing a job.")
 model CloseJobResult {}
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response payload from closing a job synchronously.")
 model CloseJobResultWithOkResponse {
   @doc("Response after closing a job.")
@@ -1244,6 +1253,7 @@ model CloseJobResultWithOkResponse {
 @doc("Response payload from cancelling a job.")
 model CancelJobResult {}
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("OK Response payload from cancelling a job.")
 model CancelJobResultWithOkResponse {
   @doc("Response after cancelling a job.")
@@ -1260,6 +1270,7 @@ model CancelJobResultWithOkResponse {
 @doc("Response payload from completing a job.")
 model CompleteJobResult {}
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("OK Response payload from completing a job.")
 model CompleteJobResultWithOkResponse {
   @doc("Response after completing a job.")
@@ -1276,6 +1287,7 @@ model CompleteJobResultWithOkResponse {
 @doc("Response payload from declining a job.")
 model DeclineJobOfferResult {}
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("OK Response payload from declining a job.")
 model DeclineJobOfferResultWithOkResponse {
   @doc("Response payload from declining a job.")

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -838,6 +838,7 @@ union ParticipantKind {
   external: "external",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.c2025_04_01_Preview)
 @doc("Request payload for sending a conversation message.")
 model SendConversationMessageOptions {
@@ -855,6 +856,7 @@ model SendConversationMessageResult {
   messageId: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.c2025_04_01_Preview)
 @resource("messages/conversations")
 @doc("Request payload for creating a conversation.")
@@ -1025,6 +1027,7 @@ union MessagePlatformKind {
   whatsApp: "whatsApp",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.c2025_04_01_Preview)
 @doc("Request payload for adding participants to a conversation.")
 model AddParticipantsOptions {
@@ -1032,6 +1035,7 @@ model AddParticipantsOptions {
   participants: ConversationParticipant[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.c2025_04_01_Preview)
 @doc("Request payload for removing participants from a conversation.")
 model RemoveParticipantsOptions {

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/common.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/common.tsp
@@ -116,6 +116,7 @@ model Placement {
  * Additional parameters for Reimaging Non-Ephemeral Virtual Machine.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "For backward compatibility with existing Compute contract naming"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model OSProfileProvisioningData {
   @doc("Specifies the password of the administrator account. <br><br> **Minimum-length (Windows):** 8 characters <br><br> **Minimum-length (Linux):** 6 characters <br><br> **Max-length (Windows):** 123 characters <br><br> **Max-length (Linux):** 72 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\" <br><br> For resetting the password, see [How to reset the Remote Desktop service or its login password in a Windows VM](https://docs.microsoft.com/troubleshoot/azure/virtual-machines/reset-rdp) <br><br> For resetting root password, see [Manage users, SSH, and check or repair disks on Azure Linux VMs using the VMAccess Extension](https://docs.microsoft.com/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection)")
   @secret
@@ -144,5 +145,6 @@ model VirtualMachineReimageParameters {
   /**
    * Specifies information required for reimaging the non-ephemeral OS disk.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osProfile?: OSProfileProvisioningData;
 }

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/models.tsp
@@ -247,6 +247,7 @@ model FlexProperties {
   @maxItems(5)
   vmSizeProfiles: Array<VmSizeProfile>;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The operating system type for the VMs")
   osType: OsType;
 
@@ -745,6 +746,7 @@ model GetOperationStatusResponse {
   results: Array<ResourceOperation>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Static read response for the singleton bulk VM operations proxy endpoint")
 model BulkVmOperationsReadResponse {
   @doc("Fully qualified resource ID for the singleton bulk VM operations proxy resource")
@@ -776,6 +778,7 @@ model CancelOperationsResponse {
 
 // ----------- BulkOperationErrors ---------
 @@identifiers(ListBulkOperationErrorsResponse.value, #[]);
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-07-06-preview`)
 @doc("The response from listing bulk operation errors")
 model ListBulkOperationErrorsResponse is Azure.Core.Page<ResourceOperation>;

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/virtualMachineProfile.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/virtualMachineProfile.tsp
@@ -20,6 +20,7 @@ model BulkactionVMProperties {
   @doc("Specifies additional capabilities enabled or disabled on the virtual machine.")
   additionalCapabilities?: AdditionalCapabilities;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed once VM is provisioned.")
   osProfile?: OSProfile;
 
@@ -107,6 +108,7 @@ model StorageProfile {
   @doc("Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.")
   imageReference?: ImageReference;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).")
   osDisk?: OSDisk;
 
@@ -164,6 +166,7 @@ model ImageReference extends SubResource {
 
 @doc("Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).")
 model OSDisk {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("This property allows you to specify the type of the OS that is included in the disk if creating a VM from user-image or a specialized VHD. Possible values are: Windows, Linux.")
   osType?: OperatingSystemTypes;
 
@@ -954,6 +957,7 @@ model VirtualMachineNetworkInterfaceConfigurationProperties {
   @doc("The dns settings to be applied on the network interfaces.")
   dnsSettings?: VirtualMachineNetworkInterfaceDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the IP configurations of the network interface.")
   @identifiers(#["name"])
   ipConfigurations: VirtualMachineNetworkInterfaceIPConfiguration[];
@@ -1040,6 +1044,7 @@ model VirtualMachinePublicIPAddressConfigurationProperties {
   @doc("The dns settings to be applied on the publicIP addresses .")
   dnsSettings?: VirtualMachinePublicIPAddressDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The list of IP tags associated with the public IP address.")
   @identifiers(#[])
   ipTags?: VirtualMachineIpTag[];
@@ -1067,8 +1072,10 @@ model VirtualMachinePublicIPAddressDnsSettingsConfiguration {
   domainNameLabelScope?: DomainNameLabelScopeTypes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("Contains the IP tag associated with the public IP address.")
 model VirtualMachineIpTag {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("IP tag type. Example: FirstPartyUsage.")
   ipTagType?: string;
 
@@ -1253,6 +1260,7 @@ model ScheduledEventsProfile {
   @doc("Specifies Terminate Scheduled Event related configurations.")
   terminateNotificationProfile?: TerminateNotificationProfile;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies OS Image Scheduled Event related configurations.")
   osImageNotificationProfile?: OSImageNotificationProfile;
 }

--- a/specification/compute/resource-manager/Microsoft.Compute/Recommender/skuMixPlacementModels.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Recommender/skuMixPlacementModels.tsp
@@ -137,6 +137,7 @@ model SkuMixPlacementCapacityProfile {
   allocationStrategy: SkuMixPlacementAllocationStrategy;
 
   /** The OS type. Required when allocationStrategy is LowestPrice because pricing varies by OS. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: SkuMixPlacementOSType;
 
   /** Zone allocation policy. Default: BestEffortBalanced. */

--- a/specification/computebulkactions/ComputeBulkActions.Management/scheduledactionmodel.tsp
+++ b/specification/computebulkactions/ComputeBulkActions.Management/scheduledactionmodel.tsp
@@ -346,6 +346,7 @@ model ExecuteTypeRequest {
   correlationid: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Common model for operation response")
 model OperationResponse {
   @doc("The description of the operation response")

--- a/specification/computebulkactions/ComputeBulkActions.Management/virtualMachineProfile.tsp
+++ b/specification/computebulkactions/ComputeBulkActions.Management/virtualMachineProfile.tsp
@@ -17,6 +17,7 @@ model VirtualMachineProfile {
   @doc("Specifies additional capabilities enabled or disabled on the virtual machine.")
   additionalCapabilities?: AdditionalCapabilities;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed once VM is provisioned.")
   osProfile?: OSProfile;
 
@@ -101,6 +102,7 @@ model StorageProfile {
   @doc("Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.")
   imageReference?: ImageReference;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).")
   osDisk?: OSDisk;
 
@@ -136,6 +138,7 @@ model ImageReference extends SubResource {
 
 @doc("Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).")
 model OSDisk {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("This property allows you to specify the type of the OS that is included in the disk if creating a VM from user-image or a specialized VHD. Possible values are: Windows, Linux.")
   osType?: OperatingSystemTypes;
 
@@ -926,6 +929,7 @@ model VirtualMachineNetworkInterfaceConfigurationProperties {
   @doc("The dns settings to be applied on the network interfaces.")
   dnsSettings?: VirtualMachineNetworkInterfaceDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the IP configurations of the network interface.")
   @identifiers(#["name"])
   ipConfigurations: VirtualMachineNetworkInterfaceIPConfiguration[];
@@ -1012,6 +1016,7 @@ model VirtualMachinePublicIPAddressConfigurationProperties {
   @doc("The dns settings to be applied on the publicIP addresses .")
   dnsSettings?: VirtualMachinePublicIPAddressDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The list of IP tags associated with the public IP address.")
   @identifiers(#[])
   ipTags?: VirtualMachineIpTag[];
@@ -1039,8 +1044,10 @@ model VirtualMachinePublicIPAddressDnsSettingsConfiguration {
   domainNameLabelScope?: DomainNameLabelScopeTypes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("Contains the IP tag associated with the public IP address.")
 model VirtualMachineIpTag {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("IP tag type. Example: FirstPartyUsage.")
   ipTagType?: string;
 
@@ -1225,6 +1232,7 @@ model ScheduledEventsProfile {
   @doc("Specifies Terminate Scheduled Event related configurations.")
   terminateNotificationProfile?: TerminateNotificationProfile;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies OS Image Scheduled Event related configurations.")
   osImageNotificationProfile?: OSImageNotificationProfile;
 }

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/common.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/common.tsp
@@ -154,5 +154,6 @@ model VirtualMachineReimageParameters {
   /**
    * Specifies information required for reimaging the non-ephemeral OS disk.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osProfile?: OSProfileProvisioningData;
 }

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/models.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/models.tsp
@@ -645,6 +645,7 @@ model FlexProperties {
   @maxItems(5)
   vmSizeProfiles: Array<VmSizeProfile>;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The operating system type for the VMs")
   osType: OsType;
 

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/occurrencemodels.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/occurrencemodels.tsp
@@ -85,6 +85,7 @@ model OccurrenceResource is ScheduledActionResource {
 }
 
 @@identifiers(OccurrenceResourceListResponse.value, #[]);
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2025-04-15-preview`)
 model OccurrenceResourceListResponse is Azure.Core.Page<OccurrenceResource>;
 

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/scheduledactionmodels.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/scheduledactionmodels.tsp
@@ -82,6 +82,7 @@ model ScheduledActionResource {
 }
 
 @@identifiers(ResourceListResponse.value, #[]);
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2025-04-15-preview`)
 model ResourceListResponse is Azure.Core.Page<ScheduledActionResource>;
 
@@ -182,6 +183,7 @@ model ScheduledActionsExtensionProperties {
   resourceNotificationSettings?: Array<NotificationProperties>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2025-04-15-preview`)
 @doc("The response from scheduled action resource requests, which contains the status of each resource")
 model ScheduledActionResourceOperationResponse {

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/virtualMachineProfile.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/virtualMachineProfile.tsp
@@ -21,6 +21,7 @@ model BulkActionVMProperties {
   @doc("Specifies additional capabilities enabled or disabled on the virtual machine.")
   additionalCapabilities?: AdditionalCapabilities;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed once VM is provisioned.")
   osProfile?: OSProfile;
 
@@ -1013,6 +1014,7 @@ model VirtualMachineNetworkInterfaceConfigurationProperties {
   @doc("The dns settings to be applied on the network interfaces.")
   dnsSettings?: VirtualMachineNetworkInterfaceDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Specifies the IP configurations of the network interface.")
   @identifiers(#["name"])
   ipConfigurations: VirtualMachineNetworkInterfaceIPConfiguration[];
@@ -1104,6 +1106,7 @@ model VirtualMachinePublicIPAddressConfigurationProperties {
   @doc("The dns settings to be applied on the publicIP addresses .")
   dnsSettings?: VirtualMachinePublicIPAddressDnsSettingsConfiguration;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The list of IP tags associated with the public IP address.")
   @identifiers(#[])
   ipTags?: VirtualMachineIpTag[];
@@ -1132,9 +1135,11 @@ model VirtualMachinePublicIPAddressDnsSettingsConfiguration {
   domainNameLabelScope?: DomainNameLabelScopeTypes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Microsoft.ComputeSchedule.Versions.`2026-04-15-preview`)
 @doc("Contains the IP tag associated with the public IP address.")
 model VirtualMachineIpTag {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("IP tag type. Example: FirstPartyUsage.")
   ipTagType?: string;
 

--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -466,6 +466,7 @@ model AcceptCborHeader {
   accept: "application/cbor";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-03-26`)
 @doc("Response containing COSE_Key_Set (array of COSE_Key maps) in CBOR format")
 model ScittKeysResponse {
@@ -478,6 +479,7 @@ model ScittKeysResponse {
   body: bytes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.`2026-03-26`)
 @doc("Response containing a single COSE_Key (map, not array) in CBOR format")
 model ScittKeyResponse {

--- a/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/models.tsp
+++ b/specification/confidentialledger/resource-manager/Microsoft.ConfidentialLedger/ConfidentialLedger/models.tsp
@@ -426,6 +426,7 @@ model ConfidentialLedgerRestore {
 /**
  * Object representing the restore response of a Confidential Ledger Resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @removed(Versions.v2026_02_23)
 model ConfidentialLedgerRestoreResponse {
   /**
@@ -561,6 +562,7 @@ model ManagedCCFBackup {
  * Object representing the backup response of a Managed CCF Resource.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @removed(Versions.v2026_02_23)
 model ManagedCCFBackupResponse {
   /**
@@ -597,6 +599,7 @@ model ManagedCCFRestore {
  * Object representing the restore response of a Managed CCF Resource.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @removed(Versions.v2026_02_23)
 model ManagedCCFRestoreResponse {
   /**

--- a/specification/confluent/resource-manager/Microsoft.Confluent/Confluent/models.tsp
+++ b/specification/confluent/resource-manager/Microsoft.Confluent/Confluent/models.tsp
@@ -303,6 +303,7 @@ model ConfluentAgreementProperties {
 /**
  * Default error response for resource provider
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ResourceProviderDefaultErrorResponse {
   /**
@@ -1220,6 +1221,7 @@ model AccessRoleBindingNameListSuccessResponse {
 /**
  * Result of GET request to list Confluent operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetEnvironmentsResponse is Azure.Core.Page<SCEnvironmentRecord>;
 
 /**
@@ -1282,6 +1284,7 @@ model SCMetadataEntity {
 /**
  * Result of GET request to list clusters in the environment of a confluent organization
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListClustersSuccessResponse is Azure.Core.Page<SCClusterRecord>;
 
 /**
@@ -1426,6 +1429,7 @@ model SCClusterByokEntity {
 /**
  * Result of GET request to list schema registry clusters in the environment of a confluent organization
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListSchemaRegistryClustersResponse
   is Azure.Core.Page<SchemaRegistryClusterRecord>;
 
@@ -1825,11 +1829,13 @@ model PartnerInfoBase {
 /**
  * Result of GET request to list connectors in the cluster of a confluent organization
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListConnectorsSuccessResponse is Azure.Core.Page<ConnectorResource>;
 
 /**
  * Result of GET request to list topics in the cluster of a confluent organization
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListTopicsSuccessResponse is Azure.Core.Page<TopicRecord>;
 
 /**
@@ -2570,6 +2576,7 @@ model AccessPointProperties {
  * SaaS guid & PublisherId for Activate and Validate SaaS Resource
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is an established abbreviation"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.Confluent.Versions.v2026_06_02_preview)
 model ActivateSaaSParameterRequest {
   /**
@@ -2587,6 +2594,7 @@ model ActivateSaaSParameterRequest {
  * Marketplace SaaS resource details.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is an established abbreviation"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.Confluent.Versions.v2026_06_02_preview)
 model SaaSResourceDetailsResponse
   is Azure.ResourceManager.CommonTypes.ProxyResource {
@@ -2613,6 +2621,7 @@ model SaaSData {
  * Response of get latest linked SaaS resource operation
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is an established abbreviation"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Microsoft.Confluent.Versions.v2026_06_02_preview)
 model LatestLinkedSaaSResponse {
   /**

--- a/specification/connectedcache/resource-manager/Microsoft.ConnectedCache/ConnectedCache/models.tsp
+++ b/specification/connectedcache/resource-manager/Microsoft.ConnectedCache/ConnectedCache/models.tsp
@@ -155,6 +155,7 @@ union MccIssueType {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @removed(Versions.v2024_11_30_preview)
 @doc("Model representing Cache Node for ConnectedCache resource")
 model CacheNodeOldResponse {
@@ -287,6 +288,7 @@ model CustomerEntity {
 
 @doc("Model representing customer for connected cache resource")
 model AdditionalCustomerProperties {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Customer resource last PeeringDB update timestamp.")
   @visibility(Lifecycle.Read)
   @removed(Versions.v2024_11_30_preview)

--- a/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/models.tsp
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/models.tsp
@@ -1602,6 +1602,7 @@ model ReservationRecommendationDetailsUsageProperties {
  *
  *  * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the "Retry-After" header.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model HighCasedErrorResponse {
   /**

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/models.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/models.tsp
@@ -17,6 +17,7 @@ namespace Microsoft.ContainerInstance;
  * Response for network dependencies, always empty list.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "For backward compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NetworkDependenciesResponse is string[];
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/aimodel.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/aimodel.tsp
@@ -60,12 +60,14 @@ model ModelSpec {
 }
 
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Reserved as an extensibility envelope so future versions can add optional filters without changing the SDK method signature."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_02_preview)
 @doc("Request body for the AI model `calculateCost` action.")
 model CalculateCostRequest {
   // intentionally empty for v1; future versions may add filters
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_02_preview)
 @doc("Response body for the AI model `calculateCost` action.")
 model CalculateCostResponse {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -228,6 +228,7 @@ model ManagedClusterAgentPoolProfileProperties {
    * Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   enableNodePublicIP?: boolean;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -1707,6 +1707,7 @@ model NodeImageVersion {
   /**
    * The operating system of the node image. Example: AKSUbuntu
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   os?: string;
 
   /**
@@ -2645,6 +2646,7 @@ model BastionProfile {
    *
    * This field cannot be updated. To change IP address after creation, please disable and re-enable the managed bastion with the new public IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Create, Lifecycle.Read)
   publicIpAddressId?: Azure.Core.armResourceIdentifier<[
     {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/FlexNodeBootstrap.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/FlexNodeBootstrap.tsp
@@ -192,5 +192,6 @@ model BootstrapKubeletConfig {
  * Empty request body for listing FlexNode bootstrap data.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "The POST action accepts an empty JSON object for forward-compatible request shape."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_02_preview)
 model ListBootstrapDataRequest {}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/Machine.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/Machine.tsp
@@ -513,6 +513,7 @@ model MachineNetworkProperties {
    * Whether the machine is allocated its own public IP. Some scenarios may require the machine to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. The default is false.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_05_02_preview)
   enableNodePublicIP?: boolean;
 
@@ -520,6 +521,7 @@ model MachineNetworkProperties {
    * The public IP prefix ID which VM node should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_05_02_preview)
   nodePublicIPPrefixID?: Azure.Core.armResourceIdentifier<[
     {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MeshMembership.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MeshMembership.tsp
@@ -160,6 +160,7 @@ model MeshMembershipPrivateConnectProfile {
   /**
    * The private IP address of the member cluster private FQDN. This is a read-only property populated by the service.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   privateIpAddress?: string;
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/PrivateEndpointConnection.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/PrivateEndpointConnection.tsp
@@ -100,6 +100,7 @@ interface PrivateEndpointConnectionsOps
 /**
  * Async 200 OK response for delete with LRO polling headers.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Resource deleted successfully.")
 model PrivateEndpointConnectionDeleteOkResponse {
   ...OkResponse;

--- a/specification/cosmos-db/data-plane/Tables/models.tsp
+++ b/specification/cosmos-db/data-plane/Tables/models.tsp
@@ -108,6 +108,7 @@ alias EtagResponseHeader = {
 /**
  * The properties for the table query response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TableQueryResponse {
   /**
    * The metadata response of the table.
@@ -160,6 +161,7 @@ model TableProperties {
 /**
  * The properties for the table entity query response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TableEntityQueryResponse {
   /**
    * The metadata response of the table.
@@ -388,6 +390,7 @@ model TablesError {
 /// Conditional responses
 
 /** The table properties as returned in an echo response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TableResponse {
   ...TableProperties;
 
@@ -401,6 +404,7 @@ model TableResponse {
 }
 
 /** Create table successful response with content */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateTableEchoResponse {
   /** 201 Created. Includes echo response */
   @statusCode statusCode: 201;
@@ -424,6 +428,7 @@ model CreateTableEchoResponse {
 }
 
 /** Create table response with no content */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateTableResponse {
   /** 204 No Content. Response with no echo. */
   @statusCode statusCode: 204;
@@ -439,6 +444,7 @@ model CreateTableResponse {
 }
 
 /** Insert entity successful response with content */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InsertEntityEchoResponse {
   /** 201 Created. Includes echo response */
   @statusCode statusCode: 201;
@@ -464,6 +470,7 @@ model InsertEntityEchoResponse {
 }
 
 /** Insert entity response with no content */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InsertEntityResponse {
   /** 204 No Content. Response with no echo. */
   @statusCode statusCode: 204;

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -113,6 +113,7 @@ model GarnetClusterResourceProperties {
 /** Endpoint for clients to connect to the cluster. */
 model GarnetClusterResourcePropertiesEndPointsItem {
   /** Ipv4 address of the endpoint. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 
   /** Port number. */
@@ -1369,6 +1370,7 @@ enum RoleDefinitionType {
  * Chaos Fault List Response.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_04_01_preview)
 model chaosFaultListResponse is Azure.Core.Page<chaosFaultResource>;
 
@@ -5194,6 +5196,7 @@ model TableResource {
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TableGetPropertiesOptions extends OptionsResource {}
 
 /**

--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/models.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/models.tsp
@@ -1428,6 +1428,7 @@ model CostAllocationProportion {
 /**
  * The cost allocation rule check name availability request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CostAllocationRuleCheckNameAvailabilityRequest {
   /**
    * Rule name
@@ -1443,6 +1444,7 @@ model CostAllocationRuleCheckNameAvailabilityRequest {
 /**
  * The cost allocation rule check name availability response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CostAllocationRuleCheckNameAvailabilityResponse {
   /**
    * Whether this rule name is available
@@ -2645,6 +2647,7 @@ model BlobInfo {
  *
  *  * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the "Retry-After" header.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model GenerateCostDetailsReportErrorResponse {
   /**
@@ -2736,6 +2739,7 @@ model DownloadURL {
  *
  *  * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the "Retry-After" header.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model GenerateDetailedCostReportErrorResponse {
   /**
@@ -4715,6 +4719,7 @@ model ViewListResult {
 /**
  * Error response indicates that the service is not able to process the incoming request. The reason is provided in the error message. \n\nSome Error responses: \n\n * 429 TooManyRequests - Request is throttled. Retry after waiting for the time specified in the \"x-ms-ratelimit-microsoft.consumption-retry-after\" header. \n\n * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the \"Retry-After\" header.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/dashboard/resource-manager/Microsoft.Dashboard/Dashboard/models.tsp
+++ b/specification/dashboard/resource-manager/Microsoft.Dashboard/Dashboard/models.tsp
@@ -188,6 +188,7 @@ union ManagedPrivateEndpointConnectionStatus {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ManagedGrafanaListResponse is Azure.Core.Page<ManagedGrafana>;
 
 /**
@@ -790,6 +791,7 @@ model GrafanaAvailablePlugin {
 /**
  * The list of managed private endpoints of a grafana resource
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ManagedPrivateEndpointModelListResponse
   is Azure.Core.Page<ManagedPrivateEndpointModel>;
 
@@ -877,6 +879,7 @@ model ManagedPrivateEndpointUpdateParameters {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model IntegrationFabricListResponse is Azure.Core.Page<IntegrationFabric>;
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -928,6 +931,7 @@ model IntegrationFabricPropertiesUpdateParameters {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ManagedDashboardListResponse is Azure.Core.Page<ManagedDashboard>;
 
 /**
@@ -970,6 +974,7 @@ model ResourceSku {
 /**
  * The list response for dashboard definitions.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_09_01_preview)
 model DashboardDefinitionListResponse is Azure.Core.Page<DashboardDefinition>;
 

--- a/specification/databasefleetmanager/resource-manager/Microsoft.DatabaseFleetManager/DatabaseFleetManager/models.tsp
+++ b/specification/databasefleetmanager/resource-manager/Microsoft.DatabaseFleetManager/DatabaseFleetManager/models.tsp
@@ -304,12 +304,14 @@ model FirewallRuleProperties {
   /**
    * Start IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read, Lifecycle.Create)
   startIpAddress?: string;
 
   /**
    * End IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read, Lifecycle.Create)
   endIpAddress?: string;
 

--- a/specification/databasewatcher/resource-manager/Microsoft.DatabaseWatcher/DatabaseWatcher/sqlDbDatabaseTarget.tsp
+++ b/specification/databasewatcher/resource-manager/Microsoft.DatabaseWatcher/DatabaseWatcher/sqlDbDatabaseTarget.tsp
@@ -15,6 +15,7 @@ model SqlDbSingleDatabaseTargetProperties extends TargetProperties {
   @doc("The Azure SQL DB single database target.")
   targetType: "SqlDb";
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The Azure resource ID of an Azure SQL DB database target.")
   sqlDbResourceId: armResourceIdentifier<[
     {

--- a/specification/databox/resource-manager/Microsoft.DataBox/DataBox/models.tsp
+++ b/specification/databox/resource-manager/Microsoft.DataBox/DataBox/models.tsp
@@ -2204,6 +2204,7 @@ model RegionConfigurationResponse {
 /**
  * Schedule availability for given sku in a region.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ScheduleAvailabilityResponse {
   /**
    * List of dates available to schedule
@@ -2215,6 +2216,7 @@ model ScheduleAvailabilityResponse {
 /**
  * Transport options available for given sku in a region.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TransportAvailabilityResponse {
   /**
    * List of transport availability details for given region
@@ -2238,6 +2240,7 @@ model TransportAvailabilityDetails {
 /**
  * Device capabilities for given sku in a region
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DeviceCapabilityResponse {
   /**
    * List of device capabilities available for a given region and a given sku

--- a/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/models.tsp
+++ b/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/models.tsp
@@ -3702,6 +3702,7 @@ model RawCertificateData {
 /**
  * The upload registration certificate response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UploadCertificateResponse {
   /**
    * Specifies authentication type.
@@ -3967,6 +3968,7 @@ model ComputeResource {
 /**
  * Resource Move details
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataBoxEdgeMoveRequest {
   /**
    * Target resource group ARMId
@@ -4491,6 +4493,7 @@ model LoadBalancerConfig {
   /**
    * Load balancer ipconfig
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipRange?: string[];
 }
 

--- a/specification/databricks/resource-manager/Microsoft.Databricks/Databricks/models.tsp
+++ b/specification/databricks/resource-manager/Microsoft.Databricks/Databricks/models.tsp
@@ -569,6 +569,7 @@ model WorkspaceCustomParameters {
   /**
    * Boolean indicating whether the public IP should be disabled. Default value is true. Not allowed in Serverless ComputeMode workspace.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   enableNoPublicIp?: WorkspaceNoPublicIPBooleanParameter;
 
   /**
@@ -589,6 +590,7 @@ model WorkspaceCustomParameters {
   /**
    * Name of the Public IP for No Public IP workspace with managed vNet. Not allowed in Serverless ComputeMode workspace.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   publicIpName?: WorkspaceCustomStringParameter;
 
   /**
@@ -1113,6 +1115,7 @@ model Resource {
 /**
  * Contains details when the response code indicates an error.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -1297,6 +1300,7 @@ model EndpointDetail {
   /**
    * An IP Address that Domain Name currently resolves to.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 
   /**

--- a/specification/datadog/resource-manager/Microsoft.Datadog/Datadog/models.tsp
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/Datadog/models.tsp
@@ -169,6 +169,7 @@ union Status {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DatadogAgreementResourceListResponse
   is Azure.Core.Page<DatadogAgreementResource>;
 
@@ -307,6 +308,7 @@ model DatadogApplicationKey {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DatadogApiKeyListResponse is Azure.Core.Page<DatadogApiKey>;
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -336,6 +338,7 @@ model DatadogApiKey {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DatadogHostListResponse is Azure.Core.Page<DatadogHost>;
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -401,6 +404,7 @@ model DatadogLogsAgent {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LinkedResourceListResponse is Azure.Core.Page<LinkedResource>;
 
 /**
@@ -421,6 +425,7 @@ model LinkedResource {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoredResourceListResponse is Azure.Core.Page<MonitoredResource>;
 
 /**
@@ -501,6 +506,7 @@ model OperationDisplay {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DatadogMonitorResourceListResponse
   is Azure.Core.Page<DatadogMonitorResource>;
 
@@ -875,6 +881,7 @@ model DatadogSetPasswordLink {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoringTagRulesListResponse is Azure.Core.Page<MonitoringTagRules>;
 
 /**
@@ -984,6 +991,7 @@ model AgentRules {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DatadogSingleSignOnResourceListResponse
   is Azure.Core.Page<DatadogSingleSignOnResource>;
 

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/models.tsp
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/models.tsp
@@ -3283,6 +3283,7 @@ enum DayOfWeek {
 }
 
 /** A list of operations that can be performed by the Data Factory service. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OperationListResponse {
   /** List of Data Factory operations supported by the Data Factory resource provider. */
   @pageItems
@@ -3976,6 +3977,7 @@ model SubResource {
 /**
  * Update integration runtime request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateIntegrationRuntimeRequest {
   /**
    * Enables or disables the auto-update feature of the self-hosted integration runtime. See https://go.microsoft.com/fwlink/?linkid=854189.
@@ -5920,6 +5922,7 @@ model PrivateLinkConnectionApprovalRequestResource extends SubResource {
 /**
  * A request to approve or reject a private endpoint connection
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PrivateLinkConnectionApprovalRequest {
   /**
    * The state of a private link connection
@@ -6400,6 +6403,7 @@ model AzureKeyVaultSecretReference extends SecretBase {
 /**
  * A list of integration runtime status.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model IntegrationRuntimeStatusListResponse
   is Azure.Core.Page<IntegrationRuntimeStatusResponse>;
 
@@ -6509,6 +6513,7 @@ model DatasetReference {
 /**
  * Response body structure for get data factory operation status.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetDataFactoryOperationStatusResponse {
   ...Record<unknown>;
 
@@ -7869,6 +7874,7 @@ model CosmosDbSqlApiCollectionDataset extends Dataset {
 /**
  * CosmosDB (SQL API) Collection dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbSqlApiCollectionDatasetTypeProperties {
   /**
    * CosmosDB (SQL API) collection name. Type: string (or Expression with resultType string).
@@ -7894,6 +7900,7 @@ model DocumentDbCollectionDataset extends Dataset {
 /**
  * DocumentDB Collection dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DocumentDbCollectionDatasetTypeProperties {
   /**
    * Document Database collection name. Type: string (or Expression with resultType string).
@@ -8161,6 +8168,7 @@ model MongoDbCollectionDataset extends Dataset {
 /**
  * MongoDB database dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbCollectionDatasetTypeProperties {
   /**
    * The table name of the MongoDB database. Type: string (or Expression with resultType string).
@@ -8186,6 +8194,7 @@ model MongoDbAtlasCollectionDataset extends Dataset {
 /**
  * MongoDB Atlas database dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbAtlasCollectionDatasetTypeProperties {
   /**
    * The collection name of the MongoDB Atlas database. Type: string (or Expression with resultType string).
@@ -8211,6 +8220,7 @@ model MongoDbV2CollectionDataset extends Dataset {
 /**
  * MongoDB database dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbV2CollectionDatasetTypeProperties {
   /**
    * The collection name of the MongoDB database. Type: string (or Expression with resultType string).
@@ -8236,6 +8246,7 @@ model CosmosDbMongoDbApiCollectionDataset extends Dataset {
 /**
  * CosmosDB (MongoDB API) database dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbMongoDbApiCollectionDatasetTypeProperties {
   /**
    * The collection name of the CosmosDB (MongoDB API) database. Type: string (or Expression with resultType string).
@@ -8433,6 +8444,7 @@ model AmazonRedshiftTableDatasetTypeProperties {
 /**
  * The Db2 table dataset.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model Db2TableDataset extends Dataset {
   /**
    * Db2 table dataset properties.
@@ -8448,6 +8460,7 @@ model Db2TableDataset extends Dataset {
 /**
  * Db2 table dataset properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model Db2TableDatasetTypeProperties {
   /**
    * This property will be retired. Please consider using schema + table properties instead.
@@ -12134,6 +12147,7 @@ model CosmosDbLinkedService extends LinkedService {
 /**
  * CosmosDB linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbLinkedServiceTypeProperties {
   /**
    * The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
@@ -13361,6 +13375,7 @@ model SybaseLinkedServiceTypeProperties {
 /**
  * Linked service for DB2 data source.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model Db2LinkedService extends LinkedService {
   /**
    * DB2 linked service properties.
@@ -13376,6 +13391,7 @@ model Db2LinkedService extends LinkedService {
 /**
  * DB2 linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model Db2LinkedServiceTypeProperties {
   /**
    * The connection string. It is mutually exclusive with server, database, authenticationType, userName, packageCollection and certificateCommonName property. Type: string, SecureString or AzureKeyVaultSecretReference.
@@ -14074,6 +14090,7 @@ model MongoDbLinkedService extends LinkedService {
 /**
  * MongoDB linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbLinkedServiceTypeProperties {
   /**
    * The IP address or server name of the MongoDB server. Type: string (or Expression with resultType string).
@@ -14145,6 +14162,7 @@ model MongoDbAtlasLinkedService extends LinkedService {
 /**
  * MongoDB Atlas linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbAtlasLinkedServiceTypeProperties {
   /**
    * The MongoDB Atlas connection string. Type: string, SecureString or AzureKeyVaultSecretReference. Type: string, SecureString or AzureKeyVaultSecretReference.
@@ -14180,6 +14198,7 @@ model MongoDbV2LinkedService extends LinkedService {
 /**
  * MongoDB linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MongoDbV2LinkedServiceTypeProperties {
   /**
    * The MongoDB connection string. Type: string, SecureString or AzureKeyVaultSecretReference. Type: string, SecureString or AzureKeyVaultSecretReference.
@@ -14210,6 +14229,7 @@ model CosmosDbMongoDbApiLinkedService extends LinkedService {
 /**
  * CosmosDB (MongoDB API) linked service properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbMongoDbApiLinkedServiceTypeProperties {
   /**
    * Whether the CosmosDB (MongoDB API) server version is higher than 3.2. The default value is false. Type: boolean (or Expression with resultType boolean).
@@ -21551,6 +21571,7 @@ model MicrosoftAccessSource extends CopySource {
  * A copy activity source for Db2 databases.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(TabularSource)
 model Db2Source extends CopySource {
   ...TabularSourceProperties;

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationCosmosDbMongo.tsp
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationCosmosDbMongo.tsp
@@ -13,6 +13,7 @@ namespace Microsoft.DataMigration;
 /**
  * Database Migration Resource for Mongo to CosmosDb.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DatabaseMigrationCosmosDbMongo
   is Azure.ResourceManager.ProxyResource<DatabaseMigrationPropertiesCosmosDbMongo> {
   ...ResourceNameParameter<

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlDb.tsp
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlDb.tsp
@@ -36,6 +36,7 @@ alias DatabaseMigrationSqlDbOps = Azure.ResourceManager.Legacy.ExtensionOperatio
     providerNamespace: "Microsoft.Sql";
 
     /** The name of the target SQL DB instance. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("servers")
     @key
@@ -46,6 +47,7 @@ alias DatabaseMigrationSqlDbOps = Azure.ResourceManager.Legacy.ExtensionOperatio
     ...Extension.ExtensionProviderNamespace<DatabaseMigrationSqlDb>;
 
     /** The name of the target database. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("databaseMigrations")
     @key
@@ -66,6 +68,7 @@ alias DatabaseMigrationSqlDbOpsWithPattern = Azure.ResourceManager.Legacy.Extens
     providerNamespace: "Microsoft.Sql";
 
     /** The name of the target SQL DB instance. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("servers")
     @key
@@ -77,6 +80,7 @@ alias DatabaseMigrationSqlDbOpsWithPattern = Azure.ResourceManager.Legacy.Extens
     ...Extension.ExtensionProviderNamespace<DatabaseMigrationSqlDb>;
 
     /** The name of the target database. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("databaseMigrations")
     @key

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlMi.tsp
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlMi.tsp
@@ -46,6 +46,7 @@ alias DatabaseMigrationSqlMiOps = Azure.ResourceManager.Legacy.ExtensionOperatio
     ...Extension.ExtensionProviderNamespace<DatabaseMigrationSqlMi>;
 
     /** The name of the target database. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("databaseMigrations")
     @key

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlVm.tsp
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/DatabaseMigrationSqlVm.tsp
@@ -46,6 +46,7 @@ alias DatabaseMigrationSqlVmOps = Azure.ResourceManager.Legacy.ExtensionOperatio
     ...Extension.ExtensionProviderNamespace<DatabaseMigrationSqlVm>;
 
     /** The name of the target database. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @path
     @segment("databaseMigrations")
     @key

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/models.tsp
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/models.tsp
@@ -2077,6 +2077,7 @@ enum ServerLevelPermissionsGroup {
  * Database Migration Resource properties for CosmosDb for Mongo.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DatabaseMigrationPropertiesCosmosDbMongo
   extends DatabaseMigrationBaseProperties {
   /**
@@ -3099,6 +3100,7 @@ model DatabaseMigrationBaseListResult is Azure.Core.Page<DatabaseMigrationBase>;
 /**
  * The response of a DatabaseMigrationCosmosDbMongo list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DatabaseMigrationCosmosDbMongoListResult
   is Azure.Core.Page<DatabaseMigrationCosmosDbMongo>;
 
@@ -3556,6 +3558,7 @@ model ServiceSku {
 /**
  * Service health status
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataMigrationServiceStatusResponse {
   /**
    * The DMS instance agent version
@@ -6562,6 +6565,7 @@ model MigrateSqlServerSqlDbSyncDatabaseInput {
 /**
  * Types of validations to run after the migration
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MigrationValidationOptions {
   /**
    * Allows to compare the schema information between source and target.
@@ -11138,6 +11142,7 @@ model DataMigrationProjectMetadata {
   /**
    * Target database name
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   targetDbName?: string;
 

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/models.tsp
@@ -2846,6 +2846,7 @@ model AzureBackupFindRestorableTimeRangesRequestResource
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DppWorkerRequest {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   subscriptionId?: string;

--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/UserSession.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/UserSession.tsp
@@ -130,6 +130,7 @@ interface UserSessions {
 /**
  * Request body for sending a message to a UserSession.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SendMessageRequest {
   /**
    * Represents message sent to a UserSession.

--- a/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/AdooAuthResponse.tsp
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/AdooAuthResponse.tsp
@@ -13,6 +13,7 @@ namespace Microsoft.DevHub;
 /**
  * Singleton response of ADO OAuth.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @singleton("default")
 @subscriptionResource
 model AdooAuthResponse is Azure.ResourceManager.ProxyResource<ADOOAuth> {

--- a/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/GitHubOAuthResponse.tsp
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/GitHubOAuthResponse.tsp
@@ -14,6 +14,7 @@ namespace Microsoft.DevHub;
  * Singleton response of GitHubOAuth containing
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @singleton("default")
 @subscriptionResource
 model GitHubOAuthResponse

--- a/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/models.tsp
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/models.tsp
@@ -1519,6 +1519,7 @@ model ADOOAuth {
 /**
  * The response from List ADOOAuth operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AdooAuthListResponse is Azure.Core.Page<AdooAuthResponse>;
 
 /**

--- a/specification/deviceregistry/DeviceRegistry.Management/namespaces.tsp
+++ b/specification/deviceregistry/DeviceRegistry.Management/namespaces.tsp
@@ -104,6 +104,7 @@ model NamespaceMigrateRequest {
   resourceIds?: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_07_01_preview)
 @doc("Response for the migrate asset resources operation into Namespace resource.")
 model NamespaceMigrateResponse {

--- a/specification/deviceregistry/DeviceRegistry.Management/ns_assets.tsp
+++ b/specification/deviceregistry/DeviceRegistry.Management/ns_assets.tsp
@@ -35,6 +35,7 @@ model NamespaceAsset is TrackedResource<NamespaceAssetProperties> {
   extendedLocation: ExtendedLocation;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_04_01)
 @doc("The request body for the executeAction operation on NamespaceAsset.")
 model NamespaceAssetExecuteActionRequest {
@@ -67,6 +68,7 @@ union ManagementActionExecutionStatus {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_04_01)
 @doc("The response body for the executeAction operation on NamespaceAsset.")
 model NamespaceAssetExecuteActionResponse {

--- a/specification/deviceregistry/DeviceRegistry.Management/ns_devices.tsp
+++ b/specification/deviceregistry/DeviceRegistry.Management/ns_devices.tsp
@@ -51,6 +51,7 @@ alias NamespaceDevicePropertiesUpdate = {
   enabled?: boolean;
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request payload for revoking device credentials.")
 @added(Versions.v2026_03_01_preview)
 @removed(Versions.v2026_04_01)
@@ -59,6 +60,7 @@ model DeviceCredentialsRevokeRequest {
   disable?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request payload for revoking device credentials.")
 @added(Versions.v2026_03_01_preview)
 @removed(Versions.v2026_04_01)

--- a/specification/deviceregistry/DeviceRegistry.Management/ns_policy.tsp
+++ b/specification/deviceregistry/DeviceRegistry.Management/ns_policy.tsp
@@ -151,6 +151,7 @@ union BringYourOwnRootStatus {
   ActiveButPendingRenewal: "ActiveButPendingRenewal",
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_01_preview)
 @removed(Versions.v2026_04_01)
 @doc("Request payload for activating a Bring Your Own Root policy with a customer-provided signed certificate.")

--- a/specification/deviceupdate/data-plane/duiothub/models.tsp
+++ b/specification/deviceupdate/data-plane/duiothub/models.tsp
@@ -411,6 +411,7 @@ model Step {
 /**
  * Common error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
@@ -1423,11 +1423,13 @@ model CustomImagePropertiesFromVm {
   /**
    * The Windows OS information of the VM.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   windowsOsInfo?: WindowsOsInfo;
 
   /**
    * The Linux OS information of the VM.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   linuxOsInfo?: LinuxOsInfo;
 }
 
@@ -1877,6 +1879,7 @@ model NetworkInterfaceProperties {
 /**
  * Properties of a virtual machine that determine how it is connected to a load balancer.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model SharedPublicIpAddressConfiguration {
   /**
    * The incoming NAT rules

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/routes.tsp
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/routes.tsp
@@ -43,6 +43,7 @@ interface Operations {
 /**
  * Response for operations that return with 202 Accepted status code.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AcceptedResponse {
   /**
    * HTTP status code 202

--- a/specification/discovery/Discovery.Supercomputer.Management/nodePool.tsp
+++ b/specification/discovery/Discovery.Supercomputer.Management/nodePool.tsp
@@ -110,6 +110,7 @@ model NodePoolProperties {
   @visibility(Lifecycle.Read, Lifecycle.Create)
   scaleSetPriority?: ScaleSetPriority = ScaleSetPriority.Regular;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The size of the OS disk in GB. If not specified, the default is 120 GB.")
   @added(Versions.v2026_06_01)
   @visibility(Lifecycle.Read, Lifecycle.Create)

--- a/specification/domainregistration/resource-manager/Microsoft.DomainRegistration/DomainRegistration/models.tsp
+++ b/specification/domainregistration/resource-manager/Microsoft.DomainRegistration/DomainRegistration/models.tsp
@@ -360,6 +360,7 @@ model LogSpecification {
 /**
  * App Service error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**
@@ -1020,6 +1021,7 @@ model TldLegalAgreement {
 /**
  * The server could not understand the request due to invalid syntax.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmBadRequestResponse {
   ...TypeSpec.Http.Response<400>;

--- a/specification/domainservices/resource-manager/Microsoft.AAD/DomainServices/models.tsp
+++ b/specification/domainservices/resource-manager/Microsoft.AAD/DomainServices/models.tsp
@@ -589,12 +589,14 @@ model ReplicaSet {
   /**
    * List of Domain Controller IP Address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   domainControllerIpAddress?: string[];
 
   /**
    * External access ip address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   externalAccessIpAddress?: string;
 

--- a/specification/dynatrace/resource-manager/Dynatrace.Observability/DynatraceObservability/models.tsp
+++ b/specification/dynatrace/resource-manager/Dynatrace.Observability/DynatraceObservability/models.tsp
@@ -362,6 +362,7 @@ model LogStatusRequest {
 /**
  * List of all the resources being monitored by Dynatrace monitor resource
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoredResourceListResponse is Azure.Core.Page<MonitoredResource>;
 
 /**
@@ -533,6 +534,7 @@ model MetricRules {
 /**
  * Dynatrace resource can be created or not.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateResourceSupportedResponse {
   /**
    * Represents the properties of the resource.
@@ -916,6 +918,7 @@ model OperationDisplay {
 /**
  * Request for getting connected resources count for a Marketplace Subscription Id
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MarketplaceSubscriptionIdRequest {
   /**
    * Marketplace Subscription Id
@@ -1049,6 +1052,7 @@ model MetricsStatusResponse {
 /**
  * Response of a list App Services Operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AppServiceListResponse is Azure.Core.Page<AppServiceInfo>;
 
 /**
@@ -1178,6 +1182,7 @@ model LinkableEnvironmentRequest {
 /**
  * Response for getting all the linkable environments
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LinkableEnvironmentListResponse
   is Azure.Core.Page<LinkableEnvironmentResponse>;
 

--- a/specification/edge/resource-manager/Microsoft.Edge/disconnectedOperations/models.tsp
+++ b/specification/edge/resource-manager/Microsoft.Edge/disconnectedOperations/models.tsp
@@ -320,6 +320,7 @@ model ImageUpdateProperties {
   @doc("Details of security updates included in this image release.")
   securityUpdates: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @doc("The operating system version provided by this image update.")
   osVersion: string;

--- a/specification/edgemarketplace/Microsoft.EdgeMarketPlace.Management/models.tsp
+++ b/specification/edgemarketplace/Microsoft.EdgeMarketPlace.Management/models.tsp
@@ -249,6 +249,7 @@ model MarketplaceSkuVersion {
   launchType?: OfferLaunchType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Access token request object")
 model AccessTokenRequest {
   @doc("The name of the publisher.")
@@ -289,6 +290,7 @@ model DiskAccessToken {
   accessToken: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Access token request object")
 model AccessTokenReadRequest {
   @doc("The name of the publisher.")

--- a/specification/edgeorder/resource-manager/Microsoft.EdgeOrder/EdgeOrder/models.tsp
+++ b/specification/edgeorder/resource-manager/Microsoft.EdgeOrder/EdgeOrder/models.tsp
@@ -2597,6 +2597,7 @@ model PurchaseMeterDetails extends MeterDetails {
 /**
  * Resource move request body.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceMoveRequest {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   targetResourceGroup?: string;

--- a/specification/education/resource-manager/Microsoft.Education/Education/models.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/models.tsp
@@ -236,6 +236,7 @@ model ErrorResponseBody {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ErrorResponse {
   /**
    * Error code
@@ -251,6 +252,7 @@ model ErrorResponse {
 /**
  * Describes the error if the operation is not successful.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**
@@ -263,6 +265,7 @@ model DefaultErrorResponse {
 /**
  * Error response describing why the operation failed.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DeleteErrorResponse {
   /**
@@ -275,6 +278,7 @@ model DeleteErrorResponse {
 /**
  * List of Grants info.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GrantListResponse {
   /**
    * The GrantDetails items on this page.

--- a/specification/education/resource-manager/Microsoft.Education/Education/routes.tsp
+++ b/specification/education/resource-manager/Microsoft.Education/Education/routes.tsp
@@ -11,6 +11,7 @@ using Azure.ResourceManager;
 
 namespace Microsoft.Education;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("code redeemed")
 model RedeemCodeResponse {
   ...OkResponse;

--- a/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/models.tsp
+++ b/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/models.tsp
@@ -263,6 +263,7 @@ model OperationResult {
 /**
  * RP default error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ResourceProviderDefaultErrorResponse {
   /**
@@ -301,6 +302,7 @@ model ErrorResponseBody {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ElasticMonitorResourceListResponse
   is Azure.Core.Page<ElasticMonitorResource>;
 
@@ -619,6 +621,7 @@ model IdentityProperties {
 /**
  * List of elastic versions available in a region.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ElasticVersionsListResponse is Azure.Core.Page<ElasticVersionListFormat>;
 
 /**
@@ -772,6 +775,7 @@ model FilteringTag {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoredResourceListResponse is Azure.Core.Page<MonitoredResource>;
 
 /**
@@ -991,6 +995,7 @@ model PartnerBillingEntity {
 /**
  *  List of all active elastic deployments.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ConnectedPartnerResourcesListResponse
   is Azure.Core.Page<ConnectedPartnerResourcesListFormat>;
 
@@ -1038,6 +1043,7 @@ model ConnectedPartnerResourceProperties {
  * Response of a list operation.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OpenAIIntegrationRPModelListResponse
   is Azure.Core.Page<OpenAIIntegrationRPModel>;
 
@@ -1100,12 +1106,14 @@ model OpenAIIntegrationStatusResponseProperties {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoringTagRulesListResponse is Azure.Core.Page<MonitoringTagRules>;
 
 /**
  * Response of a list operation.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VMHostListResponse is Azure.Core.Page<VMResources>;
 
 /**

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.ContainerRegistry/ContainerRegistry.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.ContainerRegistry/ContainerRegistry.tsp
@@ -116,6 +116,7 @@ model ContainerRegistryArtifactEventTarget {
 }
 
 /** The request that generated the event. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ContainerRegistryEventRequest {
   /** The ID of the request that initiated the event. */
   id: string;

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.EventGrid/EventGrid.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.EventGrid/EventGrid.tsp
@@ -72,6 +72,7 @@ either the validationCode or the validationUrl received in a
 SubscriptionValidationEvent. When the validationCode is used, the
 SubscriptionValidationResponse can be used to build the response.
 */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SubscriptionValidationResponse {
   /** The validation response sent by the subscriber to Azure Event Grid to complete the validation of an event subscription. */
   validationResponse: string;

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Resources/Resources.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Resources/Resources.tsp
@@ -46,11 +46,13 @@ namespace Microsoft.EventGrid.SystemEvents {
   }
 
   /** The details of the HTTP request. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
   model ResourceHttpRequest {
     /** The client request ID. */
     clientRequestId?: string;
 
     /** The client IP address. */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     clientIpAddress?: string;
 
     /** The request method. */

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/models.tsp
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/models.tsp
@@ -470,6 +470,7 @@ model AvailableCluster {
 /**
  * Error response indicates Event Hub service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/fist/resource-manager/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/models.tsp
+++ b/specification/fist/resource-manager/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/models.tsp
@@ -685,6 +685,7 @@ model WorkspaceProperties {
   provisioningState?: ProvisioningState;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Properties for generating an upload URL")
 model GenerateUploadUrlRequest {
   @doc("A unique ID for the firmware to be uploaded.")

--- a/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/models.tsp
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/models.tsp
@@ -2253,6 +2253,7 @@ model ResourcewithSettableName {
 /**
  * Error response indicates Front Door service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -2271,6 +2272,7 @@ model ErrorResponse {
 /**
  * Error response indicates Front Door service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/Assignments/models.tsp
@@ -13,6 +13,7 @@ namespace Microsoft.GuestConfiguration;
 /**
  * Error response of an operation failure.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/HanaOnAzure/models.tsp
+++ b/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/HanaOnAzure/models.tsp
@@ -122,6 +122,7 @@ model Display {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/models.tsp
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/models.tsp
@@ -673,6 +673,7 @@ model HardwareProfile {
 /**
  * The Linux operation systems profile.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model OsProfile {
   /**
    * The Linux OS profile.

--- a/specification/healthcareapis/resource-manager/Microsoft.HealthcareApis/HealthcareApis/models.tsp
+++ b/specification/healthcareapis/resource-manager/Microsoft.HealthcareApis/HealthcareApis/models.tsp
@@ -361,6 +361,7 @@ model ServicesProperties {
   /**
    * The settings for the Cosmos DB database backing the service.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   cosmosDbConfiguration?: ServiceCosmosDbConfigurationInfo;
 
   /**
@@ -413,6 +414,7 @@ model ServiceAccessPolicyEntry {
 /**
  * The settings for the Cosmos DB database backing the service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model ServiceCosmosDbConfigurationInfo {
   /**
    * The provisioned throughput for the backing database.

--- a/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models.tsp
@@ -23,6 +23,7 @@ union DeidentificationOperationType {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Customizations options to override default service behaviors.")
 model SharedCustomizationOptions {
   @maxLength(16)

--- a/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models_document_flow.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models_document_flow.tsp
@@ -125,6 +125,7 @@ model DeidentificationDocumentLocation {
 }
 
 // TODO: Add documentation link for customization options.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Customizations options to override default service behaviors for job usage.")
 model DeidentificationJobCustomizationOptions {
   ...SharedCustomizationOptions;

--- a/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models_text_flow.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.DeidServices/models_text_flow.tsp
@@ -35,6 +35,7 @@ model DeidentificationResult {
 }
 
 // TODO: Add documentation link for customization options.
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Customizations options to override default service behaviors for synchronous usage.")
 model DeidentificationCustomizationOptions {
   ...SharedCustomizationOptions;

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/models.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/models.tsp
@@ -265,10 +265,12 @@ model HorizonDbReplicaForPatchUpdate {
 
 @doc("Properties of a HorizonDB firewall rule.")
 model HorizonDbFirewallRuleProperties {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The start IP address of the firewall rule (IPv4).")
   @visibility(Lifecycle.Create, Lifecycle.Update, Lifecycle.Read)
   startIpAddress: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The end IP address of the firewall rule (IPv4).")
   @visibility(Lifecycle.Create, Lifecycle.Update, Lifecycle.Read)
   endIpAddress: string;

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/models.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/models.tsp
@@ -486,12 +486,14 @@ model AgentPoolProfile {
   /**
    * The particular KubernetesVersion Image OS Type (Linux, Windows)
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: OsType;
 
   /**
    * Specifies the OS SKU used by the agent pool. The default is CBLMariner if OSType is Linux. The default is Windows2019 when OSType is Windows.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" ""
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osSKU?: OSSKU;
 
   /**
@@ -864,6 +866,7 @@ model ProvisionedClusterPoolUpgradeProfile {
   /**
    * The particular KubernetesVersion Image OS Type (Linux, Windows)
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
@@ -962,6 +965,7 @@ model AgentPoolProvisioningStatusStatus {
 /**
  * The list kubeconfig result response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListCredentialResponse {
   /**
    * Operation Id
@@ -1110,12 +1114,14 @@ model KubernetesVersionReadiness {
   /**
    * The particular KubernetesVersion Image OS Type (Linux, Windows)
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
   /**
    * Specifies the OS SKU used by the agent pool. The default is CBLMariner if OSType is Linux. The default is Windows2019 when OSType is Windows.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osSku?: OSSKU;
 
   /**
@@ -1235,6 +1241,7 @@ model VirtualNetworkProperties {
   /**
    * IP Address Prefix of the network
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddressPrefix?: string;
 
   /**

--- a/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/HybridCompute/models.tsp
+++ b/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/HybridCompute/models.tsp
@@ -3825,6 +3825,7 @@ model AgentVersion {
   /**
    * Defines the os type.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 }
 

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/models.tsp
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/ImageBuilder/models.tsp
@@ -655,6 +655,7 @@ model ImageTemplateVmProfile {
    * Size of the OS disk in GB. Omit or specify 0 to use Azure's default OS disk size.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @minValue(0)
   osDiskSizeGB?: int32 = 0;
 

--- a/specification/informatica/resource-manager/Informatica.DataManagement/Informatica/main.tsp
+++ b/specification/informatica/resource-manager/Informatica.DataManagement/Informatica/main.tsp
@@ -199,6 +199,7 @@ model ServerlessRuntimeDataDisk {
   @doc("Type of the data disk")
   type?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Server Host or IP Address")
   serverHostOrIpAddress?: string;
 
@@ -447,6 +448,7 @@ model UserDetails {
   phoneNumber?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Serverless Runtime environment Metadata response.")
 model ServerlessMetadataResponse {
   @doc("type of the runtime environment.")

--- a/specification/iothub/resource-manager/Microsoft.Devices/IoTHub/models.tsp
+++ b/specification/iothub/resource-manager/Microsoft.Devices/IoTHub/models.tsp
@@ -2209,6 +2209,7 @@ model OperationInputs {
 /**
  * The properties indicating whether a given IoT hub name is available.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model IotHubNameAvailabilityInfo {
   /**
    * The value which indicates whether the provided name is available.

--- a/specification/keyvault/data-plane/Administration/Settings/models.tsp
+++ b/specification/keyvault/data-plane/Administration/Settings/models.tsp
@@ -34,6 +34,7 @@ union SettingTypeEnum {
 /**
  * The update settings request object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSettingRequest {
   /**
    * The value of the pool setting.

--- a/specification/keyvault/data-plane/Certificates/models.tsp
+++ b/specification/keyvault/data-plane/Certificates/models.tsp
@@ -517,6 +517,7 @@ model SubjectAlternativeNames {
   /**
    * IP addresses; supports IPv4 and IPv6.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @Versioning.added(KeyVault.Versions.v2025_06_01_preview)
   ipAddresses?: string[];
 }

--- a/specification/keyvault/data-plane/Keys/models.tsp
+++ b/specification/keyvault/data-plane/Keys/models.tsp
@@ -1301,6 +1301,7 @@ model KeyRotationPolicyAttributes {
 /**
  * The get random bytes request object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetRandomBytesRequest {
   /**
    * The requested number of random bytes.

--- a/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
+++ b/specification/liftrcommvault/Commvault.ContentStore.Management/main.tsp
@@ -78,6 +78,7 @@ model SaaSData {
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is a well-known acronym"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("SaaS guid for Activate and Validate SaaS Resource")
 @added(Versions.v6_preview)
 model ActivateSaaSParameterRequest {
@@ -87,6 +88,7 @@ model ActivateSaaSParameterRequest {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "SaaS response model"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is a well-known acronym"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Marketplace SaaS resource details.")
 @added(Versions.v6_preview)
 model SaaSResourceDetailsResponse
@@ -96,6 +98,7 @@ model SaaSResourceDetailsResponse
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SaaS is a well-known acronym"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response of get latest linked SaaS resource operation")
 @added(Versions.v6_preview)
 model LatestLinkedSaaSResponse {
@@ -771,6 +774,7 @@ union Operator {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The properties of StopBackupProtectionGroupRequest")
 model StopBackupProtectionGroupRequest {
   @doc("The reason for stopping the backup")
@@ -782,6 +786,7 @@ model StopBackupProtectionGroupRequest {
   comment?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The properties of BackupProtectionGroupRequest")
 model BackupProtectionGroupRequest {
   #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "identifiers not applicable across version type change"
@@ -796,6 +801,7 @@ model BackupProtectionGroupRequest {
   backupOptions: BackupOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Backup job response for a Protection Group")
 model BackupProtectionGroupResponse {
   @doc("The Commvault response for taskId")
@@ -834,6 +840,7 @@ model VmGuid {
   id: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The backup options for the VM backup")
 model BackupOptions {
   @doc("Indicates whether to stop backup or not for the VM")
@@ -1008,6 +1015,7 @@ model VmInfo {
   @visibility(Lifecycle.Read, Lifecycle.Create)
   subnetId?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The identifier to check if to attach and swap disk of the VM.")
   @visibility(Lifecycle.Read, Lifecycle.Create)
   attachAndSwapOsDisk?: boolean;
@@ -1038,6 +1046,7 @@ model VmDestinationInfo {
   vmInfoList: VmInfo[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The properties of RestoreProtectionItemRequest")
 model RestoreProtectionItemRequest {
   @doc("Check whether inplace or out of place restore.")
@@ -1057,6 +1066,7 @@ model RestoreProtectionItemRequest {
   vmDestinationInfo: VmDestinationInfo;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response for count protected items operation.")
 @added(Versions.v7_preview)
 model CountProtectedItemsResponse {
@@ -1064,6 +1074,7 @@ model CountProtectedItemsResponse {
   count: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request to count protected items for the provided CCA resource IDs across subscriptions.")
 @added(Versions.v7_preview)
 model CountProtectedItemsRequest {
@@ -1124,6 +1135,7 @@ model RestorePoints {
   restoreTimes: int64[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Restore resource response for a Protected Item")
 model RestoreProtectionItemResponse {
   @doc("The Commvault response for taskId")

--- a/specification/liftrmongodb/MongoDB.Atlas.Management/main.tsp
+++ b/specification/liftrmongodb/MongoDB.Atlas.Management/main.tsp
@@ -292,6 +292,7 @@ model ClusterProperties {
   @visibility(Lifecycle.Create, Lifecycle.Read)
   regionName: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("MongoDB version running on the cluster.")
   @visibility(Lifecycle.Read)
   mongoDbVersion?: string;

--- a/specification/loadtestservice/data-plane/loadtesting/models.tsp
+++ b/specification/loadtestservice/data-plane/loadtesting/models.tsp
@@ -421,6 +421,7 @@ model Test {
   kind?: TestKind;
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "IP is an abbervation and should be all caps"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(APIVersions.v2023_04_01_preview)
   @doc("Inject load test engines without deploying public IP for outbound access")
   publicIPDisabled?: boolean;
@@ -926,6 +927,7 @@ model TestRun {
   debugLogsEnabled?: boolean;
 
   #suppress "@azure-tools/typespec-azure-core/casing-style" "IP is an abbervation and should be all caps"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(APIVersions.v2023_04_01_preview)
   @doc("Inject load test engines without deploying public IP for outbound access")
   @visibility(Lifecycle.Read)
@@ -1162,6 +1164,7 @@ model ArtifactsContainerInfo {
   expireDateTime?: utcDateTime;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request to clone an existing test into a new test.")
 @added(APIVersions.v2025_03_01_preview)
 model CloneTestRequest {
@@ -1315,6 +1318,7 @@ model DimensionValueList {
   nextLink?: ResourceLocation<DimensionValueList>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Metric Dimensions")
 model MetricDimensionsRequest {
   @doc("Metric name")

--- a/specification/loadtestservice/resource-manager/Microsoft.LoadTestService/loadtesting/models.tsp
+++ b/specification/loadtestservice/resource-manager/Microsoft.LoadTestService/loadtesting/models.tsp
@@ -252,6 +252,7 @@ model LoadTestProperties {
   encryption?: EncryptionProperties;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Check quota availability response object.")
 model CheckQuotaAvailabilityResponse {
   @doc("Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}")

--- a/specification/machinelearningservices/AzureAI.Assets/common.tsp
+++ b/specification/machinelearningservices/AzureAI.Assets/common.tsp
@@ -38,6 +38,7 @@ model OnlineRequestSettings {
   maxConcurrentRequestsPerInstance: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("LongRunningNullResponse")
 model LongRunningNullResponse {
   @doc("Polling Uri.")
@@ -45,6 +46,7 @@ model LongRunningNullResponse {
   location: ResourceLocation<ResourceOperationStatus<PutAssetLROResponse>>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("PutAssetLROResponse")
 model PutAssetLROResponse {
   @doc("Response of completed put asset lro.")

--- a/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
@@ -3924,6 +3924,7 @@ model VirtualMachineSize {
    * The OS VHD disk size, in MB, allowed by the virtual machine size.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Existing API contract uses this naming convention"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @summary("OS VHD Disk size")
   @visibility(Lifecycle.Read)
   osVhdSizeMB?: int32;
@@ -4437,6 +4438,7 @@ model Endpoint {
    * Host IP over which the application is exposed from the container
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   hostIp?: string | null;
 }
 
@@ -4490,6 +4492,7 @@ model VolumeDefinition {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BindOptions {
   /**
    * Type of Bind Option
@@ -4511,6 +4514,7 @@ model BindOptions {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VolumeOptions {
   /**
    * Indicate whether volume is nocopy
@@ -4520,6 +4524,7 @@ model VolumeOptions {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TmpfsOptions {
   /**
    * Mention the Tmpfs size
@@ -4582,6 +4587,7 @@ model AmlComputeNodeInformation {
    * Private IP address of the compute node.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @summary("Private IP address.")
   privateIpAddress?: string | null;
@@ -4590,6 +4596,7 @@ model AmlComputeNodeInformation {
    * Public IP address of the compute node.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   @summary("Public IP address.")
   publicIpAddress?: string | null;
@@ -6455,6 +6462,7 @@ model FeatureWindow {
 /**
  * Response payload for creating a backfill request for a given feature set version
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FeaturesetVersionBackfillResponse {
   /**
    * List of jobs submitted as part of the backfill request.
@@ -8272,6 +8280,7 @@ model WorkspaceProperties {
   /**
    * The list of IPv4  addresses that are allowed to access the workspace.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @removed(Versions.v2025_12_01)
   @added(Versions.v2026_01_15_preview)
   @removed(Versions.v2026_03_01)
@@ -8441,6 +8450,7 @@ model EncryptionProperty {
    * The byok cosmosdb account that customer brings to store customer's data
    * with encryption
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   cosmosDbResourceId?: string;
 
   /**
@@ -8566,6 +8576,7 @@ model ManagedNetworkSettings {
    * Public IP address assigned to the Azure Firewall.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   firewallPublicIpAddress?: string | null;
 }
@@ -8627,6 +8638,7 @@ model NetworkAcls {
    * Rules governing the accessibility of a resource from a specific ip address or ip range.
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "Array items do not have stable identifiers"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipRules?: IPRule[];
 }
 
@@ -8739,10 +8751,12 @@ model ServerlessComputeSettings {
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
 model ServiceManagedResourcesSettings {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   cosmosDb?: CosmosDbSettings;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbSettings {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
   collectionsThroughput?: int32;
@@ -8885,6 +8899,7 @@ model WorkspacePropertiesUpdateParameters {
    * The list of IPv4 addresses that are allowed to access the workspace.
    */
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @removed(Versions.v2025_12_01)
   @added(Versions.v2026_01_15_preview)
   @removed(Versions.v2026_03_01)
@@ -9248,6 +9263,7 @@ model RaiBlocklistProperties {
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Empty model used as placeholder in API"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Required for swagger compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @OpenAPI.extension("x-ms-identifiers", #["name"])
 model RaiBlocklistItemsBulkAddRequest is RaiBlocklistItemBulkRequest[];
 
@@ -9991,6 +10007,7 @@ model SystemService {
   /**
    * Public IP address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   publicIpAddress?: string;
 
@@ -10676,11 +10693,13 @@ model ImageMetadata {
   /**
    * Specifies whether this compute instance is running on the latest operating system image.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   isLatestOsImageVersion?: boolean;
 
   /**
    * Metadata about the os patching.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osPatchingStatus?: OsPatchingStatus;
 }
@@ -10688,6 +10707,7 @@ model ImageMetadata {
 /**
  * Returns metadata about the os patching.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model OsPatchingStatus {
   /**
    * The os patching status.
@@ -10714,6 +10734,7 @@ model OsPatchingStatus {
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Required for swagger compatibility"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @OpenAPI.extension("x-ms-identifiers", #["/error/code"])
   osPatchingErrors?: ErrorResponse[] | null;
 }
@@ -10726,6 +10747,7 @@ model ComputeInstanceConnectivityEndpoints {
    * Public IP Address of this ComputeInstance.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   publicIpAddress?: string | null;
 
@@ -10733,6 +10755,7 @@ model ComputeInstanceConnectivityEndpoints {
    * Private IP Address of this ComputeInstance (local to the VNET in which the compute instance is deployed).
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   privateIpAddress?: string | null;
 }

--- a/specification/machinelearningservices/data-plane/DatasetDataplane/models.tsp
+++ b/specification/machinelearningservices/data-plane/DatasetDataplane/models.tsp
@@ -340,6 +340,7 @@ model AssetId {
 }
 
 /** Batch response containing resolved data URIs. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchDataUriResponse {
   /** Map of resolved data URIs. */
   values?: Record<DataUriV2Response>;
@@ -392,6 +393,7 @@ model CreateUnregisteredOutputData {
 }
 
 /** Request for data call operations (preview, profile, schema). */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataCallRequest {
   /** The data URI. */
   dataUri?: string;
@@ -464,6 +466,7 @@ model DataField {
 }
 
 /** A resolved data URI response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataUriV2Response {
   /** The URI. */
   uri?: string;
@@ -774,6 +777,7 @@ model ErrorAdditionalInfo {
 }
 
 /** The error response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /** The root error. */
@@ -877,6 +881,7 @@ model HttpResponseMessage {
 }
 
 /** A nested structure of errors. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InnerErrorResponse {
   /** The error code. */
   code?: string;
@@ -896,6 +901,7 @@ model KeyValuePairStringIEnumerable {
 }
 
 /** A long-running operation response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LongRunningOperationResponse {
   /** The completion result. */
   completionResult?: string;

--- a/specification/machinelearningservices/data-plane/ModelDataplane/models.tsp
+++ b/specification/machinelearningservices/data-plane/ModelDataplane/models.tsp
@@ -528,6 +528,7 @@ model InnerErrorDetails {
 }
 
 /** Error response from the service. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @clientName("ModelErrorResponse")
 model ErrorResponse {
   /** The error code. */
@@ -918,6 +919,7 @@ model FeedIndexEntityRequestDto {
 }
 
 /** Request body for listing models. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ListModelsRequest {
   /** Filter by model name. */
   name?: string;
@@ -972,6 +974,7 @@ model ListModelsRequest {
 }
 
 /** Paginated response of models. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ModelPagedResponse {
   /** The list of models. */
   @pageItems
@@ -985,6 +988,7 @@ model ModelPagedResponse {
 }
 
 /** Paginated response of models with next request. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ModelListModelsRequestPagedResponse {
   /** The list of models. */
   @pageItems
@@ -1013,6 +1017,7 @@ model ModelBatchResponseDto {
 }
 
 /** Model container request. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ModelContainerRequest {
   /** The container name. */
   name: string;

--- a/specification/machinelearningservices/data-plane/RunHistory/models.tsp
+++ b/specification/machinelearningservices/data-plane/RunHistory/models.tsp
@@ -173,6 +173,7 @@ union SpanStatus {
 // ============================================================
 
 /** Request to add or modify run service instances. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AddOrModifyRunServiceInstancesRequest {
   /** The service instances to add or modify. */
   instances?: Record<ServiceInstance>;
@@ -263,6 +264,7 @@ model BaseEvent {
 }
 
 /** Request to batch add or modify runs. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchAddOrModifyRunRequest {
   /** The list of runs to add or modify. */
   runs?: CreateRun[];
@@ -306,6 +308,7 @@ model BatchIMetricV2 {
 }
 
 /** A batch request for run data. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRunDataRequest {
   /** The requests keyed by identifier. */
   requests?: Record<GetRunDataRequest>;
@@ -354,6 +357,7 @@ model Compute {
 }
 
 /** Compute request information. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ComputeRequest {
   /** The node count. */
   nodeCount?: int32;
@@ -635,6 +639,7 @@ model ErrorAdditionalInfo {
 }
 
 /** The error response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @clientName("RunHistoryErrorResponse")
 model ErrorResponse {
   /** The root error. */
@@ -714,6 +719,7 @@ model ExperimentQueryParams {
 }
 
 /** A request to get run data. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetRunDataRequest {
   /** The run ID. */
   runId?: string;
@@ -747,6 +753,7 @@ model GetRunsByIds {
 }
 
 /** A request to get sampled metrics. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetSampledMetricRequest {
   /** The metric name. */
   metricName?: string;
@@ -780,6 +787,7 @@ model IMetricV2 {
 }
 
 /** A nested structure of errors. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InnerErrorResponse {
   /** The error code. */
   code?: string;
@@ -804,6 +812,7 @@ model JobCost {
 }
 
 /** A key-value pair of BaseEvent and ErrorResponse. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model KeyValuePairBaseEventErrorResponse {
   /** The event key. */
   key?: BaseEvent;
@@ -868,6 +877,7 @@ model ListMetrics {
 }
 
 /** A long-running null response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LongRunningNullResponse {}
 
 /** A metric definition. */
@@ -1148,6 +1158,7 @@ model QueueingInfo {
 }
 
 /** A request to retrieve full fidelity metrics. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RetrieveFullFidelityMetricRequest {
   /** The metric name. */
   metricName?: string;
@@ -1582,6 +1593,7 @@ model RunMetric {
 }
 
 /** Run options. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RunOptions {
   /** Whether to generate a data container ID if not specified. */
   generateDataContainerIdIfNotSpecified?: boolean;

--- a/specification/machinelearningservices/data-plane/WorkspaceDataplane/models.tsp
+++ b/specification/machinelearningservices/data-plane/WorkspaceDataplane/models.tsp
@@ -82,6 +82,7 @@ model ComputeRuntimeDto {
 }
 
 /** CosmosDB settings. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model CosmosDbSettings {
   /** Collections throughput. */
   collectionsThroughput?: int32;
@@ -90,6 +91,7 @@ model CosmosDbSettings {
 /** Encryption configuration. */
 model EncryptionProperty {
   /** The byok cosmosdb account that customer brings to store customer's data with encryption. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   cosmosDbResourceId?: string;
 
   /** Identity to be used with the keyVault. */
@@ -236,6 +238,7 @@ model PrivateLinkServiceConnectionState {
 /** Service managed resources settings. */
 model ServiceManagedResourcesSettings {
   /** CosmosDB settings. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   cosmosDb?: CosmosDbSettings;
 }
 

--- a/specification/machinelearningservices/data-plane/WorkspaceDataplane/routes.tsp
+++ b/specification/machinelearningservices/data-plane/WorkspaceDataplane/routes.tsp
@@ -39,6 +39,7 @@ interface Workspaces {
 }
 
 /** Accepted response with location header for polling. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AcceptedResponse {
   /** HTTP status code. */
   @statusCode statusCode: 202;

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/back-compatible.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/back-compatible.tsp
@@ -226,7 +226,9 @@ using TypeSpec.Versioning;
 // Backward compatibility models for list results
 model InternetGatewayRulesListResult is Azure.Core.Page<InternetGatewayRule>;
 model InternetGatewaysListResult is Azure.Core.Page<InternetGateway>;
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpCommunitiesListResult is Azure.Core.Page<IpCommunity>;
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpPrefixesListResult is Azure.Core.Page<IpPrefix>;
 model L2IsolationDomainsListResult is Azure.Core.Page<L2IsolationDomain>;
 model L3IsolationDomainsListResult is Azure.Core.Page<L3IsolationDomain>;

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/ExternalNetwork.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/ExternalNetwork.tsp
@@ -368,6 +368,7 @@ model L3OptionAProperties {
   ]>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("External Network Administrative State request")
 @added(Versions.v2024_06_15_preview)
 model ExternalNetworkBfdAdministrativeStateRequest {
@@ -379,6 +380,7 @@ model ExternalNetworkBfdAdministrativeStateRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response for ExternalNetwork BFD Administrative State response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("External Network Administrative State response")
 @added(Versions.v2024_06_15_preview)
 model ExternalNetworkBfdAdministrativeStateResponse

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/InternalNetwork.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/InternalNetwork.tsp
@@ -462,6 +462,7 @@ union IsMonitoringEnabled {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Internal Network Administrative State Request")
 @added(Versions.v2024_06_15_preview)
 model InternalNetworkBgpAdministrativeStateRequest {
@@ -483,6 +484,7 @@ model InternalNetworkUpdateBgpAdministrativeStateRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response for InternalNetwork BGP Administrative State response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Internal Network Administrative State Response")
 @added(Versions.v2024_06_15_preview)
 model InternalNetworkBgpAdministrativeStateResponse
@@ -512,6 +514,7 @@ model InternalNetworkUpdateBgpAdministrativeStateResponseProperties {
   neighborAddressAdministrativeStatus?: NeighborAddressBgpAdministrativeStatus[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Internal Network BFD Administrative State request")
 @added(Versions.v2024_06_15_preview)
 model InternalNetworkBfdAdministrativeStateRequest {
@@ -556,6 +559,7 @@ model InternalNetworkUpdateBfdAdministrativeStateResponseProperties {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response for InternalNetwork BFD Administrative State response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Internal Network BFD Administrative State response")
 @added(Versions.v2024_06_15_preview)
 model InternalNetworkBfdAdministrativeStateResponse
@@ -600,6 +604,7 @@ model InternalNetworkBmpProperties {
 @doc("Internal Network BMP Configuration")
 @added(Versions.v2024_06_15_preview)
 model InternalNetworkBmpPatchProperties {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("BMP Collector Address.")
   @added(Versions.v2024_06_15_preview)
   @minItems(1)

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpCommunity.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpCommunity.tsp
@@ -3,6 +3,7 @@ import "./common.tsp";
 using TypeSpec.Versioning;
 
 namespace Microsoft.ManagedNetworkFabric;
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Community Properties defines the resource properties.")
 model IpCommunityProperties {
   ...AnnotationResource;
@@ -38,6 +39,7 @@ model IpCommunityProperties {
   administrativeState?: AdministrativeState;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Community patchable properties.")
 model IpCommunityPatchableProperties {
   @doc("List of IP Community Rules.")

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpExtendedCommunity.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpExtendedCommunity.tsp
@@ -4,6 +4,7 @@ using TypeSpec.Versioning;
 
 namespace Microsoft.ManagedNetworkFabric;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Extended Community Properties defines the resource properties.")
 model IpExtendedCommunityProperties {
   ...AnnotationResource;
@@ -36,6 +37,7 @@ model IpExtendedCommunityProperties {
   administrativeState?: AdministrativeState;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Extended Community patchable properties.")
 model IpExtendedCommunityPatchableProperties {
   @doc("List of IP Extended Community Rules.")
@@ -65,6 +67,7 @@ model IpExtendedCommunityPatch extends TagsUpdate {
   properties?: IpExtendedCommunityPatchProperties;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Extended Community patchable properties.")
 model IpExtendedCommunityPatchProperties {
   ...AnnotationResource;

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpPrefix.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/IpPrefix.tsp
@@ -4,6 +4,7 @@ using TypeSpec.Versioning;
 
 namespace Microsoft.ManagedNetworkFabric;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Prefix Properties defines the properties of the resource.")
 model IpPrefixProperties {
   ...AnnotationResource;
@@ -39,6 +40,7 @@ model IpPrefixProperties {
   administrativeState?: AdministrativeState;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Prefix patchable properties.")
 model IpPrefixPatchableProperties {
   @doc("The list of IP Prefix Rules.")
@@ -73,6 +75,7 @@ model IpPrefixPatch extends TagsUpdate {
   properties?: IpPrefixPatchProperties;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("IP Prefix patchable properties.")
 model IpPrefixPatchProperties {
   ...AnnotationResource;

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkDevice.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkDevice.tsp
@@ -191,6 +191,7 @@ model NetworkDeviceResyncPasswordsResponse {
   ...OperationStatusResult;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response body for a ResyncCertificates request on a Network Device.")
 @added(Versions.v2025_07_15)
 model NetworkDeviceResyncCertificatesResponse {

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkFabric.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkFabric.tsp
@@ -625,6 +625,7 @@ model FeatureFlagProperties {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Arm Configuration Diff Response.")
 @added(Versions.v2024_06_15_preview)
 model ArmConfigurationDiffResponse extends CommonErrorResponse {
@@ -650,6 +651,7 @@ model ArmConfigurationDiffResponseProperties {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("View Device Configuration Response.")
 @added(Versions.v2024_06_15_preview)
 model ViewDeviceConfigurationResponse extends CommonErrorResponse {
@@ -711,6 +713,7 @@ model CommitBatchStatusRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Commit Batch Status Response.")
 @added(Versions.v2024_06_15_preview)
 model CommitBatchStatusResponse extends CommonErrorResponse {
@@ -754,6 +757,7 @@ model DiscardCommitBatchRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Discard Commit Batch Response.")
 @added(Versions.v2024_06_15_preview)
 model DiscardCommitBatchResponse extends CommonErrorResponse {

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkToNetworkInterconnect.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/NetworkToNetworkInterconnect.tsp
@@ -372,6 +372,7 @@ union IsManagementType {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("NNI Bidirectional Forwarding Detection (BFD) Administrative State request.")
 @added(Versions.v2024_06_15_preview)
 model NniBfdAdministrativeStateRequest {
@@ -383,6 +384,7 @@ model NniBfdAdministrativeStateRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending common error response"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("NNI Bidirectional Forwarding Detection (BFD) Administrative State response.")
 @added(Versions.v2024_06_15_preview)
 model NniBfdAdministrativeStateResponse extends CommonErrorResponse {

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/common.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/models/common.tsp
@@ -405,6 +405,7 @@ model IpMatchConditionPatch {
   @doc("IP Prefix Type that needs to be matched.")
   prefixType?: PrefixType;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The list of IP Prefixes that need to be matched.")
   @minItems(1)
   @removed(Versions.v2025_07_15)
@@ -415,6 +416,7 @@ model IpMatchConditionPatch {
   @added(Versions.v2025_07_15)
   ipPrefixValues?: string[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The List of IP Group Names that need to be matched.")
   @minItems(1)
   @removed(Versions.v2025_07_15)

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpCommunity.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpCommunity.tsp
@@ -11,6 +11,7 @@ model IpCommunity is Azure.ResourceManager.TrackedResource<
   IpCommunityProperties,
   false
 > {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Name of the IP Community.")
   @pattern("^[a-zA-Z]{1}[a-zA-Z0-9-_]{2,127}$")
   @path

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpExtendedCommunity.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpExtendedCommunity.tsp
@@ -11,6 +11,7 @@ model IpExtendedCommunity is Azure.ResourceManager.TrackedResource<
   IpExtendedCommunityProperties,
   false
 > {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Name of the IP Extended Community.")
   @pattern("^[a-zA-Z]{1}[a-zA-Z0-9-_]{2,127}$")
   @path

--- a/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpPrefix.tsp
+++ b/specification/managednetworkfabric/resource-manager/Microsoft.ManagedNetworkFabric/ManagedNetworkFabric/resources/IpPrefix.tsp
@@ -11,6 +11,7 @@ model IpPrefix is Azure.ResourceManager.TrackedResource<
   IpPrefixProperties,
   false
 > {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Name of the IP Prefix.")
   @pattern("^[a-zA-Z]{1}[a-zA-Z0-9-_]{2,127}$")
   @path

--- a/specification/management/resource-manager/Microsoft.Management/ManagementGroups/models.tsp
+++ b/specification/management/resource-manager/Microsoft.Management/ManagementGroups/models.tsp
@@ -244,6 +244,7 @@ model ManagementGroupInfoProperties {
 /**
  * The error object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -411,6 +412,7 @@ model ManagementGroupChildInfo {
 /**
  * Management group creation parameters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateManagementGroupRequest {
   /**
    * The fully qualified ID for the management group.  For example, /providers/Microsoft.Management/managementGroups/0000000-0000-0000-0000-000000000000
@@ -587,6 +589,7 @@ model AzureAsyncOperationResults {
 /**
  * Management group patch parameters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PatchManagementGroupRequest {
   /**
    * The friendly name of the management group.
@@ -758,6 +761,7 @@ model HierarchySettingsProperties {
 /**
  * Parameters for creating or updating Management Group settings
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CreateOrUpdateSettingsRequest {
   /**
    * The properties of the request to create or update Management Group settings
@@ -828,6 +832,7 @@ model OperationDisplayProperties {
 /**
  * Management group name availability check parameters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CheckNameAvailabilityRequest {
   /**
    * the name to check for availability

--- a/specification/management/resource-manager/Microsoft.Management/ServiceGroups/models.tsp
+++ b/specification/management/resource-manager/Microsoft.Management/ServiceGroups/models.tsp
@@ -107,4 +107,5 @@ model ParentServiceGroupProperties {
 /**
  * Response holding an array of service groups and a nextLink that supports pagination
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ServiceGroupCollectionResponse is Azure.Core.Page<ServiceGroup>;

--- a/specification/maps/data-plane/Geolocation/common/common.tsp
+++ b/specification/maps/data-plane/Geolocation/common/common.tsp
@@ -357,6 +357,7 @@ model ErrorAdditionalInfo {
 /**
  * Common error response for Azure Maps APIs to return error details for failed operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MapsErrorResponse {
   /**
@@ -421,6 +422,7 @@ model MapsInnerError {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Geolocation/models.tsp
+++ b/specification/maps/data-plane/Geolocation/models.tsp
@@ -8,6 +8,7 @@ namespace MapsGeolocation;
  * This object is returned from a successful call to IP Address to country/region
  * API
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpAddressToLocationResult {
   /**
    * The object containing the country/region information.
@@ -18,6 +19,7 @@ model IpAddressToLocationResult {
   /**
    * The IP Address of the request.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddress?: string;
 }
@@ -41,6 +43,7 @@ model CountryRegion {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/maps/data-plane/Geolocation/routes.tsp
+++ b/specification/maps/data-plane/Geolocation/routes.tsp
@@ -43,6 +43,7 @@ interface Geolocation {
       /**
        * The IP address. Both IPv4 and IPv6 are allowed.
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("ip")
       ipAddress: string;
     },

--- a/specification/maps/data-plane/Render/common/common.tsp
+++ b/specification/maps/data-plane/Render/common/common.tsp
@@ -357,6 +357,7 @@ model ErrorAdditionalInfo {
 /**
  * Common error response for Azure Maps APIs to return error details for failed operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MapsErrorResponse {
   /**
@@ -421,6 +422,7 @@ model MapsInnerError {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Render/models.tsp
+++ b/specification/maps/data-plane/Render/models.tsp
@@ -226,6 +226,7 @@ union MediaType {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/maps/data-plane/Route/common/common.tsp
+++ b/specification/maps/data-plane/Route/common/common.tsp
@@ -324,6 +324,7 @@ model ErrorAdditionalInfo {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Route/models.tsp
+++ b/specification/maps/data-plane/Route/models.tsp
@@ -1155,6 +1155,7 @@ enum GeoJsonObjectType {
 /**
  * This object is the request body.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DirectionsRequest {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -1529,6 +1530,7 @@ alias AxleCount = {
  * Alternative route.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteDirectionsResponse extends FeatureCollection {
   /**
    * Alternative route.
@@ -1622,6 +1624,7 @@ model FeatureProperties {
  * Common error response for Azure Maps APIs to return error details for failed
  * operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MapsErrorResponse {
   /**
@@ -1718,6 +1721,7 @@ alias OptionalId = {
 /**
  * This object is returned from a successful Directions Batch service call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DirectionsBatchResponse {
   /**
    * Summary for the batch request
@@ -1761,6 +1765,7 @@ model DirectionsBatchResponseItem {
 /**
  * This object is the request body.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SnapToRoadsRequest {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -1835,6 +1840,7 @@ model InputSnapToRoadsFeaturesItem {
 /**
  * This object is returned from a successful call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SnapToRoadsResponse {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -1933,6 +1939,7 @@ model SnapToRoadsBatchRequestItem {
 /**
  * This object is returned from a successful Snap To Roads Batch service call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SnapToRoadsBatchResponse {
   /**
    * Summary for the batch request
@@ -1978,6 +1985,7 @@ model SnapToRoadsBatchResponseItem {
  * and additional properties. Refer to [RFC
  * 7946](https://www.rfc-editor.org/rfc/rfc7946) for details.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteRangeRequest {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is Feature. For
@@ -2127,6 +2135,7 @@ model RouteRangeVehicleSpec {
 /**
  * This object is returned from a successful call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteRangeResponse {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -2208,6 +2217,7 @@ model RouteRangeBatchRequestItem {
 /**
  * This object is returned from a successful Route Range Batch service call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteRangeBatchResponse {
   /**
    * Summary for the batch request
@@ -2254,6 +2264,7 @@ model RouteRangeBatchResponseItem {
  * additional properties. Refer to [RFC
  * 7946](https://www.rfc-editor.org/rfc/rfc7946) for details.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteMatrixRequest {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -2432,6 +2443,7 @@ model RouteMatrixVehicleSpec extends VehicleSpec {}
 /**
  * This object is returned from a successful call.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteMatrixResponse {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is Feature. For
@@ -2552,6 +2564,7 @@ model RouteMatrixItemResult {
  * additional properties. Refer to [RFC
  * 7946](https://www.rfc-editor.org/rfc/rfc7946) for details.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteMatrixAsyncRequest {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -2712,6 +2725,7 @@ model RouteOperationResult {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -2729,6 +2743,7 @@ model ErrorResponse {
 /**
  * This object represents the result of a successful route operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("kind")
 model RouteOperationResponse {
   /**
@@ -2741,6 +2756,7 @@ model RouteOperationResponse {
  * Specifies the driving instructions and additional properties for each maneuver
  * point in the route Leg.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RouteMatrixAsyncResponse extends RouteOperationResponse {
   ...RouteMatrixResponse;
 

--- a/specification/maps/data-plane/Search/common/common.tsp
+++ b/specification/maps/data-plane/Search/common/common.tsp
@@ -262,6 +262,7 @@ model ErrorAdditionalInfo {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Search/models.tsp
+++ b/specification/maps/data-plane/Search/models.tsp
@@ -1082,6 +1082,7 @@ union AutocompleteResultTypeEnum {
  * Encoded as a [`GeoJSON FeatureCollection`](https://www.rfc-editor.org/rfc/rfc7946) whose
  * `features` array contains one `Feature` per geocoded location.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GeocodingResponse {
   /**
    * The `GeoJSON` object type of a successful `Get Geocoding` or `Get Reverse Geocoding`
@@ -1475,6 +1476,7 @@ model GeocodingBatchRequestItem {
  * many of the submitted queries succeeded plus a `batchItems` array containing one response
  * entry per query in the request, in the same order as the request `batchItems` array.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GeocodingBatchResponse {
   /**
    * Aggregate counts for the batch as a whole, the total submitted queries and how many of
@@ -1697,6 +1699,7 @@ model ReverseGeocodingBatchRequestItem {
  * array contains one `Feature` per autocomplete suggestion, ranked from most to least
  * likely.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AutocompleteResponse {
   /**
    * The `GeoJSON` object type of a successful `Get Autocomplete` response body. Always
@@ -1791,6 +1794,7 @@ model AutocompleteProperties {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/maps/data-plane/Timezone/common/common.tsp
+++ b/specification/maps/data-plane/Timezone/common/common.tsp
@@ -357,6 +357,7 @@ model ErrorAdditionalInfo {
 /**
  * Common error response for Azure Maps APIs to return error details for failed operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MapsErrorResponse {
   /**
@@ -421,6 +422,7 @@ model MapsInnerError {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Timezone/models.tsp
+++ b/specification/maps/data-plane/Timezone/models.tsp
@@ -266,6 +266,7 @@ model TimeTransition {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/maps/data-plane/Traffic/common/common.tsp
+++ b/specification/maps/data-plane/Traffic/common/common.tsp
@@ -262,6 +262,7 @@ model ErrorAdditionalInfo {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Traffic/models.tsp
+++ b/specification/maps/data-plane/Traffic/models.tsp
@@ -78,6 +78,7 @@ union FeaturesItemTypeEnum {
  * A GeoJSON feature collection object that contains a list of traffic incidents
  * features.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TrafficIncidentResponse {
   /**
    * Specifies the `GeoJSON` type. The only supported object type is
@@ -218,6 +219,7 @@ model TrafficIncidentFeatureProperties {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/maps/data-plane/Weather/common/common.tsp
+++ b/specification/maps/data-plane/Weather/common/common.tsp
@@ -357,6 +357,7 @@ model ErrorAdditionalInfo {
 /**
  * Common error response for Azure Maps APIs to return error details for failed operations.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model MapsErrorResponse {
   /**
@@ -421,6 +422,7 @@ model MapsInnerError {
 /**
  * This type represents the request body for the Batch service.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /**
    * The list of queries to process.

--- a/specification/maps/data-plane/Weather/models.tsp
+++ b/specification/maps/data-plane/Weather/models.tsp
@@ -938,6 +938,7 @@ model WindDirection {
  * details for failed operations. (This also follows the OData error response
  * format.).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/AdminRequestApprovalsResource.tsp
+++ b/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/AdminRequestApprovalsResource.tsp
@@ -14,6 +14,7 @@ namespace Microsoft.Marketplace;
 /**
  * Admin request approval resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @parentResource(PrivateStore)
 model AdminRequestApprovalsResource
   is Azure.ResourceManager.ProxyResource<AdminRequestApprovalProperties> {

--- a/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/RequestApprovalResource.tsp
+++ b/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/RequestApprovalResource.tsp
@@ -14,6 +14,7 @@ namespace Microsoft.Marketplace;
 /**
  * Request approval resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @parentResource(PrivateStore)
 model RequestApprovalResource
   is Azure.ResourceManager.ProxyResource<RequestApprovalProperties> {

--- a/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/models.tsp
+++ b/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/models.tsp
@@ -286,6 +286,7 @@ model SystemData {
 /**
  * Error response indicates Microsoft.Marketplace service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -819,6 +820,7 @@ model BulkCollectionsResponse {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OfferListResponse is Azure.Core.Page<Offer>;
 
 /**

--- a/specification/marketplacecatalog/data-plane/Search/models.tsp
+++ b/specification/marketplacecatalog/data-plane/Search/models.tsp
@@ -253,6 +253,7 @@ model MarketingMaterial {
   learnUri?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Search response object")
 model SearchResponse {
   @doc("The search facets")
@@ -305,6 +306,7 @@ model SuggestionsItem {
   suggestionType: SuggestionType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Suggestions response object")
 model SuggestionsResponse {
   @doc("The search results")
@@ -314,6 +316,7 @@ model SuggestionsResponse {
   totalCount?: int64;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Facets response object")
 model FacetsResponse {
   @doc("The facet items results")

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/ArmModels/Options/AKSAssessmentOptions.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/ArmModels/Options/AKSAssessmentOptions.tsp
@@ -11,6 +11,7 @@ using OpenAPI;
 namespace Microsoft.Migrate;
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("ARM model of AKS Assessment Options.")
 @parentResource(AssessmentProject)
 model AKSAssessmentOptions is ProxyResource<AKSAssessmentOptionsProperties> {

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/Common/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/Common/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/DataModels/Recommendation/NodePool.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AKSAssessments/DataModels/Recommendation/NodePool.tsp
@@ -21,6 +21,7 @@ model NodePool {
   @visibility(Lifecycle.Read)
   mode: NodePoolMode;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets os type.")
   @visibility(Lifecycle.Read)
   osType: OSType;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/NormalizedContract/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/NormalizedContract/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/WebModels/AvsAssessedMachineV2.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/WebModels/AvsAssessedMachineV2.tsp
@@ -182,6 +182,7 @@ model AvsAssessedNetworkAdapter {
   @visibility(Lifecycle.Read)
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("IP V4 addresses for the machine.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/WebModels/AvsGraphAssessmentOptions.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AvsAssessments/WebModels/AvsGraphAssessmentOptions.tsp
@@ -10,6 +10,7 @@ using OpenAPI;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("AVS Assessment Summary REST resource.")
 @parentResource(AssessmentProject)
 model AvsGraphAssessmentOptions

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Common/Models.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Common/Models.tsp
@@ -202,6 +202,7 @@ model CostByStorageType {
 
 @doc("The distribution by operating system.")
 model DistributionByOperatingSystem {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The Os classification type.")
   @visibility(Lifecycle.Read)
   osClassificationType?: string;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/EvaluatedEntities/EvaluatedSqlEntity.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/EvaluatedEntities/EvaluatedSqlEntity.tsp
@@ -62,6 +62,7 @@ model EvaluatedSqlEntityProperties {
   @visibility(Lifecycle.Read)
   virtualizationType?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("DB count in instance.")
   @visibility(Lifecycle.Read)
   dbCount?: int32;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/AvsSummary.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/AvsSummary.tsp
@@ -86,6 +86,7 @@ model AvsNodeSummary {
   @visibility(Lifecycle.Read)
   estimatedCost?: float32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS licensing cost.")
   @visibility(Lifecycle.Read)
   osLicensingCost?: float32;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/IaasSummary.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/IaasSummary.tsp
@@ -91,6 +91,7 @@ model AzureIaasVmSummary {
   @visibility(Lifecycle.Read)
   estimatedCost?: float32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS licensing cost.")
   @visibility(Lifecycle.Read)
   osLicensingCost?: float32;
@@ -129,6 +130,7 @@ model AzureIaasSqlSummary {
   @visibility(Lifecycle.Read)
   estimatedCost?: float32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS licensing cost.")
   @visibility(Lifecycle.Read)
   osLicensingCost?: float32;
@@ -184,6 +186,7 @@ model OnPremisesIaasSummary {
   @visibility(Lifecycle.Read)
   onPremisesIaasCostForDecommissioned?: CostDetails;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The OS licensing details.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -203,6 +206,7 @@ model OnPremisesIaasSummary {
   @identifiers(#[])
   distributionByVirtualization?: DistributionByVirtualization[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Iaas OS Support Status Distribution.")
   @visibility(Lifecycle.Read)
   iaasOsSupportStatusDistribution?: SupportStatusDistribution;
@@ -211,6 +215,7 @@ model OnPremisesIaasSummary {
   @visibility(Lifecycle.Read)
   iaasSqlSupportStatusDistribution?: SupportStatusDistribution;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS Service Pack Insight.")
   @visibility(Lifecycle.Read)
   osServicePackInsight?: ServicePackInsight;
@@ -243,8 +248,10 @@ model OnPremisesIaasSummary {
   onPremisesIaasDecommissionedSustainabilityDetails?: CarbonEmissionsDetails;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("The Iaas OS licensing details.")
 model IaasOsLicensingDetails {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The OS type.")
   @visibility(Lifecycle.Read)
   osType?: string;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/OverviewSummary.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/OverviewSummary.tsp
@@ -87,10 +87,12 @@ model OverviewSummaryProperties {
   @visibility(Lifecycle.Read)
   utilizationData?: UtilizationData;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Shows the infrastructure as a service machine OS distribution.")
   @visibility(Lifecycle.Read)
   iaasOsDistribution?: IaasOsDistribution;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS Support Status Distribution.")
   @visibility(Lifecycle.Read)
   osSupportStatusDistribution?: SupportStatusDistribution;
@@ -171,6 +173,7 @@ model ServersDiscovered {
   notApplicable?: int32;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("Shows the infrastructure as a service machine OS distribution.")
 model IaasOsDistribution {
   @doc("Number of Windows servers.")

--- a/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/PaasSummary.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/BusinessCases/WebModels/Summaries/PaasSummary.tsp
@@ -109,6 +109,7 @@ model EstimatedCostByTarget {
   @visibility(Lifecycle.Read)
   azureSqlMiCost?: float32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Azure SQL DB cost.")
   @visibility(Lifecycle.Read)
   azureSqlDbCost?: float32;
@@ -143,6 +144,7 @@ model AzureSqlSummary {
   @identifiers(#[])
   distributionByServiceTierForSqlMi?: SqlServiceTier[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Distribution by service tiers for SQL DB.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -289,6 +291,7 @@ model OnPremisesPaasSummary {
   @visibility(Lifecycle.Read)
   onPremisesWebAppSummary?: OnPremisesWebAppSummary;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS Support Status Distribution.")
   @visibility(Lifecycle.Read)
   osSupportStatusDistribution?: SupportStatusDistribution;
@@ -297,6 +300,7 @@ model OnPremisesPaasSummary {
   @visibility(Lifecycle.Read)
   sqlSupportStatusDistribution?: SupportStatusDistribution;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("OS Service Pack Insight.")
   @visibility(Lifecycle.Read)
   osServicePackInsight?: ServicePackInsight;

--- a/specification/migrate/resource-manager/Microsoft.Migrate/HeterogenousAssessments/Common/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/HeterogenousAssessments/Common/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/MachineAssessments/Normalized Contract/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/MachineAssessments/Normalized Contract/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/MachineAssessments/WebModels/MachineGraphAssessmentOptions.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/MachineAssessments/WebModels/MachineGraphAssessmentOptions.tsp
@@ -10,6 +10,7 @@ using OpenAPI;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Machine Assessment REST resource.")
 @parentResource(AssessmentProject)
 model MachineGraphAssessmentOptions

--- a/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/Common/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/Common/CommonModels.tsp
@@ -275,6 +275,7 @@ model SqlMigrationGuideline {
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("SQL target options.")
 model SqlPaaSTargetOptions {
   @doc("Gets or sets the Azure SQL compute tier.")
@@ -302,6 +303,7 @@ model SqlMiSettings {
   azureSqlInstanceType?: AzureSqlInstanceType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("SQL database assessment settings.")
 model SqlDbSettings {
   @doc("Gets or sets the azure SQL service tier.")
@@ -326,6 +328,7 @@ model SqlMiSettingsV3 {
   azureSqlInstanceType?: AzureSqlInstanceType;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("SQL database assessment settings V3.")
 model SqlDbSettingsV3 {
   @doc("Gets or sets the azure SQL service tier.")

--- a/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/Normalized Contract/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/Normalized Contract/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -205,6 +206,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/AssessedSqlDatabaseV3.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/AssessedSqlDatabaseV3.tsp
@@ -43,6 +43,7 @@ model AssessedSqlDatabaseV3Properties is AssessedWorkloadProperties<
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "Need to mention MegaBytes and hence used GB, Mb would give Gigabits"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @doc("The sql db source information")
 model SqlDbExtendedDetails {
   @doc("The linked availability group overview.")

--- a/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/SqlAssessmentV3.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/SqlAssessmentV3.tsp
@@ -32,6 +32,7 @@ model SqlAssessmentV3Properties is AssessmentProperties<
 
 @doc("SQL assessment settings class.")
 model SqlAssessmentSettings is AssessmentSettings {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets or sets user configurable setting to display the azure hybrid use benefit.")
   osLicense?: OsLicense;
 

--- a/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/SqlGraphAssessmentOptions.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/SqlAssessments/WebModels/SqlGraphAssessmentOptions.tsp
@@ -14,6 +14,7 @@ using OpenAPI;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("SQL Assessment REST resource.")
 @parentResource(AssessmentProject)
 model SqlGraphAssessmentOptions

--- a/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/RefreshEntities/RefreshEntities.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/RefreshEntities/RefreshEntities.tsp
@@ -10,6 +10,7 @@ using Azure.ResourceManager;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Request body for refreshing migration entities and groups.")
 @added(ApiVersions.v2026_02_01_preview)
 model RefreshEntitiesRequest {
@@ -28,6 +29,7 @@ model RefreshEntitiesRequest {
   ]>>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Response body for refresh migration entities operation.")
 @added(ApiVersions.v2026_02_01_preview)
 model RefreshEntitiesResponse {

--- a/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/Tasks/TaskSummary.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/Tasks/TaskSummary.tsp
@@ -12,6 +12,7 @@ using TypeSpec.OpenAPI;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ApiVersions.v2025_03_30_preview)
 @doc("Task Summary Request model.")
 model TaskSummaryRequest {
@@ -29,6 +30,7 @@ model TaskSummaryRequest {
   ]>;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ApiVersions.v2025_03_30_preview)
 @doc("Task Summary Response model.")
 model TaskSummaryResponse {

--- a/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/Waves/GenerateWavePlan.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/Waves/WebModels/Waves/GenerateWavePlan.tsp
@@ -3,6 +3,7 @@ using TypeSpec.Versioning;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Data model of Download URL for wave recommendation report.")
 @added(ApiVersions.v2025_12_01_preview)
 model GenerateWavePlanRequest {
@@ -13,6 +14,7 @@ model GenerateWavePlanRequest {
   migrationPath?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Data model of Download URL for wave recommendation report.")
 @added(ApiVersions.v2025_12_01_preview)
 model GenerateWavePlanResponse {

--- a/specification/migrate/resource-manager/Microsoft.Migrate/WebAppAssessments/Common/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/WebAppAssessments/Common/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.Migrate/WebAppAssessments/WebModels/WebAppGraphAssessmentOptions.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/WebAppAssessments/WebModels/WebAppGraphAssessmentOptions.tsp
@@ -10,6 +10,7 @@ using OpenAPI;
 
 namespace Microsoft.Migrate;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("WebApp assessment resource.")
 @parentResource(AssessmentProject)
 model WepAppGraphAssessmentOptions

--- a/specification/migrate/resource-manager/Microsoft.Migrate/WebAppCompoundAssessments/Common/StandardizedContracts/CommonModels.tsp
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/WebAppCompoundAssessments/Common/StandardizedContracts/CommonModels.tsp
@@ -21,6 +21,7 @@ model SharedResourcesDto {
   @identifiers(#[])
   sharedLogDisks?: AzureManagedDiskSkuDto[];
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the list of shared Temporary database disks.")
   @visibility(Lifecycle.Read)
   @identifiers(#[])
@@ -204,6 +205,7 @@ model AssessedNetworkAdaptersV3 {
   @doc("Gets the mac address.")
   macAddress?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Gets the ip addresses.")
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];

--- a/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/models.tsp
+++ b/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/models.tsp
@@ -2041,6 +2041,7 @@ model HypervSiteUpdateProperties {
 /**
  * DependencyMap ServiceMap extensions Client GroupMembers Request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DependencyMapServiceMapextensionsClientGroupMembersRequest {
   /**
    * id of machine
@@ -2299,6 +2300,7 @@ model HypervSiteUsage {
 /**
  * DependencyMap ServiceMap extensions ExportDependencies Request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DependencyMapServiceMapextensionsExportDependenciesRequest {
   /**
    * start time
@@ -2316,6 +2318,7 @@ model DependencyMapServiceMapextensionsExportDependenciesRequest {
 /**
  * The body of export machine errors request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExportMachineErrorsRequest {
   /**
    * Gets or sets the properties.
@@ -2336,6 +2339,7 @@ model RequestExportMachineErrorsProperties {
 /**
  * DependencyMap ServiceMapextensions Scope MapRequest
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DependencyMapServiceMapextensionsScopeMapRequest {
   /**
    * start time
@@ -2358,6 +2362,7 @@ model DependencyMapServiceMapextensionsScopeMapRequest {
 /**
  * DependencyMap ServiceMap extensions SingleMachine DetailedMap Request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DependencyMapServiceMapextensionsSingleMachineDetailedMapRequest {
   /**
    * id of machine
@@ -2794,6 +2799,7 @@ model HypervMachineProperties {
   /**
    * Operating System Details extracted from the guest             bu executing script inside the guest VM.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   guestOsDetails?: GuestOsDetails;
 
@@ -3074,6 +3080,7 @@ model HypervNetworkAdapter {
   /**
    * Static IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   staticIpAddress?: string;
 
@@ -3096,6 +3103,7 @@ model HypervNetworkAdapter {
   /**
    * Gets IP addresses for the machine.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddressList?: string[];
 
@@ -3107,46 +3115,55 @@ model HypervNetworkAdapter {
   /**
    * Gets or sets Type of the IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddressType?: string;
 }
 
 /**
  * Second level object.  Data related to a machine's operating system.             Serialized and stored as part of Machine Rest object.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model GuestOsDetails {
   /**
    * Gets or sets the type of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
    * Gets or sets the Name of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osName?: string;
 
   /**
    * Gets or sets the Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVersion?: string;
 
   /**
    * Gets or sets the Architecture of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osArchitecture?: string;
 
   /**
    * Gets or sets the Distro of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osDistro?: string;
 
   /**
    * Gets or sets the Major Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osMajorVersion?: string;
 
   /**
    * Gets or sets the Variant of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVariant?: string;
 
   /**
@@ -3564,6 +3581,7 @@ model SqlServerApplication {
   /**
    * Gets or sets the value which reflects if Named Pipe is enabled or not.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   isTcpIpEnabled?: boolean;
 
@@ -3739,36 +3757,43 @@ model OperatingSystem {
   /**
    * Gets or sets the type of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
    * Gets or sets the Name of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osName?: string;
 
   /**
    * Gets or sets the Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVersion?: string;
 
   /**
    * Gets or sets the Architecture of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osArchitecture?: string;
 
   /**
    * Gets or sets the Distro of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osDistro?: string;
 
   /**
    * Gets or sets the Major Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osMajorVersion?: string;
 
   /**
    * Gets or sets the Variant of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVariant?: string;
 }
 
@@ -3994,6 +4019,7 @@ model RunAsAccountProperties {
 /**
  * DependencyMap ServiceMap extensions ServerGroup Members Request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DependencyMapServiceMapextensionsServerGroupMembersRequest {
   /**
    * port of server
@@ -4114,6 +4140,7 @@ model ImportSiteUpdateProperties {
 /**
  * Import URI response class.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SasUriResponse {
   /**
    * Gets or sets the job ARM ID.
@@ -4381,6 +4408,7 @@ model ImportMachineProperties {
   /**
    * IP Addresses.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddresses?: string[];
 
@@ -4582,21 +4610,25 @@ model WebRoleOperatingSystem {
   /**
    * Gets or sets the type of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
    * Gets or sets the Name of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osName?: string;
 
   /**
    * Gets or sets the Version of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osVersion?: string;
 
   /**
    * Gets or sets the Architecture of the operating system.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osArchitecture?: string;
 }
 
@@ -4647,6 +4679,7 @@ model MasterSiteUpdateProperties {
 /**
  * ErrorSummaryRequest body
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ErrorSummaryRequest {
   /**
    * Gets or sets the Appliance Name.
@@ -4822,6 +4855,7 @@ model SQLInventoryImportBody {
 /**
  * ExportSqlServerRequest body
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExportSqlServersRequest {
   /**
    * Gets or sets the Appliance Name.
@@ -5417,6 +5451,7 @@ model SqlServerProperties {
   /**
    * Gets or sets size of temp database.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   tempDbSizeInMb?: float32;
 
   /**
@@ -5650,6 +5685,7 @@ model SqlServerV2UpdateProperties {
   /**
    * Gets or sets size of temp database.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   tempDbSizeInMb?: float32;
 
   /**
@@ -5862,6 +5898,7 @@ model DiscoverySiteDataSourceProperties {
 /**
  * ExportWebAppsRequest body
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExportWebAppsRequest {
   /**
    * filter options.
@@ -6181,6 +6218,7 @@ model FrontEndBinding {
   /**
    * Gets or sets the IP Address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 }
 
@@ -7137,6 +7175,7 @@ model ServerSiteResourceUpdateProperties {
 /**
  * The properties of ServerSiteUsageResponse.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ServerSiteUsageResponse {
   /**
    * Gets or sets the number of run as accounts in the site.
@@ -7211,6 +7250,7 @@ model ServerProperties {
    *             bu executing
    * script inside the guest VM.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   guestOsDetails?: GuestOsDetails;
 
@@ -7447,6 +7487,7 @@ model ServerNetworkAdapter {
   /**
    * Gets IP addresses for the machine.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddressList?: string[];
 
@@ -7458,6 +7499,7 @@ model ServerNetworkAdapter {
   /**
    * Gets or sets Type of the IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddressType?: string;
 }
 
@@ -7718,6 +7760,7 @@ model VmwareSiteUsage {
 /**
  * ExportMachinesRequest body
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExportMachinesRequest {
   /**
    * filter options.
@@ -7962,6 +8005,7 @@ model VmwareMachineProperties {
    *             bu executing
    * script inside the guest VM.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   guestOsDetails?: GuestOsDetails;
 
@@ -8280,6 +8324,7 @@ model VmwareNetworkAdapter {
   /**
    * Gets IP addresses for the machine.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddressList?: string[];
 
@@ -8291,6 +8336,7 @@ model VmwareNetworkAdapter {
   /**
    * Gets or sets Type of the IP address.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddressType?: string;
 }
 

--- a/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/enclaveConnection/enclaveConnection.tsp
+++ b/specification/mission/resource-manager/Microsoft.Mission/Mission/resourcetypes/enclaveConnection/enclaveConnection.tsp
@@ -52,6 +52,7 @@ model EnclaveConnectionProperties {
   @doc("Source CIDR.")
   sourceCidr?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @removed(Microsoft.Mission.Versions.v2025_05_01_preview)
   @doc("Source IP group Resource Id.")
   @visibility(Lifecycle.Read, Lifecycle.Create)

--- a/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/User.tsp
+++ b/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/User.tsp
@@ -63,6 +63,7 @@ model IdentityUserProperties {
 @added(Versions.v2025_04_01_preview)
 model DatabaseRole {
   /** Database scope that the role is assigned to. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   db: string;
 
   /** The role that is assigned to the user on the database scope. */

--- a/specification/monitor/data-plane/OperationalInsights/models.tsp
+++ b/specification/monitor/data-plane/OperationalInsights/models.tsp
@@ -115,6 +115,7 @@ model ErrorDetail {
 }
 
 /** Contains details when the response code indicates an error. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /** The error details. */
@@ -600,12 +601,14 @@ model MetadataPermissionsApplicationsItem {
 }
 
 /** An array of requests. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchRequest {
   /** An single request in a batch. */
   requests: BatchQueryRequest[];
 }
 
 /** A single request in a batch. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchQueryRequest {
   /** Unique ID corresponding to each request in the batch. */
   id: string;
@@ -636,12 +639,14 @@ model BatchQueryRequest {
 }
 
 /** Response to a batch query. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchResponse {
   /** An array of responses corresponding to each individual request in a batch. */
   responses?: BatchQueryResponse[];
 }
 
 /** Contains the batch query response and the headers, id, and status of the request */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BatchQueryResponse {
   /** Unique ID corresponding to each request in the batch. */
   id?: string;

--- a/specification/monitor/resource-manager/Microsoft.Insights/DataCollectionRuleConfigurationMetadata/models.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/DataCollectionRuleConfigurationMetadata/models.tsp
@@ -9,6 +9,7 @@ using Azure.Core.Traits;
 using Azure.ResourceManager;
 
 /** Request body for fetching configuration metadata. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataCollectionRuleConfigurationMetadataRequest {
   /** DCR Kind for which metadata is being requested (e.g., PlatformTelemetry). */
   dcrKind?: string;
@@ -21,6 +22,7 @@ model DataCollectionRuleConfigurationMetadataRequest {
 }
 
 /** Response containing configuration metadata for data collection rules. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataCollectionRuleConfigurationMetadataResponse {
   /** The configuration metadata for platform telemetry. */
   configurationMetadata?: ConfigurationMetadata;

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/models.tsp
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/models.tsp
@@ -1932,6 +1932,7 @@ model OperationProgressResponseType {
 /**
  * The response of get private dns zone suffix.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GetPrivateDnsZoneSuffixResponse {
   /**
    * Represents the private DNS zone suffix.

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Elastic/ElasticVolume.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Elastic/ElasticVolume.tsp
@@ -162,6 +162,7 @@ model ElasticVolumeDataProtectionPatchProperties {
 @added(Versions.v2026_05_15_preview)
 model ElasticMountTargetProperties {
   /** The mount target's IPv4 address, used to mount the volume */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddress?: ipV4Address;
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/SubvolumeInfo.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/SubvolumeInfo.tsp
@@ -70,6 +70,7 @@ model SubvolumeProperties {
  */
 #suppress "deprecated" "Suppress this warning until the property is removed."
 #deprecated "Deprecated. This model will be removed in a future API version."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SubvolumePatchRequest {
   /**
    * Subvolume Properties

--- a/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/NetworkCloud/cloudservicesnetworks/CloudServicesNetwork_models.tsp
+++ b/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/NetworkCloud/cloudservicesnetworks/CloudServicesNetwork_models.tsp
@@ -273,6 +273,7 @@ model EndpointDependency {
 /**
  * CloudServicesNetworkStorageOptions represents the storage options for the cloud services network.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CloudServicesNetworkStorageOptions {
   /**
    * The indicator to enable shared storage on the cloud services network. If not specified, the allocation will align with the standard storage enablement.

--- a/specification/newrelic/NewRelicObservability.Management/models.tsp
+++ b/specification/newrelic/NewRelicObservability.Management/models.tsp
@@ -370,6 +370,7 @@ model OperationDisplay {
 /**
  * Response of get all accounts Operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AccountsListResponse is Azure.Core.Page<AccountResource>;
 
 /**
@@ -649,6 +650,7 @@ model SaaSData {
 /**
  * Response of get all organizations Operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OrganizationsListResponse is Azure.Core.Page<OrganizationResource>;
 
 /**
@@ -687,6 +689,7 @@ model OrganizationProperties {
 /**
  * Response of get all plan data Operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PlanDataListResponse is Azure.Core.Page<PlanDataResource>;
 
 /**
@@ -905,6 +908,7 @@ model AppServicesGetRequest {
 /**
  * Response of a list app services Operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AppServicesListResponse is Azure.Core.Page<AppServiceInfo>;
 
 /**
@@ -973,6 +977,7 @@ model HostsGetRequest {
  * Response of a list VM Host Operation.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VMHostsListResponse is Azure.Core.Page<VMInfo>;
 
 /**
@@ -998,6 +1003,7 @@ model VMInfo {
 /**
  * List of all the resources being monitored by NewRelic monitor resource
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model MonitoredResourceListResponse is Azure.Core.Page<MonitoredResource>;
 
 /**
@@ -1104,6 +1110,7 @@ model PartnerBillingEntity {
 /**
  *  List of all active newrelic deployments.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ConnectedPartnerResourcesListResponse
   is Azure.Core.Page<ConnectedPartnerResourcesListFormat>;
 
@@ -1270,6 +1277,7 @@ model MonitoredSubscription {
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LinkedResourceListResponse is Azure.Core.Page<LinkedResource>;
 
 /**

--- a/specification/nginx/resource-manager/Nginx.NginxPlus/NginxPlus/models.tsp
+++ b/specification/nginx/resource-manager/Nginx.NginxPlus/NginxPlus/models.tsp
@@ -245,6 +245,7 @@ model NginxDeploymentApiKeyResponseProperties {
 /**
  * Nginx Deployment Api Key List Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NginxDeploymentApiKeyListResponse
   is Azure.Core.Page<NginxDeploymentApiKeyResponse>;
 
@@ -297,11 +298,13 @@ model NginxCertificateErrorResponseBody {
 /**
  * Nginx Certificate List Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NginxCertificateListResponse is Azure.Core.Page<NginxCertificate>;
 
 /**
  * Response of a list operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NginxConfigurationListResponse
   is Azure.Core.Page<NginxConfigurationResponse>;
 
@@ -998,6 +1001,7 @@ model NginxDeploymentUpdatePropertiesNginxAppProtect {
 /**
  * Nginx Deployment List Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NginxDeploymentListResponse is Azure.Core.Page<NginxDeployment>;
 
 /**
@@ -1107,6 +1111,7 @@ model NginxDeploymentDefaultWafPolicyProperties {
 /**
  * Nginx Deployment Waf Policy List Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NginxDeploymentWafPolicyListResponse
   is Azure.Core.Page<NginxDeploymentWafPolicyMetadata>;
 
@@ -1189,6 +1194,7 @@ model NginxDeploymentWafPolicyError {
 /**
  * Nginx Deployment Waf Policy Analysis Create Request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_11_01)
 model NginxDeploymentWafPolicyAnalysisCreateRequest {
   /**
@@ -1217,6 +1223,7 @@ model NginxDeploymentWafPolicyAnalysisData {
 /**
  * Nginx Deployment Waf Policy Analysis Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_11_01)
 model NginxDeploymentWafPolicyAnalysisResponse {
   /**

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/models.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/models.tsp
@@ -1441,6 +1441,7 @@ model ConnectionDetails {
   /**
    * IP address of the Private Endpoint. This is not used by Notification Hubs.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   privateIpAddress?: string;
 

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/models.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/models.tsp
@@ -3155,6 +3155,7 @@ model ARMErrorResponseBody {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ArmErrorResponse {
   /**
    * ARM error response body.
@@ -3163,12 +3164,14 @@ model ArmErrorResponse {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmNotFoundBodyResponse {
   @body error: ArmErrorResponse;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("ignore")
 model ArmNotFoundResponse {
   ...Response<404>;

--- a/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/basedb/dbSystem.tsp
+++ b/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/basedb/dbSystem.tsp
@@ -110,6 +110,7 @@ model DbSystemBaseProperties {
   @minValue(2)
   dataStorageSizeInGbs?: int32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("The DB system options.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
   dbSystemOptions?: DbSystemOptions;
@@ -308,6 +309,7 @@ union DbSystemSourceType {
   string,
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v20250701_preview)
 @doc("DbSystemOptions resource properties.")
 model DbSystemOptions {

--- a/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/basedb/dbVersion.tsp
+++ b/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/basedb/dbVersion.tsp
@@ -41,6 +41,7 @@ model DbVersionProperties {
   @doc("True if this version of the Oracle Database software is the latest version for a release.")
   isLatestForMajorVersion?: boolean;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("True if this version of the Oracle Database software is the preview version.")
   isPreviewDbVersion?: boolean;
 
@@ -51,15 +52,18 @@ model DbVersionProperties {
   supportsPdb?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v20250701_preview)
 @doc("Provides DbVersion query parameter for list operations.")
 model DbVersionFilter {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @query
   @doc("If provided, filters the results to the set of database versions which are supported for the given shape. e.g., VM.Standard.E5.Flex")
   @minLength(1)
   @maxLength(255)
   dbSystemShape?: BaseDbSystemShapes;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @query
   @doc("The DB system AzureId. If provided, filters the results to the set of database versions which are supported for the DB system.")
   dbSystemId?: DbSystemResourceId;

--- a/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/exadata/dbSystemShapes.tsp
+++ b/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/models/exadata/dbSystemShapes.tsp
@@ -109,6 +109,7 @@ model DbSystemShapeProperties {
   shapeAttributes?: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v20241201_preview)
 @doc("Provides GiMinorVersion query parameter for list operations.")
 model DbSystemShapeFilter {

--- a/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/inma.tsp
@@ -11,6 +11,7 @@ using Azure.Core.Foundations;
 
 namespace Microsoft.PlanetaryComputer;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Generic paged response model")
 @friendlyName("{name}PagedResponse", T)
 model Page<T> {

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.common.images.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.common.images.tsp
@@ -9,6 +9,7 @@ namespace Microsoft.PlanetaryComputer;
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImagePngResponse {
   /**
    * status code
@@ -30,6 +31,7 @@ model ImagePngResponse {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageJpegResponse {
   /**
    * status code
@@ -51,6 +53,7 @@ model ImageJpegResponse {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageJpgResponse {
   /**
    * status code
@@ -72,6 +75,7 @@ model ImageJpgResponse {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageJp2Response {
   /**
    * status code
@@ -93,6 +97,7 @@ model ImageJp2Response {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ApplicationXbinaryResponse {
   /**
    * status code
@@ -114,6 +119,7 @@ model ApplicationXbinaryResponse {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageWebpResponse {
   /**
    * status code
@@ -135,6 +141,7 @@ model ImageWebpResponse {
 /**
  * Return an image.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageTiffResponse {
   /**
    * status code

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.stac.config.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.stac.config.tsp
@@ -69,6 +69,7 @@ model RenderOption {
 /**
  * Defines parameters for vector tile rendering.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RenderOptionVectorOptions {
   /**
    * Asset key containing the TileJSON URL.

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.common.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.common.tsp
@@ -474,6 +474,7 @@ model TileJsonMetadata {
 /**
  * Successful Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model WmtsCapabilitiesXmlResponse {
   /**
    * status code for WMTSCapabilitiesXmlResponse

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.image-exports.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.image-exports.tsp
@@ -57,6 +57,7 @@ model ImageParameters {
 /**
  * Response model for image exports
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ImageResponse {
   /**
    * URL of the exported image

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.map-legends.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.map-legends.tsp
@@ -31,6 +31,7 @@ using TypeSpec.Http;
  * - The interval `[-2, 0]` is mapped to the color `[0, 0, 0, 0]` (transparent black).
  * - The interval `[1, 32]` is mapped to the color `[255, 255, 178, 255]` (opaque yellow).
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model IntervalLegendsResponse {
   /**
    * status code
@@ -54,4 +55,5 @@ model IntervalLegendsResponse {
  */
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "ClassMap legend values are RGBA color arrays, not strings."
 #suppress "@azure-tools/typespec-autorest/no-unknown" "ClassMap legend values are RGBA color arrays but additionalProperties cannot express array items."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ClassMapLegendResponse is Record<unknown>;

--- a/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.mosaics.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/models.tiler.mosaics.tsp
@@ -366,6 +366,7 @@ model TilerStacSearchDefinition {
 /**
  * Return list of assets
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ApplicationJsonResponse {
   /**
    * status code

--- a/specification/orbital/Microsoft.PlanetaryComputer/routes.stac.config.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/routes.stac.config.tsp
@@ -9,6 +9,7 @@ using TypeSpec.Http;
 namespace Microsoft.PlanetaryComputer;
 
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "STAC queryable definitions contain mixed types (objects, booleans, strings)"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Queryable definitions response.")
 model QueryableDefinitionsResponse is Record<unknown>;
 

--- a/specification/orbital/Microsoft.PlanetaryComputer/routes.tiler.items.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/routes.tiler.items.tsp
@@ -15,9 +15,11 @@ namespace Microsoft.PlanetaryComputer;
 @doc("Map of band names to their statistics.")
 model BandStatisticsMap is Record<BandStatistics>;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Return dataset's statistics.")
 model AssetStatisticsResponse is Record<BandStatisticsMap>;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Return dataset's basic info.")
 model TilerInfoMapResponse is Record<TilerInfo>;
 

--- a/specification/orbital/Microsoft.PlanetaryComputer/sas.tsp
+++ b/specification/orbital/Microsoft.PlanetaryComputer/sas.tsp
@@ -49,6 +49,7 @@ model SharedAccessSignatureSignedLink {
 /**
  * Successful Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SharedAccessSignatureTokenResponse {
   /**
    * Status code
@@ -65,6 +66,7 @@ model SharedAccessSignatureTokenResponse {
 /**
  * Successful Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SharedAccessSignatureSignedHrefResponse {
   /**
    * Status code

--- a/specification/paloaltonetworks/resource-manager/PaloAltoNetworks.Cloudngfw/Cloudngfw/models.tsp
+++ b/specification/paloaltonetworks/resource-manager/PaloAltoNetworks.Cloudngfw/Cloudngfw/models.tsp
@@ -2286,6 +2286,7 @@ model CustomCaptureConfigurationsFilter {
   @doc("Network protocol — TCP or UDP.")
   protocol: CustomCaptureConfigurationsProtocol;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Source IPv4 address in dotted format (e.g., 10.0.0.5).")
   sourceIpAddress: string;
 
@@ -2294,6 +2295,7 @@ model CustomCaptureConfigurationsFilter {
   @maxValue(65535)
   sourcePort?: int32;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Destination IPv4 address in dotted format (e.g., 52.39.204.87).")
   destinationIpAddress: string;
 

--- a/specification/peering/resource-manager/Microsoft.Peering/Peering/models.tsp
+++ b/specification/peering/resource-manager/Microsoft.Peering/Peering/models.tsp
@@ -409,6 +409,7 @@ model CdnPeeringPrefixProperties {
 /**
  * The error response that indicates why an operation has failed.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/playwrighttesting/PlaywrightTesting.AuthManager/main.tsp
+++ b/specification/playwrighttesting/PlaywrightTesting.AuthManager/main.tsp
@@ -148,6 +148,7 @@ alias GetBrowsersParams = {
   @doc("The run id provided by client for corresponding remote test run.")
   runId?: string;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @query
   @doc("The os provided by client for remote test runs.")
   os?: OS = OS.Linux;

--- a/specification/postgresql/DBforPostgreSQL.Management/models.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/models.tsp
@@ -2037,32 +2037,38 @@ model MigrationProperties {
   /**
    * Metadata of source database server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   sourceDbServerMetadata?: DbServerMetadata;
 
   /**
    * Metadata of target database server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   targetDbServerMetadata?: DbServerMetadata;
 
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.")
   sourceDbServerResourceId?: string;
 
   /**
    * Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   sourceDbServerFullyQualifiedDomainName?: string;
 
   /**
    * Identifier of the target database server resource.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   targetDbServerResourceId?: string;
 
   /**
    * Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   targetDbServerFullyQualifiedDomainName?: string;
 
   /**
@@ -2081,6 +2087,7 @@ model MigrationProperties {
   /**
    * Indicates whether to setup logical replication on source server, if needed.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   setupLogicalReplicationOnSourceDbIfNeeded?: LogicalReplicationOnSourceServer;
 
   /**
@@ -2170,6 +2177,7 @@ model MigrationSubstateDetails {
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbDetails?: Record<DatabaseMigrationState>;
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   validationDetails?: ValidationDetails;
@@ -2178,6 +2186,7 @@ model MigrationSubstateDetails {
 /**
  * Migration state of a database.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DatabaseMigrationState {
   /**
    * Name of database.
@@ -2292,6 +2301,7 @@ model ValidationDetails {
   /**
    * Details of server level validations.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @identifiers(#["databaseName"])
   dbLevelValidationDetails?: DbLevelValidationStatus[];
 }
@@ -2335,6 +2345,7 @@ model ValidationMessage {
 /**
  * Validation status summary for a database.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model DbLevelValidationStatus {
   /**
    * Name of database.
@@ -2464,17 +2475,20 @@ model MigrationResourceForPatch {
  * Migration properties.
  */
 model MigrationPropertiesForPatch {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.")
   sourceDbServerResourceId?: string;
 
   /**
    * Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   sourceDbServerFullyQualifiedDomainName?: string;
 
   /**
    * Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   targetDbServerFullyQualifiedDomainName?: string;
 
   /**
@@ -2493,6 +2507,7 @@ model MigrationPropertiesForPatch {
   /**
    * Indicates whether to setup logical replication on source server, if needed.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   setupLogicalReplicationOnSourceDbIfNeeded?: LogicalReplicationOnSourceServer;
 
   /**
@@ -3856,6 +3871,7 @@ scalar PrivateDnsZoneSuffix extends string;
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model CustomErrorResponse {
   @body
@@ -3915,6 +3931,7 @@ union NetworkMigrationState {
 /**
  * Status of a network migration operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model MigrateNetworkStatus {
   /**
    * Identifier of the subscription.

--- a/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
+++ b/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/models.tsp
@@ -210,6 +210,7 @@ model DedicatedCapacityAdministrators {
 /**
  * The error object
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/programmableconnectivity/Azure.ProgrammableConnectivity/apis/common.tsp
+++ b/specification/programmableconnectivity/Azure.ProgrammableConnectivity/apis/common.tsp
@@ -56,6 +56,7 @@ model NetworkAccessIdentifierModel {
   networkAccessIdentifier?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 @doc("A custom error response for APC.")
 model ApcErrorResponse {

--- a/specification/providerhub/ProviderHub.Management/models.tsp
+++ b/specification/providerhub/ProviderHub.Management/models.tsp
@@ -1779,10 +1779,12 @@ model FeaturesRule {
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceProviderManifestPropertiesRequestHeaderOptions
   extends RequestHeaderOptions {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RequestHeaderOptions {
   /**
    * The opt in headers.
@@ -1917,6 +1919,7 @@ model ResourceAccessRole {
 /**
  * Options for error response messages.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceProviderManagementErrorResponseMessageOptions {
   /**
    * Type of server failure response message.
@@ -1962,10 +1965,12 @@ model ResourceProviderCapabilities {
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceProviderManifestPropertiesTemplateDeploymentOptions
   extends TemplateDeploymentOptions {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model TemplateDeploymentOptions {
   /**
    * Whether preflight is supported.
@@ -2206,6 +2211,7 @@ model ResourceProviderManifestPropertiesResourceGroupLockOptionDuringMove {
 /**
  * Response options.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceProviderManifestPropertiesResponseOptions {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   serviceClientOptionsType?: ServiceClientOptionsType;
@@ -2729,10 +2735,12 @@ model ResourceTypeEndpointDstsConfiguration extends DstsConfiguration {}
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRegistrationPropertiesExtensionOptions
   extends ResourceTypeExtensionOptions {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeExtensionOptions {
   /**
    * Resource creation begin.
@@ -2749,6 +2757,7 @@ model ResourceTypeExtensionOptionsResourceCreationBegin
   extends ExtensionOptions {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExtensionOptions {
   /**
    * The request.
@@ -2985,6 +2994,7 @@ model CheckNameAvailabilitySpecifications {
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRegistrationPropertiesRequestHeaderOptions
   extends RequestHeaderOptions {}
 
@@ -3006,10 +3016,12 @@ model SubscriptionStateRule {
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRegistrationPropertiesTemplateDeploymentOptions
   extends TemplateDeploymentOptions {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExtendedLocationOptions {
   /**
    * The type.
@@ -3304,6 +3316,7 @@ model ResourceTypeRegistrationPropertiesCapacityRule {
 /**
  * Marketplace options.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRegistrationPropertiesMarketplaceOptions {
   /**
    * Add-on plan conversion allowed.
@@ -3352,6 +3365,7 @@ model ResourceTypeRegistrationPropertiesResourceQueryManagement {
 /**
  * Resource management options.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRegistrationPropertiesResourceManagementOptions {
   /**
    * Batch provisioning support.
@@ -3920,6 +3934,7 @@ model ResourceProviderManifestFeaturesRule extends FeaturesRule {}
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceProviderManifestRequestHeaderOptions
   extends RequestHeaderOptions {}
 
@@ -4121,6 +4136,7 @@ model ResourceTypeFeaturesRule extends FeaturesRule {}
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceTypeRequestHeaderOptions extends RequestHeaderOptions {}
 
 /**

--- a/specification/purestorage/resource-manager/PureStorage.Block/PureStorageBlock/main.tsp
+++ b/specification/purestorage/resource-manager/PureStorage.Block/PureStorageBlock/main.tsp
@@ -1190,6 +1190,7 @@ model ProtectionParameters {
 @added(Versions.v2026_01_01_preview)
 @doc("ISCSI connection endpoint details")
 model IscsiEndpoint {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @doc("IP address of the endpoint")
   ip: string;
 
@@ -1208,6 +1209,7 @@ model IscsiConnectionParameters {
   endpoints: IscsiEndpoint[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_01_01_preview)
 @doc("Connection parameters response")
 model ConnectionParametersResponse {

--- a/specification/purview/data-plane/datamap/models.tsp
+++ b/specification/purview/data-plane/datamap/models.tsp
@@ -500,6 +500,7 @@ model AtlasEntityHeader {
   status?: EntityStatus;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("An error response from the service")
 @error
 model AtlasErrorResponse {
@@ -580,6 +581,7 @@ model BulkImportResult {
   successImportInfoList?: ImportInfo[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Business metadata to send to the service")
 model BusinessMetadataOptions {
   @doc("InputStream of file")

--- a/specification/quantum/data-plane/Quantum/common/models-jobs.tsp
+++ b/specification/quantum/data-plane/Quantum/common/models-jobs.tsp
@@ -144,6 +144,7 @@ model JobDetails extends ItemDetails {
 }
 
 /** Options for updating a job. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(QuantumWorkspaceAPIVersion.v2025_09_01_preview)
 @parentResource(Quantum.Workspace.QuantumWorkspace)
 @resource("jobs")

--- a/specification/quantum/data-plane/Quantum/common/models-storage.tsp
+++ b/specification/quantum/data-plane/Quantum/common/models-storage.tsp
@@ -22,6 +22,7 @@ model BlobDetails {
 }
 
 /** SAS URI operation response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SasUriResponse {
   /** A URL with a SAS token to upload a blob for execution in the given workspace. */
   @visibility(Lifecycle.Read)

--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/models.tsp
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/models.tsp
@@ -185,6 +185,7 @@ model GroupQuotasEntityBase {
  * The provisioning state for the operation.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LROResponse extends Azure.ResourceManager.CommonTypes.ProxyResource {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   properties?: LROResponseProperties;
@@ -739,6 +740,7 @@ model GroupQuotasEnforcementStatusProperties {
 /**
  * List of Azure regions, where the group quotas is enabled for enforcement.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GroupQuotasEnforcementListResponse {
   /**
    * List of Azure Regions.
@@ -836,6 +838,7 @@ model ResourceName {
 /**
  * Error.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ExceptionResponse {
   /**
@@ -1123,6 +1126,7 @@ model SubscriptionQuotaAllocationsStatusList {
 /**
  * Resource definition with the requested quota.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceBaseRequest {
   /**
    * The resource name, such as SKU name.
@@ -1168,6 +1172,7 @@ model CommonResourceProperties {
 /**
  * Quota limits request response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaLimitsResponse {
   /**
    * List of quota limits with the quota request status.
@@ -1213,6 +1218,7 @@ model LimitObject extends LimitJsonObject {
 /**
  * Quota request response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaRequestOneResourceSubmitResponse {
   /**
    * Quota request ID.
@@ -1318,6 +1324,7 @@ model QuotaRequestOneResourceProperties {
 /**
  * Quota request response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaRequestSubmitResponse {
   /**
    * Quota request ID.

--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/transfer-models.tsp
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/transfer-models.tsp
@@ -334,6 +334,7 @@ model IncomingQuotaTransferProperties {
 /**
  * Request body for the donor cancel action.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model QuotaTransferCancelRequest {
   /**
@@ -346,6 +347,7 @@ model QuotaTransferCancelRequest {
 /**
  * Request body for the recipient approve action.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model IncomingQuotaTransferApproveRequest {
   /**
@@ -358,6 +360,7 @@ model IncomingQuotaTransferApproveRequest {
 /**
  * Request body for the recipient reject action.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model IncomingQuotaTransferRejectRequest {
   /**

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
@@ -417,6 +417,7 @@ model RawCertificateData {
 /**
  * Certificate corresponding to a vault that can be used by clients to register themselves with the vault.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model VaultCertificateResponse {
   /**
    * Resource name associated with the resource.
@@ -1722,6 +1723,7 @@ model ResourceCertificateAndAcsDetails extends ResourceCertificateDetails {
   authType: "AccessControlService";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ClientDiscoveryResponse
   is Azure.Core.Page<ClientDiscoveryValueForSingleApi>;
 

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/models.tsp
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/models.tsp
@@ -2285,6 +2285,7 @@ model PrepareDataMoveRequest {
 /**
  * Operation result response for Vault Storage Config
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("objectType")
 model VaultStorageConfigOperationResultResponse {
   /**
@@ -2660,6 +2661,7 @@ model OperationResultInfoBase {
 /**
  * This is the base class for operation result responses.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OperationWorkerResponse {
   /**
    * HTTP Status Code of the operation.
@@ -2703,6 +2705,7 @@ model ValidateOperationRequestResource {
 /**
  * Base class for validate operation request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @discriminator("objectType")
 model ValidateOperationRequest {
   /**
@@ -2713,6 +2716,7 @@ model ValidateOperationRequest {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidateOperationsResponse {
   /**
    * Base class for validate operation response.
@@ -2723,6 +2727,7 @@ model ValidateOperationsResponse {
 /**
  * Base class for validate operation response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidateOperationResponse {
   /**
    * Gets the validation result
@@ -3287,6 +3292,7 @@ model UnlockDeleteResponse {
 /**
  * Patch Request content to update recovery point for given RecoveryPointId
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_01_31_preview)
 @removed(Versions.v2026_02_01)
 @added(Versions.v2026_03_31_preview)
@@ -6821,6 +6827,7 @@ model OperationResultInfo extends OperationResultInfoBase {
 /**
  * Prepare DataMove Response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PrepareDataMoveResponse
   extends VaultStorageConfigOperationResultResponse {
   /**
@@ -6994,6 +7001,7 @@ model SimpleSchedulePolicyV2 extends SchedulePolicy {
  * AzureRestoreValidation request.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidateIaasVMRestoreOperationRequest extends ValidateOperationRequest {
   /**
    * This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types.
@@ -7013,6 +7021,7 @@ alias ValidateRestoreOperationRequestProperties = {
 /**
  * AzureRestoreValidation request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidateRestoreOperationRequest extends ValidateOperationRequest {
   /**
    * This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types.
@@ -8294,6 +8303,7 @@ model ClientScriptForConnect {
   /**
    * OS type - Windows, Linux etc. for which this file / folder restore client script works.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 
   /**
@@ -8867,6 +8877,7 @@ model FetchTieringCostSavingsInfoForVaultRequest
 /**
  * Operations List response which contains list of available APIs.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ClientDiscoveryResponse {
   /**
    * List of available operations.
@@ -8962,6 +8973,7 @@ model CrossTenantVaultMappingProperties {
 /**
  * Request to remove a cross-tenant vault mapping for cross-tenant restore.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_31_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_31_preview)
@@ -8992,6 +9004,7 @@ union VaultMappingState {
  * Response for CheckVaultMappingStatus API.
  * Contains information about whether a source vault is mapped to a target vault.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_31_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_31_preview)
@@ -9010,6 +9023,7 @@ model CrossTenantVaultMappingStatusResponse {
 /**
  * Request to generate a vault credential certificate for cross-tenant restore.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_31_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_31_preview)
@@ -9023,6 +9037,7 @@ model VaultCredentialCertificateRequest {
 /**
  * Options for self-signed certificate generation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_31_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_31_preview)
@@ -9037,6 +9052,7 @@ model VaultCredentialCertificateCreateOptions {
  * Response containing the generated vault credential certificate
  * and associated AAD identity details for MARS agent registration.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_03_31_preview)
 @removed(Versions.v2026_05_01)
 @added(Versions.v2026_05_31_preview)

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/Fabric.tsp
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/Fabric.tsp
@@ -53,6 +53,7 @@ alias FabricOps = Azure.ResourceManager.Legacy.LegacyOperations<
   }
 >;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model FabricAcceptedLroResponse<FinalResult extends
   | TypeSpec.Reflection.Model
   | unknown

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/ProtectionContainer.tsp
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/ProtectionContainer.tsp
@@ -62,6 +62,7 @@ alias ReplicationProtectionContainersOps = Azure.ResourceManager.Legacy.LegacyOp
   }
 >;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ProtectionContainerAcceptedLroResponse<FinalResult extends
   | TypeSpec.Reflection.Model
   | unknown

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/RecoveryServicesProvider.tsp
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/RecoveryServicesProvider.tsp
@@ -31,6 +31,7 @@ model RecoveryServicesProvider
   location?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RecoveryServicesProviderAcceptedLroResponse<FinalResult extends
   | TypeSpec.Reflection.Model
   | unknown

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/ReplicationProtectedItem.tsp
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/ReplicationProtectedItem.tsp
@@ -69,6 +69,7 @@ alias ReplicationProtectedItemsOps = Azure.ResourceManager.Legacy.LegacyOperatio
   }
 >;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ReplicationProtectedItemAcceptedLroResponse<FinalResult extends
   | TypeSpec.Reflection.Model
   | unknown

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/models.tsp
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/models.tsp
@@ -5281,6 +5281,7 @@ model AddVCenterRequestProperties {
  * Input required to update vCenter.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateVCenterRequest {
   /**
    * The update VCenter Request Properties.
@@ -8216,6 +8217,7 @@ model A2AReplicationDetails extends ReplicationProviderSpecificSettings {
   /**
    * The OS family name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osFamilyName?: string;
 
   /**
@@ -10047,6 +10049,7 @@ model FabricQueryParameter {
   /**
    * The OS type to be used for fetching agent details.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType?: string;
 }
 
@@ -11768,6 +11771,7 @@ alias HyperVVirtualMachineDetailsProperties = {
   /**
    * The Last replication time.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osDetails?: OSDetails;
 
   /**
@@ -13057,6 +13061,7 @@ model InMageDiskExclusionInput {
 /**
  * Guest disk signature based disk exclusion option when doing enable protection of virtual machine in InMage provider.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InMageVolumeExclusionOptions {
   /**
    * The volume label. The disk having any volume with this label will be excluded from replication.
@@ -13072,6 +13077,7 @@ model InMageVolumeExclusionOptions {
 /**
  * Guest disk signature based disk exclusion option when doing enable protection of virtual machine in InMage provider.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model InMageDiskSignatureExclusionOptions {
   /**
    * The guest signature of disk to be excluded from replication.
@@ -15440,6 +15446,7 @@ model InMageRcmMobilityAgentDetails {
   /**
    * The OS family name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osFamilyName?: string;
 
   /**

--- a/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/models.tsp
+++ b/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/models.tsp
@@ -636,6 +636,7 @@ model APIServerProfile {
   /**
    * The IP of the cluster API server.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ip?: string;
 }
@@ -657,6 +658,7 @@ model IngressProfile {
   /**
    * The IP of the ingress.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ip?: string;
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/models.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/models.tsp
@@ -354,6 +354,7 @@ model CheckNameAvailabilityParameters {
 /**
  * The response of listUpgradeNotifications.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model NotificationListResponse is Azure.Core.Page<UpgradeNotification>;
 
 /**

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/ResourceHealth/models.tsp
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/ResourceHealth/models.tsp
@@ -584,6 +584,7 @@ model ServiceImpactingEventIncidentProperties {
 /**
  * Error details.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/models.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/models.tsp
@@ -15,6 +15,7 @@ model DeploymentListResult is Azure.Core.Page<DeploymentExtended>;
 /**
  * Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.)
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ErrorResponse {
   /** The error code. */
   @visibility(Lifecycle.Read)
@@ -816,6 +817,7 @@ model OnErrorDeployment {
 /**
  * Specifies whether template expressions are evaluated within the scope of the parent template or nested template.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExpressionEvaluationOptions {
   /**
    * The scope to be used for evaluation of parameters, variables and functions in a nested template.

--- a/specification/resources/resource-manager/Microsoft.Resources/resourceValidator/models.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/resourceValidator/models.tsp
@@ -8,6 +8,7 @@ using Azure.ResourceManager;
 namespace ResourceValidator;
 
 /** Request to validate resources */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceValidationRequest {
   /** The resource provider namespace of the resources being validated */
   provider: string;
@@ -65,6 +66,7 @@ model ResourceValidationResponseProperties {
 }
 
 /** Resource validator successful response */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ResourceValidationResponse {
   /** Details about the results of the validation */
   properties: ResourceValidationResponseProperties;

--- a/specification/resources/resource-manager/Microsoft.Resources/resources/models.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/resources/models.tsp
@@ -271,6 +271,7 @@ model CloudError {
 }
 
 /** Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.) */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ErrorResponse {
   /** The error code. */
   @visibility(Lifecycle.Read)
@@ -628,6 +629,7 @@ model Permission {
 /**
  * The provider registration definition.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ProviderRegistrationRequest {
   /**
    * The provider consent.
@@ -885,6 +887,7 @@ model ResourceGroupPatchable {
 /**
  * Export resource group template request parameters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ExportTemplateRequest {
   /**
    * The IDs of the resources to filter the export by. To export all resources, supply an array with single entry '*'.

--- a/specification/resources/resource-manager/Microsoft.Resources/subscriptions/models.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/subscriptions/models.tsp
@@ -569,6 +569,7 @@ model TenantIdDescription {
 /**
  * Check zone peers request parameters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CheckZonePeersRequest {
   /**
    * The Microsoft location.

--- a/specification/riskiq/Easm/models.tsp
+++ b/specification/riskiq/Easm/models.tsp
@@ -860,6 +860,7 @@ model GuidPair {
 model HostAsset extends InventoryAsset {
   host?: string;
   domain?: string;
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddresses?: ObservedString[];
   webComponents?: WebComponent[];
   headers?: ObservedHeader[];
@@ -878,6 +879,7 @@ model HostAsset extends InventoryAsset {
   resourceUrls?: ResourceUrl[];
   scanMetadata?: ScanMetadata[];
   asns?: ObservedLong[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipBlocks?: IpBlock[];
   responseBodies?: ObservedString[];
   domainAsset?: DomainAsset;
@@ -949,7 +951,9 @@ model InnerError {
 model InventoryAsset {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Documentation will be added next preview version"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpAddressAsset extends InventoryAsset {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
   asns?: ObservedLong[];
   reputations?: Reputation[];
@@ -960,6 +964,7 @@ model IpAddressAsset extends InventoryAsset {
   cookies?: Cookie[];
   sslCerts?: SslCertAsset[];
   services?: Service[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipBlocks?: IpBlock[];
   sources?: Source[];
   firstSeen?: utcDateTime;
@@ -979,7 +984,9 @@ model IpAddressAsset extends InventoryAsset {
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Documentation will be added next preview version"
 #suppress "@azure-tools/typespec-client-generator-core/property-name-conflict" "Overwritten in client.tsp, but tsp pipelines run from main.tsp as well"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpBlock {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipBlock?: string;
   sources?: Source[];
   firstSeen?: utcDateTime;
@@ -989,7 +996,9 @@ model IpBlock {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Documentation will be added next preview version"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpBlockAsset extends InventoryAsset {
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipBlock?: string;
   asns?: ObservedLong[];
   bgpPrefixes?: ObservedString[];
@@ -1001,7 +1010,9 @@ model IpBlockAsset extends InventoryAsset {
   registrarCreatedAt?: ObservedLong[];
   registrarUpdatedAt?: ObservedLong[];
   netRanges?: ObservedString[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   startIp?: string;
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   endIp?: string;
   reputations?: Reputation[];
   detailedFromWhoisAt?: utcDateTime;
@@ -1100,6 +1111,7 @@ model PageAsset extends InventoryAsset {
   url?: url;
   httpMethod?: string;
   service?: string;
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddresses?: ObservedString[];
   successful?: ObservedBoolean[];
   httpResponseCodes?: ObservedInteger[];
@@ -1138,10 +1150,13 @@ model PageAsset extends InventoryAsset {
   parkedPage?: ObservedBoolean[];
   resourceUrls?: ResourceUrl[];
   guids?: GuidPair[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   finalIpAddresses?: ObservedString[];
   asns?: ObservedLong[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipBlocks?: IpBlock[];
   finalAsns?: ObservedLong[];
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   finalIpBlocks?: IpBlock[];
   responseBodies?: ObservedString[];
   domainAsset?: DomainAsset;
@@ -2062,6 +2077,7 @@ model HostAssetResource extends AssetResource {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Documentation will be added next preview version"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpAddressAssetResource extends AssetResource {
   @doc("The kind of AssetResource")
   kind: "ipAddress";
@@ -2071,6 +2087,7 @@ model IpAddressAssetResource extends AssetResource {
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Documentation will be added next preview version"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpBlockAssetResource extends AssetResource {
   @doc("The kind of AssetResource")
   kind: "ipBlock";

--- a/specification/scvmm/ScVmm.Management/models.tsp
+++ b/specification/scvmm/ScVmm.Management/models.tsp
@@ -333,10 +333,12 @@ model VirtualMachineTemplateProperties {
   vmmServerId?: VmmServerId;
 
   /** Gets the type of the os. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
   /** Gets os name. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osName?: string;
 
@@ -567,6 +569,7 @@ model VirtualMachineInstanceProperties {
   availabilitySets?: AvailabilitySetListItem[];
 
   /** OS properties. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read, Lifecycle.Create)
   osProfile?: OsProfileForVmInstance;
 
@@ -627,6 +630,7 @@ model AvailabilitySetListItem {
 }
 
 /** Defines the resource properties. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model OsProfileForVmInstance {
   /** Gets or sets the admin username. */
   @added(Versions.v2025_03_13)
@@ -641,14 +645,17 @@ model OsProfileForVmInstance {
   computerName?: string;
 
   /** Gets the type of the os. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
   /** Gets os sku. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osSku?: string;
 
   /** Gets os version. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osVersion?: string;
 
@@ -827,6 +834,7 @@ model Checkpoint {
 }
 
 /** Defines the stop action properties. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model StopVirtualMachineOptions {
   /** Gets or sets a value indicating whether to request non-graceful VM shutdown. True value for this flag indicates non-graceful shutdown whereas false indicates otherwise. Defaults to false. */
   skipShutdown?: SkipShutdown = SkipShutdown.`false`;
@@ -952,10 +960,12 @@ model VirtualMachineTemplateInventoryItem extends InventoryItemProperties {
   memoryMB?: int32;
 
   /** Gets the type of the os. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
   /** Gets os name. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osName?: string;
 
@@ -966,14 +976,17 @@ model VirtualMachineTemplateInventoryItem extends InventoryItemProperties {
 /** The Virtual machine inventory item. */
 model VirtualMachineInventoryItem extends InventoryItemProperties {
   /** Gets the type of the os. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 
   /** Gets os name. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osName?: string;
 
   /** Gets os version. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osVersion?: string;
 
@@ -987,6 +1000,7 @@ model VirtualMachineInventoryItem extends InventoryItemProperties {
   generation?: int64;
 
   /** Gets or sets the nic ip addresses. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddresses?: string[];
 
   /** Cloud inventory resource details where the VM is present. */

--- a/specification/search/data-plane/Search/models-index.tsp
+++ b/specification/search/data-plane/Search/models-index.tsp
@@ -480,6 +480,7 @@ union AutocompleteMode {
 }
 
 /** Parameters grouped for search operations. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SearchOptions {
   /** A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. */
   @query("$count")
@@ -611,6 +612,7 @@ model SearchOptions {
 }
 
 /** Parameters grouped for suggest operations. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SuggestOptions {
   /** An OData expression that filters the documents considered for suggestions. */
   @query("$filter")
@@ -816,6 +818,7 @@ model QueryRewritesValuesDebugInfo {
 }
 
 /** Parameters for filtering, sorting, faceting, paging, and other search query behaviors. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SearchRequest {
   /** A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. */
   count?: boolean;
@@ -1195,6 +1198,7 @@ model SuggestResult {
 }
 
 /** Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SuggestRequest {
   /** An OData expression that filters the documents considered for suggestions. */
   filter?: string;
@@ -1318,6 +1322,7 @@ model AutocompleteItem {
 }
 
 /** Parameters for fuzzy matching, and other autocomplete query behaviors. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AutocompleteRequest {
   /** The search text on which to base autocomplete results. */
   search: string;

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -12,6 +12,7 @@ using TypeSpec.Versioning;
 namespace Search;
 
 /** The input contract for the retrieval request. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model KnowledgeBaseRetrievalRequest {
   /** A list of chat message style input. */
   @added(Versions.v2026_05_01_preview)
@@ -55,6 +56,7 @@ model KnowledgeBaseRetrievalRequest {
 }
 
 /** The output contract for the retrieval response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model KnowledgeBaseRetrievalResponse {
   /** The response messages. */
   response?: KnowledgeBaseMessage[];
@@ -1153,6 +1155,7 @@ model KnowledgeBaseErrorAdditionalInfo {
 }
 
 /** Successful retrieval response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model KnowledgeBaseRetrievalSuccessResponse {
   /** The retrieval response is successfully returned. */
   @statusCode
@@ -1164,6 +1167,7 @@ model KnowledgeBaseRetrievalSuccessResponse {
 }
 
 /** Partial retrieval response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model KnowledgeBaseRetrievalPartialResponse {
   /** A partial retrieval response is returned. */
   @statusCode

--- a/specification/search/data-plane/Search/models-service.tsp
+++ b/specification/search/data-plane/Search/models-service.tsp
@@ -3279,6 +3279,7 @@ model ListDataSourcesResult {
 }
 
 /** The type of the keysOrIds. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DocumentKeysOrIds {
   /** document keys to be reset */
   documentKeys?: string[];
@@ -3903,6 +3904,7 @@ model ListSkillsetsResult {
 
 /** The type of the skill names. */
 #suppress "@azure-tools/typespec-client-generator-core/property-name-conflict"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SkillNames {
   /** the names of skills to be reset. */
   skillNames?: string[];
@@ -4015,6 +4017,7 @@ model SearchIndex {
 }
 
 /** Represents a search index definition, which describes the fields and search behavior of an index. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SearchIndexResponse {
   /** The name of the index. */
   name: string;
@@ -4218,6 +4221,7 @@ model ScoringFunction {
 }
 
 /** Defines options to control Cross-Origin Resource Sharing (CORS) for an index. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CorsOptions {
   /** The list of origins from which JavaScript code will be granted access to your index. Can contain a list of hosts of the form {protocol}://{fully-qualified-domain-name}[:{port#}], or a single '*' to allow all origins (not recommended). */
   allowedOrigins: string[];
@@ -4422,6 +4426,7 @@ model VectorSearchCompression {
 }
 
 /** Contains the options for rescoring. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model RescoringOptions {
   /** If set to true, after the initial search on the compressed vectors, the similarity scores are recalculated using the full-precision vectors. This will improve recall at the expense of latency. */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Pre-existing API contract"
@@ -4496,6 +4501,7 @@ model GetIndexStatisticsResult {
 }
 
 /** Specifies some text and analysis components used to break that text into tokens. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AnalyzeRequest {
   /** The text to break into tokens. */
   text: string;

--- a/specification/search/data-plane/Search/models-shared.tsp
+++ b/specification/search/data-plane/Search/models-shared.tsp
@@ -235,6 +235,7 @@ alias SearchKnowledgeBaseOperation<
 >;
 
 /** Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.). */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /** The error object. */

--- a/specification/search/resource-manager/Microsoft.Search/Search/models.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/models.tsp
@@ -1000,6 +1000,7 @@ model AzureActiveDirectoryApplicationCredentials {
 /**
  * Defines the options for how the search service authenticates a data plane request. This cannot be set if 'disableLocalAuth' is set to true.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DataPlaneAuthOptions {
   /**
    * Indicates that only the API key can be used for authentication.

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/models.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/models.tsp
@@ -5026,12 +5026,14 @@ model EnrichmentIpAddressBody {
   /**
    * The dotted-decimal or colon-separated string representation of the IP address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddress?: string;
 }
 
 /**
  * Geodata information for a given IP address
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2025_10_01_preview)
 model EnrichmentIpGeodata {
   /**
@@ -5076,11 +5078,13 @@ model EnrichmentIpGeodata {
   /**
    * The dotted-decimal or colon-separated string representation of the IP address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipAddr?: string;
 
   /**
    * A description of the connection type of this IP address
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipRoutingType?: string;
 
   /**
@@ -5431,6 +5435,7 @@ model EntityTimelineParameters {
 /**
  * The entity timeline result operation response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_10_01_preview)
 model EntityTimelineResponse {
   /**
@@ -5521,6 +5526,7 @@ model EntityTimelineItem {
 /**
  * Retrieve queries for entity result operation response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_10_01_preview)
 model GetQueriesResponse {
   /**
@@ -5593,6 +5599,7 @@ model EntityGetInsightsParameters {
 /**
  * The Get Insights result operation response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2025_10_01_preview)
 model EntityGetInsightsResponse {
   /**
@@ -15463,6 +15470,7 @@ model IpEntity extends Entity {
  * Ip entity property bag.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model IpEntityProperties extends EntityCommonProperties {
   /**
    * The IP address as string, e.g. 127.0.0.1 (either in Ipv4 or Ipv6)
@@ -16237,6 +16245,7 @@ model NicEntityProperties extends EntityCommonProperties {
   /**
    * The IP entity id of this network interface
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   ipAddressEntityId?: string;
 

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/routes.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/routes.tsp
@@ -90,6 +90,7 @@ op listGeodataByIp(
   /**
    * IP address (v4 or v6) to be enriched
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @bodyRoot
   ipAddressBody: EnrichmentIpAddressBody,
 ): ArmResponse<EnrichmentIpGeodata> | CloudError;

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/models.tsp
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/models.tsp
@@ -677,6 +677,7 @@ model NamespaceReplicaLocation {
 /**
  * The resource management error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/ManagedCluster.tsp
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/ManagedCluster.tsp
@@ -1091,6 +1091,7 @@ model ManagedMaintenanceWindowStatusContent {
 /**
  * Describes the request to apply a maintenance window on a Service Fabric Managed Cluster.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_05_01_preview)
 model ApplyMaintenanceWindowRequest {
   /**

--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/NodeType.tsp
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/ServiceFabricManagedClusters/NodeType.tsp
@@ -564,6 +564,7 @@ model NodeTypeProperties {
   /**
    * Specifies whether the node type should use a resilient ephemeral OS disk when using a supported SKU size. A resilient ephemeral OS disk provides improved reliability for ephemeral OS disks by enabling full caching.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2026_02_01)
   enableResilientEphemeralOsDisk?: boolean;
 

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/models.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/models.tsp
@@ -555,6 +555,7 @@ model FirewallRules {
   /**
    * This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   ipRanges?: string[];
 
   /**

--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/main.tsp
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/main.tsp
@@ -150,6 +150,7 @@ model SecurityPolicyProperties {
   wafPolicy?: WafPolicy;
 
   /** Ip Access Policy of the Traffic Controller Security Policy. Single Security Policy can have only one policy type set. */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @added(Versions.v2025_03_01_preview)
   ipAccessRulesPolicy?: IpAccessRulesPolicy;
 

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/SignalRService/models.tsp
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/SignalRService/models.tsp
@@ -1038,6 +1038,7 @@ model SignalRNetworkACLs {
   /**
    * IP rules for filtering public traffic
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @identifiers(#[])
   @maxItems(30)
   ipRules?: IPRule[];

--- a/specification/sphere/resource-manager/Microsoft.AzureSphere/AzureSphere/models.tsp
+++ b/specification/sphere/resource-manager/Microsoft.AzureSphere/AzureSphere/models.tsp
@@ -421,6 +421,7 @@ model ProofOfPossessionNonceRequest {
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatible"
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Existing use case"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ProofOfPossessionNonceResponse extends CertificateProperties {}
 
 /**
@@ -807,6 +808,7 @@ model GenerateCapabilityImageRequest {
 /**
  * Signed device capability image response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SignedCapabilityImageResponse {
   /**
    * The signed device capability image as a UTF-8 encoded base 64 string.

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -5184,6 +5184,7 @@ model DatabaseAutomaticTuningProperties {
  * Automatic tuning properties for individual advisors.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Azure.ResourceManager.Legacy.feature(Features.DatabaseAutomaticTuning)
 model AutomaticTuningOptions {
   /**
@@ -9057,6 +9058,7 @@ model JobStepOutput {
  * The execution options of a job step.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Azure.ResourceManager.Legacy.feature(Features.JobSteps)
 model JobStepExecutionOptions {
   /**
@@ -13861,6 +13863,7 @@ model AutomaticTuningServerProperties {
  * Automatic tuning properties for individual advisors.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Azure.ResourceManager.Legacy.feature(Features.ServerAutomaticTuning)
 model AutomaticTuningServerOptions {
   /**
@@ -14220,6 +14223,7 @@ model CheckNameAvailabilityRequest {
  * The result of a name availability check.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Azure.ResourceManager.Legacy.feature(Features.Servers)
 model CheckNameAvailabilityResponse {
   /**

--- a/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/models.tsp
+++ b/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/models.tsp
@@ -354,6 +354,7 @@ enum AssessmentDayOfWeek {
  * Operating System of the current SQL Virtual Machine.
  */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 enum OsType {
   Windows,
   Linux,
@@ -793,6 +794,7 @@ model SqlVirtualMachineProperties {
   /**
    * Operating System of the current SQL Virtual Machine.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   osType?: OsType;
 }

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1853,6 +1853,7 @@ model LeaseContainerRequest {
 /**
  * Lease Container response schema.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LeaseContainerResponse {
   /**
    * Returned unique lease ID that must be included with any request to delete the container, or to renew, change, or release the lease.
@@ -2534,6 +2535,7 @@ model LeaseShareRequest {
 /**
  * Lease Share response schema.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LeaseShareResponse {
   /**
    * Returned unique lease ID that must be included with any request to delete the share, or to renew, change, or release the lease.
@@ -4504,6 +4506,7 @@ model DeletedAccountProperties {
 /**
  * An error response from the storage resource provider.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/storage/data-plane/BlobStorage/Common/models.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/models.tsp
@@ -583,6 +583,7 @@ enum SkuName {
 }
 
 /** The result of the List Containers API. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListContainersResponse {
   /** The service endpoint. */
@@ -1292,6 +1293,7 @@ model RetentionPolicy {
 // List Blobs
 
 /** The result of the List Blobs API. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListBlobsResponse {
   /** The service endpoint. */
@@ -1376,6 +1378,7 @@ enum QueryRequestType {
 }
 
 /** Groups the set of query request settings. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QueryRequest {
   /** Required. The type of the provided query expression. */
   @Xml.name("QueryType") queryType: QueryRequestType;
@@ -2543,6 +2546,7 @@ model BlobHierarchyList {
 }
 
 /** The result of the List Blobs Hierarchical API. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListBlobsHierarchicalResponse {
   /** The service endpoint. */

--- a/specification/storage/data-plane/DataLakeStorage/models.tsp
+++ b/specification/storage/data-plane/DataLakeStorage/models.tsp
@@ -293,6 +293,7 @@ model AclFailedEntry {
 }
 
 /** The response for set access control recursive operations. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SetAccessControlRecursiveResponse {
   /** The number of directories successfully processed. */
   directoriesSuccessful?: int32;
@@ -310,6 +311,7 @@ model SetAccessControlRecursiveResponse {
 // List Blobs Hierarchy models (XML)
 
 /** An enumeration of blobs. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListBlobsHierarchySegmentResponse {
   /** The service endpoint. */

--- a/specification/storage/data-plane/FileStorage/models.tsp
+++ b/specification/storage/data-plane/FileStorage/models.tsp
@@ -630,6 +630,7 @@ model HandleItem {
   @Xml.name("SessionId") sessionId: string;
 
   /** Client IP that opened the handle */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @Xml.name("ClientIp") clientIp: string;
 
   /** Name of the client machine where the share is being mounted */
@@ -653,6 +654,7 @@ model HandleItem {
 }
 
 /** An enumeration of directories and files. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListFilesAndDirectoriesSegmentResponse {
   /** The service endpoint. */
@@ -703,6 +705,7 @@ model ListFilesAndDirectoriesSegmentResponse {
 }
 
 /** An enumeration of handles. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListHandlesResponse {
   /** The handle list. */
@@ -717,6 +720,7 @@ model ListHandlesResponse {
 }
 
 /** An enumeration of shares. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListSharesResponse {
   /** The service endpoint. */

--- a/specification/storage/data-plane/QueueStorage/models.tsp
+++ b/specification/storage/data-plane/QueueStorage/models.tsp
@@ -327,6 +327,7 @@ union GeoReplicationStatus {
 }
 
 /** The list queues response. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @Xml.name("EnumerationResults")
 model ListQueuesResponse {
   /** The service endpoint. */

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/models.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/models.tsp
@@ -2360,6 +2360,7 @@ model AmlFilesystemCheckSubnetError {
   filesystemSubnet?: AmlFilesystemCheckSubnetErrorFilesystemSubnet;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model BadRequestResponse is AmlFilesystemCheckSubnetError {
   ...Response<400>;
 }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/models.tsp
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/models.tsp
@@ -2676,6 +2676,7 @@ model OperationEntityListResult is Azure.Core.Page<OperationEntity>;
 /**
  * Standard OK response with Azure request tracking headers.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model CustomOkResponse {
   @doc("HTTP 200 OK status code")
   @statusCode

--- a/specification/translation/data-plane/DocumentTranslation/models.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/models.tsp
@@ -146,6 +146,7 @@ model StartTranslationDetails {
   options?: BatchOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Translation batch request options")
 @added(Versions.v2024_11_01_preview)
 model BatchOptions {
@@ -153,6 +154,7 @@ model BatchOptions {
   translateTextWithinImage?: boolean = false;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Definition for the input batch translation request")
 model BatchRequest {
   @doc("Source of the input documents")
@@ -248,6 +250,7 @@ model Glossary {
   storageSource?: StorageSource;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("""
   Contains unified error information used for HTTP responses across any Cognitive
   Service. Instances
@@ -559,6 +562,7 @@ model StartTranslationBody {
   body: StartTranslationDetails;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Get Translations Status options")
 model GetTranslationsStatusOptions {
   @doc("""
@@ -634,6 +638,7 @@ model GetTranslationsStatusOptions {
   orderby?: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Get Documents Status options")
 model GetDocumentsStatusOptions {
   @doc("Format - uuid.  The operation id")

--- a/specification/translation/data-plane/TextTranslation/models-shared.tsp
+++ b/specification/translation/data-plane/TextTranslation/models-shared.tsp
@@ -30,6 +30,7 @@ alias CommonResultHeaders = {
   requestId: string;
 };
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Representation of the Error Response from Translator Service.")
 @error
 model ErrorResponse {

--- a/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
@@ -20,24 +20,28 @@ namespace Microsoft.Web;
 scalar stringApplicationJson extends string;
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmBadRequestResponse {
   ...TypeSpec.Http.Response<400>;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmNotFoundResponse {
   ...TypeSpec.Http.Response<404>;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmConflictResponse {
   ...TypeSpec.Http.Response<409>;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ArmTooManyRequestsResponse {
   ...TypeSpec.Http.Response<429>;
@@ -1867,6 +1871,7 @@ model AseV3NetworkingConfigurationProperties {
 /**
  * App Service error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model DefaultErrorResponse {
   /**
@@ -6237,6 +6242,7 @@ model DiagnosticDetectorCollection
  * Class representing Response from Diagnostic Detectors
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DiagnosticDetectorResponse extends ProxyOnlyResource {
   /**
    * DiagnosticDetectorResponse resource specific properties
@@ -13554,6 +13560,7 @@ model DeletedAppRestoreRequestProperties {
  * Details about app recovery operation.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model SnapshotRestoreRequest extends ProxyOnlyResource {
   /**
    * SnapshotRestoreRequest resource specific properties
@@ -14348,6 +14355,7 @@ model RegenerateActionParameter {
 /**
  * Error response indicates Logic service is not able to process the incoming request. The error property contains the error details.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -15095,6 +15103,7 @@ model RequestHistoryProperties {
 /**
  * A request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model Request {
   /**
    * A list of all the headers attached to the request.
@@ -15116,6 +15125,7 @@ model Request {
 /**
  * A response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model Response {
   /**
    * A list of all the headers attached to the response.
@@ -15982,6 +15992,7 @@ model HttpScaleRule {
 /**
  * A request to approve or reject a private endpoint connection
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model PrivateLinkConnectionApprovalRequest {
   /**
    * The state of a private link connection
@@ -16129,6 +16140,7 @@ model AppserviceGithubToken {
 /**
  * Appservice Github token request content.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AppserviceGithubTokenRequest {
   /**
    * Code string to exchange for Github Access token

--- a/specification/web/resource-manager/Microsoft.Web/AppService/routes.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/routes.tsp
@@ -108,6 +108,7 @@ op listBillingMeters is ArmProviderActionSync<
     /**
      * App Service OS type meters used for
      */
+    #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
     @query("osType")
     osType?: string;
   },
@@ -331,6 +332,7 @@ interface ProviderOperationGroup {
     Response = ApplicationStackCollection,
     Parameters = {
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("osTypeSelected")
       osTypeSelected?: ProviderOsTypeSelected;
     },
@@ -350,6 +352,7 @@ interface ProviderOperationGroup {
       /**
        * Stack OS Type
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("stackOsType")
       stackOsType?: ProviderStackOsType;
     },
@@ -371,6 +374,7 @@ interface ProviderOperationGroup {
       /**
        * Stack OS Type
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("stackOsType")
       stackOsType?: ProviderStackOsType;
     },
@@ -392,6 +396,7 @@ interface ProviderOperationGroup {
       /**
        * Stack OS Type
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("stackOsType")
       stackOsType?: ProviderStackOsType;
     },
@@ -411,6 +416,7 @@ interface ProviderOperationGroup {
       /**
        * Stack OS Type
        */
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("stackOsType")
       stackOsType?: ProviderStackOsType;
     },
@@ -429,6 +435,7 @@ interface ProviderOperationGroup {
     Scope = SubscriptionActionScope,
     Parameters = {
       #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+      #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
       @query("osTypeSelected")
       osTypeSelected?: ProviderOsTypeSelected;
     },

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/models.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/models.tsp
@@ -868,6 +868,7 @@ model WebPubSubNetworkACLs {
   /**
    * IP rules for filtering public traffic
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @maxItems(30)
   @identifiers(#[])
   ipRules?: IPRule[];

--- a/specification/workloads/Workloads.SAPDiscoverySite.Management/models.tsp
+++ b/specification/workloads/Workloads.SAPDiscoverySite.Management/models.tsp
@@ -360,6 +360,7 @@ model ServerInstanceProperties {
 /**
  * Defines the request body for updating Server Instances resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateServerInstanceRequest {
   /**
    * Server instances properties.
@@ -463,6 +464,7 @@ model ExcelPerformanceData extends PerformanceData {
    * Provide the source Database size in GB. Applicable only if SAP instance type for this server instance is 'DB'.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "GB is short for Gigabytes."
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @visibility(Lifecycle.Read)
   totalSourceDbSizeGB?: int32;
 

--- a/specification/workloads/Workloads.SAPMonitor.Management/models.tsp
+++ b/specification/workloads/Workloads.SAPMonitor.Management/models.tsp
@@ -328,6 +328,7 @@ model AppServicePlanConfiguration {
 /**
  * Defines the request body for updating SAP monitor resource.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateMonitorRequest {
   ...ArmTagsProperty;
   ...ManagedServiceIdentityProperty;
@@ -477,6 +478,7 @@ model SapLandscapeMonitorMetricThresholds {
 /**
  * Gets or sets the provider properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model HanaDbProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the target virtual machine size.
@@ -486,6 +488,7 @@ model HanaDbProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the hana database name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbName?: string;
 
   /**
@@ -501,17 +504,20 @@ model HanaDbProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the database user name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbUsername?: string;
 
   /**
    * Gets or sets the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @secret
   dbPassword?: string;
 
   /**
    * Gets or sets the key vault URI to secret with the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPasswordUri?: string;
 
   /**
@@ -610,6 +616,7 @@ model SapNetWeaverProviderInstanceProperties
 /**
  * Gets or sets the PrometheusOS provider properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model PrometheusOsProviderInstanceProperties
   extends ProviderSpecificProperties {
   /**
@@ -642,6 +649,7 @@ model PrometheusOsProviderInstanceProperties
 /**
  * Gets or sets the DB2 provider properties.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 model Db2ProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the target virtual machine name.
@@ -651,27 +659,32 @@ model Db2ProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the db2 database name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbName?: string;
 
   /**
    * Gets or sets the db2 database sql port.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPort?: string;
 
   /**
    * Gets or sets the db2 database user name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbUsername?: string;
 
   /**
    * Gets or sets the db2 database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @secret
   dbPassword?: string;
 
   /**
    * Gets or sets the key vault URI to secret with the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPasswordUri?: string;
 
   /**
@@ -749,22 +762,26 @@ model MsSqlServerProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the database sql port.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPort?: string;
 
   /**
    * Gets or sets the database user name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbUsername?: string;
 
   /**
    * Gets or sets the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @secret
   dbPassword?: string;
 
   /**
    * Gets or sets the key vault URI to secret with the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPasswordUri?: string;
 
   /**
@@ -801,27 +818,32 @@ model OracleProviderInstanceProperties extends ProviderSpecificProperties {
   /**
    * Gets or sets the oracle database sql port.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPort?: string;
 
   /**
    * Gets or sets the oracle database name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbName?: string;
 
   /**
    * Gets or sets the oracle database user name.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbUsername?: string;
 
   /**
    * Gets or sets the oracle database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @secret
   dbPassword?: string;
 
   /**
    * Gets or sets the key vault URI to secret with the database password.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   dbPasswordUri?: string;
 
   /**

--- a/specification/workloads/Workloads.SAPVirtualInstance.Management/models.tsp
+++ b/specification/workloads/Workloads.SAPVirtualInstance.Management/models.tsp
@@ -1005,6 +1005,7 @@ model Resource {
  * Defines the request body for updating Virtual Instance for SAP.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SAP is used for representing the company product."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSAPVirtualInstanceRequest {
   /**
    * Gets or sets the Resource tags.
@@ -1311,6 +1312,7 @@ model StorageInformation {
  * Defines the request body for updating SAP Central Instance.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SAP is used for representing the company product."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSAPCentralInstanceRequest {
   /**
    * Gets or sets the Resource tags.
@@ -1408,6 +1410,7 @@ model DatabaseVmDetails {
  * Defines the request body for updating SAP Database Instance.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SAP is used for representing the company product."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSAPDatabaseInstanceRequest {
   /**
    * Gets or sets the Resource tags.
@@ -1547,6 +1550,7 @@ model ApplicationServerVmDetails {
  * Defines the request body for updating SAP Application Instance.
  */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "SAP is used for representing the company product."
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model UpdateSAPApplicationInstanceRequest {
   /**
    * Gets or sets the Resource tags.
@@ -1617,6 +1621,7 @@ model WindowsConfiguration extends OSConfiguration {
   /**
    * The OS Type
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType: OSType.Windows;
 }
 
@@ -1629,6 +1634,7 @@ model OSConfiguration {
   /**
    * The OS Type
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType: OSType;
 }
 
@@ -1675,6 +1681,7 @@ model LinuxConfiguration extends OSConfiguration {
   /**
    * The OS Type
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   osType: OSType.Linux;
 }
 


### PR DESCRIPTION
Complements #45134 by suppressing the remaining \csharp-model-suffix\ and \csharp-use-standard-acronyms\ violations across TypeSpec specs in main.

- Preserves the existing generated C# SDK API surface.
- Pins \@azure-tools/typespec-client-generator-core\ and \@azure-tools/typespec-azure-rulesets\ to \
ext\ so TypeSpec validation CI confirms all violations are suppressed.
- Complements #45134 which fixed violations already present on \	ypespec-next\.
- Related linter PR: Azure/typespec-azure#4867