### PR TITLE
Suppress remaining C# naming diagnostics in main (suppressions only)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -230,6 +230,7 @@ model TracesDataGenerationJobOptions extends DataGenerationJobOptions {
   type: "traces";
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The options for a task generation data generation job. Use with multiturn evaluation scenarios and with prompt, file, or agent sources. Generated dataset rows include fields such as `id`, `category`, `test_case_description`, and `desired_num_turns`.")
 @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
 model TaskGenerationDataGenerationJobOptions extends DataGenerationJobOptions {

--- a/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
@@ -32,6 +32,7 @@ alias ServiceTraits = NoRepeatableRequests &
   RequestIdResponseHeaderTrait &
   QueryParametersTrait<Azure.Core.ExpandQueryParameter>;
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model HealthInsightsErrorResponse is Azure.Core.Foundations.ErrorResponse {
   ...RequestIdResponseHeader;
 }

--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/model.radiologyinsights.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/model.radiologyinsights.tsp
@@ -33,6 +33,7 @@ model RadiologyInsightsModelConfiguration {
   locale?: string;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Options regarding follow up recommendation inferences and finding inferences.")
 model RadiologyInsightsInferenceOptions {
   @doc("Follow-up recommendation options.")
@@ -50,6 +51,7 @@ model RadiologyInsightsInferenceOptions {
   qualityMeasureOptions?: QualityMeasureOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Follow-up recommendation options.")
 model FollowupRecommendationOptions {
   @doc("Include/Exclude follow-up recommendations without a specific radiology procedure. Default is false.")
@@ -62,12 +64,14 @@ model FollowupRecommendationOptions {
   provideFocusedSentenceEvidence?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("Finding options.")
 model FindingOptions {
   @doc("If this is true, provide the sentence that contains the first token of the finding's clinical indicator (i.e. the medical problem), if there is one. This sentence is provided as an extension with url 'ci_sentence', next to the token evidence. Default is false.")
   provideFocusedSentenceEvidence?: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ApiVersion.v2024_10_01)
 @doc("Guidance options.")
 model GuidanceOptions {
@@ -75,6 +79,7 @@ model GuidanceOptions {
   showGuidanceInHistory: boolean;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ApiVersion.v2024_10_01)
 @doc("Quality Measure Options.")
 model QualityMeasureOptions {

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/ComponentAPIs/models.tsp
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/ComponentAPIs/models.tsp
@@ -165,6 +165,7 @@ model ApplicationInsightsComponentAPIKey {
 /**
  * An Application Insights component API Key creation request definition.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model APIKeyRequest {
   /**
@@ -323,6 +324,7 @@ model ApplicationInsightsComponentExportConfiguration {
 /**
  * An Application Insights component Continuous Export configuration request definition.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ApplicationInsightsComponentExportRequest {
   /**
    * The document types to be exported, as comma separated values. Allowed values include 'Requests', 'Event', 'Exceptions', 'Metrics', 'PageViews', 'PageViewPerformance', 'Rdd', 'PerformanceCounters', 'Availability', 'Messages'.

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/Components/models.tsp
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/Components/models.tsp
@@ -224,6 +224,7 @@ model ApplicationInsightsComponentProperties {
   /**
    * Disable IP masking.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   DisableIpMasking?: boolean;
 
@@ -411,6 +412,7 @@ model ComponentPurgeBodyFilters {
 /**
  * Response containing operationId for a specific purge action.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ComponentPurgeResponse {
   /**
    * Id to use when querying for status for a particular purge operation.
@@ -421,6 +423,7 @@ model ComponentPurgeResponse {
 /**
  * Response containing status for a specific purge operation.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ComponentPurgeStatusResponse {
   /**
    * Status of the operation represented by the requested Id.

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/LiveTokenApi/models.tsp
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/LiveTokenApi/models.tsp
@@ -13,6 +13,7 @@ namespace LiveTokenApi;
 /**
  * The response to a live token query.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model LiveTokenResponse {
   /**
    * JWT token for accessing live metrics stream data.

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/WebTestsApi/models.tsp
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/WebTestsApi/models.tsp
@@ -140,6 +140,7 @@ model WebTestPropertiesConfiguration {
 /**
  * The collection of request properties
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model WebTestPropertiesRequest {
   /**
    * Url location to test.

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/WorkBookOperations/models.tsp
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/WorkBookOperations/models.tsp
@@ -66,6 +66,7 @@ model OperationDisplay {
 /**
  * Error response indicates Insights service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/Authorization/RoleAssignmentScheduleRequest.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/Authorization/RoleAssignmentScheduleRequest.tsp
@@ -15,6 +15,7 @@ namespace Microsoft.Authorization;
 /**
  * Role Assignment schedule request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-duplicate-base-parameter" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @extensionResource
 model RoleAssignmentScheduleRequest

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/Authorization/RoleEligibilityScheduleRequest.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/Authorization/RoleEligibilityScheduleRequest.tsp
@@ -15,6 +15,7 @@ namespace Microsoft.Authorization;
 /**
  * Role Eligibility schedule request
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-duplicate-base-parameter" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @extensionResource
 model RoleEligibilityScheduleRequest

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/RoleAssignment/models.tsp
@@ -112,6 +112,7 @@ model ValidationResponseErrorInfo {
 /**
  * Validation response
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model ValidationResponse {
   /**
    * Whether or not validation succeeded

--- a/specification/cognitiveservices/ContentSafety/models.tsp
+++ b/specification/cognitiveservices/ContentSafety/models.tsp
@@ -321,6 +321,7 @@ model ProvenanceContent {
   uri: url;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(ContentSafety.Versions.v2026_07_01_preview)
 @doc("Input describing the media to inspect using Content Provenance Detection.")
 model DetectProvenanceOptions {

--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/Common/main.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/Common/main.tsp
@@ -274,6 +274,7 @@ model Context {
 /**
  * Describes the format of Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**
@@ -374,6 +375,7 @@ model ErrorResponseErrorAdditionalInfoItem {
 /**
  * Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.)
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model CommonErrorResponse {
   /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -2004,6 +2004,7 @@ model FrontendIPConfigurationPropertiesFormat {
 }
 
 /** DDoS protection settings for a frontend IP configuration. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 @added(Versions.v2025_07_01)
 model DdosFrontendIpConfigurationSettings {
   /** The reference to the DDoS Custom Policy resource. */
@@ -3799,6 +3800,7 @@ model PrivateLinkServiceIpConfiguration extends SubResource {
 /**
  * Properties of private link service IP configuration.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model PrivateLinkServiceIpConfigurationProperties {
@@ -3887,6 +3889,7 @@ model RouteNextHopEcmp {
   /**
    * List of next hop IP addresses for ECMP routing. Must contain between 2 and 64 IP addresses.
    */
+  #suppress "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms" "Name kept for backward compatibility"
   @minItems(2)
   @maxItems(64)
   nextHopIpAddresses: string[];
@@ -4129,6 +4132,7 @@ model AddressSpace {
 /**
  * DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualNetwork)
 model DhcpOptions {

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/models.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/models.tsp
@@ -295,6 +295,7 @@ model TypedErrorInfo {
 /**
  * Error response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -356,231 +356,277 @@ model QueryOptionsH {
 
 // QueryOptions for operations
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyTrackedResourcesListQueryResultsForManagementGroupQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyTrackedResourcesListQueryResultsForSubscriptionQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyTrackedResourcesListQueryResultsForResourceGroupQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyTrackedResourcesListQueryResultsForResourceQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForManagementGroupQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForSubscriptionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForResourceGroupQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForResourceQueryOptions {
   ...QueryOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForPolicySetDefinitionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForPolicyDefinitionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForSubscriptionLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyEventsListQueryResultsForResourceGroupLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForManagementGroupQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForManagementGroupQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForSubscriptionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForSubscriptionQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForResourceGroupQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForResourceGroupQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForResourceQueryOptions {
   ...QueryOptions;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForResourceQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForPolicySetDefinitionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForPolicySetDefinitionQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForPolicyDefinitionQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForPolicyDefinitionQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForSubscriptionLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForSubscriptionLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesListQueryResultsForResourceGroupLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsB;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyStatesSummarizeForResourceGroupLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsC;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model PolicyMetadataListQueryOptions {
   ...QueryOptionsG;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForSubscriptionQueryOptions {
   ...QueryOptionsD;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForResourceGroupQueryOptions {
   ...QueryOptionsD;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForResourceQueryOptions {
   ...QueryOptionsE;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForPolicyDefinitionQueryOptions {
   ...QueryOptionsD;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForSubscriptionLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsD;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model ComponentPolicyStatesListQueryResultsForResourceGroupLevelPolicyAssignmentQueryOptions {
   ...QueryOptionsD;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListDeploymentsAtManagementGroupQueryOptions {
   ...QueryOptionsG;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListForManagementGroupQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListDeploymentsAtSubscriptionQueryOptions {
   ...QueryOptionsG;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListForSubscriptionQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListDeploymentsAtResourceGroupQueryOptions {
   ...QueryOptionsG;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListForResourceGroupQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListDeploymentsAtResourceQueryOptions {
   ...QueryOptionsG;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model RemediationsListForResourceQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model AttestationsListForSubscriptionQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model AttestationsListForResourceGroupQueryOptions {
   ...QueryOptionsH;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model AttestationsListForResourceQueryOptions {
   ...QueryOptionsH;

--- a/specification/quantum/data-plane/Quantum/common/models-jobs.tsp
+++ b/specification/quantum/data-plane/Quantum/common/models-jobs.tsp
@@ -169,6 +169,7 @@ model JobUpdateOptions {
 }
 
 /** Response returned when a job update succeeds. */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(QuantumWorkspaceAPIVersion.v2025_09_01_preview)
 model JobUpdateResponse {
   /** The name of the job. */

--- a/specification/reservations/resource-manager/Microsoft.Capacity/Reservations/Quota/models.tsp
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/Reservations/Quota/models.tsp
@@ -176,6 +176,7 @@ model ResourceName {
 /**
  * The API error.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ExceptionResponse {
   /**
@@ -369,6 +370,7 @@ model CurrentQuotaLimit {
 /**
  * Quotas (service limits) in the request response.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaLimitsResponse is Azure.Core.Page<CurrentQuotaLimit>;
 
 /**
@@ -384,6 +386,7 @@ model CreateGenericQuotaRequestParameters {
 /**
  * Response for the quota submission request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaRequestOneResourceSubmitResponse {
   /**
    * The quota request ID.
@@ -441,6 +444,7 @@ model QuotaRequestOneResourceProperties {
 /**
  * Response for the quota submission request.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model QuotaRequestSubmitResponse {
   /**
    * The quota request ID.

--- a/specification/reservations/resource-manager/Microsoft.Capacity/Reservations/Reservations/models.tsp
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/Reservations/Reservations/models.tsp
@@ -2199,6 +2199,7 @@ model OperationList {
 /**
  * The response containing operation information
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model OperationResponse {
   /**
    * Name of the operation
@@ -3003,6 +3004,7 @@ model ReservationSummary {
 /**
  * Error response indicates that the service is not able to process the incoming request. The reason is provided in the error message.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @error
 model ErrorResponse {
   /**

--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/common/main.tsp
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/ResourceGraph/common/main.tsp
@@ -11,6 +11,7 @@ namespace ResourceGraphCommon;
 /**
  * An error response from the API.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @summary("Error response.")
 @error
 model ErrorResponse {

--- a/specification/security/resource-manager/Microsoft.Security/Security/AssessmentAPI/models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/AssessmentAPI/models.tsp
@@ -1034,6 +1034,7 @@ model SecurityAssessmentList {
 /**
  * Describes properties of an assessment.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model SecurityAssessmentPropertiesResponse
@@ -1047,6 +1048,7 @@ model SecurityAssessmentPropertiesResponse
 /**
  * The result of the assessment
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model AssessmentStatusResponse extends AssessmentStatus {
   /**

--- a/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/DefenderForStorageAPI/models.tsp
@@ -411,6 +411,7 @@ model StartMalwareScanRequestProperties {
 /**
  * Request body for starting a malware scan with optional filters.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_01_01_preview)
 model StartMalwareScanRequest {
   /**

--- a/specification/security/resource-manager/Microsoft.Security/Security/SecurityConnectorsDevOpsAPI/models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/SecurityConnectorsDevOpsAPI/models.tsp
@@ -450,6 +450,7 @@ model TargetBranchConfiguration {
 /**
  * List of RP resources which supports pagination.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AzureDevOpsProjectListResponse {
   /**
    * The AzureDevOpsProject items on this page.
@@ -525,6 +526,7 @@ model AzureDevOpsProjectProperties {
 /**
  * List of RP resources which supports pagination.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model AzureDevOpsRepositoryListResponse {
   /**
    * The AzureDevOpsRepository items on this page.
@@ -618,6 +620,7 @@ model AzureDevOpsRepositoryProperties {
 /**
  * List of RP resources which supports pagination.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model DevOpsConfigurationListResponse {
   /**
    * The DevOpsConfiguration items on this page.
@@ -844,6 +847,7 @@ model GitHubOwnerProperties {
 /**
  * List of RP resources which supports pagination.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GitHubRepositoryListResponse {
   /**
    * The GitHubRepository items on this page.
@@ -1030,6 +1034,7 @@ model GitLabGroupProperties {
 /**
  * List of RP resources which supports pagination.
  */
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 model GitLabProjectListResponse {
   /**
    * The GitLabProject items on this page.


### PR DESCRIPTION
## Summary

- Adds targeted suppressions for all remaining C# naming diagnostics in `main`.
- Contains exactly 84 `csharp-model-suffix` and 4 `csharp-use-standard-acronyms` suppressions across 23 TypeSpec files.
- Does not suppress `no-unnamed-types`, default-value mismatch, or other unrelated diagnostics.
- Preserves existing REST API and generated SDK surfaces; no declarations or client names are changed.
- The diff is suppression-only; there are no package or lockfile changes.

This is the suppression-only alternative to #45175.

## Validation

A temporary validation revision installed the same compatible stack proven by #45191:

- TCGC `0.71.0-dev.11`
- Azure rulesets `0.71.0-dev.3`
- TypeSpec compiler `1.15.0-dev.16`

All six TypeSpec Validation - All shards ran across Ubuntu and Windows. The complete Ubuntu logs contained:

- 0 `csharp-model-suffix` diagnostics
- 0 `csharp-use-standard-acronyms` diagnostics

The remaining TSV failures were from unrelated TypeSpec rules and are intentionally outside this PR's scope.

Related linter PR: Azure/typespec-azure#4867
Related merged typespec-next suppression PR: #45191