### PR TITLE
[Java] Associate Cognitive Services account connections with resource

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
+++ b/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
@@ -32,6 +32,9 @@ options:
     flavor: azure
     use-object-for-unknown: true
     float32-as-double: false
+    resource-collection-associations:
+      - resource: ConnectionPropertiesV2BasicResource
+        collection: AccountConnections
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-cognitiveservices"
     flavor: azure


### PR DESCRIPTION
Associates ConnectionPropertiesV2BasicResource with AccountConnections for Java generation. This restores the account-scoped fluent definition and by-ID APIs while keeping project connections as direct operations.

Validated locally with tsp-client update.