### PR TITLE
SecurityInsights: add Push data connector kind

### DIFF
--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/CreatePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/CreatePushDataConnector.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+    "dataConnector": {
+      "kind": "Push",
+      "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+      "properties": {
+        "connectorDefinitionName": "PushConnectorDefinition",
+        "auth": {
+          "type": "Push",
+          "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+          "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+        },
+        "dcrConfig": {
+          "streamName": "Custom-PushConnector",
+          "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+          "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_CreateOrUpdate",
+  "title": "Creates or updates a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/DeletePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/DeletePushDataConnector.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataConnectors_Delete",
+  "title": "Delete a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/GetPushDataConnectorById.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-07-01/dataConnectors/GetPushDataConnectorById.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "kind": "Push",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_Get",
+  "title": "Get a Push data connector"
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/CreatePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/CreatePushDataConnector.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+    "dataConnector": {
+      "kind": "Push",
+      "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+      "properties": {
+        "connectorDefinitionName": "PushConnectorDefinition",
+        "auth": {
+          "type": "Push",
+          "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+          "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+        },
+        "dcrConfig": {
+          "streamName": "Custom-PushConnector",
+          "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+          "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_CreateOrUpdate",
+  "title": "Creates or updates a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/DeletePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/DeletePushDataConnector.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataConnectors_Delete",
+  "title": "Delete a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/GetPushDataConnectorById.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/examples/2026-08-01-preview/dataConnectors/GetPushDataConnectorById.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "kind": "Push",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_Get",
+  "title": "Get a Push data connector"
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/models.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/models.tsp
@@ -923,6 +923,12 @@ union DataConnectorKind {
    */
   @added(Versions.v2026_08_01_preview)
   PurviewAudit: "PurviewAudit",
+
+  /**
+   * Push
+   */
+  @added(Versions.v2026_07_01)
+  Push: "Push",
 }
 
 /**
@@ -3058,6 +3064,12 @@ union CcpAuthType {
    * None
    */
   None: "None",
+
+  /**
+   * Push
+   */
+  @added(Versions.v2026_07_01)
+  Push: "Push",
 }
 
 /**
@@ -11650,6 +11662,43 @@ model RestApiPollerDataConnector extends DataConnector {
 }
 
 /**
+ * Represents Push data connector.
+ */
+@added(Versions.v2026_07_01)
+model PushDataConnector extends DataConnector {
+  /**
+   * Push data connector properties.
+   */
+  properties?: PushDataConnectorProperties;
+
+  /**
+   * The data connector kind
+   */
+  kind: "Push";
+}
+
+/**
+ * Push data connector properties.
+ */
+@added(Versions.v2026_07_01)
+model PushDataConnectorProperties {
+  /**
+   * The connector definition name (the dataConnectorDefinition resource id).
+   */
+  connectorDefinitionName: string;
+
+  /**
+   * The authentication model.
+   */
+  auth: CcpAuthConfig;
+
+  /**
+   * The DCR related properties.
+   */
+  dcrConfig?: DCRConfiguration;
+}
+
+/**
  * Rest Api Poller data connector properties.
  */
 model RestApiPollerDataConnectorProperties {
@@ -12199,6 +12248,27 @@ model BasicAuthModel extends CcpAuthConfig {
    * The auth type
    */
   type: "Basic";
+}
+
+/**
+ * Model for API authentication for Push data connectors.
+ */
+@added(Versions.v2026_07_01)
+model PushAuthModel extends CcpAuthConfig {
+  /**
+   * The Entra application (client) id used to push data to the data collection endpoint.
+   */
+  appId?: string;
+
+  /**
+   * The service principal id of the Entra application.
+   */
+  servicePrincipalId?: string;
+
+  /**
+   * The auth type
+   */
+  type: "Push";
 }
 
 /**

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/CreatePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/CreatePushDataConnector.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+    "dataConnector": {
+      "kind": "Push",
+      "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+      "properties": {
+        "connectorDefinitionName": "PushConnectorDefinition",
+        "auth": {
+          "type": "Push",
+          "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+          "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+        },
+        "dcrConfig": {
+          "streamName": "Custom-PushConnector",
+          "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+          "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_CreateOrUpdate",
+  "title": "Creates or updates a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/DeletePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/DeletePushDataConnector.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataConnectors_Delete",
+  "title": "Delete a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/GetPushDataConnectorById.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/examples/dataConnectors/GetPushDataConnectorById.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "kind": "Push",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_Get",
+  "title": "Get a Push data connector"
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/openapi.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/preview/2026-08-01-preview/openapi.json
@@ -3108,6 +3108,9 @@
           "Get a PurviewAudit data connector": {
             "$ref": "./examples/dataConnectors/GetPurviewAuditDataConnectorById.json"
           },
+          "Get a Push data connector": {
+            "$ref": "./examples/dataConnectors/GetPushDataConnectorById.json"
+          },
           "Get a RestApiPoller data connector": {
             "$ref": "./examples/dataConnectors/GetRestApiPollerById.json"
           },
@@ -3234,6 +3237,9 @@
           "Creates or updates a PurviewAudit data connector": {
             "$ref": "./examples/dataConnectors/CreatePurviewAuditDataConnector.json"
           },
+          "Creates or updates a Push data connector.": {
+            "$ref": "./examples/dataConnectors/CreatePushDataConnector.json"
+          },
           "Creates or updates a Threat Intelligence Taxii data connector.": {
             "$ref": "./examples/dataConnectors/CreateThreatIntelligenceTaxiiDataConnector.json"
           },
@@ -3314,6 +3320,9 @@
           },
           "Delete a PurviewAudit data connector": {
             "$ref": "./examples/dataConnectors/DeletePurviewAuditDataConnector.json"
+          },
+          "Delete a Push data connector.": {
+            "$ref": "./examples/dataConnectors/DeletePushDataConnector.json"
           },
           "Delete an MicrosoftPurviewInformationProtection data connector": {
             "$ref": "./examples/dataConnectors/DeleteMicrosoftPurviewInformationProtectionDataConnetor.json"
@@ -14745,7 +14754,8 @@
         "GitHub",
         "ServiceBus",
         "Oracle",
-        "None"
+        "None",
+        "Push"
       ],
       "x-ms-enum": {
         "name": "CcpAuthType",
@@ -14805,6 +14815,11 @@
             "name": "None",
             "value": "None",
             "description": "None"
+          },
+          {
+            "name": "Push",
+            "value": "Push",
+            "description": "Push"
           }
         ]
       }
@@ -16304,7 +16319,8 @@
         "IOT",
         "GCP",
         "RestApiPoller",
-        "PurviewAudit"
+        "PurviewAudit",
+        "Push"
       ],
       "x-ms-enum": {
         "name": "DataConnectorKind",
@@ -16434,6 +16450,11 @@
             "name": "PurviewAudit",
             "value": "PurviewAudit",
             "description": "PurviewAudit"
+          },
+          {
+            "name": "Push",
+            "value": "Push",
+            "description": "Push"
           }
         ]
       }
@@ -25233,6 +25254,64 @@
         {
           "$ref": "#/definitions/DataConnectorTenantId"
         }
+      ]
+    },
+    "PushAuthModel": {
+      "type": "object",
+      "description": "Model for API authentication for Push data connectors.",
+      "properties": {
+        "appId": {
+          "type": "string",
+          "description": "The Entra application (client) id used to push data to the data collection endpoint."
+        },
+        "servicePrincipalId": {
+          "type": "string",
+          "description": "The service principal id of the Entra application."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CcpAuthConfig"
+        }
+      ],
+      "x-ms-discriminator-value": "Push"
+    },
+    "PushDataConnector": {
+      "type": "object",
+      "description": "Represents Push data connector.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PushDataConnectorProperties",
+          "description": "Push data connector properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataConnector"
+        }
+      ],
+      "x-ms-discriminator-value": "Push"
+    },
+    "PushDataConnectorProperties": {
+      "type": "object",
+      "description": "Push data connector properties.",
+      "properties": {
+        "connectorDefinitionName": {
+          "type": "string",
+          "description": "The connector definition name (the dataConnectorDefinition resource id)."
+        },
+        "auth": {
+          "$ref": "#/definitions/CcpAuthConfig",
+          "description": "The authentication model."
+        },
+        "dcrConfig": {
+          "$ref": "#/definitions/DCRConfiguration",
+          "description": "The DCR related properties."
+        }
+      },
+      "required": [
+        "connectorDefinitionName",
+        "auth"
       ]
     },
     "Query": {

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/CreatePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/CreatePushDataConnector.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+    "dataConnector": {
+      "kind": "Push",
+      "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+      "properties": {
+        "connectorDefinitionName": "PushConnectorDefinition",
+        "auth": {
+          "type": "Push",
+          "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+          "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+        },
+        "dcrConfig": {
+          "streamName": "Custom-PushConnector",
+          "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+          "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "kind": "Push",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_CreateOrUpdate",
+  "title": "Creates or updates a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/DeletePushDataConnector.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/DeletePushDataConnector.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "operationalInsightsResourceProvider": "Microsoft.OperationalInsights",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DataConnectors_Delete",
+  "title": "Delete a Push data connector."
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/GetPushDataConnectorById.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/examples/dataConnectors/GetPushDataConnectorById.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "d0cfe6b2-9ac0-4464-9919-dccaee2e48c0",
+    "resourceGroupName": "myRg",
+    "workspaceName": "myWorkspace",
+    "dataConnectorId": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/d0cfe6b2-9ac0-4464-9919-dccaee2e48c0/resourceGroups/myRg/providers/Microsoft.OperationalInsights/workspaces/myWorkspace/providers/Microsoft.SecurityInsights/dataConnectors/Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "name": "Push_afef3743-0c88-469c-84ff-ca2e87dc1e48",
+        "type": "Microsoft.SecurityInsights/dataConnectors",
+        "etag": "\"0300bf09-0000-0000-0000-5c37296e0000\"",
+        "kind": "Push",
+        "properties": {
+          "connectorDefinitionName": "PushConnectorDefinition",
+          "auth": {
+            "type": "Push",
+            "appId": "9b93b3d8-1b3f-4b7c-8b6e-1f2a3c4d5e6f",
+            "servicePrincipalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+          },
+          "dcrConfig": {
+            "streamName": "Custom-PushConnector",
+            "dataCollectionEndpoint": "https://example-dce.eastus-1.ingest.monitor.azure.com",
+            "dataCollectionRuleImmutableId": "dcr-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DataConnectors_Get",
+  "title": "Get a Push data connector"
+}

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/openapi.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/stable/2026-07-01/openapi.json
@@ -2460,6 +2460,9 @@
           "Get a PremiumMicrosoftDefenderForThreatIntelligence data connector": {
             "$ref": "./examples/dataConnectors/GetPremiumMicrosoftDefenderForThreatIntelligenceById.json"
           },
+          "Get a Push data connector": {
+            "$ref": "./examples/dataConnectors/GetPushDataConnectorById.json"
+          },
           "Get a RestApiPoller data connector": {
             "$ref": "./examples/dataConnectors/GetRestApiPollerById.json"
           },
@@ -2550,6 +2553,9 @@
           "Creates or updates a PremiumMicrosoftDefenderForThreatIntelligence data connector.": {
             "$ref": "./examples/dataConnectors/CreatePremiumMicrosoftDefenderForThreatIntelligenceDataConnector.json"
           },
+          "Creates or updates a Push data connector.": {
+            "$ref": "./examples/dataConnectors/CreatePushDataConnector.json"
+          },
           "Creates or updates an Office365 data connector.": {
             "$ref": "./examples/dataConnectors/CreateOfficeDataConnetor.json"
           },
@@ -2607,6 +2613,9 @@
           }
         },
         "x-ms-examples": {
+          "Delete a Push data connector.": {
+            "$ref": "./examples/dataConnectors/DeletePushDataConnector.json"
+          },
           "Delete an MicrosoftThreatIntelligence data connector": {
             "$ref": "./examples/dataConnectors/DeleteMicrosoftThreatIntelligenceDataConnector.json"
           },
@@ -8442,7 +8451,8 @@
         "GitHub",
         "ServiceBus",
         "Oracle",
-        "None"
+        "None",
+        "Push"
       ],
       "x-ms-enum": {
         "name": "CcpAuthType",
@@ -8502,6 +8512,11 @@
             "name": "None",
             "value": "None",
             "description": "None"
+          },
+          {
+            "name": "Push",
+            "value": "Push",
+            "description": "Push"
           }
         ]
       }
@@ -9268,7 +9283,8 @@
         "MicrosoftDefenderAdvancedThreatProtection",
         "MicrosoftThreatIntelligence",
         "PremiumMicrosoftDefenderForThreatIntelligence",
-        "RestApiPoller"
+        "RestApiPoller",
+        "Push"
       ],
       "x-ms-enum": {
         "name": "DataConnectorKind",
@@ -9328,6 +9344,11 @@
             "name": "RestApiPoller",
             "value": "RestApiPoller",
             "description": "RestApiPoller"
+          },
+          {
+            "name": "Push",
+            "value": "Push",
+            "description": "Push"
           }
         ]
       }
@@ -13652,6 +13673,64 @@
           }
         ]
       }
+    },
+    "PushAuthModel": {
+      "type": "object",
+      "description": "Model for API authentication for Push data connectors.",
+      "properties": {
+        "appId": {
+          "type": "string",
+          "description": "The Entra application (client) id used to push data to the data collection endpoint."
+        },
+        "servicePrincipalId": {
+          "type": "string",
+          "description": "The service principal id of the Entra application."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CcpAuthConfig"
+        }
+      ],
+      "x-ms-discriminator-value": "Push"
+    },
+    "PushDataConnector": {
+      "type": "object",
+      "description": "Represents Push data connector.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PushDataConnectorProperties",
+          "description": "Push data connector properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataConnector"
+        }
+      ],
+      "x-ms-discriminator-value": "Push"
+    },
+    "PushDataConnectorProperties": {
+      "type": "object",
+      "description": "Push data connector properties.",
+      "properties": {
+        "connectorDefinitionName": {
+          "type": "string",
+          "description": "The connector definition name (the dataConnectorDefinition resource id)."
+        },
+        "auth": {
+          "$ref": "#/definitions/CcpAuthConfig",
+          "description": "The authentication model."
+        },
+        "dcrConfig": {
+          "$ref": "#/definitions/DCRConfiguration",
+          "description": "The DCR related properties."
+        }
+      },
+      "required": [
+        "connectorDefinitionName",
+        "auth"
+      ]
     },
     "RegistryHive": {
       "type": "string",


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

## Purpose of this PR

- [ ] New resource provider.
- [x] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [ ] Other, please clarify.

This PR adds the following Microsoft Security Insights API versions:

- `2026-07-01` stable
- `2026-08-01-preview`

It also introduces the Push data connector, including:

- The `Push` data connector and authentication kinds.
- `PushDataConnector`, `PushDataConnectorProperties`, and `PushAuthModel`.
- Create, get, and delete examples for both API versions.
- Regenerated OpenAPI specifications for both versions.

TypeSpec validation and compilation completed successfully.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the [Resource Provider guidelines](https://aka.ms/rpguidelines), including the [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.

