### PR TITLE
[trigger] namespace review for aimanager packages (temporary, revert before merge)

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aimanager/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/containerserviceaimanager"
+    default: "sdk/containerserviceaimanagerx"
 emit:
   - "@azure-tools/typespec-autorest"
 linter:
@@ -17,23 +17,23 @@ options:
     use-read-only-status-schema: true
   "@azure-tools/typespec-python":
     service-dir: "sdk/containerservice"
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-containerserviceaimanager"
-    namespace: "azure.mgmt.containerserviceaimanager"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-containerserviceaimanagerx"
+    namespace: "azure.mgmt.containerserviceaimanagerx"
     generate-test: true
     generate-sample: true
     flavor: azure
   "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.ContainerServiceAIManager"
+    namespace: "Azure.ResourceManager.ContainerServiceAIManagerX"
     emitter-output-dir: "{output-dir}/sdk/aimanager/{namespace}"
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerserviceaimanager"
-    namespace: "com.azure.resourcemanager.containerserviceaimanager"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerserviceaimanagerx"
+    namespace: "com.azure.resourcemanager.containerserviceaimanagerx"
     service-name: "Container Service AI Manager"
     flavor: azure
   "@azure-tools/typespec-go":
-    service-dir: "sdk/resourcemanager/containerserviceaimanager"
-    emitter-output-dir: "{output-dir}/{service-dir}/armcontainerserviceaimanager"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerserviceaimanager"
+    service-dir: "sdk/resourcemanager/containerserviceaimanagerx"
+    emitter-output-dir: "{output-dir}/{service-dir}/armcontainerserviceaimanagerx"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerserviceaimanagerx"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true
@@ -44,6 +44,6 @@ options:
     service-dir: "sdk/containerservice"
     flavor: azure
     experimental-extensible-enums: true
-    emitter-output-dir: "{output-dir}/{service-dir}/arm-containerserviceaimanager"
+    emitter-output-dir: "{output-dir}/{service-dir}/arm-containerserviceaimanagerx"
     package-details:
-      name: "@azure/arm-containerserviceaimanager"
+      name: "@azure/arm-containerserviceaimanagerx"


### PR DESCRIPTION
TEMPORARY: all five SDK package names are suffixed with `x` to trigger the namespace review for every language (Go, Python, Java, JS, .NET). This will be reverted before merge. Do not merge as-is.
