### PR TITLE
Fix package detector for non-project TypeSpec configs

### DIFF
--- a/.github/workflows/src/package-name-approval/detect-namespaces.js
+++ b/.github/workflows/src/package-name-approval/detect-namespaces.js
@@ -236,6 +236,13 @@ export default async function detectNamespaces({ context, core }) {
 
   for (const { file, basePath } of changedTspconfigs) {
     const tspConfigDir = dirname(join(cwd, file));
+    if (!existsSync(join(tspConfigDir, "main.tsp"))) {
+      core.warning(
+        `Skipping package name detection for ${file}: no main.tsp found in its directory`,
+      );
+      continue;
+    }
+
     core.info(`Running typespec-metadata emitter for: ${file}`);
 
     const prResult = await runMetadataEmitter(tspConfigDir, core);

--- a/.github/workflows/src/package-name-approval/detect-namespaces.js
+++ b/.github/workflows/src/package-name-approval/detect-namespaces.js
@@ -64,10 +64,11 @@ const METADATA_LANG_MAP = {
  * package names and namespaces for all configured languages.
  *
  * @param {string} tspConfigDir - Absolute path to the directory containing tspconfig.yaml
+ * @param {string} entrypoint - Absolute path to the TypeSpec entrypoint
  * @param {import("@actions/core")} core
  * @returns {Promise<EmitterResult>}
  */
-async function runMetadataEmitter(tspConfigDir, core) {
+async function runMetadataEmitter(tspConfigDir, entrypoint, core) {
   /** @type {Record<string, string>} */
   const packageNames = {};
   /** @type {Record<string, string>} */
@@ -79,7 +80,7 @@ async function runMetadataEmitter(tspConfigDir, core) {
   const tspArgs = [
     "tsp",
     "compile",
-    tspConfigDir,
+    entrypoint,
     "--emit",
     "@azure-tools/typespec-metadata",
     "--output-dir",
@@ -122,6 +123,22 @@ async function runMetadataEmitter(tspConfigDir, core) {
   return { packageNames, namespaces, isMgmt, isDataPlane };
 }
 
+/**
+ * Prefer the standard project entrypoint, then fall back to an SDK client entrypoint.
+ *
+ * @param {string} tspConfigDir - Absolute path to the directory containing tspconfig.yaml
+ * @returns {string | null}
+ */
+function findTypeSpecEntrypoint(tspConfigDir) {
+  for (const filename of ["main.tsp", "client.tsp"]) {
+    const entrypoint = join(tspConfigDir, filename);
+    if (existsSync(entrypoint)) {
+      return entrypoint;
+    }
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Base branch compilation
 // ---------------------------------------------------------------------------
@@ -143,9 +160,15 @@ async function compileBaseVersion(file, baseRefDir, core) {
   }
 
   const baseTspConfigDir = dirname(baseTspConfigPath);
+  const entrypoint = findTypeSpecEntrypoint(baseTspConfigDir);
+  if (!entrypoint) {
+    core.warning(`No main.tsp or client.tsp found for base version of ${file}, treating as new`);
+    return null;
+  }
+
   try {
     core.info(`Compiling base branch version: ${file}`);
-    return await runMetadataEmitter(baseTspConfigDir, core);
+    return await runMetadataEmitter(baseTspConfigDir, entrypoint, core);
   } catch (e) {
     core.warning(
       `Failed to compile base version of ${file}: ${/** @type {Error} */ (e).message}, treating as new`,
@@ -236,16 +259,17 @@ export default async function detectNamespaces({ context, core }) {
 
   for (const { file, basePath } of changedTspconfigs) {
     const tspConfigDir = dirname(join(cwd, file));
-    if (!existsSync(join(tspConfigDir, "main.tsp"))) {
+    const entrypoint = findTypeSpecEntrypoint(tspConfigDir);
+    if (!entrypoint) {
       core.warning(
-        `Skipping package name detection for ${file}: no main.tsp found in its directory`,
+        `Skipping package name detection for ${file}: no main.tsp or client.tsp found in its directory`,
       );
       continue;
     }
 
     core.info(`Running typespec-metadata emitter for: ${file}`);
 
-    const prResult = await runMetadataEmitter(tspConfigDir, core);
+    const prResult = await runMetadataEmitter(tspConfigDir, entrypoint, core);
     if (prResult.isMgmt) isMgmt = true;
     if (prResult.isDataPlane) isDataPlane = true;
 

--- a/.github/workflows/test/package-name-approval/detect-namespaces.test.js
+++ b/.github/workflows/test/package-name-approval/detect-namespaces.test.js
@@ -231,8 +231,7 @@ describe("detect-namespaces (dual tsp compile)", () => {
     core = createMockCore();
     context = createMockContext();
     context.payload = { pull_request: { number: 46 }, action: "opened" };
-    const file =
-      "specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml";
+    const file = "specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml";
     mockFileStatuses([file]);
 
     execFileMock.mockClear();

--- a/.github/workflows/test/package-name-approval/detect-namespaces.test.js
+++ b/.github/workflows/test/package-name-approval/detect-namespaces.test.js
@@ -227,7 +227,7 @@ describe("detect-namespaces (dual tsp compile)", () => {
     expect(core.setOutput).not.toHaveBeenCalled();
   });
 
-  it("should skip a tspconfig whose directory has no main.tsp", async () => {
+  it("should fall back to client.tsp when main.tsp is absent", async () => {
     core = createMockCore();
     context = createMockContext();
     context.payload = { pull_request: { number: 46 }, action: "opened" };
@@ -239,12 +239,46 @@ describe("detect-namespaces (dual tsp compile)", () => {
       (/** @type {string} */ path) =>
         !(path.includes("HealthInsights.RadiologyInsights") && path.endsWith("main.tsp")),
     );
+    readFileMock.mockResolvedValue(
+      makeMetadataJson(
+        {
+          csharp: [
+            {
+              packageName: "Azure.Health.Insights.RadiologyInsights",
+              namespace: "Azure.Health.Insights.RadiologyInsights",
+            },
+          ],
+        },
+        "data",
+      ),
+    );
+
+    await detectNamespaces(args());
+
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    for (const call of execFileMock.mock.calls) {
+      expect(call[1][2]).toMatch(/[/\\]client\.tsp$/);
+    }
+    expect(core.setOutput).not.toHaveBeenCalled();
+  });
+
+  it("should skip a tspconfig whose directory has no supported entrypoint", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 47 }, action: "opened" };
+    const file = "specification/test/ClientOptions/tspconfig.yaml";
+    mockFileStatuses([file]);
+
+    execFileMock.mockClear();
+    existsSyncMock.mockImplementation(
+      (/** @type {string} */ path) => !(path.endsWith("main.tsp") || path.endsWith("client.tsp")),
+    );
 
     await detectNamespaces(args());
 
     expect(execFileMock).not.toHaveBeenCalled();
     expect(core.warning).toHaveBeenCalledWith(
-      `Skipping package name detection for ${file}: no main.tsp found in its directory`,
+      `Skipping package name detection for ${file}: no main.tsp or client.tsp found in its directory`,
     );
     expect(core.setOutput).not.toHaveBeenCalled();
   });
@@ -252,7 +286,7 @@ describe("detect-namespaces (dual tsp compile)", () => {
   it("should filter unchanged package names using dual tsp compile", async () => {
     core = createMockCore();
     context = createMockContext();
-    context.payload = { pull_request: { number: 47 }, action: "synchronize" };
+    context.payload = { pull_request: { number: 48 }, action: "synchronize" };
     const file = "specification/compute/Compute.Management/tspconfig.yaml";
     mockFileStatuses([file]);
 

--- a/.github/workflows/test/package-name-approval/detect-namespaces.test.js
+++ b/.github/workflows/test/package-name-approval/detect-namespaces.test.js
@@ -227,6 +227,29 @@ describe("detect-namespaces (dual tsp compile)", () => {
     expect(core.setOutput).not.toHaveBeenCalled();
   });
 
+  it("should skip a tspconfig whose directory has no main.tsp", async () => {
+    core = createMockCore();
+    context = createMockContext();
+    context.payload = { pull_request: { number: 46 }, action: "opened" };
+    const file =
+      "specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml";
+    mockFileStatuses([file]);
+
+    execFileMock.mockClear();
+    existsSyncMock.mockImplementation(
+      (/** @type {string} */ path) =>
+        !(path.includes("HealthInsights.RadiologyInsights") && path.endsWith("main.tsp")),
+    );
+
+    await detectNamespaces(args());
+
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(
+      `Skipping package name detection for ${file}: no main.tsp found in its directory`,
+    );
+    expect(core.setOutput).not.toHaveBeenCalled();
+  });
+
   it("should filter unchanged package names using dual tsp compile", async () => {
     core = createMockCore();
     context = createMockContext();


### PR DESCRIPTION
## Summary

- prefer `main.tsp` as the package detector entrypoint
- fall back to `client.tsp` for SDK-only TypeSpec configurations such as Health Insights Radiology
- skip with an explicit warning only when neither supported entrypoint exists
- add regression coverage for both the `client.tsp` fallback and final skip path

Fixes #45204.

## Validation

- package-name detector test suite: 11 passed
- JavaScript syntax checks passed
- Prettier and `git diff --check` passed