### PR TITLE
[Event Grid] Add Control Plane API Version 2026-06-15-preview

### DIFF
--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_CreateOrUpdate.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateInfo": {
+      "properties": {
+        "description": "This is a test certificate",
+        "encodedCertificate": "base64EncodePemFormattedCertificateString"
+      }
+    },
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "CaCertificates_CreateOrUpdate",
+  "title": "CaCertificates_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateInfo": {
       "properties": {
         "description": "This is a test certificate",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "CaCertificates_Delete",
+  "title": "CaCertificates_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateName": "exampleCACertificateName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateName": "exampleCACertificateName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "CaCertificates_Get",
+  "title": "CaCertificates_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_ListByNamespace.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/caCertificates?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleCACertificateName1",
+            "type": "Microsoft.EventGrid/namespaces/caCertificates",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+            "properties": {
+              "description": "This is a test Root certificate",
+              "encodedCertificate": "base64EncodePemFormattedCertificateString",
+              "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+              "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CaCertificates_ListByNamespace",
+  "title": "CaCertificates_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/CaCertificates_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelInfo": {
       "properties": {
         "channelType": "PartnerTopic",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelInfo": {
+      "properties": {
+        "channelType": "PartnerTopic",
+        "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+        "messageForActivation": "Example message to approver",
+        "partnerTopicInfo": {
+          "name": "examplePartnerTopic1",
+          "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+          "resourceGroupName": "examplerg2",
+          "source": "ContosoCorp.Accounts.User1"
+        }
+      }
+    },
+    "channelName": "exampleChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Channels_CreateOrUpdate",
+  "title": "Channels_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleEventChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Channels_Delete",
+  "title": "Channels_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleEventChannelName1",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleChannelName1",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          },
+          "provisioningState": "Succeeded",
+          "readinessState": "NeverActivated"
+        }
+      }
+    }
+  },
+  "operationId": "Channels_Get",
+  "title": "Channels_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "examplechannel",
     "partnerNamespaceName": "examplenamespace",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "examplechannel",
+    "partnerNamespaceName": "examplenamespace",
+    "resourceGroupName": "examplerg",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnernamespaces/examplenamespace",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "Channels_GetFullUrl",
+  "title": "Channels_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_ListByPartnerNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_ListByPartnerNamespace.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampleChannelName1",
+            "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+            "properties": {
+              "channelType": "PartnerTopic",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Example message to approver",
+              "partnerTopicInfo": {
+                "name": "examplePartnerTopic1",
+                "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+                "resourceGroupName": "examplerg2",
+                "source": "ContosoCorp.Accounts.User1"
+              },
+              "provisioningState": "Succeeded",
+              "readinessState": "NeverActivated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Channels_ListByPartnerNamespace",
+  "title": "Channels_ListByPartnerNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_ListByPartnerNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_ListByPartnerNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleChannelName1",
     "channelUpdateParameters": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Channels_Update.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleChannelName1",
+    "channelUpdateParameters": {
+      "properties": {
+        "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:11.785Z"
+      }
+    },
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Channels_Update",
+  "title": "Channels_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_CreateOrUpdate.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupInfo": {
+      "properties": {
+        "description": "This is a test client group",
+        "query": "attributes.b IN ['a', 'b', 'c']"
+      }
+    },
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    }
+  },
+  "operationId": "ClientGroups_CreateOrUpdate",
+  "title": "ClientGroups_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupInfo": {
       "properties": {
         "description": "This is a test client group",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ClientGroups_Delete",
+  "title": "ClientGroups_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupName": "exampleClientGroupName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupName": "exampleClientGroupName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_Get.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    }
+  },
+  "operationId": "ClientGroups_Get",
+  "title": "ClientGroups_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ClientGroups_ListByNamespace.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/clientGroups?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleClientGroupName1",
+            "type": "Microsoft.EventGrid/namespaces/clientGroups",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+            "properties": {
+              "description": "This is a test client group",
+              "query": "attributes.b IN ['a', 'b', 'c']"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ClientGroups_ListByNamespace",
+  "title": "ClientGroups_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientInfo": {
       "properties": {
         "description": "This is a test client",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_CreateOrUpdate.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientInfo": {
+      "properties": {
+        "description": "This is a test client",
+        "attributes": {
+          "deviceTypes": [
+            "Fan",
+            "Light",
+            "AC"
+          ],
+          "floor": 3,
+          "room": "345"
+        },
+        "clientCertificateAuthentication": {
+          "validationScheme": "SubjectMatchesAuthenticationName"
+        },
+        "state": "Enabled"
+      }
+    },
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "Clients_CreateOrUpdate",
+  "title": "Clients_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientName": "exampleClientName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Clients_Delete",
+  "title": "Clients_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientName": "exampleClientName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_Get.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "Clients_Get",
+  "title": "Clients_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Clients_ListByNamespace.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/clients?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleClientName1",
+            "type": "Microsoft.EventGrid/namespaces/clients",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+            "properties": {
+              "description": "This is a test client",
+              "attributes": {
+                "deviceTypes": [
+                  "Light",
+                  "1"
+                ],
+                "floor": 3,
+                "room": "345a"
+              },
+              "clientCertificateAuthentication": {
+                "validationScheme": "SubjectMatchesAuthenticationName"
+              },
+              "provisioningState": "Succeeded",
+              "state": "Enabled"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clients_ListByNamespace",
+  "title": "Clients_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_CreateOrUpdate",
+  "title": "DomainEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainEventSubscriptions_Delete",
+  "title": "DomainEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_Get",
+  "title": "DomainEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_GetDeliveryAttributes",
+  "title": "DomainEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_GetFullUrl",
+  "title": "DomainEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_List.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_List",
+  "title": "DomainEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_Update",
+  "title": "DomainEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_CreateOrUpdate",
+  "title": "DomainTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
@@ -11,8 +11,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainTopicEventSubscriptions_Delete",
+  "title": "DomainTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Get.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_Get",
+  "title": "DomainTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "DomainTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_GetFullUrl",
+  "title": "DomainTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_List.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_List",
+  "title": "DomainTopicEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Update.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_Update",
+  "title": "DomainTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_CreateOrUpdate.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainTopicName": "exampledomaintopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampledomaintopic1",
+        "type": "Microsoft.EventGrid/domains/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1/topics/exampledomaintopic1",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopics_CreateOrUpdate",
+  "title": "DomainTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainTopicName": "exampledomaintopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainTopicName": "exampledomaintopic1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainTopicName": "exampledomaintopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainTopics_Delete",
+  "title": "DomainTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Get.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "domainTopicName": "topic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "topic1",
+        "type": "Microsoft.EventGrid/domains/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2/topics/topic1",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopics_Get",
+  "title": "DomainTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "domainTopicName": "topic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_ListByDomain.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_ListByDomain.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_ListByDomain.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/DomainTopics_ListByDomain.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "domainCli100topic1",
+            "type": "Microsoft.EventGrid/domains/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/devexprg/providers/Microsoft.EventGrid/domains/domainCli100/topics/domainCli100topic1",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "domainCli100topic2",
+            "type": "Microsoft.EventGrid/domains/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/devexprg/providers/Microsoft.EventGrid/domains/domainCli100/topics/domainCli100topic2",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopics_ListByDomain",
+  "title": "DomainTopics_ListByDomain"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_CreateOrUpdate.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainInfo": {
+      "location": "westus2",
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "domainName": "exampledomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampledomain1",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_CreateOrUpdate",
+  "title": "Domains_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainInfo": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Domains_Delete",
+  "title": "Domains_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampledomain2",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+        "location": "westcentralus",
+        "properties": {
+          "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_Get",
+  "title": "Domains_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListByResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampledomain1",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampledomain2",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Domains_ListByResourceGroup",
+  "title": "Domains_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListBySubscription.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampledomain1",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampledomain2",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Domains_ListBySubscription",
+  "title": "Domains_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Domains_ListSharedAccessKeys",
+  "title": "Domains_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "regenerateKeyRequest": {
       "keyName": "key1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Domains_RegenerateKey",
+  "title": "Domains_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainUpdateParameters": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Domains_Update.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainUpdateParameters": {
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "exampledomain1",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_Update",
+  "title": "Domains_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "AzureFunction",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "HybridConnection",
+          "properties": {
+            "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "ServiceBusQueue",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "ServiceBusTopic",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "StorageQueue",
+          "properties": {
+            "queueMessageTimeToLiveInSeconds": 300,
+            "queueName": "queue1",
+            "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResource.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription10",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription10",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResourceGroup.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForSubscription.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "",
+            "subjectEndsWith": ""
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_CreateOrUpdateForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForCustomTopic.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription10",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResource.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription10",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForResourceGroup.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_DeleteForSubscription.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetDeliveryAttributes",
+  "title": "EventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResource.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetForSubscription.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForCustomTopic.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResource.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResourceGroup.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_GetFullUrlForSubscription.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByDomainTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByDomainTopic.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "examplerg",
     "domainName": "domain1",
     "topicName": "topic1",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByDomainTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByDomainTopic.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "domainName": "domain1",
+    "topicName": "topic1",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListByDomainTopic",
+  "title": "EventSubscriptions_ListByDomainTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByResource.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "providerNamespace": "Microsoft.EventGrid",
+    "resourceTypeName": "topics",
+    "resourceName": "exampletopic2",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListByResource",
+  "title": "EventSubscriptions_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListByResource.json
@@ -5,7 +5,7 @@
     "providerNamespace": "Microsoft.EventGrid",
     "resourceTypeName": "topics",
     "resourceName": "exampletopic2",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription4",
+            "name": "examplesubscription4",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalByResourceGroup",
+  "title": "EventSubscriptions_ListGlobalByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroup.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "resourceGroupName": "examplerg",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.Resources.ResourceGroups"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.Resources.ResourceGroups"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalByResourceGroupForTopicType",
+  "title": "EventSubscriptions_ListGlobalByResourceGroupForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          },
+          {
+            "name": "examplesubscription4",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription4",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalBySubscription",
+  "title": "EventSubscriptions_ListGlobalBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.Resources.Subscriptions"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.Resources.Subscriptions"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalBySubscriptionForTopicType",
+  "title": "EventSubscriptions_ListGlobalBySubscriptionForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroup.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalByResourceGroup",
+  "title": "EventSubscriptions_ListRegionalByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.EventHub.namespaces"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalByResourceGroupForTopicType",
+  "title": "EventSubscriptions_ListRegionalByResourceGroupForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscription.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "EventHub",
+                "properties": {
+                  "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalBySubscription",
+  "title": "EventSubscriptions_ListRegionalBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.EventHub.namespaces"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalBySubscriptionForTopicType",
+  "title": "EventSubscriptions_ListRegionalBySubscriptionForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.EventHub.namespaces"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "AzureFunction",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "EventHub",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "HybridConnection",
+        "properties": {
+          "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "ServiceBusQueue",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "ServiceBusTopic",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "StorageQueue",
+        "properties": {
+          "queueMessageTimeToLiveInSeconds": 300,
+          "queueName": "queue1",
+          "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResource.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForResourceGroup.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "EventHub",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForSubscription.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/EventSubscriptions_UpdateForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ExtensionTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ExtensionTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "providerNamespace": "microsoft.storage",
     "resourceGroupName": "examplerg",
     "resourceName": "exampleResourceName",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ExtensionTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/ExtensionTopics_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "providerNamespace": "microsoft.storage",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceTypeName": "storageaccounts",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "providers/Microsoft.EventGrid/extensionTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default",
+        "properties": {
+          "description": "Extension topic for /subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default that can be used to obtain metrics",
+          "systemTopic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleResourceName-2a41650f-00dd-4790-b3ab-dabd12d227cb"
+        }
+      }
+    }
+  },
+  "operationId": "ExtensionTopics_Get",
+  "title": "ExtensionTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deliveryConfiguration": {
+          "deliveryMode": "Queue",
+          "queue": {
+            "eventTimeToLive": "P1D",
+            "maxDeliveryCount": 4,
+            "receiveLockDurationInSeconds": 60
+          }
+        },
+        "eventDeliverySchema": "CloudEventSchemaV1_0"
+      }
+    },
+    "eventSubscriptionName": "examplenamespacetopicEventSub2",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_CreateOrUpdate",
+  "title": "NamespaceTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deliveryConfiguration": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplenamespacetopicEventSub2",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Delete",
+  "title": "NamespaceTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplenamespacetopicEventSub2",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
@@ -11,8 +11,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplenamespacetopicEventSub1",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplenamespacetopicEventSub1",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Get",
+  "title": "NamespaceTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName",
+    "namespaceName": "exampleNamespace",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopic"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "NamespaceTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName",
     "namespaceName": "exampleNamespace",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_GetFullUrl",
+  "title": "NamespaceTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplenamespacetopicEventSub1",
+            "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub1",
+            "properties": {
+              "deliveryConfiguration": {
+                "deliveryMode": "Queue",
+                "queue": {
+                  "eventTimeToLive": "P1D",
+                  "maxDeliveryCount": 5,
+                  "receiveLockDurationInSeconds": 50
+                }
+              },
+              "eventDeliverySchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": null
+          },
+          {
+            "name": "examplenamespacetopicEventSub2",
+            "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+            "properties": {
+              "deliveryConfiguration": {
+                "deliveryMode": "Queue",
+                "queue": {
+                  "eventTimeToLive": "P1D",
+                  "maxDeliveryCount": 4,
+                  "receiveLockDurationInSeconds": 60
+                }
+              },
+              "eventDeliverySchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_ListByNamespaceTopic",
+  "title": "NamespaceTopicEventSubscriptions_ListByNamespaceTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Update.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleNamespaceTopicEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "properties": {
+        "deliveryConfiguration": {
+          "deliveryMode": "Queue",
+          "queue": {
+            "eventTimeToLive": "P1D",
+            "maxDeliveryCount": 3,
+            "receiveLockDurationInSeconds": 60
+          }
+        },
+        "eventDeliverySchema": "CloudEventSchemaV1_0"
+      }
+    },
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopicName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceTopicEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 3,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    },
+    "202": {
+      "body": {
+        "name": "exampleNamespaceTopicEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 3,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Updating"
+        },
+        "systemData": null
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Update",
+  "title": "NamespaceTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleNamespaceTopicEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "properties": {
@@ -61,8 +61,8 @@
         "systemData": null
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_CreateOrUpdate.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "namespaceTopicInfo": {
+      "properties": {
+        "eventRetentionInDays": 1,
+        "inputSchema": "CloudEventSchemaV1_0",
+        "publisherType": "Custom"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Creating",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_CreateOrUpdate",
+  "title": "NamespaceTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "namespaceTopicInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NamespaceTopics_Delete",
+  "title": "NamespaceTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e41",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e41/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_Get",
+  "title": "NamespaceTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e41",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListByNamespace.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplenamespacetopic2",
+            "type": "Microsoft.EventGrid/namespaces/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+            "properties": {
+              "eventRetentionInDays": 1,
+              "inputSchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded",
+              "publisherType": "Custom"
+            },
+            "systemData": null
+          },
+          {
+            "name": "examplenamespacetopic4",
+            "type": "Microsoft.EventGrid/namespaces/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic4",
+            "properties": {
+              "eventRetentionInDays": 1,
+              "inputSchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded",
+              "publisherType": "Custom"
+            },
+            "systemData": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_ListByNamespace",
+  "title": "NamespaceTopics_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_ListSharedAccessKeys.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_ListSharedAccessKeys",
+  "title": "NamespaceTopics_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "regenerateKeyRequest": {
       "keyName": "key1"
@@ -18,8 +18,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_RegenerateKey.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_RegenerateKey",
+  "title": "NamespaceTopics_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "namespaceTopicUpdateParameters": {
       "properties": {
@@ -40,8 +40,8 @@
         "systemData": null
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NamespaceTopics_Update.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "namespaceTopicUpdateParameters": {
+      "properties": {
+        "eventRetentionInDays": 1
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopicName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_Update",
+  "title": "NamespaceTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceInfo": {
       "location": "westus",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_CreateOrUpdate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceInfo": {
+      "location": "westus",
+      "properties": {
+        "topicSpacesConfiguration": {
+          "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+          "state": "Enabled"
+        }
+      },
+      "tags": {
+        "tag1": "value11",
+        "tag2": "value22"
+      }
+    },
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/Namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Creating",
+          "topicSpacesConfiguration": {
+            "hostname": null,
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value11",
+          "key2": "value22"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/Namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Creating",
+          "topicSpacesConfiguration": {
+            "hostname": null,
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value11",
+          "key2": "value22"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "Namespaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "Namespaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "West US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2",
+          "key3": "value3"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "Namespaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListByResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/namespaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleNamespaceName1",
+            "type": "Microsoft.EventGrid/namespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+            "location": "West US",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicSpacesConfiguration": {
+                "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+                "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+                "state": "Enabled"
+              }
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "Namespaces_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListBySubscription.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleNamespaceName1",
+            "type": "Microsoft.EventGrid/namespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+            "location": "West US",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicSpacesConfiguration": {
+                "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+                "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+                "state": "Enabled"
+              }
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListBySubscription",
+  "title": "Namespaces_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListSharedAccessKeys",
+  "title": "Namespaces_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_RegenerateKey.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKey",
+  "title": "Namespaces_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "regenerateKeyRequest": {
       "keyName": "key1"
@@ -17,8 +17,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "namespaceUpdateParameters": {
       "tags": {
@@ -46,8 +46,8 @@
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_Update.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "namespaceUpdateParameters": {
+      "tags": {
+        "tag1": "value1Updated"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "West US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value1Updated"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "Namespaces_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ValidateCustomDomainOwnership.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ValidateCustomDomainOwnership.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -36,8 +36,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ValidateCustomDomainOwnership.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Namespaces_ValidateCustomDomainOwnership.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "customDomainsForTopicSpacesConfiguration": [
+          {
+            "certificateUrl": "string",
+            "expectedTxtRecordName": "txt-record-name-2",
+            "expectedTxtRecordValue": "txt-record-value-2",
+            "fullyQualifiedDomainName": "custom-domain-name-2",
+            "identity": {
+              "type": "SystemAssigned"
+            },
+            "validationState": "Pending"
+          }
+        ],
+        "customDomainsForTopicsConfiguration": [
+          {
+            "certificateUrl": "string",
+            "expectedTxtRecordName": "txt-record-name-1",
+            "expectedTxtRecordValue": "txt-record-value-1",
+            "fullyQualifiedDomainName": "custom-domain-name-1",
+            "identity": {
+              "type": "SystemAssigned"
+            },
+            "validationState": "Pending"
+          }
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_ValidateCustomDomainOwnership",
+  "title": "Namespaces_ValidateCustomDomainOwnership"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "associationName": "someAssociation",
     "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "associationName": "someAssociation",
+    "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+            "location": "West US",
+            "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+          },
+          "profile": {
+            "name": "someProfile",
+            "accessRules": [
+              {
+                "name": "ipRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "1",
+            "diagnosticSettingsVersion": "1",
+            "enabledLogCategories": [
+              "NspOutbound"
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "someAssociation",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "title": "NetworkSecurityPerimeterConfigurations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_List.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+            "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+                "location": "West US",
+                "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+              },
+              "profile": {
+                "name": "someProfile",
+                "accessRules": [
+                  {
+                    "name": "ipRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "1",
+                "diagnosticSettingsVersion": "1",
+                "enabledLogCategories": [
+                  "NspOutbound"
+                ]
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "someAssociation",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "title": "NetworkSecurityPerimeterConfigurations_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "resourceName": "exampleResourceName",
     "resourceType": "topics",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Reconcile.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Reconcile.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "associationName": "someAssociation",
     "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
     "resourceGroupName": "examplerg",
@@ -49,8 +49,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Reconcile.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/NetworkSecurityPerimeterConfigurations_Reconcile.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "associationName": "someAssociation",
+    "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+            "location": "West US",
+            "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+          },
+          "profile": {
+            "name": "someProfile",
+            "accessRules": [
+              {
+                "name": "ipRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "1",
+            "diagnosticSettingsVersion": "1",
+            "enabledLogCategories": [
+              "NspOutbound"
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "someAssociation",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurations_Reconcile"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Operations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Operations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Operations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Operations_List.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.EventGrid/register/action",
+            "display": {
+              "description": "Registers the eventSubscription for the EventGrid resource provider and enables the creation of Event Grid subscriptions.",
+              "operation": "Registers the EventGrid Resource Provider",
+              "provider": "Microsoft Event Grid",
+              "resource": "EventGrid Resource Provider"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/write",
+            "display": {
+              "description": "Create or update a eventSubscription",
+              "operation": "Write EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/read",
+            "display": {
+              "description": "Read a eventSubscription",
+              "operation": "Read EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/delete",
+            "display": {
+              "description": "Delete a eventSubscription",
+              "operation": "Delete EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/write",
+            "display": {
+              "description": "Create or update a topic",
+              "operation": "Write Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/read",
+            "display": {
+              "description": "Read a topic",
+              "operation": "Read Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/delete",
+            "display": {
+              "description": "Delete a topic",
+              "operation": "Delete Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "Operations_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_AuthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_AuthorizePartner.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerInfo": {
+      "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+      "partnerName": "Contoso.Finance",
+      "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_AuthorizePartner",
+  "title": "PartnerConfigurations_AuthorizePartner"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_AuthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_AuthorizePartner.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerInfo": {
       "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
       "partnerName": "Contoso.Finance",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerConfigurationInfo": {
       "properties": {
         "partnerAuthorization": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_CreateOrUpdate.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerConfigurationInfo": {
+      "properties": {
+        "partnerAuthorization": {
+          "authorizedPartnersList": [
+            {
+              "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+              "partnerName": "Contoso.Finance",
+              "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+            },
+            {
+              "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+              "partnerName": "fabrikam.HR",
+              "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+            }
+          ],
+          "defaultMaximumExpirationTimeInDays": 10
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_CreateOrUpdate",
+  "title": "PartnerConfigurations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerConfigurations_Delete",
+  "title": "PartnerConfigurations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_Get",
+  "title": "PartnerConfigurations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListByResourceGroup.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventGrid/partnerConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+            "location": "global",
+            "properties": {
+              "partnerAuthorization": {
+                "authorizedPartnersList": [
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                    "partnerName": "Contoso.Finance",
+                    "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+                  },
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                    "partnerName": "fabrikam.HR",
+                    "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+                  }
+                ],
+                "defaultMaximumExpirationTimeInDays": 10
+              }
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_ListByResourceGroup",
+  "title": "PartnerConfigurations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListBySubscription.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventGrid/partnerConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+            "location": "global",
+            "properties": {
+              "partnerAuthorization": {
+                "authorizedPartnersList": [
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                    "partnerName": "Contoso.Finance",
+                    "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+                  },
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                    "partnerName": "fabrikam.HR",
+                    "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+                  }
+                ],
+                "defaultMaximumExpirationTimeInDays": 10
+              }
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_ListBySubscription",
+  "title": "PartnerConfigurations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_UnauthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_UnauthorizePartner.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerInfo": {
+      "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+      "partnerName": "Contoso.Finance",
+      "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_UnauthorizePartner",
+  "title": "PartnerConfigurations_UnauthorizePartner"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_UnauthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_UnauthorizePartner.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerInfo": {
       "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
       "partnerName": "Contoso.Finance",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Update.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerConfigurationUpdateParameters": {
+      "properties": {
+        "defaultMaximumExpirationTimeInDays": 100
+      },
+      "tags": {
+        "tag1": "value11",
+        "tag2": "value22"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 100
+          }
+        },
+        "tags": {
+          "tag1": "value11",
+          "tag2": "value22"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 100
+          }
+        },
+        "tags": {
+          "tag1": "value11",
+          "tag2": "value22"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_Update",
+  "title": "PartnerConfigurations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerConfigurations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerConfigurationUpdateParameters": {
       "properties": {
         "defaultMaximumExpirationTimeInDays": 100

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Activate.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestination1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Activated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Activate",
+  "title": "PartnerDestinations_Activate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Activate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestination1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_CreateOrUpdate.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestination": {
+      "location": "westus2",
+      "properties": {
+        "endpointBaseUrl": "https://www.example/endpoint",
+        "endpointServiceContext": "This is an example",
+        "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+        "messageForActivation": "Sample Activation message",
+        "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404"
+      }
+    },
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "tags": {
+      "tag1": "value1",
+      "tag2": "value2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "westus2",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://www.example/endpoint",
+          "endpointServiceContext": "string",
+          "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+          "messageForActivation": "Sample Activation message",
+          "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "westus2",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://www.example/endpoint",
+          "endpointServiceContext": "string",
+          "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+          "messageForActivation": "Sample Activation message",
+          "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_CreateOrUpdate",
+  "title": "PartnerDestinations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestination": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerDestinations_Delete",
+  "title": "PartnerDestinations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Get",
+  "title": "PartnerDestinations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListByResourceGroup.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerDestinationName1",
+            "type": "Microsoft.EventGrid/partnerDestinations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "endpointBaseUrl": "https://somepartnerhostname",
+              "endpointServiceContext": "ContosoCorp.Accounts.User1",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Some message to the approver",
+              "provisioningState": "Succeeded"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_ListByResourceGroup",
+  "title": "PartnerDestinations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListBySubscription.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerDestinationName1",
+            "type": "Microsoft.EventGrid/partnerDestinations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "endpointBaseUrl": "https://somepartnerhostname",
+              "endpointServiceContext": "ContosoCorp.Accounts.User1",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Some message to the approver",
+              "provisioningState": "Succeeded"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_ListBySubscription",
+  "title": "PartnerDestinations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "partnerDestinationUpdateParameters": {
       "tags": {
@@ -72,8 +72,8 @@
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerDestinations_Update.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "partnerDestinationUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Update",
+  "title": "PartnerDestinations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceInfo": {
       "location": "westus",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_CreateOrUpdate.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceInfo": {
+      "location": "westus",
+      "properties": {
+        "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_CreateOrUpdate",
+  "title": "PartnerNamespaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerNamespaces_Delete",
+  "title": "PartnerNamespaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "Central US EUAP",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2",
+          "key3": "value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_Get",
+  "title": "PartnerNamespaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListByResourceGroup.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "partnerNamespace123",
+            "type": "Microsoft.EventGrid/partnerNamespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/partnerNamespace123",
+            "location": "Central US EUAP",
+            "properties": {
+              "endpoint": "https://partnernamespace123.centraluseuap-1.eventgrid.azure.net/api/events",
+              "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListByResourceGroup",
+  "title": "PartnerNamespaces_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListBySubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "partnerNamespace123",
+            "type": "Microsoft.EventGrid/partnerNamespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerNamespaces/partnerNamespace123",
+            "location": "Central US EUAP",
+            "properties": {
+              "endpoint": "https://partnernamespace123.centraluseuap-1.eventgrid.azure.net/api/events",
+              "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListBySubscription",
+  "title": "PartnerNamespaces_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListSharedAccessKeys",
+  "title": "PartnerNamespaces_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "regenerateKeyRequest": {
       "keyName": "key1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_RegenerateKey",
+  "title": "PartnerNamespaces_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Update.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "partnerNamespaceUpdateParameters": {
+      "tags": {
+        "tag1": "value1"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "Central US EUAP",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_Update",
+  "title": "PartnerNamespaces_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerNamespaces_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "partnerNamespaceUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationInfo": {
       "location": "global",
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationInfo": {
+      "location": "global",
+      "tags": {
+        "key1": "value1",
+        "key2": "Value2",
+        "key3": "Value3"
+      }
+    },
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_CreateOrUpdate",
+  "title": "PartnerRegistrations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerRegistrations_Delete",
+  "title": "PartnerRegistrations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_Get",
+  "title": "PartnerRegistrations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListByResourceGroup.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ContosoCorpAccount1",
+            "type": "Microsoft.EventGrid/partnerRegistrations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+            "location": "global",
+            "properties": {
+              "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "Value2",
+              "key3": "Value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_ListByResourceGroup",
+  "title": "PartnerRegistrations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListBySubscription.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ContosoCorpAccount1",
+            "type": "Microsoft.EventGrid/partnerRegistrations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+            "location": "global",
+            "properties": {
+              "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "Value2",
+              "key3": "Value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_ListBySubscription",
+  "title": "PartnerRegistrations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Update.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "partnerRegistrationUpdateParameters": {
+      "tags": {
+        "NewKey": "NewValue"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "NewKey": "NewValue"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_Update",
+  "title": "PartnerRegistrations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerRegistrations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "partnerRegistrationUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_CreateOrUpdate",
+  "title": "PartnerTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Delete",
+  "title": "PartnerTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Get",
+  "title": "PartnerTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "PartnerTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_GetFullUrl",
+  "title": "PartnerTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 10
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+            }
+          },
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_ListByPartnerTopic",
+  "title": "PartnerTopicEventSubscriptions_ListByPartnerTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Update",
+  "title": "PartnerTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Activate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Activate.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Activated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Activate",
+  "title": "PartnerTopics_Activate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicInfo": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_CreateOrUpdate.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicInfo": {
+      "location": "westus2",
+      "properties": {
+        "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+        "messageForActivation": "Example message for activation",
+        "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+        "partnerTopicFriendlyDescription": "Example description",
+        "source": "ContosoCorp.Accounts.User1"
+      }
+    },
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "tags": {
+      "tag1": "value1",
+      "tag2": "value2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+          "messageForActivation": "Example message for activation",
+          "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+          "partnerTopicFriendlyDescription": "Example description",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+          "messageForActivation": "Example message for activation",
+          "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+          "partnerTopicFriendlyDescription": "Example description",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopics_CreateOrUpdate",
+  "title": "PartnerTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Deactivate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Deactivate.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Deactivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Deactivate",
+  "title": "PartnerTopics_Deactivate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Deactivate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Deactivate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerTopics_Delete",
+  "title": "PartnerTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Get",
+  "title": "PartnerTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListByResourceGroup.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerTopic1",
+            "type": "Microsoft.EventGrid/partnerTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "provisioningState": "Succeeded",
+              "source": "ContosoCorp.Accounts.User1"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopics_ListByResourceGroup",
+  "title": "PartnerTopics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListBySubscription.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerTopic1",
+            "type": "Microsoft.EventGrid/partnerTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "provisioningState": "Succeeded",
+              "source": "ContosoCorp.Accounts.User1"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopics_ListBySubscription",
+  "title": "PartnerTopics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Update.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "partnerTopicUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Update",
+  "title": "PartnerTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PartnerTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "partnerTopicUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_CreateOrUpdate.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingInfo": {
+      "properties": {
+        "clientGroupName": "exampleClientGroupName1",
+        "permission": "Publisher",
+        "topicSpaceName": "exampleTopicSpaceName1"
+      }
+    },
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    }
+  },
+  "operationId": "PermissionBindings_CreateOrUpdate",
+  "title": "PermissionBindings_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingName": "examplePermissionBindingName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PermissionBindings_Delete",
+  "title": "PermissionBindings_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingName": "examplePermissionBindingName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    }
+  },
+  "operationId": "PermissionBindings_Get",
+  "title": "PermissionBindings_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PermissionBindings_ListByNamespace.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/permissionBindings?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "examplePermissionBindingName1",
+            "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+            "properties": {
+              "clientGroupName": "exampleClientGroupName1",
+              "permission": "Publisher",
+              "provisioningState": "Succeeded",
+              "topicSpaceName": "exampleTopicSpaceName1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PermissionBindings_ListByNamespace",
+  "title": "PermissionBindings_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "PrivateEndpointConnections_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Test",
+            "actionsRequired": "None",
+            "status": "Pending"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "PrivateEndpointConnections_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_ListByResource.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+            "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+            "properties": {
+              "groupIds": [
+                "topic"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Test",
+                "actionsRequired": "None",
+                "status": "Pending"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_ListByResource",
+  "title": "PrivateEndpointConnections_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_ListByResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Update.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "approving connection",
+          "actionsRequired": "None",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approving connection",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approving connection",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Update",
+  "title": "PrivateEndpointConnections_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateEndpointConnections_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnection": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateLinkResourceName": "topic",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateLinkResourceName": "topic",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "topic",
+        "type": "Microsoft.EventGrid/topics/privateLinkResources",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/topics/exampletopic1/privateLinkResources/topic",
+        "properties": {
+          "displayName": "Event Grid topic",
+          "groupId": "topic",
+          "requiredMembers": [
+            "topic"
+          ],
+          "requiredZoneNames": [
+            "privatelink.eventgrid.azure.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "PrivateLinkResources_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_ListByResource.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "topic",
+            "type": "Microsoft.EventGrid/topics/privateLinkResources",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/topics/exampletopic1/privateLinkResources/topic",
+            "properties": {
+              "displayName": "Event Grid topic",
+              "groupId": "topic",
+              "requiredMembers": [
+                "topic"
+              ],
+              "requiredZoneNames": [
+                "privatelink.eventgrid.azure.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByResource",
+  "title": "PrivateLinkResources_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/PrivateLinkResources_ListByResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_CreateOrUpdate",
+  "title": "SystemTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SystemTopicEventSubscriptions_Delete",
+  "title": "SystemTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_Get",
+  "title": "SystemTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "SystemTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_GetFullUrl",
+  "title": "SystemTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_ListBySystemTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_ListBySystemTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_ListBySystemTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_ListBySystemTopic.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 10
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+            }
+          },
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_ListBySystemTopic",
+  "title": "SystemTopicEventSubscriptions_ListBySystemTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_Update",
+  "title": "SystemTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_CreateOrUpdate.json
@@ -1,0 +1,127 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicInfo": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {}
+        }
+      },
+      "location": "centraluseuap",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": [
+            {
+              "keyEncryptionKeyIdentity": {
+                "type": "UserAssigned",
+                "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+              },
+              "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+            }
+          ]
+        },
+        "platformCapabilities": {
+          "confidentialCompute": {
+            "mode": "Enabled"
+          }
+        },
+        "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+        "topicType": "microsoft.storage.storageaccounts"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic1",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleSystemTopic1",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopics_CreateOrUpdate",
+  "title": "SystemTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SystemTopics_Delete",
+  "title": "SystemTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopics_Get",
+  "title": "SystemTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListByResourceGroup.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "pubstgrunnerb71cd29e-86fad330-7bac-4238-8cab-9e46b75165aa",
+            "type": "Microsoft.EventGrid/systemTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/pubstgrunnerb71cd29e-86fad330-7bac-4238-8cab-9e46b75165aa",
+            "location": "centraluseuap",
+            "properties": {
+              "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+              "provisioningState": "Succeeded",
+              "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+              "topicType": "microsoft.storage.storageaccounts"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopics_ListByResourceGroup",
+  "title": "SystemTopics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListBySubscription.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampleSystemTopic2",
+            "type": "Microsoft.EventGrid/systemTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+            "location": "centraluseuap",
+            "properties": {
+              "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+              "provisioningState": "Succeeded",
+              "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+              "topicType": "microsoft.storage.storageaccounts"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopics_ListBySubscription",
+  "title": "SystemTopics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Update.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1",
+    "systemTopicUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "location": "centraluseuap",
+        "properties": {
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        },
+        "tags": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "location": "centraluseuap",
+        "properties": {
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "SystemTopics_Update",
+  "title": "SystemTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/SystemTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_CreateOrUpdate",
+  "title": "TopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "TopicEventSubscriptions_Delete",
+  "title": "TopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_Get",
+  "title": "TopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "TopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_GetFullUrl",
+  "title": "TopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_List.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_List",
+  "title": "TopicEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_Update",
+  "title": "TopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_CreateOrUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceInfo": {
+      "properties": {
+        "topicTemplates": [
+          "filter1",
+          "filter2"
+        ]
+      }
+    },
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "TopicSpaces_CreateOrUpdate",
+  "title": "TopicSpaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "TopicSpaces_Delete",
+  "title": "TopicSpaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "TopicSpaces_Get",
+  "title": "TopicSpaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicSpaces_ListByNamespace.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/topicSpaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleTopicSpaceName1",
+            "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicTemplates": [
+                "filter1",
+                "filter2"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicSpaces_ListByNamespace",
+  "title": "TopicSpaces_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "topicTypeName": "Microsoft.Storage.StorageAccounts"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_Get.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "topicTypeName": "Microsoft.Storage.StorageAccounts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft.Storage.StorageAccounts",
+        "type": "Microsoft.EventGrid/topicTypes",
+        "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts",
+        "properties": {
+          "description": "Microsoft Storage service events.",
+          "displayName": "Storage Accounts",
+          "provider": "Microsoft.Storage",
+          "provisioningState": "Succeeded",
+          "resourceRegionType": "RegionalResource"
+        }
+      }
+    }
+  },
+  "operationId": "TopicTypes_Get",
+  "title": "TopicTypes_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_List.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Eventhub.Namespaces",
+            "type": "Microsoft.EventGrid/topicTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Eventhub.Namespaces",
+            "properties": {
+              "description": "Microsoft EventHubs service events.",
+              "displayName": "EventHubs Namespace",
+              "provider": "Microsoft.Eventhub",
+              "provisioningState": "Succeeded",
+              "resourceRegionType": "RegionalResource"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.StorageAccounts",
+            "type": "Microsoft.EventGrid/topicTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts",
+            "properties": {
+              "description": "Microsoft Storage service events.",
+              "displayName": "Storage Accounts",
+              "provider": "Microsoft.Storage",
+              "provisioningState": "Succeeded",
+              "resourceRegionType": "RegionalResource"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicTypes_List",
+  "title": "TopicTypes_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_ListEventTypes.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "topicTypeName": "Microsoft.Storage.StorageAccounts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage.BlobCreated",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobCreated",
+            "properties": {
+              "description": "Raised when a blob is created.",
+              "displayName": "Blob Created",
+              "schemaUrl": "tbd"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.BlobDeleted",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobDeleted",
+            "properties": {
+              "description": "Raised when a blob is deleted.",
+              "displayName": "Blob Deleted",
+              "schemaUrl": "tbd"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicTypes_ListEventTypes",
+  "title": "TopicTypes_ListEventTypes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/TopicTypes_ListEventTypes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "topicTypeName": "Microsoft.Storage.StorageAccounts"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdate.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicInfo": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {}
+        }
+      },
+      "location": "westus2",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": [
+            {
+              "keyEncryptionKeyIdentity": {
+                "type": "UserAssigned",
+                "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+              },
+              "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+            }
+          ]
+        },
+        "platformCapabilities": {
+          "confidentialCompute": {
+            "mode": "Enabled"
+          }
+        }
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "westus2",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "Topics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdateForAzureArc.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdateForAzureArc.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdateForAzureArc.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_CreateOrUpdateForAzureArc.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicInfo": {
+      "extendedLocation": {
+        "name": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourcegroups/examplerg/providers/Microsoft.ExtendedLocation/CustomLocations/exampleCustomLocation",
+        "type": "CustomLocation"
+      },
+      "kind": "AzureArc",
+      "location": "westus2",
+      "properties": {
+        "inputSchema": "CloudEventSchemaV1_0"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "extendedLocation": {
+          "name": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourcegroups/examplerg/providers/Microsoft.ExtendedLocation/CustomLocations/exampleCustomLocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "kind": "AzureArc",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "Topics_CreateOrUpdateForAzureArc"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg1",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic1"
@@ -8,8 +8,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg1",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Topics_Delete",
+  "title": "Topics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampletopic2",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "westcentralus",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Get",
+  "title": "Topics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListByResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampletopic1",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampletopic2",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListByResourceGroup",
+  "title": "Topics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListBySubscription.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampletopic1",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampletopic2",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListBySubscription",
+  "title": "Topics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListEventTypes.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "providerNamespace": "Microsoft.Storage",
+    "resourceGroupName": "examplerg",
+    "resourceName": "ExampleStorageAccount",
+    "resourceTypeName": "storageAccounts",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage.BlobCreated",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobCreated",
+            "properties": {
+              "description": "Raised when a blob is created.",
+              "displayName": "Blob Created",
+              "schemaUrl": "tbd"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.BlobDeleted",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobDeleted",
+            "properties": {
+              "description": "Raised when a blob is deleted.",
+              "displayName": "Blob Deleted",
+              "schemaUrl": "tbd"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListEventTypes",
+  "title": "Topics_ListEventTypes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListEventTypes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "providerNamespace": "Microsoft.Storage",
     "resourceGroupName": "examplerg",
     "resourceName": "ExampleStorageAccount",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Topics_ListSharedAccessKeys",
+  "title": "Topics_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "regenerateKeyRequest": {
       "keyName": "key1"
     },
@@ -17,8 +17,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_RegenerateKey.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Topics_RegenerateKey",
+  "title": "Topics_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic1",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/Topics_Update.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic1",
+    "topicUpdateParameters": {
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Update",
+  "title": "Topics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "verifiedPartnerName": "Contoso.Finance"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_Get.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "verifiedPartnerName": "Contoso.Finance"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Contoso.Finance",
+        "type": "Microsoft.EventGrid/verifiedPartners",
+        "id": "/providers/Microsoft.EventGrid/verifiedPartners/Contoso.Finance",
+        "properties": {
+          "organizationName": "Contoso",
+          "partnerDestinationDetails": {
+            "description": "This is custom description",
+            "longDescription": "This is long custom description",
+            "setupUri": "https://www.example.com/"
+          },
+          "partnerDisplayName": "Contoso - Finance Department",
+          "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71",
+          "partnerTopicDetails": {
+            "description": "This is short description",
+            "longDescription": "This is really long long... long description",
+            "setupUri": "https://www.example.com/"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VerifiedPartners_Get",
+  "title": "VerifiedPartners_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/examples/2026-06-15-preview/VerifiedPartners_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Contoso.Finance",
+            "type": "Microsoft.EventGrid/verifiedPartners",
+            "id": "/providers/Microsoft.EventGrid/verifiedPartners/Contoso.Finance",
+            "properties": {
+              "organizationName": "Contoso",
+              "partnerDestinationDetails": {
+                "description": "This is custom description",
+                "longDescription": "This is long custom description",
+                "setupUri": "https://www.example.com/"
+              },
+              "partnerDisplayName": "Contoso - Finance Department",
+              "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71",
+              "partnerTopicDetails": {
+                "description": "This is short description",
+                "longDescription": "This is really long long... long description",
+                "setupUri": "https://www.example.com/"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VerifiedPartners_List",
+  "title": "VerifiedPartners_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/main.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/main.tsp
@@ -63,8 +63,13 @@ enum Versions {
   /**
    * The 2025-11-15-preview API version.
    */
-  @previewVersion
   v2025_11_15_preview: "2025-11-15-preview",
+
+  /**
+   * The 2026-06-15-preview API version.
+   */
+  @previewVersion
+  v2026_06_15_preview: "2026-06-15-preview",
 }
 
 interface Operations

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
@@ -560,7 +560,7 @@ union TlsVersion {
   `1.2`: "1.2",
 
   /**
-   * 1.3
+   * TLS version 1.3.
    */
   @added(Versions.v2026_06_15_preview)
   `1.3`: "1.3",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
@@ -8,6 +8,7 @@ using TypeSpec.Http;
 using Azure.ResourceManager;
 using Azure.Core;
 using Azure.ResourceManager.Foundations;
+using TypeSpec.Versioning;
 
 namespace Microsoft.EventGrid;
 
@@ -557,6 +558,30 @@ union TlsVersion {
    * 1.2
    */
   `1.2`: "1.2",
+
+  /**
+   * 1.3
+   */
+  @added(Versions.v2026_06_15_preview)
+  `1.3`: "1.3",
+}
+
+/**
+ * Specifies the IP address type for the namespace.
+ */
+@added(Versions.v2026_06_15_preview)
+union IpAddressType {
+  string,
+
+  /**
+   * The namespace supports IPv4 only. This is the default.
+   */
+  IPv4: "IPv4",
+
+  /**
+   * The namespace supports both IPv4 and IPv6 (dual-stack).
+   */
+  DualStack: "DualStack",
 }
 
 /**
@@ -3574,6 +3599,12 @@ model NamespaceProperties {
   inboundIpRules?: InboundIpRule[];
 
   /**
+   * This property specifies the IP address type for the namespace.
+   */
+  @added(Versions.v2026_06_15_preview)
+  ipAddressType?: IpAddressType;
+
+  /**
    * Minimum TLS version of the publisher allowed to publish to this namespace. Only TLS version 1.2 is supported.
    */
   minimumTlsVersionAllowed?: TlsVersion;
@@ -4018,6 +4049,12 @@ model NamespaceUpdateParameterProperties {
    */
   @identifiers(#[])
   inboundIpRules?: InboundIpRule[];
+
+  /**
+   * This property specifies the IP address type for the namespace.
+   */
+  @added(Versions.v2026_06_15_preview)
+  ipAddressType?: IpAddressType;
 
   /**
    * Auto-scale configuration for the namespace resource

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
@@ -1,0 +1,20375 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "EventGridManagementClient",
+    "version": "2025-11-15-preview",
+    "description": "Azure EventGrid Management Client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "CaCertificates"
+    },
+    {
+      "name": "Namespaces"
+    },
+    {
+      "name": "Channels"
+    },
+    {
+      "name": "PartnerNamespaces"
+    },
+    {
+      "name": "ClientGroups"
+    },
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "Domains"
+    },
+    {
+      "name": "DomainTopics"
+    },
+    {
+      "name": "EventSubscriptions"
+    },
+    {
+      "name": "TopicEventSubscriptions"
+    },
+    {
+      "name": "DomainEventSubscriptions"
+    },
+    {
+      "name": "EventSubscriptionOperationGroup"
+    },
+    {
+      "name": "SystemTopicEventSubscriptions"
+    },
+    {
+      "name": "PartnerTopicEventSubscriptions"
+    },
+    {
+      "name": "Subscriptions"
+    },
+    {
+      "name": "NamespaceTopics"
+    },
+    {
+      "name": "PartnerConfigurations"
+    },
+    {
+      "name": "PartnerDestinations"
+    },
+    {
+      "name": "PartnerRegistrations"
+    },
+    {
+      "name": "PartnerTopics"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "PermissionBindings"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "PrivateLinkResources"
+    },
+    {
+      "name": "SystemTopics"
+    },
+    {
+      "name": "Topics"
+    },
+    {
+      "name": "ExtensionTopics"
+    },
+    {
+      "name": "TopicSpaces"
+    },
+    {
+      "name": "TopicTypeInfos"
+    },
+    {
+      "name": "VerifiedPartners"
+    }
+  ],
+  "paths": {
+    "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "EventSubscriptions_Get",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Get an event subscription.",
+        "description": "Get properties of an event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_GetForCustomTopic": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_AzureFunctionDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_EventHubDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_EventHubDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_HybridConnectionDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_StorageQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json"
+          },
+          "EventSubscriptions_GetForCustomTopic_WebhookDestination": {
+            "$ref": "./examples/EventSubscriptions_GetForCustomTopic_WebhookDestination.json"
+          },
+          "EventSubscriptions_GetForResource": {
+            "$ref": "./examples/EventSubscriptions_GetForResource.json"
+          },
+          "EventSubscriptions_GetForResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_GetForResourceGroup.json"
+          },
+          "EventSubscriptions_GetForSubscription": {
+            "$ref": "./examples/EventSubscriptions_GetForSubscription.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "EventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Create or update an event subscription.",
+        "description": "Asynchronously creates a new event subscription or updates an existing event subscription based on the specified scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_CreateOrUpdateForCustomTopic": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForResource": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForResource.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForResourceGroup.json"
+          },
+          "EventSubscriptions_CreateOrUpdateForSubscription": {
+            "$ref": "./examples/EventSubscriptions_CreateOrUpdateForSubscription.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "EventSubscriptions_Update",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Update an event subscription.",
+        "description": "Asynchronously updates an existing event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_UpdateForCustomTopic": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_EventHubDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json"
+          },
+          "EventSubscriptions_UpdateForCustomTopic_WebhookDestination": {
+            "$ref": "./examples/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json"
+          },
+          "EventSubscriptions_UpdateForResource": {
+            "$ref": "./examples/EventSubscriptions_UpdateForResource.json"
+          },
+          "EventSubscriptions_UpdateForResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_UpdateForResourceGroup.json"
+          },
+          "EventSubscriptions_UpdateForSubscription": {
+            "$ref": "./examples/EventSubscriptions_UpdateForSubscription.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "EventSubscriptions_Delete",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Delete an event subscription.",
+        "description": "Delete an existing event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_DeleteForCustomTopic": {
+            "$ref": "./examples/EventSubscriptions_DeleteForCustomTopic.json"
+          },
+          "EventSubscriptions_DeleteForResource": {
+            "$ref": "./examples/EventSubscriptions_DeleteForResource.json"
+          },
+          "EventSubscriptions_DeleteForResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_DeleteForResourceGroup.json"
+          },
+          "EventSubscriptions_DeleteForSubscription": {
+            "$ref": "./examples/EventSubscriptions_DeleteForSubscription.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "EventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Get delivery attributes for an event subscription.",
+        "description": "Get all delivery attributes for an event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/EventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "EventSubscriptions_GetFullUrl",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Get full URL of an event subscription.",
+        "description": "Get the full endpoint URL for an event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "undefined",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_GetFullUrlForCustomTopic": {
+            "$ref": "./examples/EventSubscriptions_GetFullUrlForCustomTopic.json"
+          },
+          "EventSubscriptions_GetFullUrlForResource": {
+            "$ref": "./examples/EventSubscriptions_GetFullUrlForResource.json"
+          },
+          "EventSubscriptions_GetFullUrlForResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_GetFullUrlForResourceGroup.json"
+          },
+          "EventSubscriptions_GetFullUrlForSubscription": {
+            "$ref": "./examples/EventSubscriptions_GetFullUrlForSubscription.json"
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.EventGrid/extensionTopics/default": {
+      "get": {
+        "operationId": "ExtensionTopics_Get",
+        "tags": [
+          "ExtensionTopics"
+        ],
+        "summary": "Get properties of an extension topic.",
+        "description": "Get the properties of an extension topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExtensionTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExtensionTopics_Get": {
+            "$ref": "./examples/ExtensionTopics_Get.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "summary": "List available operations.",
+        "description": "List the available operations supported by the Microsoft.EventGrid resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/topicTypes": {
+      "get": {
+        "operationId": "TopicTypes_List",
+        "tags": [
+          "TopicTypeInfos"
+        ],
+        "summary": "List topic types.",
+        "description": "List all registered topic types.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicTypesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicTypes_List": {
+            "$ref": "./examples/TopicTypes_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}": {
+      "get": {
+        "operationId": "TopicTypes_Get",
+        "tags": [
+          "TopicTypeInfos"
+        ],
+        "summary": "Get a topic type.",
+        "description": "Get information about a topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicTypeInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicTypes_Get": {
+            "$ref": "./examples/TopicTypes_Get.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventTypes": {
+      "get": {
+        "operationId": "TopicTypes_ListEventTypes",
+        "tags": [
+          "TopicTypeInfos"
+        ],
+        "summary": "List event types.",
+        "description": "List event types for a topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventTypesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicTypes_ListEventTypes": {
+            "$ref": "./examples/TopicTypes_ListEventTypes.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/verifiedPartners": {
+      "get": {
+        "operationId": "VerifiedPartners_List",
+        "tags": [
+          "VerifiedPartners"
+        ],
+        "summary": "List all verified partners.",
+        "description": "Get a list of all verified partners.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerifiedPartnersListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "VerifiedPartners_List": {
+            "$ref": "./examples/VerifiedPartners_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.EventGrid/verifiedPartners/{verifiedPartnerName}": {
+      "get": {
+        "operationId": "VerifiedPartners_Get",
+        "tags": [
+          "VerifiedPartners"
+        ],
+        "summary": "Get a verified partner.",
+        "description": "Get properties of a verified partner.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "verifiedPartnerName",
+            "in": "path",
+            "description": "Name of the verified partner.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerifiedPartner"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "VerifiedPartners_Get": {
+            "$ref": "./examples/VerifiedPartners_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/domains": {
+      "get": {
+        "operationId": "Domains_ListBySubscription",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "List domains under an Azure subscription.",
+        "description": "List all the domains under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_ListBySubscription": {
+            "$ref": "./examples/Domains_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListGlobalBySubscription",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "Get an aggregated list of all global event subscriptions under an Azure subscription.",
+        "description": "List all aggregated global event subscriptions under a specific Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListGlobalBySubscription": {
+            "$ref": "./examples/EventSubscriptions_ListGlobalBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/locations/{location}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListRegionalBySubscription",
+        "summary": "List all regional event subscriptions under an Azure subscription.",
+        "description": "List all event subscriptions from the given location under a specific Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListRegionalBySubscription": {
+            "$ref": "./examples/EventSubscriptions_ListRegionalBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/locations/{location}/topicTypes/{topicTypeName}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListRegionalBySubscriptionForTopicType",
+        "summary": "List all regional event subscriptions under an Azure subscription for a topic type.",
+        "description": "List all event subscriptions from the given location under a specific Azure subscription and topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListRegionalBySubscriptionForTopicType": {
+            "$ref": "./examples/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/namespaces": {
+      "get": {
+        "operationId": "Namespaces_ListBySubscription",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "List namespaces under an Azure subscription.",
+        "description": "List all the namespaces under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespacesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_ListBySubscription": {
+            "$ref": "./examples/Namespaces_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/partnerConfigurations": {
+      "get": {
+        "operationId": "PartnerConfigurations_ListBySubscription",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "List partner configurations under an Azure subscription.",
+        "description": "List all the partner configurations under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfigurationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_ListBySubscription": {
+            "$ref": "./examples/PartnerConfigurations_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/partnerDestinations": {
+      "get": {
+        "operationId": "PartnerDestinations_ListBySubscription",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "List partner destinations under an Azure subscription.",
+        "description": "List all the partner destinations under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestinationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_ListBySubscription": {
+            "$ref": "./examples/PartnerDestinations_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/partnerNamespaces": {
+      "get": {
+        "operationId": "PartnerNamespaces_ListBySubscription",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "List partner namespaces under an Azure subscription.",
+        "description": "List all the partner namespaces under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespacesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_ListBySubscription": {
+            "$ref": "./examples/PartnerNamespaces_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/partnerRegistrations": {
+      "get": {
+        "operationId": "PartnerRegistrations_ListBySubscription",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "List partner registrations under an Azure subscription.",
+        "description": "List all the partner registrations under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistrationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_ListBySubscription": {
+            "$ref": "./examples/PartnerRegistrations_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/partnerTopics": {
+      "get": {
+        "operationId": "PartnerTopics_ListBySubscription",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "List partner topics under an Azure subscription.",
+        "description": "List all the partner topics under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_ListBySubscription": {
+            "$ref": "./examples/PartnerTopics_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/systemTopics": {
+      "get": {
+        "operationId": "SystemTopics_ListBySubscription",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "List system topics under an Azure subscription.",
+        "description": "List all the system topics under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SystemTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_ListBySubscription": {
+            "$ref": "./examples/SystemTopics_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListGlobalBySubscriptionForTopicType",
+        "summary": "List all global event subscriptions for a topic type.",
+        "description": "List all global event subscriptions under an Azure subscription for a topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListGlobalBySubscriptionForTopicType": {
+            "$ref": "./examples/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/topics": {
+      "get": {
+        "operationId": "Topics_ListBySubscription",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "List topics under an Azure subscription.",
+        "description": "List all the topics under an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_ListBySubscription": {
+            "$ref": "./examples/Topics_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceTypeName}/{resourceName}/providers/Microsoft.EventGrid/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListByResource",
+        "tags": [
+          "EventSubscriptionOperationGroup"
+        ],
+        "summary": "List all event subscriptions.",
+        "description": "List all event subscriptions that have been created for a specific resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "Namespace of the provider of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceTypeName",
+            "in": "path",
+            "description": "Name of the resource type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListByResource": {
+            "$ref": "./examples/EventSubscriptions_ListByResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceTypeName}/{resourceName}/providers/Microsoft.EventGrid/eventTypes": {
+      "get": {
+        "operationId": "Topics_ListEventTypes",
+        "summary": "List topic event types.",
+        "description": "List event types for a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EventTypesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_ListEventTypes": {
+            "$ref": "./examples/Topics_ListEventTypes.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "summary": "Get all network security perimeter configurations for resource.",
+        "description": "Get all network security perimeter configurations associated with a topic or domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The type of the resource. This can be either \\\\'topics\\\\', or \\\\'domains\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains"
+            ],
+            "x-ms-enum": {
+              "name": "NetworkSecurityPerimeterResourceType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                }
+              ]
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource group within the user's subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurations_List": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "summary": "Get a specific network security perimeter configuration.",
+        "description": "Get a specific network security perimeter configuration with a topic or domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The type of the resource. This can be either \\\\'topics\\\\', or \\\\'domains\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains"
+            ],
+            "x-ms-enum": {
+              "name": "NetworkSecurityPerimeterResourceType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                }
+              ]
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource group within the user's subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "perimeterGuid",
+            "in": "path",
+            "description": "Unique identifier for perimeter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "Association name to association network security perimeter resource to profile",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurations_Get": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurations_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "summary": "Reconcile a specific network security perimeter configuration for a given network security perimeter association.",
+        "description": "Reconcile a specific network security perimeter configuration for a given network security perimeter association with a topic or domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The type of the resource. This can be either \\\\'topics\\\\', or \\\\'domains\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains"
+            ],
+            "x-ms-enum": {
+              "name": "NetworkSecurityPerimeterResourceType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                }
+              ]
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource group within the user's subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "perimeterGuid",
+            "in": "path",
+            "description": "Unique identifier for perimeter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "Association name to association network security perimeter resource to profile",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurations_Reconcile": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurations_Reconcile.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkSecurityPerimeterConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_ListByResource",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Lists all private endpoint connections under a resource.",
+        "description": "Get all private endpoint connections under a topic, domain, or partner namespace or namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains",
+              "partnerNamespaces",
+              "namespaces"
+            ],
+            "x-ms-enum": {
+              "name": "PrivateEndpointConnectionsParentType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                },
+                {
+                  "name": "partnerNamespaces",
+                  "value": "partnerNamespaces",
+                  "description": "partnerNamespaces"
+                },
+                {
+                  "name": "namespaces",
+                  "value": "namespaces",
+                  "description": "namespaces"
+                }
+              ]
+            }
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_ListByResource": {
+            "$ref": "./examples/PrivateEndpointConnections_ListByResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Get a specific private endpoint connection.",
+        "description": "Get a specific private endpoint connection under a topic, domain, or partner namespace or namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains",
+              "partnerNamespaces",
+              "namespaces"
+            ],
+            "x-ms-enum": {
+              "name": "PrivateEndpointConnectionsParentType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                },
+                {
+                  "name": "partnerNamespaces",
+                  "value": "partnerNamespaces",
+                  "description": "partnerNamespaces"
+                },
+                {
+                  "name": "namespaces",
+                  "value": "namespaces",
+                  "description": "namespaces"
+                }
+              ]
+            }
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\'topics\\', \\'domains\\', or \\'partnerNamespaces\\' or \\'namespaces\\'.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Get": {
+            "$ref": "./examples/PrivateEndpointConnections_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_Update",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Update a specific private endpoint connection.",
+        "description": "Update a specific private endpoint connection under a topic, domain or partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains",
+              "partnerNamespaces",
+              "namespaces"
+            ],
+            "x-ms-enum": {
+              "name": "PrivateEndpointConnectionsParentType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                },
+                {
+                  "name": "partnerNamespaces",
+                  "value": "partnerNamespaces",
+                  "description": "partnerNamespaces"
+                },
+                {
+                  "name": "namespaces",
+                  "value": "namespaces",
+                  "description": "namespaces"
+                }
+              ]
+            }
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\'topics\\', \\'domains\\', or \\'partnerNamespaces\\' or \\'namespaces\\'.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnection",
+            "in": "body",
+            "description": "The private endpoint connection object to update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Update": {
+            "$ref": "./examples/PrivateEndpointConnections_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Delete a specific private endpoint connection.",
+        "description": "Delete a specific private endpoint connection under a topic, domain, or partner namespace or namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "topics",
+              "domains",
+              "partnerNamespaces",
+              "namespaces"
+            ],
+            "x-ms-enum": {
+              "name": "PrivateEndpointConnectionsParentType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "topics",
+                  "value": "topics",
+                  "description": "topics"
+                },
+                {
+                  "name": "domains",
+                  "value": "domains",
+                  "description": "domains"
+                },
+                {
+                  "name": "partnerNamespaces",
+                  "value": "partnerNamespaces",
+                  "description": "partnerNamespaces"
+                },
+                {
+                  "name": "namespaces",
+                  "value": "namespaces",
+                  "description": "namespaces"
+                }
+              ]
+            }
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\'topics\\', \\'domains\\', or \\'partnerNamespaces\\' or \\'namespaces\\'.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Azure operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Delete": {
+            "$ref": "./examples/PrivateEndpointConnections_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_ListByResource",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "summary": "List private link resources under specific topic, domain, or partner namespace or namespace.",
+        "description": "List all the private link resources under a topic, domain, or partner namespace or namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_ListByResource": {
+            "$ref": "./examples/PrivateLinkResources_ListByResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources/{privateLinkResourceName}": {
+      "get": {
+        "operationId": "PrivateLinkResources_Get",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "summary": "Get a private link resource.",
+        "description": "Get properties of a private link resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentType",
+            "in": "path",
+            "description": "The type of the parent resource. This can be either \\\\'topics\\\\', \\\\'domains\\\\', or \\\\'partnerNamespaces\\\\' or \\\\'namespaces\\\\'.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentName",
+            "in": "path",
+            "description": "The name of the parent resource (namely, either, the topic name, domain name, or partner namespace name or namespace name).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateLinkResourceName",
+            "in": "path",
+            "description": "The name of private link resource will be either topic, domain, partnerNamespace or namespace.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_Get": {
+            "$ref": "./examples/PrivateLinkResources_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains": {
+      "get": {
+        "operationId": "Domains_ListByResourceGroup",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "List domains under a resource group.",
+        "description": "List all the domains under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_ListByResourceGroup": {
+            "$ref": "./examples/Domains_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}": {
+      "get": {
+        "operationId": "Domains_Get",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Get a domain.",
+        "description": "Get properties of a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Domain"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_Get": {
+            "$ref": "./examples/Domains_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Domains_CreateOrUpdate",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Create or update a domain.",
+        "description": "Asynchronously creates or updates a new domain with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "domainInfo",
+            "in": "body",
+            "description": "Domain information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Domain"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'Domain' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Domain"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_CreateOrUpdate": {
+            "$ref": "./examples/Domains_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Domain"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Domains_Update",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Update a domain.",
+        "description": "Asynchronously updates a domain with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "domainUpdateParameters",
+            "in": "body",
+            "description": "Domain update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DomainUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "201": {
+            "description": "Resource 'Domain' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Domain"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_Update": {
+            "$ref": "./examples/Domains_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Domain"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Domains_Delete",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Delete a domain.",
+        "description": "Delete existing domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_Delete": {
+            "$ref": "./examples/Domains_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions": {
+      "get": {
+        "operationId": "DomainEventSubscriptions_List",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "List all event subscriptions for a specific domain.",
+        "description": "List all event subscriptions that have been created for a specific topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_List": {
+            "$ref": "./examples/DomainEventSubscriptions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "DomainEventSubscriptions_Get",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Get an event subscription of a domain.",
+        "description": "Get properties of an event subscription of a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_Get": {
+            "$ref": "./examples/DomainEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DomainEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Create or update an event subscription to a domain.",
+        "description": "Asynchronously creates a new event subscription or updates an existing event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EventSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/DomainEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DomainEventSubscriptions_Update",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Update an event subscription for a domain.",
+        "description": "Update an existing event subscription for a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_Update": {
+            "$ref": "./examples/DomainEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DomainEventSubscriptions_Delete",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Delete an event subscription for a domain.",
+        "description": "Delete an existing event subscription for a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_Delete": {
+            "$ref": "./examples/DomainEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "DomainEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription for domain.",
+        "description": "Get all delivery attributes for an event subscription for domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/DomainEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "DomainEventSubscriptions_GetFullUrl",
+        "tags": [
+          "DomainEventSubscriptions"
+        ],
+        "summary": "Get full URL of an event subscription for domain.",
+        "description": "Get the full endpoint URL for an event subscription for domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/DomainEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/listKeys": {
+      "post": {
+        "operationId": "Domains_ListSharedAccessKeys",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "List keys for a domain.",
+        "description": "List the two keys used to publish to a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_ListSharedAccessKeys": {
+            "$ref": "./examples/Domains_ListSharedAccessKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/regenerateKey": {
+      "post": {
+        "operationId": "Domains_RegenerateKey",
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Regenerate key for a domain.",
+        "description": "Regenerate a shared access key for a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "regenerateKeyRequest",
+            "in": "body",
+            "description": "Request body to regenerate key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DomainRegenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Domains_RegenerateKey": {
+            "$ref": "./examples/Domains_RegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics": {
+      "get": {
+        "operationId": "DomainTopics_ListByDomain",
+        "tags": [
+          "DomainTopics"
+        ],
+        "summary": "List domain topics.",
+        "description": "List all the topics in a domain.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopics_ListByDomain": {
+            "$ref": "./examples/DomainTopics_ListByDomain.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}": {
+      "get": {
+        "operationId": "DomainTopics_Get",
+        "tags": [
+          "DomainTopics"
+        ],
+        "summary": "Get a domain topic.",
+        "description": "Get properties of a domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "domainTopicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DomainTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopics_Get": {
+            "$ref": "./examples/DomainTopics_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DomainTopics_CreateOrUpdate",
+        "tags": [
+          "DomainTopics"
+        ],
+        "summary": "Create or update a domain topic.",
+        "description": "Asynchronously creates or updates a new domain topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "domainTopicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'DomainTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DomainTopic"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopics_CreateOrUpdate": {
+            "$ref": "./examples/DomainTopics_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/DomainTopic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DomainTopics_Delete",
+        "tags": [
+          "DomainTopics"
+        ],
+        "summary": "Delete a domain topic.",
+        "description": "Delete existing domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "domainTopicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopics_Delete": {
+            "$ref": "./examples/DomainTopics_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions": {
+      "get": {
+        "operationId": "DomainTopicEventSubscriptions_List",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "List all nested event subscriptions for a specific domain topic.",
+        "description": "List all event subscriptions that have been created for a specific domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_List": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "DomainTopicEventSubscriptions_Get",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Get a nested event subscription for domain topic.",
+        "description": "Get properties of a nested event subscription for a domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_Get": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DomainTopicEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Create or update a nested event subscription to a domain topic.",
+        "description": "Asynchronously creates a new event subscription or updates an existing event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EventSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DomainTopicEventSubscriptions_Update",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Update a nested event subscription for a domain topic.",
+        "description": "Update an existing event subscription for a domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_Update": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DomainTopicEventSubscriptions_Delete",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Delete a nested event subscription for a domain topic.",
+        "description": "Delete a nested existing event subscription for a domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_Delete": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "DomainTopicEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription for domain topic.",
+        "description": "Get all delivery attributes for an event subscription for domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "DomainTopicEventSubscriptions_GetFullUrl",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "Get full URL of a nested event subscription for domain topic.",
+        "description": "Get the full endpoint URL for a nested event subscription for domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DomainTopicEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/DomainTopicEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/providers/Microsoft.EventGrid/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListByDomainTopic",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "List all event subscriptions for a specific domain topic.",
+        "description": "List all event subscriptions that have been created for a specific domain topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "domainName",
+            "in": "path",
+            "description": "Name of the top level domain.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the domain topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListByDomainTopic": {
+            "$ref": "./examples/EventSubscriptions_ListByDomainTopic.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListGlobalByResourceGroup",
+        "tags": [
+          "EventSubscriptions"
+        ],
+        "summary": "List all global event subscriptions under an Azure subscription and resource group.",
+        "description": "List all global event subscriptions under a specific Azure subscription and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListGlobalByResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_ListGlobalByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/locations/{location}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListRegionalByResourceGroup",
+        "summary": "List all regional event subscriptions under an Azure subscription and resource group.",
+        "description": "List all event subscriptions from the given location under a specific Azure subscription and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListRegionalByResourceGroup": {
+            "$ref": "./examples/EventSubscriptions_ListRegionalByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/locations/{location}/topicTypes/{topicTypeName}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListRegionalByResourceGroupForTopicType",
+        "summary": "List all regional event subscriptions under an Azure subscription and resource group for a topic type.",
+        "description": "List all event subscriptions from the given location under a specific Azure subscription and resource group and topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListRegionalByResourceGroupForTopicType": {
+            "$ref": "./examples/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces": {
+      "get": {
+        "operationId": "Namespaces_ListByResourceGroup",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "List namespaces under a resource group.",
+        "description": "List all the namespaces under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespacesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_ListByResourceGroup": {
+            "$ref": "./examples/Namespaces_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}": {
+      "get": {
+        "operationId": "Namespaces_Get",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Get a namespace.",
+        "description": "Get properties of a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_Get": {
+            "$ref": "./examples/Namespaces_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Namespaces_CreateOrUpdate",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Create or update a namespace.",
+        "description": "Asynchronously creates or updates a new namespace with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "namespaceInfo",
+            "in": "body",
+            "description": "Namespace information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Namespace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'Namespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_CreateOrUpdate": {
+            "$ref": "./examples/Namespaces_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Namespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Namespaces_Update",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Update a namespace.",
+        "description": "Asynchronously updates a namespace with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "namespaceUpdateParameters",
+            "in": "body",
+            "description": "Namespace update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NamespaceUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Namespace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_Update": {
+            "$ref": "./examples/Namespaces_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Namespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Namespaces_Delete",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Delete a namespace.",
+        "description": "Delete existing namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_Delete": {
+            "$ref": "./examples/Namespaces_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates": {
+      "get": {
+        "operationId": "CaCertificates_ListByNamespace",
+        "tags": [
+          "CaCertificates"
+        ],
+        "summary": "List all CA certificates under a namespace.",
+        "description": "Get all the CA certificates under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CaCertificatesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CaCertificates_ListByNamespace": {
+            "$ref": "./examples/CaCertificates_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}": {
+      "get": {
+        "operationId": "CaCertificates_Get",
+        "tags": [
+          "CaCertificates"
+        ],
+        "summary": "Get a CA certificate.",
+        "description": "Get properties of a CA certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "caCertificateName",
+            "in": "path",
+            "description": "Name of the CA certificate.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CaCertificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CaCertificates_Get": {
+            "$ref": "./examples/CaCertificates_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "CaCertificates_CreateOrUpdate",
+        "tags": [
+          "CaCertificates"
+        ],
+        "summary": "Create or update a CA certificate.",
+        "description": "Create or update a CA certificate with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "caCertificateName",
+            "in": "path",
+            "description": "Name of the CA certificate.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "caCertificateInfo",
+            "in": "body",
+            "description": "CA certificate information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CaCertificate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CaCertificate' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CaCertificate"
+            }
+          },
+          "201": {
+            "description": "Resource 'CaCertificate' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CaCertificate"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CaCertificates_CreateOrUpdate": {
+            "$ref": "./examples/CaCertificates_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CaCertificate"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CaCertificates_Delete",
+        "tags": [
+          "CaCertificates"
+        ],
+        "summary": "Delete a CA certificate.",
+        "description": "Delete an existing CA certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "caCertificateName",
+            "in": "path",
+            "description": "Name of the CA certificate.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CaCertificates_Delete": {
+            "$ref": "./examples/CaCertificates_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups": {
+      "get": {
+        "operationId": "ClientGroups_ListByNamespace",
+        "tags": [
+          "ClientGroups"
+        ],
+        "summary": "List all client groups under a namespace.",
+        "description": "Get all the client groups under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClientGroupsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClientGroups_ListByNamespace": {
+            "$ref": "./examples/ClientGroups_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}": {
+      "get": {
+        "operationId": "ClientGroups_Get",
+        "tags": [
+          "ClientGroups"
+        ],
+        "summary": "Get a client group.",
+        "description": "Get properties of a client group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientGroupName",
+            "in": "path",
+            "description": "Name of the client group.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClientGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClientGroups_Get": {
+            "$ref": "./examples/ClientGroups_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ClientGroups_CreateOrUpdate",
+        "tags": [
+          "ClientGroups"
+        ],
+        "summary": "Create or update a client group.",
+        "description": "Create or update a client group with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientGroupName",
+            "in": "path",
+            "description": "Name of the client group.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientGroupInfo",
+            "in": "body",
+            "description": "Client group information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClientGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ClientGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ClientGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'ClientGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ClientGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClientGroups_CreateOrUpdate": {
+            "$ref": "./examples/ClientGroups_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ClientGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ClientGroups_Delete",
+        "tags": [
+          "ClientGroups"
+        ],
+        "summary": "Delete a client group.",
+        "description": "Delete an existing client group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientGroupName",
+            "in": "path",
+            "description": "Name of the client group.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClientGroups_Delete": {
+            "$ref": "./examples/ClientGroups_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients": {
+      "get": {
+        "operationId": "Clients_ListByNamespace",
+        "tags": [
+          "Clients"
+        ],
+        "summary": "List all permission bindings under a namespace.",
+        "description": "Get all the permission bindings under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClientsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Clients_ListByNamespace": {
+            "$ref": "./examples/Clients_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}": {
+      "get": {
+        "operationId": "Clients_Get",
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Get a client.",
+        "description": "Get properties of a client.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientName",
+            "in": "path",
+            "description": "Name of the client.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[-a-zA-Z0-9:\\._]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Client"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Clients_Get": {
+            "$ref": "./examples/Clients_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Clients_CreateOrUpdate",
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Create or update a client.",
+        "description": "Create or update a client with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientName",
+            "in": "path",
+            "description": "Name of the client.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[-a-zA-Z0-9:\\._]*$"
+          },
+          {
+            "name": "clientInfo",
+            "in": "body",
+            "description": "Client information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Client' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Client"
+            }
+          },
+          "201": {
+            "description": "Resource 'Client' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Client"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Clients_CreateOrUpdate": {
+            "$ref": "./examples/Clients_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Client"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Clients_Delete",
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Delete a client.",
+        "description": "Delete an existing client.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "clientName",
+            "in": "path",
+            "description": "Name of the client.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[-a-zA-Z0-9:\\._]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Clients_Delete": {
+            "$ref": "./examples/Clients_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/listKeys": {
+      "post": {
+        "operationId": "Namespaces_ListSharedAccessKeys",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "List keys for a namespace.",
+        "description": "List the two keys used to publish to a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_ListSharedAccessKeys": {
+            "$ref": "./examples/Namespaces_ListSharedAccessKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings": {
+      "get": {
+        "operationId": "PermissionBindings_ListByNamespace",
+        "tags": [
+          "PermissionBindings"
+        ],
+        "summary": "List all permission bindings under a namespace.",
+        "description": "Get all the permission bindings under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PermissionBindingsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PermissionBindings_ListByNamespace": {
+            "$ref": "./examples/PermissionBindings_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}": {
+      "get": {
+        "operationId": "PermissionBindings_Get",
+        "tags": [
+          "PermissionBindings"
+        ],
+        "summary": "Get a permission binding.",
+        "description": "Get properties of a permission binding.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "permissionBindingName",
+            "in": "path",
+            "description": "Name of the permission binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PermissionBinding"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PermissionBindings_Get": {
+            "$ref": "./examples/PermissionBindings_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PermissionBindings_CreateOrUpdate",
+        "tags": [
+          "PermissionBindings"
+        ],
+        "summary": "Create or update a permission binding.",
+        "description": "Create or update a permission binding with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "permissionBindingName",
+            "in": "path",
+            "description": "Name of the permission binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "permissionBindingInfo",
+            "in": "body",
+            "description": "Permission binding information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PermissionBinding"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PermissionBinding' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PermissionBinding"
+            }
+          },
+          "201": {
+            "description": "Resource 'PermissionBinding' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PermissionBinding"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PermissionBindings_CreateOrUpdate": {
+            "$ref": "./examples/PermissionBindings_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PermissionBinding"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PermissionBindings_Delete",
+        "tags": [
+          "PermissionBindings"
+        ],
+        "summary": "Delete a permission binding.",
+        "description": "Delete an existing permission binding.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "permissionBindingName",
+            "in": "path",
+            "description": "Name of the permission binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PermissionBindings_Delete": {
+            "$ref": "./examples/PermissionBindings_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/regenerateKey": {
+      "post": {
+        "operationId": "Namespaces_RegenerateKey",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Regenerate key for a namespace.",
+        "description": "Regenerate a shared access key for a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "regenerateKeyRequest",
+            "in": "body",
+            "description": "Request body to regenerate key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NamespaceRegenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceSharedAccessKeys"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_RegenerateKey": {
+            "$ref": "./examples/Namespaces_RegenerateKey.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NamespaceSharedAccessKeys"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces": {
+      "get": {
+        "operationId": "TopicSpaces_ListByNamespace",
+        "tags": [
+          "TopicSpaces"
+        ],
+        "summary": "List all topic spaces under a namespace.",
+        "description": "Get all the topic spaces under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSpacesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicSpaces_ListByNamespace": {
+            "$ref": "./examples/TopicSpaces_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}": {
+      "get": {
+        "operationId": "TopicSpaces_Get",
+        "tags": [
+          "TopicSpaces"
+        ],
+        "summary": "Get a topic space.",
+        "description": "Get properties of a topic space.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicSpaceName",
+            "in": "path",
+            "description": "Name of the Topic space.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSpace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicSpaces_Get": {
+            "$ref": "./examples/TopicSpaces_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TopicSpaces_CreateOrUpdate",
+        "tags": [
+          "TopicSpaces"
+        ],
+        "summary": "Create or update a topic space.",
+        "description": "Create or update a topic space with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicSpaceName",
+            "in": "path",
+            "description": "Name of the Topic space.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicSpaceInfo",
+            "in": "body",
+            "description": "Topic space information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopicSpace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TopicSpace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TopicSpace"
+            }
+          },
+          "201": {
+            "description": "Resource 'TopicSpace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TopicSpace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicSpaces_CreateOrUpdate": {
+            "$ref": "./examples/TopicSpaces_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/TopicSpace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TopicSpaces_Delete",
+        "tags": [
+          "TopicSpaces"
+        ],
+        "summary": "Delete a topic space.",
+        "description": "Delete an existing topic space.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicSpaceName",
+            "in": "path",
+            "description": "Name of the Topic space.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicSpaces_Delete": {
+            "$ref": "./examples/TopicSpaces_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics": {
+      "get": {
+        "operationId": "NamespaceTopics_ListByNamespace",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "List namespace topics under a namespace.",
+        "description": "List all the namespace topics under a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_ListByNamespace": {
+            "$ref": "./examples/NamespaceTopics_ListByNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}": {
+      "get": {
+        "operationId": "NamespaceTopics_Get",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "Get a namespace topic.",
+        "description": "Get properties of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_Get": {
+            "$ref": "./examples/NamespaceTopics_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NamespaceTopics_CreateOrUpdate",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "Create a namespace topic.",
+        "description": "Asynchronously creates a new namespace topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "namespaceTopicInfo",
+            "in": "body",
+            "description": "Namespace topic information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NamespaceTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'NamespaceTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_CreateOrUpdate": {
+            "$ref": "./examples/NamespaceTopics_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NamespaceTopic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NamespaceTopics_Update",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "Update a namespace topic.",
+        "description": "Asynchronously updates a namespace topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "namespaceTopicUpdateParameters",
+            "in": "body",
+            "description": "Namespace topic update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopicUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/NamespaceTopic"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_Update": {
+            "$ref": "./examples/NamespaceTopics_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NamespaceTopic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NamespaceTopics_Delete",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "Delete a namespace topic.",
+        "description": "Delete existing namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_Delete": {
+            "$ref": "./examples/NamespaceTopics_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions": {
+      "get": {
+        "operationId": "NamespaceTopicEventSubscriptions_ListByNamespaceTopic",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "List event subscriptions of a namespace topic.",
+        "description": "List event subscriptions that belong to a specific namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_ListByNamespaceTopic": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "NamespaceTopicEventSubscriptions_Get",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get an event subscription of a namespace topic.",
+        "description": "Get properties of an event subscription of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_Get": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NamespaceTopicEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Create or update an event subscription of a namespace topic.",
+        "description": "Asynchronously creates or updates an event subscription of a namespace topic with the specified parameters. Existing event subscriptions will be updated with this API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the delivery mode, filter information, and others.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Subscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'Subscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Subscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NamespaceTopicEventSubscriptions_Update",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Update event subscription of a namespace topic.",
+        "description": "Update an existing event subscription of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Subscription"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_Update": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Subscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NamespaceTopicEventSubscriptions_Delete",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Delete an event subscription of a namespace topic.",
+        "description": "Delete an existing event subscription of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_Delete": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "NamespaceTopicEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription of a namespace topic.",
+        "description": "Get all delivery attributes for an event subscription of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "NamespaceTopicEventSubscriptions_GetFullUrl",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get full URL of an event subscription of a namespace topic.",
+        "description": "Get the full endpoint URL for an event subscription of a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopicEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/NamespaceTopicEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/listKeys": {
+      "post": {
+        "operationId": "NamespaceTopics_ListSharedAccessKeys",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "List keys for a namespace topic.",
+        "description": "List the two keys used to publish to a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_ListSharedAccessKeys": {
+            "$ref": "./examples/NamespaceTopics_ListSharedAccessKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/regenerateKey": {
+      "post": {
+        "operationId": "NamespaceTopics_RegenerateKey",
+        "tags": [
+          "NamespaceTopics"
+        ],
+        "summary": "Regenerate key for a namespace topic.",
+        "description": "Regenerate a shared access key for a namespace topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the namespace topic.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "regenerateKeyRequest",
+            "in": "body",
+            "description": "Request body to regenerate key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopicRegenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSharedAccessKeys"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NamespaceTopics_RegenerateKey": {
+            "$ref": "./examples/NamespaceTopics_RegenerateKey.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TopicSharedAccessKeys"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/validateCustomDomainOwnership": {
+      "post": {
+        "operationId": "Namespaces_ValidateCustomDomainOwnership",
+        "tags": [
+          "Namespaces"
+        ],
+        "summary": "Validate ownership for all custom domains in a namespace.",
+        "description": "Performs ownership validation via checking TXT records for all custom domains in a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "namespaceName",
+            "in": "path",
+            "description": "Name of the namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomDomainOwnershipValidationResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Namespaces_ValidateCustomDomainOwnership": {
+            "$ref": "./examples/Namespaces_ValidateCustomDomainOwnership.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CustomDomainOwnershipValidationResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations": {
+      "get": {
+        "operationId": "PartnerConfigurations_ListByResourceGroup",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "List partner configurations under a resource group.",
+        "description": "List all the partner configurations under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfigurationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_ListByResourceGroup": {
+            "$ref": "./examples/PartnerConfigurations_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default": {
+      "get": {
+        "operationId": "PartnerConfigurations_Get",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Get a partner configuration.",
+        "description": "Get properties of a partner configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_Get": {
+            "$ref": "./examples/PartnerConfigurations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerConfigurations_CreateOrUpdate",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Create or update a partner configuration.",
+        "description": "Synchronously creates or updates a partner configuration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerConfigurationInfo",
+            "in": "body",
+            "description": "Partner configuration information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PartnerConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'PartnerConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_CreateOrUpdate": {
+            "$ref": "./examples/PartnerConfigurations_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PartnerConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PartnerConfigurations_Update",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Update a partner configuration.",
+        "description": "Synchronously updates a partner configuration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerConfigurationUpdateParameters",
+            "in": "body",
+            "description": "Partner configuration update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerConfigurationUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'PartnerConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_Update": {
+            "$ref": "./examples/PartnerConfigurations_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/PartnerConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PartnerConfigurations_Delete",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Delete a partner configuration.",
+        "description": "Delete existing partner configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_Delete": {
+            "$ref": "./examples/PartnerConfigurations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default/authorizePartner": {
+      "post": {
+        "operationId": "PartnerConfigurations_AuthorizePartner",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Authorize a partner.",
+        "description": "Authorize a single partner either by partner registration immutable Id or by partner name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerInfo",
+            "in": "body",
+            "description": "The information of the partner to be authorized.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Partner"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_AuthorizePartner": {
+            "$ref": "./examples/PartnerConfigurations_AuthorizePartner.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default/unauthorizePartner": {
+      "post": {
+        "operationId": "PartnerConfigurations_UnauthorizePartner",
+        "tags": [
+          "PartnerConfigurations"
+        ],
+        "summary": "Unauthorize a partner.",
+        "description": "Unauthorize a single partner either by partner registration immutable Id or by partner name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerInfo",
+            "in": "body",
+            "description": "The information of the partner to be unauthorized.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Partner"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerConfigurations_UnauthorizePartner": {
+            "$ref": "./examples/PartnerConfigurations_UnauthorizePartner.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations": {
+      "get": {
+        "operationId": "PartnerDestinations_ListByResourceGroup",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "List partner destinations under a resource group.",
+        "description": "List all the partner destinations under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestinationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_ListByResourceGroup": {
+            "$ref": "./examples/PartnerDestinations_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}": {
+      "get": {
+        "operationId": "PartnerDestinations_Get",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "Get a partner destination.",
+        "description": "Get properties of a partner destination.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerDestinationName",
+            "in": "path",
+            "description": "Name of the partner destination.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_Get": {
+            "$ref": "./examples/PartnerDestinations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerDestinations_CreateOrUpdate",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "Create a partner destination.",
+        "description": "Asynchronously creates a new partner destination with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerDestinationName",
+            "in": "path",
+            "description": "Name of the partner destination.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "partnerDestination",
+            "in": "body",
+            "description": "Partner destination create information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PartnerDestination' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            }
+          },
+          "201": {
+            "description": "Resource 'PartnerDestination' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_CreateOrUpdate": {
+            "$ref": "./examples/PartnerDestinations_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PartnerDestination"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PartnerDestinations_Update",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "Update a partner destination.",
+        "description": "Asynchronously updates a partner destination with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerDestinationName",
+            "in": "path",
+            "description": "Name of the partner destination.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "partnerDestinationUpdateParameters",
+            "in": "body",
+            "description": "Partner destination update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerDestinationUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            }
+          },
+          "201": {
+            "description": "Resource 'PartnerDestination' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_Update": {
+            "$ref": "./examples/PartnerDestinations_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PartnerDestination"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PartnerDestinations_Delete",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "Delete a partner destination.",
+        "description": "Delete existing partner destination.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerDestinationName",
+            "in": "path",
+            "description": "Name of the partner destination.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_Delete": {
+            "$ref": "./examples/PartnerDestinations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}/activate": {
+      "post": {
+        "operationId": "PartnerDestinations_Activate",
+        "tags": [
+          "PartnerDestinations"
+        ],
+        "summary": "Activate a partner destination.",
+        "description": "Activate a newly created partner destination.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerDestinationName",
+            "in": "path",
+            "description": "Name of the partner destination.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerDestination"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerDestinations_Activate": {
+            "$ref": "./examples/PartnerDestinations_Activate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces": {
+      "get": {
+        "operationId": "PartnerNamespaces_ListByResourceGroup",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "List partner namespaces under a resource group.",
+        "description": "List all the partner namespaces under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespacesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_ListByResourceGroup": {
+            "$ref": "./examples/PartnerNamespaces_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}": {
+      "get": {
+        "operationId": "PartnerNamespaces_Get",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "Get a partner namespace.",
+        "description": "Get properties of a partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_Get": {
+            "$ref": "./examples/PartnerNamespaces_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerNamespaces_CreateOrUpdate",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "Create a partner namespace.",
+        "description": "Asynchronously creates a new partner namespace with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerNamespaceInfo",
+            "in": "body",
+            "description": "PartnerNamespace information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'PartnerNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespace"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_CreateOrUpdate": {
+            "$ref": "./examples/PartnerNamespaces_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PartnerNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PartnerNamespaces_Update",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "Update a partner namespace.",
+        "description": "Asynchronously updates a partner namespace with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerNamespaceUpdateParameters",
+            "in": "body",
+            "description": "Partner namespace update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespaceUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "201": {
+            "description": "Resource 'PartnerNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespace"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_Update": {
+            "$ref": "./examples/PartnerNamespaces_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PartnerNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PartnerNamespaces_Delete",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "Delete a partner namespace.",
+        "description": "Delete existing partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_Delete": {
+            "$ref": "./examples/PartnerNamespaces_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels": {
+      "get": {
+        "operationId": "Channels_ListByPartnerNamespace",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "List channels.",
+        "description": "List all the channels in a partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ChannelsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_ListByPartnerNamespace": {
+            "$ref": "./examples/Channels_ListByPartnerNamespace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}": {
+      "get": {
+        "operationId": "Channels_Get",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "Get a channel.",
+        "description": "Get properties of a channel.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelName",
+            "in": "path",
+            "description": "Name of the channel.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Channel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_Get": {
+            "$ref": "./examples/Channels_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Channels_CreateOrUpdate",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "Create or update a channel.",
+        "description": "Synchronously creates or updates a new channel with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelName",
+            "in": "path",
+            "description": "Name of the channel.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelInfo",
+            "in": "body",
+            "description": "Channel information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Channel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Channel' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Channel"
+            }
+          },
+          "201": {
+            "description": "Resource 'Channel' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Channel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_CreateOrUpdate": {
+            "$ref": "./examples/Channels_CreateOrUpdate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Channels_Update",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "Update a Channel.",
+        "description": "Synchronously updates a channel with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelName",
+            "in": "path",
+            "description": "Name of the channel.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelUpdateParameters",
+            "in": "body",
+            "description": "Channel update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ChannelUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_Update": {
+            "$ref": "./examples/Channels_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Channels_Delete",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "Delete a channel.",
+        "description": "Delete an existing channel.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelName",
+            "in": "path",
+            "description": "Name of the channel.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_Delete": {
+            "$ref": "./examples/Channels_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}/getFullUrl": {
+      "post": {
+        "operationId": "Channels_GetFullUrl",
+        "tags": [
+          "Channels"
+        ],
+        "summary": "Get full URL of partner destination channel.",
+        "description": "Get the full endpoint URL of a partner destination channel.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "channelName",
+            "in": "path",
+            "description": "Name of the channel.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Channels_GetFullUrl": {
+            "$ref": "./examples/Channels_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/listKeys": {
+      "post": {
+        "operationId": "PartnerNamespaces_ListSharedAccessKeys",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "List keys for a partner namespace.",
+        "description": "List the two keys used to publish to a partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespaceSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_ListSharedAccessKeys": {
+            "$ref": "./examples/PartnerNamespaces_ListSharedAccessKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/regenerateKey": {
+      "post": {
+        "operationId": "PartnerNamespaces_RegenerateKey",
+        "tags": [
+          "PartnerNamespaces"
+        ],
+        "summary": "Regenerate key for a partner namespace.",
+        "description": "Regenerate a shared access key for a partner namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerNamespaceName",
+            "in": "path",
+            "description": "Name of the partner namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "regenerateKeyRequest",
+            "in": "body",
+            "description": "Request body to regenerate key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespaceRegenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerNamespaceSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerNamespaces_RegenerateKey": {
+            "$ref": "./examples/PartnerNamespaces_RegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations": {
+      "get": {
+        "operationId": "PartnerRegistrations_ListByResourceGroup",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "List partner registrations under a resource group.",
+        "description": "List all the partner registrations under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistrationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_ListByResourceGroup": {
+            "$ref": "./examples/PartnerRegistrations_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}": {
+      "get": {
+        "operationId": "PartnerRegistrations_Get",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "Get a partner registration.",
+        "description": "Gets a partner registration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerRegistrationName",
+            "in": "path",
+            "description": "Name of the partner registration.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_Get": {
+            "$ref": "./examples/PartnerRegistrations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerRegistrations_CreateOrUpdate",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "Create a partner registration.",
+        "description": "Creates a new partner registration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerRegistrationName",
+            "in": "path",
+            "description": "Name of the partner registration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerRegistrationInfo",
+            "in": "body",
+            "description": "PartnerRegistration information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PartnerRegistration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistration"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistration"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_CreateOrUpdate": {
+            "$ref": "./examples/PartnerRegistrations_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PartnerRegistration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PartnerRegistrations_Update",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "Update a partner registration.",
+        "description": "Updates a partner registration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerRegistrationName",
+            "in": "path",
+            "description": "Name of the partner registration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerRegistrationUpdateParameters",
+            "in": "body",
+            "description": "Partner registration update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistrationUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "201": {
+            "description": "Resource 'PartnerRegistration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerRegistration"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_Update": {
+            "$ref": "./examples/PartnerRegistrations_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PartnerRegistration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PartnerRegistrations_Delete",
+        "tags": [
+          "PartnerRegistrations"
+        ],
+        "summary": "Delete a partner registration.",
+        "description": "Deletes a partner registration with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerRegistrationName",
+            "in": "path",
+            "description": "Name of the partner registration.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerRegistrations_Delete": {
+            "$ref": "./examples/PartnerRegistrations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics": {
+      "get": {
+        "operationId": "PartnerTopics_ListByResourceGroup",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "List partner topics under a resource group.",
+        "description": "List all the partner topics under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_ListByResourceGroup": {
+            "$ref": "./examples/PartnerTopics_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}": {
+      "get": {
+        "operationId": "PartnerTopics_Get",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Get a partner topic.",
+        "description": "Get properties of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_Get": {
+            "$ref": "./examples/PartnerTopics_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerTopics_CreateOrUpdate",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Create a partner topic.",
+        "description": "Asynchronously creates a new partner topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerTopicInfo",
+            "in": "body",
+            "description": "Partner Topic information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PartnerTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'PartnerTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_CreateOrUpdate": {
+            "$ref": "./examples/PartnerTopics_CreateOrUpdate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "PartnerTopics_Update",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Update a partner topic.",
+        "description": "Asynchronously updates a partner topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "partnerTopicUpdateParameters",
+            "in": "body",
+            "description": "PartnerTopic update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PartnerTopicUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "201": {
+            "description": "Resource 'PartnerTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_Update": {
+            "$ref": "./examples/PartnerTopics_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PartnerTopics_Delete",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Delete a partner topic.",
+        "description": "Delete existing partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_Delete": {
+            "$ref": "./examples/PartnerTopics_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/activate": {
+      "post": {
+        "operationId": "PartnerTopics_Activate",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Activate a partner topic.",
+        "description": "Activate a newly created partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_Activate": {
+            "$ref": "./examples/PartnerTopics_Activate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/deactivate": {
+      "post": {
+        "operationId": "PartnerTopics_Deactivate",
+        "tags": [
+          "PartnerTopics"
+        ],
+        "summary": "Deactivate a partner topic.",
+        "description": "Deactivate specific partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PartnerTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopics_Deactivate": {
+            "$ref": "./examples/PartnerTopics_Deactivate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions": {
+      "get": {
+        "operationId": "PartnerTopicEventSubscriptions_ListByPartnerTopic",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "List event subscriptions of a partner topic.",
+        "description": "List event subscriptions that belong to a specific partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_ListByPartnerTopic": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_ListByPartnerTopic.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "PartnerTopicEventSubscriptions_Get",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Get an event subscription of a partner topic.",
+        "description": "Get properties of an event subscription of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_Get": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PartnerTopicEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Create or update an event subscription of a partner topic.",
+        "description": "Asynchronously creates or updates an event subscription of a partner topic with the specified parameters. Existing event subscriptions will be updated with this API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EventSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PartnerTopicEventSubscriptions_Update",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Update event subscription of a partner topic.",
+        "description": "Update an existing event subscription of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_Update": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PartnerTopicEventSubscriptions_Delete",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Delete an event subscription of a partner topic.",
+        "description": "Delete an existing event subscription of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_Delete": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "PartnerTopicEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription of a partner topic.",
+        "description": "Get all delivery attributes for an event subscription of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "PartnerTopicEventSubscriptions_GetFullUrl",
+        "tags": [
+          "PartnerTopicEventSubscriptions"
+        ],
+        "summary": "Get full URL of an event subscription of a partner topic.",
+        "description": "Get the full endpoint URL for an event subscription of a partner topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "partnerTopicName",
+            "in": "path",
+            "description": "Name of the partner topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PartnerTopicEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/PartnerTopicEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics": {
+      "get": {
+        "operationId": "SystemTopics_ListByResourceGroup",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "List system topics under a resource group.",
+        "description": "List all the system topics under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SystemTopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_ListByResourceGroup": {
+            "$ref": "./examples/SystemTopics_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}": {
+      "get": {
+        "operationId": "SystemTopics_Get",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "Get a system topic.",
+        "description": "Get properties of a system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_Get": {
+            "$ref": "./examples/SystemTopics_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SystemTopics_CreateOrUpdate",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "Create a system topic.",
+        "description": "Asynchronously creates a new system topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "systemTopicInfo",
+            "in": "body",
+            "description": "System Topic information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SystemTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'SystemTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_CreateOrUpdate": {
+            "$ref": "./examples/SystemTopics_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/SystemTopic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "SystemTopics_Update",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "Update a system topic.",
+        "description": "Asynchronously updates a system topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "systemTopicUpdateParameters",
+            "in": "body",
+            "description": "SystemTopic update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SystemTopicUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'SystemTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SystemTopic"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_Update": {
+            "$ref": "./examples/SystemTopics_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/SystemTopic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "SystemTopics_Delete",
+        "tags": [
+          "SystemTopics"
+        ],
+        "summary": "Delete a system topic.",
+        "description": "Delete existing system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopics_Delete": {
+            "$ref": "./examples/SystemTopics_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions": {
+      "get": {
+        "operationId": "SystemTopicEventSubscriptions_ListBySystemTopic",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "List event subscriptions of a system topic.",
+        "description": "List event subscriptions that belong to a specific system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_ListBySystemTopic": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_ListBySystemTopic.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "SystemTopicEventSubscriptions_Get",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Get an event subscription of a system topic.",
+        "description": "Get an event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_Get": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SystemTopicEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Create or update an event subscription for a system topic.",
+        "description": "Asynchronously creates or updates an event subscription with the specified parameters. Existing event subscriptions will be updated with this API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "SystemTopicEventSubscriptions_Update",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Update event subscription of a system topic.",
+        "description": "Update an existing event subscription of a system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_Update": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "SystemTopicEventSubscriptions_Delete",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Delete an event subscription of a system topic.",
+        "description": "Delete an existing event subscription of a system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_Delete": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "SystemTopicEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription.",
+        "description": "Get all delivery attributes for an event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "SystemTopicEventSubscriptions_GetFullUrl",
+        "tags": [
+          "SystemTopicEventSubscriptions"
+        ],
+        "summary": "Get full URL of an event subscription of a system topic.",
+        "description": "Get the full endpoint URL for an event subscription of a system topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "systemTopicName",
+            "in": "path",
+            "description": "Name of the system topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SystemTopicEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/SystemTopicEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventSubscriptions": {
+      "get": {
+        "operationId": "EventSubscriptions_ListGlobalByResourceGroupForTopicType",
+        "summary": "List all global event subscriptions under a resource group for a topic type.",
+        "description": "List all global event subscriptions under a resource group for a specific topic type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicTypeName",
+            "in": "path",
+            "description": "Name of the topic type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EventSubscriptions_ListGlobalByResourceGroupForTopicType": {
+            "$ref": "./examples/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics": {
+      "get": {
+        "operationId": "Topics_ListByResourceGroup",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "List topics under a resource group.",
+        "description": "List all the topics under a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_ListByResourceGroup": {
+            "$ref": "./examples/Topics_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}": {
+      "get": {
+        "operationId": "Topics_Get",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "Get a topic.",
+        "description": "Get properties of a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Topic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_Get": {
+            "$ref": "./examples/Topics_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Topics_CreateOrUpdate",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "Create a topic.",
+        "description": "Asynchronously creates a new topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicInfo",
+            "in": "body",
+            "description": "Topic information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Topic"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'Topic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Topic"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_CreateOrUpdate": {
+            "$ref": "./examples/Topics_CreateOrUpdate.json"
+          },
+          "Topics_CreateOrUpdateForAzureArc": {
+            "$ref": "./examples/Topics_CreateOrUpdateForAzureArc.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Topic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Topics_Update",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "Update a topic.",
+        "description": "Asynchronously updates a topic with the specified parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "topicUpdateParameters",
+            "in": "body",
+            "description": "Topic update information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopicUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "201": {
+            "description": "Resource 'Topic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Topic"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_Update": {
+            "$ref": "./examples/Topics_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Topic"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Topics_Delete",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "Delete a topic.",
+        "description": "Delete existing topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_Delete": {
+            "$ref": "./examples/Topics_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions": {
+      "get": {
+        "operationId": "TopicEventSubscriptions_List",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "List all event subscriptions for a specific topic.",
+        "description": "List all event subscriptions that have been created for a specific topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The query used to filter the search results using OData syntax. Filtering is permitted on the 'name' property only and with limited number of OData operations. These operations are: the 'contains' function as well as the following logical operations: not, and, or, eq (for equal), and ne (for not equal). No arithmetic operations are supported. The following is a valid filter example: $filter=contains(namE, 'PATTERN') and name ne 'PATTERN-1'. The following is not a valid filter example: $filter=location eq 'westus'.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of results to return per page for the list operation. Valid range for top parameter is 1 to 100. If not specified, the default number of results to be returned is 20 items per page.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_List": {
+            "$ref": "./examples/TopicEventSubscriptions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}": {
+      "get": {
+        "operationId": "TopicEventSubscriptions_Get",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Get an event subscription of a topic.",
+        "description": "Get properties of an event subscription of a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_Get": {
+            "$ref": "./examples/TopicEventSubscriptions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TopicEventSubscriptions_CreateOrUpdate",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Create or update an event subscription to a topic.",
+        "description": "Asynchronously creates a new event subscription or updates an existing event subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionInfo",
+            "in": "body",
+            "description": "Event subscription properties containing the destination and filter information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EventSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_CreateOrUpdate": {
+            "$ref": "./examples/TopicEventSubscriptions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "TopicEventSubscriptions_Update",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Update an event subscription for a topic.",
+        "description": "Update an existing event subscription for a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionUpdateParameters",
+            "in": "body",
+            "description": "Updated event subscription information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'EventSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EventSubscription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_Update": {
+            "$ref": "./examples/TopicEventSubscriptions_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EventSubscription"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TopicEventSubscriptions_Delete",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Delete an event subscription for a topic.",
+        "description": "Delete an existing event subscription for a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_Delete": {
+            "$ref": "./examples/TopicEventSubscriptions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes": {
+      "post": {
+        "operationId": "TopicEventSubscriptions_GetDeliveryAttributes",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Get delivery attributes for an event subscription for topic.",
+        "description": "Get all delivery attributes for an event subscription for topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeliveryAttributeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_GetDeliveryAttributes": {
+            "$ref": "./examples/TopicEventSubscriptions_GetDeliveryAttributes.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl": {
+      "post": {
+        "operationId": "TopicEventSubscriptions_GetFullUrl",
+        "tags": [
+          "TopicEventSubscriptions"
+        ],
+        "summary": "Get full URL of an event subscription for topic.",
+        "description": "Get the full endpoint URL for an event subscription for topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "eventSubscriptionName",
+            "in": "path",
+            "description": "Name of the event subscription to be found.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EventSubscriptionFullUrl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TopicEventSubscriptions_GetFullUrl": {
+            "$ref": "./examples/TopicEventSubscriptions_GetFullUrl.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/listKeys": {
+      "post": {
+        "operationId": "Topics_ListSharedAccessKeys",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "List keys for a topic.",
+        "description": "List the two keys used to publish to a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSharedAccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_ListSharedAccessKeys": {
+            "$ref": "./examples/Topics_ListSharedAccessKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/regenerateKey": {
+      "post": {
+        "operationId": "Topics_RegenerateKey",
+        "tags": [
+          "Topics"
+        ],
+        "summary": "Regenerate key for a topic.",
+        "description": "Regenerate a shared access key for a topic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "topicName",
+            "in": "path",
+            "description": "Name of the topic.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "regenerateKeyRequest",
+            "in": "body",
+            "description": "Request body to regenerate key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopicRegenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TopicSharedAccessKeys"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Topics_RegenerateKey": {
+            "$ref": "./examples/Topics_RegenerateKey.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TopicSharedAccessKeys"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AdvancedFilter": {
+      "type": "object",
+      "description": "This is the base type that represents an advanced filter. To configure an advanced filter, do not directly instantiate an object of this class. Instead, instantiate an object of a derived class such as BoolEqualsAdvancedFilter, NumberInAdvancedFilter, StringEqualsAdvancedFilter etc. depending on the type of the key based on which you want to filter.",
+      "properties": {
+        "operatorType": {
+          "$ref": "#/definitions/AdvancedFilterOperatorType",
+          "description": "The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others."
+        },
+        "key": {
+          "type": "string",
+          "description": "The field/property in the event based on which you want to filter."
+        }
+      },
+      "discriminator": "operatorType",
+      "required": [
+        "operatorType"
+      ]
+    },
+    "AdvancedFilterOperatorType": {
+      "type": "string",
+      "description": "The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.",
+      "enum": [
+        "NumberIn",
+        "NumberNotIn",
+        "NumberLessThan",
+        "NumberGreaterThan",
+        "NumberLessThanOrEquals",
+        "NumberGreaterThanOrEquals",
+        "BoolEquals",
+        "StringIn",
+        "StringNotIn",
+        "StringBeginsWith",
+        "StringEndsWith",
+        "StringContains",
+        "NumberInRange",
+        "NumberNotInRange",
+        "StringNotBeginsWith",
+        "StringNotEndsWith",
+        "StringNotContains",
+        "IsNullOrUndefined",
+        "IsNotNull"
+      ],
+      "x-ms-enum": {
+        "name": "AdvancedFilterOperatorType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NumberIn",
+            "value": "NumberIn",
+            "description": "NumberIn"
+          },
+          {
+            "name": "NumberNotIn",
+            "value": "NumberNotIn",
+            "description": "NumberNotIn"
+          },
+          {
+            "name": "NumberLessThan",
+            "value": "NumberLessThan",
+            "description": "NumberLessThan"
+          },
+          {
+            "name": "NumberGreaterThan",
+            "value": "NumberGreaterThan",
+            "description": "NumberGreaterThan"
+          },
+          {
+            "name": "NumberLessThanOrEquals",
+            "value": "NumberLessThanOrEquals",
+            "description": "NumberLessThanOrEquals"
+          },
+          {
+            "name": "NumberGreaterThanOrEquals",
+            "value": "NumberGreaterThanOrEquals",
+            "description": "NumberGreaterThanOrEquals"
+          },
+          {
+            "name": "BoolEquals",
+            "value": "BoolEquals",
+            "description": "BoolEquals"
+          },
+          {
+            "name": "StringIn",
+            "value": "StringIn",
+            "description": "StringIn"
+          },
+          {
+            "name": "StringNotIn",
+            "value": "StringNotIn",
+            "description": "StringNotIn"
+          },
+          {
+            "name": "StringBeginsWith",
+            "value": "StringBeginsWith",
+            "description": "StringBeginsWith"
+          },
+          {
+            "name": "StringEndsWith",
+            "value": "StringEndsWith",
+            "description": "StringEndsWith"
+          },
+          {
+            "name": "StringContains",
+            "value": "StringContains",
+            "description": "StringContains"
+          },
+          {
+            "name": "NumberInRange",
+            "value": "NumberInRange",
+            "description": "NumberInRange"
+          },
+          {
+            "name": "NumberNotInRange",
+            "value": "NumberNotInRange",
+            "description": "NumberNotInRange"
+          },
+          {
+            "name": "StringNotBeginsWith",
+            "value": "StringNotBeginsWith",
+            "description": "StringNotBeginsWith"
+          },
+          {
+            "name": "StringNotEndsWith",
+            "value": "StringNotEndsWith",
+            "description": "StringNotEndsWith"
+          },
+          {
+            "name": "StringNotContains",
+            "value": "StringNotContains",
+            "description": "StringNotContains"
+          },
+          {
+            "name": "IsNullOrUndefined",
+            "value": "IsNullOrUndefined",
+            "description": "IsNullOrUndefined"
+          },
+          {
+            "name": "IsNotNull",
+            "value": "IsNotNull",
+            "description": "IsNotNull"
+          }
+        ]
+      }
+    },
+    "AlternativeAuthenticationNameSource": {
+      "type": "string",
+      "description": "Alternative authentication name sources related to client authentication settings for namespace resource.",
+      "enum": [
+        "ClientCertificateSubject",
+        "ClientCertificateDns",
+        "ClientCertificateUri",
+        "ClientCertificateIp",
+        "ClientCertificateEmail"
+      ],
+      "x-ms-enum": {
+        "name": "AlternativeAuthenticationNameSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ClientCertificateSubject",
+            "value": "ClientCertificateSubject",
+            "description": "ClientCertificateSubject"
+          },
+          {
+            "name": "ClientCertificateDns",
+            "value": "ClientCertificateDns",
+            "description": "ClientCertificateDns"
+          },
+          {
+            "name": "ClientCertificateUri",
+            "value": "ClientCertificateUri",
+            "description": "ClientCertificateUri"
+          },
+          {
+            "name": "ClientCertificateIp",
+            "value": "ClientCertificateIp",
+            "description": "ClientCertificateIp"
+          },
+          {
+            "name": "ClientCertificateEmail",
+            "value": "ClientCertificateEmail",
+            "description": "ClientCertificateEmail"
+          }
+        ]
+      }
+    },
+    "AutoScaleConfiguration": {
+      "type": "object",
+      "description": "Auto-scale configuration for the namespace resource.",
+      "properties": {
+        "enableAutoScale": {
+          "type": "boolean",
+          "description": "Indicates whether auto-scaling is enabled for the namespace. When enabled, the namespace will automatically scale\nbetween minimumThroughputUnits and maximumThroughputUnits based on usage patterns."
+        },
+        "minimumThroughputUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of Throughput Units for auto-scaling. Valid only when EnableAutoScale is true."
+        },
+        "maximumThroughputUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of Throughput Units for auto-scaling. Valid only when EnableAutoScale is true."
+        }
+      }
+    },
+    "Azure.Core.armResourceType": {
+      "type": "string",
+      "description": "Represents an Azure Resource Type."
+    },
+    "AzureADPartnerClientAuthentication": {
+      "type": "object",
+      "description": "Microsoft Entra ID Partner Client Authentication",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureADPartnerClientAuthenticationProperties",
+          "description": "Microsoft Entra ID ClientAuthentication Properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartnerClientAuthentication"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureAD"
+    },
+    "AzureADPartnerClientAuthenticationProperties": {
+      "type": "object",
+      "description": "Properties of a Microsoft Entra ID Partner Client Authentication.",
+      "properties": {
+        "azureActiveDirectoryTenantId": {
+          "type": "string",
+          "description": "The Microsoft Entra ID Tenant ID to get the access token that will be included as the bearer token in delivery requests."
+        },
+        "azureActiveDirectoryApplicationIdOrUri": {
+          "type": "string",
+          "description": "The Microsoft Entra ID Application ID or URI to get the access token that will be included as the bearer token in delivery requests."
+        }
+      }
+    },
+    "AzureFunctionEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the azure function destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFunctionEventSubscriptionDestinationProperties",
+          "description": "Azure Function Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFunction"
+    },
+    "AzureFunctionEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties that represent the Azure Function destination of an event subscription.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource Id that represents the endpoint of the Azure Function destination of an event subscription.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Web/sites/functions"
+              }
+            ]
+          }
+        },
+        "maxEventsPerBatch": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events per batch.",
+          "default": 1
+        },
+        "preferredBatchSizeInKilobytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Preferred batch size in Kilobytes.",
+          "default": 64
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "BoolEqualsAdvancedFilter": {
+      "type": "object",
+      "description": "BoolEquals Advanced Filter.",
+      "properties": {
+        "value": {
+          "type": "boolean",
+          "description": "The boolean filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "BoolEquals"
+    },
+    "BoolEqualsFilter": {
+      "type": "object",
+      "description": "BoolEquals Filter.",
+      "properties": {
+        "value": {
+          "type": "boolean",
+          "description": "The boolean filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "BoolEquals"
+    },
+    "CaCertificate": {
+      "type": "object",
+      "description": "The CA Certificate resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CaCertificateProperties",
+          "description": "The properties of CA certificate.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CaCertificateProperties": {
+      "type": "object",
+      "description": "The properties of CA certificate.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description for the CA Certificate resource."
+        },
+        "encodedCertificate": {
+          "type": "string",
+          "description": "Base64 encoded PEM (Privacy Enhanced Mail) format certificate data."
+        },
+        "issueTimeInUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate issue time in UTC. This is a read-only field.",
+          "readOnly": true
+        },
+        "expiryTimeInUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate expiry time in UTC. This is a read-only field.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/CaCertificateProvisioningState",
+          "description": "Provisioning state of the CA Certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "CaCertificateProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the CA Certificate resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "CaCertificateProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          }
+        ]
+      }
+    },
+    "CaCertificatesListResult": {
+      "type": "object",
+      "description": "Result of the List CA Certificate operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CaCertificate items on this page",
+          "items": {
+            "$ref": "#/definitions/CaCertificate"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Channel": {
+      "type": "object",
+      "description": "Channel info.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ChannelProperties",
+          "description": "Properties of the Channel.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ChannelProperties": {
+      "type": "object",
+      "description": "Properties of the Channel.",
+      "properties": {
+        "channelType": {
+          "$ref": "#/definitions/ChannelType",
+          "description": "The type of the event channel which represents the direction flow of events."
+        },
+        "partnerTopicInfo": {
+          "$ref": "#/definitions/PartnerTopicInfo",
+          "description": "This property should be populated when channelType is PartnerTopic and represents information about the partner topic resource corresponding to the channel."
+        },
+        "partnerDestinationInfo": {
+          "$ref": "#/definitions/PartnerDestinationInfo",
+          "description": "This property should be populated when channelType is PartnerDestination and represents information about the partner destination resource corresponding to the channel."
+        },
+        "messageForActivation": {
+          "type": "string",
+          "description": "Context or helpful message that can be used during the approval process by the subscriber."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ChannelProvisioningState",
+          "description": "Provisioning state of the channel."
+        },
+        "readinessState": {
+          "$ref": "#/definitions/ReadinessState",
+          "description": "The readiness state of the corresponding partner topic."
+        },
+        "expirationTimeIfNotActivatedUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the channel. If this timer expires while the corresponding partner topic is never activated,\nthe channel and corresponding partner topic are deleted."
+        }
+      }
+    },
+    "ChannelProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the channel.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "IdleDueToMirroredPartnerTopicDeletion",
+        "IdleDueToMirroredPartnerDestinationDeletion"
+      ],
+      "x-ms-enum": {
+        "name": "ChannelProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "IdleDueToMirroredPartnerTopicDeletion",
+            "value": "IdleDueToMirroredPartnerTopicDeletion",
+            "description": "IdleDueToMirroredPartnerTopicDeletion"
+          },
+          {
+            "name": "IdleDueToMirroredPartnerDestinationDeletion",
+            "value": "IdleDueToMirroredPartnerDestinationDeletion",
+            "description": "IdleDueToMirroredPartnerDestinationDeletion"
+          }
+        ]
+      }
+    },
+    "ChannelType": {
+      "type": "string",
+      "description": "The type of the event channel which represents the direction flow of events.",
+      "enum": [
+        "PartnerTopic",
+        "PartnerDestination"
+      ],
+      "x-ms-enum": {
+        "name": "ChannelType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PartnerTopic",
+            "value": "PartnerTopic",
+            "description": "PartnerTopic"
+          },
+          {
+            "name": "PartnerDestination",
+            "value": "PartnerDestination",
+            "description": "PartnerDestination"
+          }
+        ]
+      }
+    },
+    "ChannelUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Channel update.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ChannelUpdateParametersProperties",
+          "description": "Properties of the channel update parameters.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ChannelUpdateParametersProperties": {
+      "type": "object",
+      "description": "Properties of the channel update parameters.",
+      "properties": {
+        "expirationTimeIfNotActivatedUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the channel. If this timer expires while the corresponding partner topic or partner destination is never activated,\nthe channel and corresponding partner topic or partner destination are deleted."
+        },
+        "partnerDestinationInfo": {
+          "$ref": "#/definitions/PartnerUpdateDestinationInfo",
+          "description": "Partner destination properties which can be updated if the channel is of type PartnerDestination."
+        },
+        "partnerTopicInfo": {
+          "$ref": "#/definitions/PartnerUpdateTopicInfo",
+          "description": "Partner topic properties which can be updated if the channel is of type PartnerTopic."
+        }
+      }
+    },
+    "ChannelsListResult": {
+      "type": "object",
+      "description": "Result of the List Channels operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Channel items on this page",
+          "items": {
+            "$ref": "#/definitions/Channel"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Client": {
+      "type": "object",
+      "description": "The Client resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ClientProperties",
+          "description": "The properties of client.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ClientAuthenticationSettings": {
+      "type": "object",
+      "description": "Client authentication settings for namespace resource.",
+      "properties": {
+        "alternativeAuthenticationNameSources": {
+          "type": "array",
+          "description": "Alternative authentication name sources related to client authentication settings for namespace resource.",
+          "items": {
+            "$ref": "#/definitions/AlternativeAuthenticationNameSource"
+          }
+        },
+        "customJwtAuthentication": {
+          "$ref": "#/definitions/CustomJwtAuthenticationSettings",
+          "description": "Custom JWT authentication settings for namespace resource."
+        },
+        "webhookAuthentication": {
+          "$ref": "#/definitions/WebhookAuthenticationSettings",
+          "description": "Authentication settings for a webhook endpoint within a Namespace resource."
+        }
+      }
+    },
+    "ClientCertificateAuthentication": {
+      "type": "object",
+      "description": "The certificate authentication properties for the client.",
+      "properties": {
+        "validationScheme": {
+          "$ref": "#/definitions/ClientCertificateValidationScheme",
+          "description": "The validation scheme used to authenticate the client. Default value is SubjectMatchesAuthenticationName."
+        },
+        "allowedThumbprints": {
+          "type": "array",
+          "description": "The list of thumbprints that are allowed during client authentication. This property is required only if the validationScheme is 'ThumbprintMatch'.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ClientCertificateValidationScheme": {
+      "type": "string",
+      "description": "The validation scheme used to authenticate the client. Default value is SubjectMatchesAuthenticationName.",
+      "enum": [
+        "SubjectMatchesAuthenticationName",
+        "DnsMatchesAuthenticationName",
+        "UriMatchesAuthenticationName",
+        "IpMatchesAuthenticationName",
+        "EmailMatchesAuthenticationName",
+        "ThumbprintMatch"
+      ],
+      "x-ms-enum": {
+        "name": "ClientCertificateValidationScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SubjectMatchesAuthenticationName",
+            "value": "SubjectMatchesAuthenticationName",
+            "description": "SubjectMatchesAuthenticationName"
+          },
+          {
+            "name": "DnsMatchesAuthenticationName",
+            "value": "DnsMatchesAuthenticationName",
+            "description": "DnsMatchesAuthenticationName"
+          },
+          {
+            "name": "UriMatchesAuthenticationName",
+            "value": "UriMatchesAuthenticationName",
+            "description": "UriMatchesAuthenticationName"
+          },
+          {
+            "name": "IpMatchesAuthenticationName",
+            "value": "IpMatchesAuthenticationName",
+            "description": "IpMatchesAuthenticationName"
+          },
+          {
+            "name": "EmailMatchesAuthenticationName",
+            "value": "EmailMatchesAuthenticationName",
+            "description": "EmailMatchesAuthenticationName"
+          },
+          {
+            "name": "ThumbprintMatch",
+            "value": "ThumbprintMatch",
+            "description": "ThumbprintMatch"
+          }
+        ]
+      }
+    },
+    "ClientGroup": {
+      "type": "object",
+      "description": "The Client group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ClientGroupProperties",
+          "description": "The properties of client group.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ClientGroupProperties": {
+      "type": "object",
+      "description": "The properties of client group.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description for the Client Group resource."
+        },
+        "query": {
+          "type": "string",
+          "description": "The grouping query for the clients.\nExample : attributes.keyName IN ['a', 'b', 'c']."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ClientGroupProvisioningState",
+          "description": "Provisioning state of the ClientGroup resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ClientGroupProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the ClientGroup resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "ClientGroupProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          }
+        ]
+      }
+    },
+    "ClientGroupsListResult": {
+      "type": "object",
+      "description": "Result of the List Client Group operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ClientGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/ClientGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ClientProperties": {
+      "type": "object",
+      "description": "The properties of client.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description for the Client resource."
+        },
+        "authenticationName": {
+          "type": "string",
+          "description": "The name presented by the client for authentication. The default value is the name of the resource."
+        },
+        "clientCertificateAuthentication": {
+          "$ref": "#/definitions/ClientCertificateAuthentication",
+          "description": "The client certificate authentication information."
+        },
+        "state": {
+          "type": "string",
+          "description": "Indicates if the client is enabled or not. Default value is Enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "ClientState",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              }
+            ]
+          }
+        },
+        "attributes": {
+          "type": "object",
+          "description": "Attributes for the client. Supported values are int, bool, string, string[].\nExample:\n\"attributes\": { \"room\": \"345\", \"floor\": 12, \"deviceTypes\": [\"Fan\", \"Light\"] }",
+          "additionalProperties": {}
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ClientProvisioningState",
+          "description": "Provisioning state of the Client resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ClientProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Client resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "ClientProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          }
+        ]
+      }
+    },
+    "ClientsListResult": {
+      "type": "object",
+      "description": "Result of the List Client operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Client items on this page",
+          "items": {
+            "$ref": "#/definitions/Client"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConfidentialCompute": {
+      "type": "object",
+      "description": "Azure Confidential Compute properties of the resource.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/ConfidentialComputeMode",
+          "description": "This property specifies the mode of the Azure Confidential Compute configuration.\nPossible values are 'Disabled' or 'Enabled'.\nThis is an immutable property set at the time of resource creation and cannot be modified later.\nEnabling this property ensures that messages are processed and stored in a Azure Confidential Compute environment."
+        }
+      },
+      "required": [
+        "mode"
+      ]
+    },
+    "ConfidentialComputeMode": {
+      "type": "string",
+      "description": "This property specifies the mode of the Azure Confidential Compute configuration.\nPossible values are 'Disabled' or 'Enabled'.\nThis is an immutable property set at the time of resource creation and cannot be modified later.\nEnabling this property ensures that messages are processed and stored in a Azure Confidential Compute environment.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "ConfidentialComputeMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "ConnectionState": {
+      "type": "object",
+      "description": "ConnectionState information.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PersistedConnectionStatus",
+          "description": "Status of the connection."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the connection state."
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "Actions required (if any)."
+        }
+      }
+    },
+    "CustomDomainConfiguration": {
+      "type": "object",
+      "description": "A custom domain configuration that allows users to publish to their own domain name.",
+      "properties": {
+        "fullyQualifiedDomainName": {
+          "type": "string",
+          "description": "Fully Qualified Domain Name (FQDN) for the custom domain."
+        },
+        "validationState": {
+          "$ref": "#/definitions/CustomDomainValidationState",
+          "description": "Validation state for the custom domain. This is a read only property and is initially set to 'Pending' and will be updated to 'Approved' by Event Grid only after ownership of the domain name has been successfully validated."
+        },
+        "identity": {
+          "$ref": "#/definitions/CustomDomainIdentity",
+          "description": "Identity info for accessing the certificate for the custom domain. This identity info must match an identity that has been set on the namespace."
+        },
+        "certificateUrl": {
+          "type": "string",
+          "description": "The URL for the certificate that is used for publishing to the custom domain. We currently support certificates stored in Azure Key Vault only. While certificate URL can be either\nversioned URL of the following format https://{key-vault-name}.vault.azure.net/certificates/{certificate-name}/{version-id}, or unversioned URL of the following format (e.g.,\nhttps://contosovault.vault.azure.net/certificates/contosocert, we support unversioned certificate URL only (e.g., https://contosovault.vault.azure.net/certificates/contosocert)"
+        },
+        "expectedTxtRecordName": {
+          "type": "string",
+          "description": "Expected DNS TXT record name. Event Grid will check for a TXT record with this name in the DNS record set of the custom domain name to prove ownership over the domain.\nThe values under this TXT record must contain the expected TXT record value."
+        },
+        "expectedTxtRecordValue": {
+          "type": "string",
+          "description": "Expected DNS TXT record value. Event Grid will check for a TXT record with this value in the DNS record set of the custom domain name to prove ownership over the domain."
+        }
+      },
+      "required": [
+        "fullyQualifiedDomainName"
+      ]
+    },
+    "CustomDomainIdentity": {
+      "type": "object",
+      "description": "The identity information for retrieving the certificate for the custom domain.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CustomDomainIdentityType",
+          "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'."
+        },
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "The user identity associated with the resource."
+        }
+      }
+    },
+    "CustomDomainIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "CustomDomainIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "CustomDomainOwnershipValidationResult": {
+      "type": "object",
+      "description": "Namespace custom domain ownership validation result.",
+      "properties": {
+        "customDomainsForTopicsConfiguration": {
+          "type": "array",
+          "description": "List of custom domain configurations for the namespace under topics configuration.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        },
+        "customDomainsForTopicSpacesConfiguration": {
+          "type": "array",
+          "description": "List of custom domain configurations for the namespace under topic spaces configuration.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CustomDomainValidationState": {
+      "type": "string",
+      "description": "Validation state for the custom domain. This is a read only property and is initially set to 'Pending' and will be updated to 'Approved' by Event Grid only after ownership of the domain name has been successfully validated.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "ErrorRetrievingDnsRecord"
+      ],
+      "x-ms-enum": {
+        "name": "CustomDomainValidationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Approved"
+          },
+          {
+            "name": "ErrorRetrievingDnsRecord",
+            "value": "ErrorRetrievingDnsRecord",
+            "description": "ErrorRetrievingDnsRecord"
+          }
+        ]
+      }
+    },
+    "CustomJwtAuthenticationManagedIdentity": {
+      "type": "object",
+      "description": "The identity information for retrieving the certificate for custom JWT authentication.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CustomJwtAuthenticationManagedIdentityType",
+          "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'."
+        },
+        "userAssignedIdentity": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The user identity associated with the resource.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "CustomJwtAuthenticationManagedIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "CustomJwtAuthenticationManagedIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "CustomJwtAuthenticationSettings": {
+      "type": "object",
+      "description": "Custom JWT authentication settings for namespace resource.",
+      "properties": {
+        "tokenIssuer": {
+          "type": "string",
+          "description": "Expected JWT token issuer."
+        },
+        "issuerCertificates": {
+          "type": "array",
+          "description": "Information about the certificates that are used for token validation. We currently support maximum 2 certificates.",
+          "items": {
+            "$ref": "#/definitions/IssuerCertificateInfo"
+          },
+          "x-ms-identifiers": []
+        },
+        "encodedIssuerCertificates": {
+          "type": "array",
+          "description": "Information about the encoded public certificates that are used for custom authentication.",
+          "items": {
+            "$ref": "#/definitions/EncodedIssuerCertificateInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CustomWebhookAuthenticationManagedIdentity": {
+      "type": "object",
+      "description": "The identity configuration required for authenticating a custom webhook.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CustomWebhookAuthenticationManagedIdentityType",
+          "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'."
+        },
+        "userAssignedIdentity": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The user identity associated with the resource.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "CustomWebhookAuthenticationManagedIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "CustomWebhookAuthenticationManagedIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "CustomerManagedKeyEncryption": {
+      "type": "object",
+      "description": "All Customer-managed key encryption properties for the resource.",
+      "properties": {
+        "keyEncryptionKeyUrl": {
+          "type": "string",
+          "description": "Key encryption key URL. This URL can be either versioned (e.g., https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78), or unversioned (e.g.,\nhttps://contosovault.vault.azure.net/keys/contosokek. When versioned URL is used, this version of the key will be used by Event Grid Runtime even if it is rotated. It is user\nresponsibility to update the URL with the new version by updating the namespace resource. When URL without version is used, Event Grid will query and get latest version and will\nbe used automatically."
+        },
+        "keyEncryptionKeyIdentity": {
+          "$ref": "#/definitions/KeyEncryptionKeyIdentity",
+          "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault. This is an optional property.\nWhen not specified, the SystemAssigned identity will be used."
+        },
+        "keyEncryptionKeyStatus": {
+          "$ref": "#/definitions/KeyEncryptionKeyStatus",
+          "description": "The state of the Customer Managed Key (CMK) encryption. This is a read-only property which determines if the associated key is active and valid and used\nactively by runtime as expected. When the associated CMK becomes invalid (e.g., if it is deleted, or if versioned CMK is not current anymore), Event Grid\nService will set this state to disabled to indicate that this key is not valid anymore and requires action from user.",
+          "readOnly": true
+        },
+        "keyEncryptionKeyStatusFriendlyDescription": {
+          "type": "string",
+          "description": "Friendly description about the Customer Managed Key (CMK) encryption state. This is a read-only property which determines why the associated key is revoked which\nwill help user to mitigate the issue and re-enable the CMK key.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "keyEncryptionKeyUrl"
+      ]
+    },
+    "DataResidencyBoundary": {
+      "type": "string",
+      "description": "Data Residency Boundary of the resource.",
+      "enum": [
+        "WithinGeopair",
+        "WithinRegion"
+      ],
+      "x-ms-enum": {
+        "name": "DataResidencyBoundary",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "WithinGeopair",
+            "value": "WithinGeopair",
+            "description": "WithinGeopair"
+          },
+          {
+            "name": "WithinRegion",
+            "value": "WithinRegion",
+            "description": "WithinRegion"
+          }
+        ]
+      }
+    },
+    "DeadLetterDestination": {
+      "type": "object",
+      "description": "Information about the dead letter destination for an event subscription. To configure a deadletter destination, do not directly instantiate an object of this class. Instead, instantiate an object of a derived class. Currently, StorageBlobDeadLetterDestination is the only class that derives from this class.",
+      "properties": {
+        "endpointType": {
+          "$ref": "#/definitions/DeadLetterEndPointType",
+          "description": "Type of the endpoint for the dead letter destination"
+        }
+      },
+      "discriminator": "endpointType",
+      "required": [
+        "endpointType"
+      ]
+    },
+    "DeadLetterEndPointType": {
+      "type": "string",
+      "description": "Type of the endpoint for the dead letter destination",
+      "enum": [
+        "StorageBlob"
+      ],
+      "x-ms-enum": {
+        "name": "DeadLetterEndPointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "StorageBlob",
+            "value": "StorageBlob",
+            "description": "StorageBlob"
+          }
+        ]
+      }
+    },
+    "DeadLetterWithResourceIdentity": {
+      "type": "object",
+      "description": "Information about the deadletter destination with resource identity.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/EventSubscriptionIdentity",
+          "description": "The identity to use when dead-lettering events."
+        },
+        "deadLetterDestination": {
+          "$ref": "#/definitions/DeadLetterDestination",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses the managed identity setup on the parent resource (namely, topic or domain) to acquire the authentication tokens being used during dead-lettering."
+        }
+      }
+    },
+    "DeliveryAttributeListResult": {
+      "type": "object",
+      "description": "Result of the Get delivery attributes operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A collection of DeliveryAttributeMapping",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "DeliveryAttributeMapping": {
+      "type": "object",
+      "description": "Delivery attribute mapping details.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the delivery attribute or header."
+        },
+        "type": {
+          "$ref": "#/definitions/DeliveryAttributeMappingType",
+          "description": "Type of the delivery attribute or header name."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "DeliveryAttributeMappingType": {
+      "type": "string",
+      "description": "Type of the delivery attribute or header name.",
+      "enum": [
+        "Static",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "DeliveryAttributeMappingType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Static",
+            "value": "Static",
+            "description": "Static"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic"
+          }
+        ]
+      }
+    },
+    "DeliveryConfiguration": {
+      "type": "object",
+      "description": "Properties of the delivery configuration information of the event subscription.",
+      "properties": {
+        "deliveryMode": {
+          "$ref": "#/definitions/DeliveryMode",
+          "description": "Delivery mode of the event subscription."
+        },
+        "queue": {
+          "$ref": "#/definitions/QueueInfo",
+          "description": "This property should be populated when deliveryMode is queue and represents information about the queue subscription."
+        },
+        "push": {
+          "$ref": "#/definitions/PushInfo",
+          "description": "This property should be populated when deliveryMode is push and represents information about the push subscription."
+        }
+      }
+    },
+    "DeliveryMode": {
+      "type": "string",
+      "description": "Delivery mode of the event subscription.",
+      "enum": [
+        "Queue",
+        "Push"
+      ],
+      "x-ms-enum": {
+        "name": "DeliveryMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Queue",
+            "value": "Queue",
+            "description": "Queue"
+          },
+          {
+            "name": "Push",
+            "value": "Push",
+            "description": "Push"
+          }
+        ]
+      }
+    },
+    "DeliverySchema": {
+      "type": "string",
+      "description": "The event delivery schema for the event subscription.",
+      "enum": [
+        "CloudEventSchemaV1_0"
+      ],
+      "x-ms-enum": {
+        "name": "DeliverySchema",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CloudEventSchemaV1_0",
+            "value": "CloudEventSchemaV1_0",
+            "description": "CloudEventSchemaV1_0"
+          }
+        ]
+      }
+    },
+    "DeliveryWithResourceIdentity": {
+      "type": "object",
+      "description": "Information about the delivery for an event subscription with resource identity.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/EventSubscriptionIdentity",
+          "description": "The identity to use when delivering events."
+        },
+        "destination": {
+          "$ref": "#/definitions/EventSubscriptionDestination",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses the managed identity setup on the parent resource (namely, topic or domain) to acquire the authentication tokens being used during delivery."
+        }
+      }
+    },
+    "Domain": {
+      "type": "object",
+      "description": "EventGrid Domain.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DomainProperties",
+          "description": "Properties of the Event Grid Domain resource.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The Sku pricing tier for the Event Grid Domain resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the Event Grid Domain resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "DomainProperties": {
+      "type": "object",
+      "description": "Properties of the Event Grid Domain Resource.",
+      "properties": {
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/DomainProvisioningState",
+          "description": "Provisioning state of the Event Grid Domain Resource.",
+          "readOnly": true
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this domain"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint for the Event Grid Domain Resource which is used for publishing the events.",
+          "readOnly": true
+        },
+        "inputSchema": {
+          "type": "string",
+          "description": "This determines the format that Event Grid should expect for incoming events published to the Event Grid Domain Resource.",
+          "default": "EventGridSchema",
+          "enum": [
+            "EventGridSchema",
+            "CustomEventSchema",
+            "CloudEventSchemaV1_0"
+          ],
+          "x-ms-enum": {
+            "name": "InputSchema",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "EventGridSchema",
+                "value": "EventGridSchema",
+                "description": "EventGridSchema"
+              },
+              {
+                "name": "CustomEventSchema",
+                "value": "CustomEventSchema",
+                "description": "CustomEventSchema"
+              },
+              {
+                "name": "CloudEventSchemaV1_0",
+                "value": "CloudEventSchemaV1_0",
+                "description": "CloudEventSchemaV1_0"
+              }
+            ]
+          }
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "Event Type Information for the domain. This information is provided by the publisher and can be used by the\nsubscriber to view different types of events that are published."
+        },
+        "inputSchemaMapping": {
+          "$ref": "#/definitions/InputSchemaMapping",
+          "description": "Information about the InputSchemaMapping which specified the info about mapping event payload."
+        },
+        "metricResourceId": {
+          "type": "string",
+          "description": "Metric resource id for the Event Grid Domain Resource.",
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.DomainProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the domain.",
+          "default": false
+        },
+        "autoCreateTopicWithFirstSubscription": {
+          "type": "boolean",
+          "description": "This Boolean is used to specify the creation mechanism for 'all' the Event Grid Domain Topics associated with this Event Grid Domain resource.\nIn this context, creation of domain topic can be auto-managed (when true) or self-managed (when false). The default value for this property is true.\nWhen this property is null or set to true, Event Grid is responsible of automatically creating the domain topic when the first event subscription is\ncreated at the scope of the domain topic. If this property is set to false, then creating the first event subscription will require creating a domain topic\nby the user. The self-management mode can be used if the user wants full control of when the domain topic is created, while auto-managed mode provides the\nflexibility to perform less operations and manage fewer resources by the user. Also, note that in auto-managed creation mode, user is allowed to create the\ndomain topic on demand if needed.",
+          "default": true
+        },
+        "autoDeleteTopicWithLastSubscription": {
+          "type": "boolean",
+          "description": "This Boolean is used to specify the deletion mechanism for 'all' the Event Grid Domain Topics associated with this Event Grid Domain resource.\nIn this context, deletion of domain topic can be auto-managed (when true) or self-managed (when false). The default value for this property is true.\nWhen this property is set to true, Event Grid is responsible of automatically deleting the domain topic when the last event subscription at the scope\nof the domain topic is deleted. If this property is set to false, then the user needs to manually delete the domain topic when it is no longer needed\n(e.g., when last event subscription is deleted and the resource needs to be cleaned up). The self-management mode can be used if the user wants full\ncontrol of when the domain topic needs to be deleted, while auto-managed mode provides the flexibility to perform less operations and manage fewer\nresources by the user.",
+          "default": true
+        },
+        "dataResidencyBoundary": {
+          "$ref": "#/definitions/DataResidencyBoundary",
+          "description": "Data Residency Boundary of the resource."
+        }
+      }
+    },
+    "DomainProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Event Grid Domain Resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "DomainProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "DomainRegenerateKeyRequest": {
+      "type": "object",
+      "description": "Domain regenerate share access key request.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Key name to regenerate key1 or key2."
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "DomainSharedAccessKeys": {
+      "type": "object",
+      "description": "Shared access keys of the Domain.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "description": "Shared access key1 for the domain."
+        },
+        "key2": {
+          "type": "string",
+          "description": "Shared access key2 for the domain."
+        }
+      }
+    },
+    "DomainTopic": {
+      "type": "object",
+      "description": "Domain Topic.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DomainTopicProperties",
+          "description": "Properties of the Domain Topic.",
+          "readOnly": true,
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DomainTopicProperties": {
+      "type": "object",
+      "description": "Properties of the Domain Topic.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/DomainTopicProvisioningState",
+          "description": "Provisioning state of the domain topic.",
+          "readOnly": true
+        }
+      }
+    },
+    "DomainTopicProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the domain topic.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "DomainTopicProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "DomainTopicsListResult": {
+      "type": "object",
+      "description": "Result of the List Domain Topics operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DomainTopic items on this page",
+          "items": {
+            "$ref": "#/definitions/DomainTopic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DomainUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of domain update parameter properties.",
+      "properties": {
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.DomainUpdateParameterProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this domain"
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the domain."
+        },
+        "autoCreateTopicWithFirstSubscription": {
+          "type": "boolean",
+          "description": "This Boolean is used to specify the creation mechanism for 'all' the Event Grid Domain Topics associated with this Event Grid Domain resource.\nIn this context, creation of domain topic can be auto-managed (when true) or self-managed (when false). The default value for this property is true.\nWhen this property is null or set to true, Event Grid is responsible of automatically creating the domain topic when the first event subscription is\ncreated at the scope of the domain topic. If this property is set to false, then creating the first event subscription will require creating a domain topic\nby the user. The self-management mode can be used if the user wants full control of when the domain topic is created, while auto-managed mode provides the\nflexibility to perform less operations and manage fewer resources by the user. Also, note that in auto-managed creation mode, user is allowed to create the\ndomain topic on demand if needed."
+        },
+        "autoDeleteTopicWithLastSubscription": {
+          "type": "boolean",
+          "description": "This Boolean is used to specify the deletion mechanism for 'all' the Event Grid Domain Topics associated with this Event Grid Domain resource.\nIn this context, deletion of domain topic can be auto-managed (when true) or self-managed (when false). The default value for this property is true.\nWhen this property is set to true, Event Grid is responsible of automatically deleting the domain topic when the last event subscription at the scope\nof the domain topic is deleted. If this property is set to false, then the user needs to manually delete the domain topic when it is no longer needed\n(e.g., when last event subscription is deleted and the resource needs to be cleaned up). The self-management mode can be used if the user wants full\ncontrol of when the domain topic needs to be deleted, while auto-managed mode provides the flexibility to perform less operations and manage fewer\nresources by the user."
+        },
+        "dataResidencyBoundary": {
+          "$ref": "#/definitions/DataResidencyBoundary",
+          "description": "The data residency boundary for the domain."
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "The eventTypeInfo for the domain."
+        }
+      }
+    },
+    "DomainUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Domain update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the domains resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/DomainUpdateParameterProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the resource."
+        },
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The Sku pricing tier for the domain."
+        }
+      }
+    },
+    "DomainsListResult": {
+      "type": "object",
+      "description": "Result of the List Domains operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Domain items on this page",
+          "items": {
+            "$ref": "#/definitions/Domain"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DynamicDeliveryAttributeMapping": {
+      "type": "object",
+      "description": "Dynamic delivery attribute mapping details.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DynamicDeliveryAttributeMappingProperties",
+          "description": "Properties of dynamic delivery attribute mapping.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeliveryAttributeMapping"
+        }
+      ],
+      "x-ms-discriminator-value": "Dynamic"
+    },
+    "DynamicDeliveryAttributeMappingProperties": {
+      "type": "object",
+      "description": "Properties of dynamic delivery attribute mapping.",
+      "properties": {
+        "sourceField": {
+          "type": "string",
+          "description": "JSON path in the event which contains attribute value."
+        }
+      }
+    },
+    "DynamicRoutingEnrichment": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Dynamic routing enrichment key."
+        },
+        "value": {
+          "type": "string",
+          "description": "Dynamic routing enrichment value."
+        }
+      }
+    },
+    "EncodedIssuerCertificateInfo": {
+      "type": "object",
+      "description": "Information about the public certificate that is used for custom authentication.",
+      "properties": {
+        "kid": {
+          "type": "string",
+          "description": "Identifier for the certificate."
+        },
+        "encodedCertificate": {
+          "type": "string",
+          "description": "Certificate in pem format."
+        }
+      },
+      "required": [
+        "kid",
+        "encodedCertificate"
+      ]
+    },
+    "EndpointType": {
+      "type": "string",
+      "description": "Type of the endpoint for the event subscription destination.",
+      "enum": [
+        "WebHook",
+        "EventHub",
+        "StorageQueue",
+        "HybridConnection",
+        "ServiceBusQueue",
+        "ServiceBusTopic",
+        "AzureFunction",
+        "PartnerDestination",
+        "MonitorAlert",
+        "NamespaceTopic"
+      ],
+      "x-ms-enum": {
+        "name": "EndpointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "WebHook",
+            "value": "WebHook",
+            "description": "WebHook"
+          },
+          {
+            "name": "EventHub",
+            "value": "EventHub",
+            "description": "EventHub"
+          },
+          {
+            "name": "StorageQueue",
+            "value": "StorageQueue",
+            "description": "StorageQueue"
+          },
+          {
+            "name": "HybridConnection",
+            "value": "HybridConnection",
+            "description": "HybridConnection"
+          },
+          {
+            "name": "ServiceBusQueue",
+            "value": "ServiceBusQueue",
+            "description": "ServiceBusQueue"
+          },
+          {
+            "name": "ServiceBusTopic",
+            "value": "ServiceBusTopic",
+            "description": "ServiceBusTopic"
+          },
+          {
+            "name": "AzureFunction",
+            "value": "AzureFunction",
+            "description": "AzureFunction"
+          },
+          {
+            "name": "PartnerDestination",
+            "value": "PartnerDestination",
+            "description": "PartnerDestination"
+          },
+          {
+            "name": "MonitorAlert",
+            "value": "MonitorAlert",
+            "description": "MonitorAlert"
+          },
+          {
+            "name": "NamespaceTopic",
+            "value": "NamespaceTopic",
+            "description": "NamespaceTopic"
+          }
+        ]
+      }
+    },
+    "EventDefinitionKind": {
+      "type": "string",
+      "description": "The kind of event type used.",
+      "enum": [
+        "Inline"
+      ],
+      "x-ms-enum": {
+        "name": "EventDefinitionKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inline",
+            "value": "Inline",
+            "description": "Inline"
+          }
+        ]
+      }
+    },
+    "EventDeliverySchema": {
+      "type": "string",
+      "description": "The event delivery schema for the event subscription.",
+      "enum": [
+        "EventGridSchema",
+        "CustomInputSchema",
+        "CloudEventSchemaV1_0"
+      ],
+      "x-ms-enum": {
+        "name": "EventDeliverySchema",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EventGridSchema",
+            "value": "EventGridSchema",
+            "description": "EventGridSchema"
+          },
+          {
+            "name": "CustomInputSchema",
+            "value": "CustomInputSchema",
+            "description": "CustomInputSchema"
+          },
+          {
+            "name": "CloudEventSchemaV1_0",
+            "value": "CloudEventSchemaV1_0",
+            "description": "CloudEventSchemaV1_0"
+          }
+        ]
+      }
+    },
+    "EventHubEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the event hub destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EventHubEventSubscriptionDestinationProperties",
+          "description": "Event Hub Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "EventHub"
+    },
+    "EventHubEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties for a event hub destination.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription."
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "EventSubscription": {
+      "type": "object",
+      "description": "Event Subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EventSubscriptionProperties",
+          "description": "Properties of the event subscription.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the destination for an event subscription.",
+      "properties": {
+        "endpointType": {
+          "$ref": "#/definitions/EndpointType",
+          "description": "Type of the endpoint for the event subscription destination."
+        }
+      },
+      "discriminator": "endpointType",
+      "required": [
+        "endpointType"
+      ]
+    },
+    "EventSubscriptionFilter": {
+      "type": "object",
+      "description": "Filter for the Event Subscription.",
+      "properties": {
+        "subjectBeginsWith": {
+          "type": "string",
+          "description": "An optional string to filter events for an event subscription based on a resource path prefix.\nThe format of this depends on the publisher of the events.\nWildcard characters are not supported in this path."
+        },
+        "subjectEndsWith": {
+          "type": "string",
+          "description": "An optional string to filter events for an event subscription based on a resource path suffix.\nWildcard characters are not supported in this path."
+        },
+        "includedEventTypes": {
+          "type": "array",
+          "description": "A list of applicable event types that need to be part of the event subscription. If it is desired to subscribe to all default event types, set the IncludedEventTypes to null.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isSubjectCaseSensitive": {
+          "type": "boolean",
+          "description": "Specifies if the SubjectBeginsWith and SubjectEndsWith properties of the filter\nshould be compared in a case sensitive manner.",
+          "default": false
+        },
+        "enableAdvancedFilteringOnArrays": {
+          "type": "boolean",
+          "description": "Allows advanced filters to be evaluated against an array of values instead of expecting a singular value."
+        },
+        "advancedFilters": {
+          "type": "array",
+          "description": "An array of advanced filters that are used for filtering event subscriptions.",
+          "items": {
+            "$ref": "#/definitions/AdvancedFilter"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "EventSubscriptionFullUrl": {
+      "type": "object",
+      "description": "Full endpoint URL of an event subscription",
+      "properties": {
+        "endpointUrl": {
+          "type": "string",
+          "description": "The URL that represents the endpoint of the destination of an event subscription."
+        }
+      }
+    },
+    "EventSubscriptionIdentity": {
+      "type": "object",
+      "description": "The identity information with the event subscription.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/EventSubscriptionIdentityType",
+          "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'."
+        },
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "The user identity associated with the resource."
+        },
+        "federatedIdentityCredentialInfo": {
+          "$ref": "#/definitions/FederatedIdentityCredentialInfo",
+          "description": "The details of the Federated Identity Credential (FIC) used with the resource delivery."
+        }
+      }
+    },
+    "EventSubscriptionIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. Can be either 'SystemAssigned' or 'UserAssigned'.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "EventSubscriptionIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "EventSubscriptionProperties": {
+      "type": "object",
+      "description": "Properties of the Event Subscription.",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "Name of the topic of the event subscription.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/EventSubscriptionProvisioningState",
+          "description": "Provisioning state of the event subscription.",
+          "readOnly": true
+        },
+        "destination": {
+          "$ref": "#/definitions/EventSubscriptionDestination",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses Azure Event Grid's identity to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "deliveryWithResourceIdentity": {
+          "$ref": "#/definitions/DeliveryWithResourceIdentity",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses the managed identity setup on the parent resource (namely, topic or domain) to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "filter": {
+          "$ref": "#/definitions/EventSubscriptionFilter",
+          "description": "Information about the filter for the event subscription."
+        },
+        "labels": {
+          "type": "array",
+          "description": "List of user defined labels.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expirationTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the event subscription."
+        },
+        "eventDeliverySchema": {
+          "type": "string",
+          "description": "The event delivery schema for the event subscription.",
+          "default": "EventGridSchema",
+          "enum": [
+            "EventGridSchema",
+            "CustomInputSchema",
+            "CloudEventSchemaV1_0"
+          ],
+          "x-ms-enum": {
+            "name": "EventDeliverySchema",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "EventGridSchema",
+                "value": "EventGridSchema",
+                "description": "EventGridSchema"
+              },
+              {
+                "name": "CustomInputSchema",
+                "value": "CustomInputSchema",
+                "description": "CustomInputSchema"
+              },
+              {
+                "name": "CloudEventSchemaV1_0",
+                "value": "CloudEventSchemaV1_0",
+                "description": "CloudEventSchemaV1_0"
+              }
+            ]
+          }
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/RetryPolicy",
+          "description": "The retry policy for events. This can be used to configure maximum number of delivery attempts and time to live for events."
+        },
+        "deadLetterDestination": {
+          "$ref": "#/definitions/DeadLetterDestination",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses Azure Event Grid's identity to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "deadLetterWithResourceIdentity": {
+          "$ref": "#/definitions/DeadLetterWithResourceIdentity",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses the managed identity setup on the parent resource (namely, topic or domain) to acquire the authentication tokens being used during delivery / dead-lettering."
+        }
+      }
+    },
+    "EventSubscriptionProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the event subscription.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "AwaitingManualAction"
+      ],
+      "x-ms-enum": {
+        "name": "EventSubscriptionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "AwaitingManualAction",
+            "value": "AwaitingManualAction",
+            "description": "AwaitingManualAction"
+          }
+        ]
+      }
+    },
+    "EventSubscriptionUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Event Subscription update.",
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/EventSubscriptionDestination",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses Azure Event Grid's identity to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "deliveryWithResourceIdentity": {
+          "$ref": "#/definitions/DeliveryWithResourceIdentity",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses the managed identity setup on the parent resource (topic / domain) to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "filter": {
+          "$ref": "#/definitions/EventSubscriptionFilter",
+          "description": "Information about the filter for the event subscription."
+        },
+        "labels": {
+          "type": "array",
+          "description": "List of user defined labels.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expirationTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Information about the expiration time for the event subscription."
+        },
+        "eventDeliverySchema": {
+          "$ref": "#/definitions/EventDeliverySchema",
+          "description": "The event delivery schema for the event subscription."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/RetryPolicy",
+          "description": "The retry policy for events. This can be used to configure maximum number of delivery attempts and time to live for events."
+        },
+        "deadLetterDestination": {
+          "$ref": "#/definitions/DeadLetterDestination",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses Azure Event Grid's identity to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "deadLetterWithResourceIdentity": {
+          "$ref": "#/definitions/DeadLetterWithResourceIdentity",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses the managed identity setup on the parent resource (topic / domain) to acquire the authentication tokens being used during delivery / dead-lettering."
+        }
+      }
+    },
+    "EventSubscriptionsListResult": {
+      "type": "object",
+      "description": "Result of the List EventSubscriptions operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EventSubscription items on this page",
+          "items": {
+            "$ref": "#/definitions/EventSubscription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EventType": {
+      "type": "object",
+      "description": "Event Type for a subject under a topic",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EventTypeProperties",
+          "description": "Properties of the event type.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "EventTypeInfo": {
+      "type": "object",
+      "description": "The event type information for Channels.",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/EventDefinitionKind",
+          "description": "The kind of event type used."
+        },
+        "inlineEventTypes": {
+          "type": "object",
+          "description": "A collection of inline event types for the resource. The inline event type keys are of type string which represents the name of the event.\nAn example of a valid inline event name is \"Contoso.OrderCreated\".\nThe inline event type values are of type InlineEventProperties and will contain additional information for every inline event type.",
+          "additionalProperties": {
+            "$ref": "#/definitions/InlineEventProperties"
+          }
+        }
+      }
+    },
+    "EventTypeProperties": {
+      "type": "object",
+      "description": "Properties of the event type",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Display name of the event type."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the event type."
+        },
+        "schemaUrl": {
+          "type": "string",
+          "description": "URL of the schema for this event type."
+        },
+        "isInDefaultSet": {
+          "type": "boolean",
+          "description": "IsInDefaultSet flag of the event type."
+        }
+      }
+    },
+    "EventTypesListResult": {
+      "type": "object",
+      "description": "Result of the List Event Types operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A collection of event types",
+          "items": {
+            "$ref": "#/definitions/EventType"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "Definition of an Extended Location",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Fully qualified name of the extended location."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the extended location."
+        }
+      }
+    },
+    "ExtensionTopic": {
+      "type": "object",
+      "description": "Event grid Extension Topic. This is used for getting Event Grid related metrics for Azure resources.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExtensionTopicProperties",
+          "description": "Properties of the extension topic.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ExtensionTopicProperties": {
+      "type": "object",
+      "description": "Properties of the Extension Topic",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the extension topic."
+        },
+        "systemTopic": {
+          "type": "string",
+          "description": "System topic resource id which is mapped to the source."
+        }
+      }
+    },
+    "FederatedIdentityCredentialInfo": {
+      "type": "object",
+      "description": "The details of the Federated Identity Credential (FIC) used with the resource.",
+      "properties": {
+        "federatedClientId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The Multi-Tenant Microsoft Entra ID Application where the Federated Identity Credential (FIC) is associated with."
+        }
+      },
+      "required": [
+        "federatedClientId"
+      ]
+    },
+    "Filter": {
+      "type": "object",
+      "description": "This is the base type that represents a filter. To configure a filter, do not directly instantiate an object of this class. Instead, instantiate\nan object of a derived class such as BoolEqualsFilter, NumberInFilter etc depending on the type of the key based on\nwhich you want to filter.",
+      "properties": {
+        "operatorType": {
+          "$ref": "#/definitions/FilterOperatorType",
+          "description": "The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others."
+        },
+        "key": {
+          "type": "string",
+          "description": "The field/property in the event based on which you want to filter."
+        }
+      },
+      "discriminator": "operatorType",
+      "required": [
+        "operatorType"
+      ]
+    },
+    "FilterOperatorType": {
+      "type": "string",
+      "description": "The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.",
+      "enum": [
+        "NumberIn",
+        "NumberNotIn",
+        "NumberLessThan",
+        "NumberGreaterThan",
+        "NumberLessThanOrEquals",
+        "NumberGreaterThanOrEquals",
+        "BoolEquals",
+        "StringIn",
+        "StringNotIn",
+        "StringBeginsWith",
+        "StringEndsWith",
+        "StringContains",
+        "NumberInRange",
+        "NumberNotInRange",
+        "StringNotBeginsWith",
+        "StringNotEndsWith",
+        "StringNotContains",
+        "IsNullOrUndefined",
+        "IsNotNull"
+      ],
+      "x-ms-enum": {
+        "name": "FilterOperatorType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NumberIn",
+            "value": "NumberIn",
+            "description": "NumberIn"
+          },
+          {
+            "name": "NumberNotIn",
+            "value": "NumberNotIn",
+            "description": "NumberNotIn"
+          },
+          {
+            "name": "NumberLessThan",
+            "value": "NumberLessThan",
+            "description": "NumberLessThan"
+          },
+          {
+            "name": "NumberGreaterThan",
+            "value": "NumberGreaterThan",
+            "description": "NumberGreaterThan"
+          },
+          {
+            "name": "NumberLessThanOrEquals",
+            "value": "NumberLessThanOrEquals",
+            "description": "NumberLessThanOrEquals"
+          },
+          {
+            "name": "NumberGreaterThanOrEquals",
+            "value": "NumberGreaterThanOrEquals",
+            "description": "NumberGreaterThanOrEquals"
+          },
+          {
+            "name": "BoolEquals",
+            "value": "BoolEquals",
+            "description": "BoolEquals"
+          },
+          {
+            "name": "StringIn",
+            "value": "StringIn",
+            "description": "StringIn"
+          },
+          {
+            "name": "StringNotIn",
+            "value": "StringNotIn",
+            "description": "StringNotIn"
+          },
+          {
+            "name": "StringBeginsWith",
+            "value": "StringBeginsWith",
+            "description": "StringBeginsWith"
+          },
+          {
+            "name": "StringEndsWith",
+            "value": "StringEndsWith",
+            "description": "StringEndsWith"
+          },
+          {
+            "name": "StringContains",
+            "value": "StringContains",
+            "description": "StringContains"
+          },
+          {
+            "name": "NumberInRange",
+            "value": "NumberInRange",
+            "description": "NumberInRange"
+          },
+          {
+            "name": "NumberNotInRange",
+            "value": "NumberNotInRange",
+            "description": "NumberNotInRange"
+          },
+          {
+            "name": "StringNotBeginsWith",
+            "value": "StringNotBeginsWith",
+            "description": "StringNotBeginsWith"
+          },
+          {
+            "name": "StringNotEndsWith",
+            "value": "StringNotEndsWith",
+            "description": "StringNotEndsWith"
+          },
+          {
+            "name": "StringNotContains",
+            "value": "StringNotContains",
+            "description": "StringNotContains"
+          },
+          {
+            "name": "IsNullOrUndefined",
+            "value": "IsNullOrUndefined",
+            "description": "IsNullOrUndefined"
+          },
+          {
+            "name": "IsNotNull",
+            "value": "IsNotNull",
+            "description": "IsNotNull"
+          }
+        ]
+      }
+    },
+    "FiltersConfiguration": {
+      "type": "object",
+      "description": "Filters configuration for the Event Subscription.",
+      "properties": {
+        "includedEventTypes": {
+          "type": "array",
+          "description": "A list of applicable event types that need to be part of the event subscription. If it is desired to subscribe to all default event types, set the IncludedEventTypes to null.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "filters": {
+          "type": "array",
+          "description": "An array of filters that are used for filtering event subscriptions.",
+          "items": {
+            "$ref": "#/definitions/Filter"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "HybridConnectionEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the HybridConnection destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HybridConnectionEventSubscriptionDestinationProperties",
+          "description": "Hybrid connection Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "HybridConnection"
+    },
+    "HybridConnectionEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties for a hybrid connection destination.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID of an hybrid connection that is the destination of an event subscription."
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "IdentityInfo": {
+      "type": "object",
+      "description": "The identity information for the resource.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/IdentityType",
+          "description": "The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove any identity."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of resource identity."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form:\n'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.\nThis property is currently not used and reserved for future usage.",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserIdentityProperties"
+          }
+        }
+      }
+    },
+    "IdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove any identity.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          },
+          {
+            "name": "SystemAssigned, UserAssigned",
+            "value": "SystemAssigned, UserAssigned",
+            "description": "SystemAssigned, UserAssigned"
+          }
+        ]
+      }
+    },
+    "InboundIpRule": {
+      "type": "object",
+      "properties": {
+        "ipMask": {
+          "type": "string",
+          "description": "IP Address in CIDR notation e.g., 10.0.0.0/8."
+        },
+        "action": {
+          "$ref": "#/definitions/IpActionType",
+          "description": "Action to perform based on the match or no match of the IpMask."
+        }
+      }
+    },
+    "InlineEventProperties": {
+      "type": "object",
+      "description": "Additional information about every inline event.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description for the inline event."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The displayName for the inline event."
+        },
+        "documentationUrl": {
+          "type": "string",
+          "description": "The documentationUrl for the inline event."
+        },
+        "dataSchemaUrl": {
+          "type": "string",
+          "description": "The dataSchemaUrl for the inline event."
+        }
+      }
+    },
+    "InputSchemaMapping": {
+      "type": "object",
+      "description": "By default, Event Grid expects events to be in the Event Grid event schema. Specifying an input schema mapping enables publishing to Event Grid using a custom input schema. Currently, the only supported type of InputSchemaMapping is 'JsonInputSchemaMapping'.",
+      "properties": {
+        "inputSchemaMappingType": {
+          "$ref": "#/definitions/InputSchemaMappingType",
+          "description": "Type of the custom mapping"
+        }
+      },
+      "discriminator": "inputSchemaMappingType",
+      "required": [
+        "inputSchemaMappingType"
+      ]
+    },
+    "InputSchemaMappingType": {
+      "type": "string",
+      "description": "Type of the custom mapping",
+      "enum": [
+        "Json"
+      ],
+      "x-ms-enum": {
+        "name": "InputSchemaMappingType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Json",
+            "value": "Json",
+            "description": "Json"
+          }
+        ]
+      }
+    },
+    "IpActionType": {
+      "type": "string",
+      "description": "Action to perform based on the match or no match of the IpMask.",
+      "enum": [
+        "Allow"
+      ],
+      "x-ms-enum": {
+        "name": "IpActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          }
+        ]
+      }
+    },
+    "IsNotNullAdvancedFilter": {
+      "type": "object",
+      "description": "IsNotNull Advanced Filter.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "IsNotNull"
+    },
+    "IsNotNullFilter": {
+      "type": "object",
+      "description": "IsNotNull Filter.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "IsNotNull"
+    },
+    "IsNullOrUndefinedAdvancedFilter": {
+      "type": "object",
+      "description": "IsNullOrUndefined Advanced Filter.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "IsNullOrUndefined"
+    },
+    "IsNullOrUndefinedFilter": {
+      "type": "object",
+      "description": "IsNullOrUndefined Filter.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "IsNullOrUndefined"
+    },
+    "IssuerCertificateInfo": {
+      "type": "object",
+      "description": "Information about the certificate that is used for token validation.",
+      "properties": {
+        "certificateUrl": {
+          "type": "string",
+          "description": "Keyvault certificate URL in https://keyvaultname.vault.azure.net/certificates/certificateName/certificateVersion format."
+        },
+        "identity": {
+          "$ref": "#/definitions/CustomJwtAuthenticationManagedIdentity",
+          "description": "The identity that will be used to access the certificate."
+        }
+      },
+      "required": [
+        "certificateUrl"
+      ]
+    },
+    "JsonField": {
+      "type": "object",
+      "description": "This is used to express the source of an input schema mapping for a single target field in the Event Grid Event schema. This is currently used in the mappings for the 'id', 'topic' and 'eventtime' properties. This represents a field in the input event schema.",
+      "properties": {
+        "sourceField": {
+          "type": "string",
+          "description": "Name of a field in the input event schema that's to be used as the source of a mapping."
+        }
+      }
+    },
+    "JsonFieldWithDefault": {
+      "type": "object",
+      "description": "This is used to express the source of an input schema mapping for a single target field\nin the Event Grid Event schema. This is currently used in the mappings for the 'subject',\n'eventtype' and 'dataversion' properties. This represents a field in the input event schema\nalong with a default value to be used, and at least one of these two properties should be provided.",
+      "properties": {
+        "sourceField": {
+          "type": "string",
+          "description": "Name of a field in the input event schema that's to be used as the source of a mapping."
+        },
+        "defaultValue": {
+          "type": "string",
+          "description": "The default value to be used for mapping when a SourceField is not provided or if there's no property with the specified name in the published JSON event payload."
+        }
+      }
+    },
+    "JsonInputSchemaMapping": {
+      "type": "object",
+      "description": "This enables publishing to Event Grid using a custom input schema. This can be used to map properties from a custom input JSON schema to the Event Grid event schema.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/JsonInputSchemaMappingProperties",
+          "description": "JSON Properties of the input schema mapping",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputSchemaMapping"
+        }
+      ],
+      "x-ms-discriminator-value": "Json"
+    },
+    "JsonInputSchemaMappingProperties": {
+      "type": "object",
+      "description": "This can be used to map properties of a source schema (or default values, for certain supported properties) to properties of the EventGridEvent schema.",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/JsonField",
+          "description": "The mapping information for the Id property of the Event Grid Event."
+        },
+        "topic": {
+          "$ref": "#/definitions/JsonField",
+          "description": "The mapping information for the Topic property of the Event Grid Event."
+        },
+        "eventTime": {
+          "$ref": "#/definitions/JsonField",
+          "description": "The mapping information for the EventTime property of the Event Grid Event."
+        },
+        "eventType": {
+          "$ref": "#/definitions/JsonFieldWithDefault",
+          "description": "The mapping information for the EventType property of the Event Grid Event."
+        },
+        "subject": {
+          "$ref": "#/definitions/JsonFieldWithDefault",
+          "description": "The mapping information for the Subject property of the Event Grid Event."
+        },
+        "dataVersion": {
+          "$ref": "#/definitions/JsonFieldWithDefault",
+          "description": "The mapping information for the DataVersion property of the Event Grid Event."
+        }
+      }
+    },
+    "KeyEncryption": {
+      "type": "object",
+      "description": "Properties of the Encryption settings.",
+      "properties": {
+        "customerManagedKeyEncryption": {
+          "type": "array",
+          "description": "List of all customer-managed key encryption properties for the resource. However only one key is supported at a time.",
+          "items": {
+            "$ref": "#/definitions/CustomerManagedKeyEncryption"
+          }
+        }
+      },
+      "required": [
+        "customerManagedKeyEncryption"
+      ]
+    },
+    "KeyEncryptionIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity used. Only UserAssigned or SystemAssigned Identity are supported.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "KeyEncryptionIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "KeyEncryptionKeyIdentity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/KeyEncryptionIdentityType",
+          "description": "The type of managed identity used. Only UserAssigned or SystemAssigned Identity are supported."
+        },
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure Resource fully qualified Id for the user-assigned identity associated with the resource. The resource Id takes the following format:\n'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "KeyEncryptionKeyStatus": {
+      "type": "string",
+      "description": "The state of the Customer Managed Key (CMK) encryption. This is a read-only property which determines if the associated key is active and valid and used\nactively by runtime as expected. When the associated CMK becomes invalid (e.g., if it is deleted, or if versioned CMK is not current anymore), Event Grid\nService will set this state to disabled to indicate that this key is not valid anymore and requires action from user.",
+      "enum": [
+        "Active",
+        "Revoked"
+      ],
+      "x-ms-enum": {
+        "name": "KeyEncryptionKeyStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "Active"
+          },
+          {
+            "name": "Revoked",
+            "value": "Revoked",
+            "description": "Revoked"
+          }
+        ]
+      }
+    },
+    "MonitorAlertEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the Monitor Alert destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MonitorAlertEventSubscriptionDestinationProperties",
+          "description": "Monitor Alert properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "MonitorAlert"
+    },
+    "MonitorAlertEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties that represent the Monitor Alert destination of an event subscription.",
+      "properties": {
+        "severity": {
+          "$ref": "#/definitions/MonitorAlertSeverity",
+          "description": "The severity that will be attached to every Alert fired through this event subscription.\nThis field must be provided."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description that will be attached to every Alert fired through this event subscription."
+        },
+        "actionGroups": {
+          "type": "array",
+          "description": "The list of ARM Ids of Action Groups that will be triggered on every Alert fired through this event subscription.\nEach resource ARM Id should follow this pattern: /subscriptions/{AzureSubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Insights/actionGroups/{ActionGroupName}.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Insights/actiongroups"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "MonitorAlertSeverity": {
+      "type": "string",
+      "description": "The severity that will be attached to every Alert fired through this event subscription.\nThis field must be provided.",
+      "enum": [
+        "Sev0",
+        "Sev1",
+        "Sev2",
+        "Sev3",
+        "Sev4"
+      ],
+      "x-ms-enum": {
+        "name": "MonitorAlertSeverity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Sev0",
+            "value": "Sev0",
+            "description": "Sev0"
+          },
+          {
+            "name": "Sev1",
+            "value": "Sev1",
+            "description": "Sev1"
+          },
+          {
+            "name": "Sev2",
+            "value": "Sev2",
+            "description": "Sev2"
+          },
+          {
+            "name": "Sev3",
+            "value": "Sev3",
+            "description": "Sev3"
+          },
+          {
+            "name": "Sev4",
+            "value": "Sev4",
+            "description": "Sev4"
+          }
+        ]
+      }
+    },
+    "Namespace": {
+      "type": "object",
+      "description": "Namespace resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NamespaceProperties",
+          "description": "Properties of the Namespace resource.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/NamespaceSku",
+          "description": "Represents available Sku pricing tiers."
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the Namespace resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "NamespaceProperties": {
+      "type": "object",
+      "description": "Properties of the namespace resource.",
+      "properties": {
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/NamespaceProvisioningState",
+          "description": "Provisioning state of the namespace resource.",
+          "readOnly": true
+        },
+        "topicsConfiguration": {
+          "$ref": "#/definitions/TopicsConfiguration",
+          "description": "Topics configuration information for the namespace resource"
+        },
+        "topicSpacesConfiguration": {
+          "$ref": "#/definitions/TopicSpacesConfiguration",
+          "description": "Topic spaces configuration information for the namespace resource"
+        },
+        "isZoneRedundant": {
+          "type": "boolean",
+          "description": "This is an optional property and it allows the user to specify if the namespace resource supports zone-redundancy capability or not. If this\nproperty is not specified explicitly by the user, its default value depends on the following conditions:\na. For Availability Zones enabled regions - The default property value would be true.\nb. For non-Availability Zones enabled regions - The default property value would be false.\nOnce specified, this property cannot be updated."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.PubSub.NamespaceProperties.InboundIpRules\" />"
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this namespace. Only TLS version 1.2 is supported."
+        },
+        "autoScaleConfiguration": {
+          "$ref": "#/definitions/AutoScaleConfiguration",
+          "description": "Auto-scale configuration for the namespace resource"
+        }
+      }
+    },
+    "NamespaceProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the namespace resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted",
+        "DeleteFailed",
+        "CreateFailed",
+        "UpdatedFailed"
+      ],
+      "x-ms-enum": {
+        "name": "NamespaceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          },
+          {
+            "name": "DeleteFailed",
+            "value": "DeleteFailed",
+            "description": "DeleteFailed"
+          },
+          {
+            "name": "CreateFailed",
+            "value": "CreateFailed",
+            "description": "CreateFailed"
+          },
+          {
+            "name": "UpdatedFailed",
+            "value": "UpdatedFailed",
+            "description": "UpdatedFailed"
+          }
+        ]
+      }
+    },
+    "NamespaceRegenerateKeyRequest": {
+      "type": "object",
+      "description": "Namespace regenerate share access key request.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Key name to regenerate key1 or key2."
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "NamespaceSharedAccessKeys": {
+      "type": "object",
+      "description": "Shared access keys of the Namespace.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "format": "password",
+          "description": "Shared access key1 for the namespace.",
+          "x-ms-secret": true
+        },
+        "key2": {
+          "type": "string",
+          "format": "password",
+          "description": "Shared access key2 for the namespace.",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "NamespaceSku": {
+      "type": "object",
+      "description": "Represents available Sku pricing tiers.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "The name of the SKU."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the number of Throughput Units that defines the capacity for the namespace. The property default value is\n1 which signifies 1 Throughput Unit = 1MB/s ingress and 2MB/s egress per namespace. Min capacity is 1 and\nmax allowed capacity is 20."
+        }
+      }
+    },
+    "NamespaceTopic": {
+      "type": "object",
+      "description": "Namespace topic details.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NamespaceTopicProperties",
+          "description": "Properties of the namespace topic.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NamespaceTopicEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the Namespace Topic destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NamespaceTopicEventSubscriptionDestinationProperties",
+          "description": "Namespace Topic properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "NamespaceTopic"
+    },
+    "NamespaceTopicEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties that represent the Event Grid Namespace Topic destination of an event subscription.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure resource Id that represents the endpoint of the Event Grid Namespace Topic destination of an event subscription.\nThis field is required and the Namespace Topic resource listed must already exist.\nThe resource ARM Id should follow this pattern: /subscriptions/{AzureSubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.EventGrid/namespaces/{NamespaceName}/topics/{TopicName}.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.EventGrid/namespaces/topics"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NamespaceTopicProperties": {
+      "type": "object",
+      "description": "Properties of the namespace topic.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NamespaceTopicProvisioningState",
+          "description": "Provisioning state of the namespace topic.",
+          "readOnly": true
+        },
+        "publisherType": {
+          "$ref": "#/definitions/PublisherType",
+          "description": "Publisher type of the namespace topic."
+        },
+        "inputSchema": {
+          "type": "string",
+          "description": "This determines the format that is expected for incoming events published to the topic.",
+          "default": "CloudEventSchemaV1_0",
+          "enum": [
+            "CloudEventSchemaV1_0"
+          ],
+          "x-ms-enum": {
+            "name": "EventInputSchema",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "CloudEventSchemaV1_0",
+                "value": "CloudEventSchemaV1_0",
+                "description": "CloudEventSchemaV1_0"
+              }
+            ]
+          }
+        },
+        "eventRetentionInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Event retention for the namespace topic expressed in days. The property default value is 1 day.\nMin event retention duration value is 1 day and max event retention duration value is 1 day."
+        }
+      }
+    },
+    "NamespaceTopicProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the namespace topic.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted",
+        "DeleteFailed",
+        "CreateFailed",
+        "UpdatedFailed"
+      ],
+      "x-ms-enum": {
+        "name": "NamespaceTopicProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          },
+          {
+            "name": "DeleteFailed",
+            "value": "DeleteFailed",
+            "description": "DeleteFailed"
+          },
+          {
+            "name": "CreateFailed",
+            "value": "CreateFailed",
+            "description": "CreateFailed"
+          },
+          {
+            "name": "UpdatedFailed",
+            "value": "UpdatedFailed",
+            "description": "UpdatedFailed"
+          }
+        ]
+      }
+    },
+    "NamespaceTopicUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of namespace topic update parameter properties.",
+      "properties": {
+        "eventRetentionInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Event retention for the namespace topic expressed in days. The property default value is 1 day.\nMin event retention duration value is 1 day and max event retention duration value is 1 day."
+        }
+      }
+    },
+    "NamespaceTopicUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the namespace topic update.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NamespaceTopicUpdateParameterProperties",
+          "description": "Properties of the namespace topic resource.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "NamespaceTopicsListResult": {
+      "type": "object",
+      "description": "Result of the List namespace topics operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NamespaceTopic items on this page",
+          "items": {
+            "$ref": "#/definitions/NamespaceTopic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NamespaceUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of namespace update parameter properties.",
+      "properties": {
+        "topicSpacesConfiguration": {
+          "$ref": "#/definitions/UpdateTopicSpacesConfigurationInfo",
+          "description": "Topic spaces configuration properties that can be updated."
+        },
+        "topicsConfiguration": {
+          "$ref": "#/definitions/UpdateTopicsConfigurationInfo",
+          "description": "Topics configuration properties that can be updated."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.PubSub.NamespaceUpdateParameterProperties.InboundIpRules\" />"
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "autoScaleConfiguration": {
+          "$ref": "#/definitions/UpdateAutoScaleConfiguration",
+          "description": "Auto-scale configuration for the namespace resource"
+        }
+      }
+    },
+    "NamespaceUpdateParameters": {
+      "type": "object",
+      "description": "Properties to update namespace.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the namespace resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Namespace resource identity information."
+        },
+        "sku": {
+          "$ref": "#/definitions/NamespaceSku",
+          "description": "Represents available Sku pricing tiers."
+        },
+        "properties": {
+          "$ref": "#/definitions/NamespaceUpdateParameterProperties",
+          "description": "Properties of the namespace resource.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "NamespacesListResult": {
+      "type": "object",
+      "description": "Result of the List Namespaces operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Namespace items on this page",
+          "items": {
+            "$ref": "#/definitions/Namespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityPerimeterAssociationAccessMode": {
+      "type": "string",
+      "description": "Network security perimeter access mode.",
+      "enum": [
+        "Learning",
+        "Enforced",
+        "Audit"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Learning",
+            "value": "Learning",
+            "description": "Learning"
+          },
+          {
+            "name": "Enforced",
+            "value": "Enforced",
+            "description": "Enforced"
+          },
+          {
+            "name": "Audit",
+            "value": "Audit",
+            "description": "Audit"
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterConfigProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state to reflect configuration state and indicate status of nsp profile configuration retrieval.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Accepted"
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Network security perimeter configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Properties of the network security perimeter configuration.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationIssueSeverity": {
+      "type": "string",
+      "description": "Provisioning issue severity.",
+      "enum": [
+        "Warning",
+        "Error"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationIssueSeverity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Warning",
+            "value": "Warning",
+            "description": "Warning"
+          },
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "Error"
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationIssueType": {
+      "type": "string",
+      "description": "Provisioning issue type.",
+      "enum": [
+        "MissingPerimeterConfiguration",
+        "MissingIdentityConfiguration",
+        "ConfigurationPropagationFailure",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationIssueType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MissingPerimeterConfiguration",
+            "value": "MissingPerimeterConfiguration",
+            "description": "MissingPerimeterConfiguration"
+          },
+          {
+            "name": "MissingIdentityConfiguration",
+            "value": "MissingIdentityConfiguration",
+            "description": "MissingIdentityConfiguration"
+          },
+          {
+            "name": "ConfigurationPropagationFailure",
+            "value": "ConfigurationPropagationFailure",
+            "description": "ConfigurationPropagationFailure"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "Other"
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationIssues": {
+      "type": "object",
+      "description": "Network security perimeter configuration issues.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Provisioning issue name."
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationIssuesProperties",
+          "description": "Provisioning issue properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationIssuesProperties": {
+      "type": "object",
+      "description": "Network security perimeter configuration issues properties.",
+      "properties": {
+        "issueType": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationIssueType",
+          "description": "Provisioning issue type."
+        },
+        "severity": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationIssueSeverity",
+          "description": "Provisioning issue severity."
+        },
+        "description": {
+          "type": "string",
+          "description": "Provisioning issue description."
+        },
+        "suggestedResourceIds": {
+          "type": "array",
+          "description": "ARM IDs of resources that can be associated to the same perimeter to remediate the issue.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "suggestedAccessRules": {
+          "type": "array",
+          "description": "Access rules that can be added to the same profile to remediate the issue.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "Network security perimeter configuration List.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityPerimeterConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationProfile": {
+      "type": "object",
+      "description": "Nsp configuration with profile information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nsp configuration profile name."
+        },
+        "accessRulesVersion": {
+          "type": "string",
+          "description": "Access rules version number for nsp profile."
+        },
+        "accessRules": {
+          "type": "array",
+          "description": "List of inbound or outbound access rule setup on the nsp profile.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterProfileAccessRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "diagnosticSettingsVersion": {
+          "type": "string",
+          "description": "Diagnostic settings version number for nsp profile."
+        },
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "Enabled log categories for nsp profile.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "Network security perimeter configuration information to reflect latest association and nsp profile configuration.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigProvisioningState",
+          "description": "Provisioning state to reflect configuration state and indicate status of nsp profile configuration retrieval."
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "Provisioning issues to reflect status when attempting to retrieve nsp profile configuration.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationIssues"
+          },
+          "x-ms-identifiers": []
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterInfo",
+          "description": "Perimeter info for nsp association."
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/ResourceAssociation",
+          "description": "Nsp association name and access mode of association."
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProfile",
+          "description": "Nsp profile configuration, access rules and diagnostic settings."
+        }
+      }
+    },
+    "NetworkSecurityPerimeterInfo": {
+      "type": "object",
+      "description": "Network security perimeter info.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Arm id for network security perimeter."
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Network security perimeter guid."
+        },
+        "location": {
+          "type": "string",
+          "description": "Network security perimeter location."
+        }
+      }
+    },
+    "NetworkSecurityPerimeterProfileAccessRule": {
+      "type": "object",
+      "description": "Network security perimeter profile access rule.",
+      "properties": {
+        "fullyQualifiedArmId": {
+          "type": "string",
+          "description": "Fully Qualified Arm id for network security perimeter profile access rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name for nsp access rule."
+        },
+        "type": {
+          "type": "string",
+          "description": "nsp access rule type."
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterProfileAccessRuleProperties",
+          "description": "NSP access rule properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterProfileAccessRuleDirection": {
+      "type": "string",
+      "description": "NSP access rule direction.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterProfileAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterProfileAccessRuleProperties": {
+      "type": "object",
+      "description": "Network security perimeter profile access rule properties.",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterProfileAccessRuleDirection",
+          "description": "NSP access rule direction."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "List of subscriptions.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterSubscription"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "Network security perimeters.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterInfo"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "Fully qualified domain names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "emailAddresses": {
+          "type": "array",
+          "description": "List of email addresses.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phoneNumbers": {
+          "type": "array",
+          "description": "List of phone numbers.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterSubscription": {
+      "type": "object",
+      "description": "Network security perimeter subscription inbound access rule.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Subscription id."
+        }
+      }
+    },
+    "NumberGreaterThanAdvancedFilter": {
+      "type": "object",
+      "description": "NumberGreaterThan Advanced Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberGreaterThan"
+    },
+    "NumberGreaterThanFilter": {
+      "type": "object",
+      "description": "NumberGreaterThan Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberGreaterThan"
+    },
+    "NumberGreaterThanOrEqualsAdvancedFilter": {
+      "type": "object",
+      "description": "NumberGreaterThanOrEquals Advanced Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberGreaterThanOrEquals"
+    },
+    "NumberGreaterThanOrEqualsFilter": {
+      "type": "object",
+      "description": "NumberGreaterThanOrEquals Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberGreaterThanOrEquals"
+    },
+    "NumberInAdvancedFilter": {
+      "type": "object",
+      "description": "NumberIn Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberIn"
+    },
+    "NumberInFilter": {
+      "type": "object",
+      "description": "NumberIn Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberIn"
+    },
+    "NumberInRangeAdvancedFilter": {
+      "type": "object",
+      "description": "NumberInRange Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberInRange"
+    },
+    "NumberInRangeFilter": {
+      "type": "object",
+      "description": "NumberInRange Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberInRange"
+    },
+    "NumberLessThanAdvancedFilter": {
+      "type": "object",
+      "description": "NumberLessThan Advanced Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberLessThan"
+    },
+    "NumberLessThanFilter": {
+      "type": "object",
+      "description": "NumberLessThan Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberLessThan"
+    },
+    "NumberLessThanOrEqualsAdvancedFilter": {
+      "type": "object",
+      "description": "NumberLessThanOrEquals Advanced Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberLessThanOrEquals"
+    },
+    "NumberLessThanOrEqualsFilter": {
+      "type": "object",
+      "description": "NumberLessThanOrEquals Filter.",
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The filter value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberLessThanOrEquals"
+    },
+    "NumberNotInAdvancedFilter": {
+      "type": "object",
+      "description": "NumberNotIn Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberNotIn"
+    },
+    "NumberNotInFilter": {
+      "type": "object",
+      "description": "NumberNotIn Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberNotIn"
+    },
+    "NumberNotInRangeAdvancedFilter": {
+      "type": "object",
+      "description": "NumberNotInRange Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberNotInRange"
+    },
+    "NumberNotInRangeFilter": {
+      "type": "object",
+      "description": "NumberNotInRange Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "NumberNotInRange"
+    },
+    "Operation": {
+      "type": "object",
+      "description": "Represents an operation returned by the GetOperations request.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the operation."
+        },
+        "display": {
+          "$ref": "#/definitions/OperationInfo",
+          "description": "Display name of the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin of the operation."
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "This Boolean is used to determine if the operation is a data plane action or not."
+        },
+        "properties": {
+          "description": "Properties of the operation.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "OperationInfo": {
+      "type": "object",
+      "description": "Information about an operation",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Name of the provider"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Name of the resource type"
+        },
+        "operation": {
+          "type": "string",
+          "description": "Name of the operation"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the operation"
+        }
+      }
+    },
+    "OperationsListResult": {
+      "type": "object",
+      "description": "Result of the List Operations operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Operation items on this page",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Partner": {
+      "type": "object",
+      "description": "Information about the partner.",
+      "properties": {
+        "partnerRegistrationImmutableId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The immutableId of the corresponding partner registration."
+        },
+        "partnerName": {
+          "type": "string",
+          "description": "The partner name."
+        },
+        "authorizationExpirationTimeInUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the partner authorization. If this timer expires, any request from this partner to create, update or delete resources in subscriber's\ncontext will fail. If specified, the allowed values are between 1 to the value of defaultMaximumExpirationTimeInDays specified in PartnerConfiguration.\nIf not specified, the default value will be the value of defaultMaximumExpirationTimeInDays specified in PartnerConfiguration or 7 if this value is not specified."
+        }
+      }
+    },
+    "PartnerAuthorization": {
+      "type": "object",
+      "description": "The partner authorization details.",
+      "properties": {
+        "defaultMaximumExpirationTimeInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Time used to validate the authorization expiration time for each authorized partner. If DefaultMaximumExpirationTimeInDays is\nnot specified, the default is 7 days. Otherwise, allowed values are between 1 and 365 days."
+        },
+        "authorizedPartnersList": {
+          "type": "array",
+          "description": "The list of authorized partners.",
+          "items": {
+            "$ref": "#/definitions/Partner"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PartnerClientAuthentication": {
+      "type": "object",
+      "description": "Partner client authentication",
+      "properties": {
+        "clientAuthenticationType": {
+          "type": "string",
+          "description": "Type of client authentication",
+          "default": "AzureAD",
+          "enum": [
+            "AzureAD"
+          ],
+          "x-ms-enum": {
+            "name": "PartnerClientAuthenticationType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "AzureAD",
+                "value": "AzureAD",
+                "description": "AzureAD"
+              }
+            ]
+          }
+        }
+      },
+      "discriminator": "clientAuthenticationType",
+      "required": [
+        "clientAuthenticationType"
+      ]
+    },
+    "PartnerConfiguration": {
+      "type": "object",
+      "description": "Partner configuration information",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerConfigurationProperties",
+          "description": "Properties of the partner configuration.",
+          "x-ms-client-flatten": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tags of the resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PartnerConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of the partner configuration.",
+      "properties": {
+        "partnerAuthorization": {
+          "$ref": "#/definitions/PartnerAuthorization",
+          "description": "The details of authorized partners."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PartnerConfigurationProvisioningState",
+          "description": "Provisioning state of the partner configuration."
+        }
+      }
+    },
+    "PartnerConfigurationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the partner configuration.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "PartnerConfigurationUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of partner configuration update parameter properties.",
+      "properties": {
+        "defaultMaximumExpirationTimeInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The default time used to validate the maximum expiration time for each authorized partners in days. Allowed values ar between 1 and 365 days."
+        }
+      }
+    },
+    "PartnerConfigurationUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the partner configuration update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the partner configuration resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/PartnerConfigurationUpdateParameterProperties",
+          "description": "Properties of the Topic resource.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PartnerConfigurationsListResult": {
+      "type": "object",
+      "description": "Result of the List partner configurations operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PartnerConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/PartnerConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PartnerDestination": {
+      "type": "object",
+      "description": "Event Grid Partner Destination.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerDestinationProperties",
+          "description": "Properties of the Partner Destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PartnerDestinationActivationState": {
+      "type": "string",
+      "description": "Activation state of the partner destination.",
+      "enum": [
+        "NeverActivated",
+        "Activated"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerDestinationActivationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NeverActivated",
+            "value": "NeverActivated",
+            "description": "NeverActivated"
+          },
+          {
+            "name": "Activated",
+            "value": "Activated",
+            "description": "Activated"
+          }
+        ]
+      }
+    },
+    "PartnerDestinationInfo": {
+      "type": "object",
+      "description": "Properties of the corresponding partner destination of a Channel.",
+      "properties": {
+        "azureSubscriptionId": {
+          "type": "string",
+          "description": "Azure subscription ID of the subscriber. The partner destination associated with the channel will be\ncreated under this Azure subscription."
+        },
+        "resourceGroupName": {
+          "type": "string",
+          "description": "Azure Resource Group of the subscriber. The partner destination associated with the channel will be\ncreated under this resource group."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the partner destination associated with the channel."
+        },
+        "endpointType": {
+          "type": "string",
+          "description": "Type of the endpoint for the partner destination",
+          "default": "WebHook",
+          "enum": [
+            "WebHook"
+          ],
+          "x-ms-enum": {
+            "name": "PartnerEndpointType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "WebHook",
+                "value": "WebHook",
+                "description": "WebHook"
+              }
+            ]
+          }
+        },
+        "endpointServiceContext": {
+          "type": "string",
+          "description": "Additional context of the partner destination endpoint."
+        },
+        "resourceMoveChangeHistory": {
+          "type": "array",
+          "description": "Change history of the resource move.",
+          "items": {
+            "$ref": "#/definitions/ResourceMoveChangeHistory"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "discriminator": "endpointType",
+      "required": [
+        "endpointType"
+      ]
+    },
+    "PartnerDestinationProperties": {
+      "type": "object",
+      "description": "Properties of the Partner Destination.",
+      "properties": {
+        "partnerRegistrationImmutableId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The immutable Id of the corresponding partner registration."
+        },
+        "endpointServiceContext": {
+          "type": "string",
+          "description": "Endpoint context associated with this partner destination."
+        },
+        "expirationTimeIfNotActivatedUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the partner destination. If this timer expires and the partner destination was never activated,\nthe partner destination and corresponding channel are deleted."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PartnerDestinationProvisioningState",
+          "description": "Provisioning state of the partner destination.",
+          "readOnly": true
+        },
+        "activationState": {
+          "$ref": "#/definitions/PartnerDestinationActivationState",
+          "description": "Activation state of the partner destination."
+        },
+        "endpointBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Endpoint Base URL of the partner destination"
+        },
+        "messageForActivation": {
+          "type": "string",
+          "description": "Context or helpful message that can be used during the approval process."
+        }
+      }
+    },
+    "PartnerDestinationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the partner destination.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "IdleDueToMirroredChannelResourceDeletion"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerDestinationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "IdleDueToMirroredChannelResourceDeletion",
+            "value": "IdleDueToMirroredChannelResourceDeletion",
+            "description": "IdleDueToMirroredChannelResourceDeletion"
+          }
+        ]
+      }
+    },
+    "PartnerDestinationUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Partner Destination that can be updated.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the Partner Destination resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PartnerDestinationsListResult": {
+      "type": "object",
+      "description": "Result of the List Partner Destinations operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PartnerDestination items on this page",
+          "items": {
+            "$ref": "#/definitions/PartnerDestination"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PartnerDetails": {
+      "type": "object",
+      "description": "Information about the partner.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "This is short description about the partner. The length of this description should not exceed 256 characters."
+        },
+        "longDescription": {
+          "type": "string",
+          "description": "Long description for the partner's scenarios and integration.Length of this description should not exceed 2048 characters."
+        },
+        "setupUri": {
+          "type": "string",
+          "description": "URI of the partner website that can be used by Azure customers to setup Event Grid\nintegration on an event source."
+        }
+      }
+    },
+    "PartnerEventSubscriptionDestination": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerEventSubscriptionDestinationProperties",
+          "description": "Partner Destination Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "PartnerDestination"
+    },
+    "PartnerEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The Azure Resource Id that represents the endpoint of a Partner Destination of an event subscription."
+        }
+      }
+    },
+    "PartnerNamespace": {
+      "type": "object",
+      "description": "EventGrid Partner Namespace.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerNamespaceProperties",
+          "description": "Properties of the Partner Namespace.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PartnerNamespaceProperties": {
+      "type": "object",
+      "description": "Properties of the partner namespace.",
+      "properties": {
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PartnerNamespaceProvisioningState",
+          "description": "Provisioning state of the partner namespace.",
+          "readOnly": true
+        },
+        "partnerRegistrationFullyQualifiedId": {
+          "type": "string",
+          "description": "The fully qualified ARM Id of the partner registration that should be associated with this partner namespace. This takes the following format:\n/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}."
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this partner namespace"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint for the partner namespace.",
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.PartnerNamespaceProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the partner namespace.",
+          "default": false
+        },
+        "partnerTopicRoutingMode": {
+          "type": "string",
+          "description": "This determines if events published to this partner namespace should use the source attribute in the event payload\nor use the channel name in the header when matching to the partner topic. If none is specified, source attribute routing will be used to match the partner topic.",
+          "default": "SourceEventAttribute",
+          "enum": [
+            "SourceEventAttribute",
+            "ChannelNameHeader"
+          ],
+          "x-ms-enum": {
+            "name": "PartnerTopicRoutingMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "SourceEventAttribute",
+                "value": "SourceEventAttribute",
+                "description": "SourceEventAttribute"
+              },
+              {
+                "name": "ChannelNameHeader",
+                "value": "ChannelNameHeader",
+                "description": "ChannelNameHeader"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "PartnerNamespaceProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the partner namespace.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerNamespaceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "PartnerNamespaceRegenerateKeyRequest": {
+      "type": "object",
+      "description": "PartnerNamespace regenerate shared access key request.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Key name to regenerate (key1 or key2)."
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "PartnerNamespaceSharedAccessKeys": {
+      "type": "object",
+      "description": "Shared access keys of the partner namespace.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "description": "Shared access key1 for the partner namespace."
+        },
+        "key2": {
+          "type": "string",
+          "description": "Shared access key2 for the partner namespace."
+        }
+      }
+    },
+    "PartnerNamespaceUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of Partner Namespace update parameter properties.",
+      "properties": {
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.PartnerNamespaceUpdateParameterProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this domain"
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the partner namespace."
+        }
+      }
+    },
+    "PartnerNamespaceUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Partner Namespace update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the Partner Namespace.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/PartnerNamespaceUpdateParameterProperties",
+          "description": "Properties of the Partner Namespace.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PartnerNamespacesListResult": {
+      "type": "object",
+      "description": "Result of the List Partner Namespaces operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PartnerNamespace items on this page",
+          "items": {
+            "$ref": "#/definitions/PartnerNamespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PartnerRegistration": {
+      "type": "object",
+      "description": "Information about a partner registration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerRegistrationProperties",
+          "description": "Properties of the partner registration.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PartnerRegistrationProperties": {
+      "type": "object",
+      "description": "Properties of the partner registration.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/PartnerRegistrationProvisioningState",
+          "description": "Provisioning state of the partner registration.",
+          "readOnly": true
+        },
+        "partnerRegistrationImmutableId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The immutableId of the corresponding partner registration.\nNote: This property is marked for deprecation and is not supported in any future GA API version"
+        }
+      }
+    },
+    "PartnerRegistrationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the partner registration.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerRegistrationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "PartnerRegistrationUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Partner Registration update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the partner registration resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PartnerRegistrationsListResult": {
+      "type": "object",
+      "description": "Result of the List Partner Registrations operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PartnerRegistration items on this page",
+          "items": {
+            "$ref": "#/definitions/PartnerRegistration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PartnerTopic": {
+      "type": "object",
+      "description": "Event Grid Partner Topic.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PartnerTopicProperties",
+          "description": "Properties of the Partner Topic.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the Partner Topic resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PartnerTopicActivationState": {
+      "type": "string",
+      "description": "Activation state of the partner topic.",
+      "enum": [
+        "NeverActivated",
+        "Activated",
+        "Deactivated"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerTopicActivationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NeverActivated",
+            "value": "NeverActivated",
+            "description": "NeverActivated"
+          },
+          {
+            "name": "Activated",
+            "value": "Activated",
+            "description": "Activated"
+          },
+          {
+            "name": "Deactivated",
+            "value": "Deactivated",
+            "description": "Deactivated"
+          }
+        ]
+      }
+    },
+    "PartnerTopicInfo": {
+      "type": "object",
+      "description": "Properties of the corresponding partner topic of a Channel.",
+      "properties": {
+        "azureSubscriptionId": {
+          "type": "string",
+          "description": "Azure subscription ID of the subscriber. The partner topic associated with the channel will be\ncreated under this Azure subscription."
+        },
+        "resourceGroupName": {
+          "type": "string",
+          "description": "Azure Resource Group of the subscriber. The partner topic associated with the channel will be\ncreated under this resource group."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the partner topic associated with the channel."
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "Event Type Information for the partner topic. This information is provided by the publisher and can be used by the\nsubscriber to view different types of events that are published."
+        },
+        "source": {
+          "type": "string",
+          "description": "The source information is provided by the publisher to determine the scope or context from which the events\nare originating. This information can be used by the subscriber during the approval process of the\ncreated partner topic."
+        }
+      }
+    },
+    "PartnerTopicProperties": {
+      "type": "object",
+      "description": "Properties of the Partner Topic.",
+      "properties": {
+        "partnerRegistrationImmutableId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The immutableId of the corresponding partner registration."
+        },
+        "source": {
+          "type": "string",
+          "description": "Source associated with this partner topic. This represents a unique partner resource."
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "Event Type information from the corresponding event channel."
+        },
+        "expirationTimeIfNotActivatedUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the partner topic. If this timer expires while the partner topic is still never activated,\nthe partner topic and corresponding event channel are deleted."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PartnerTopicProvisioningState",
+          "description": "Provisioning state of the partner topic.",
+          "readOnly": true
+        },
+        "activationState": {
+          "$ref": "#/definitions/PartnerTopicActivationState",
+          "description": "Activation state of the partner topic."
+        },
+        "partnerTopicFriendlyDescription": {
+          "type": "string",
+          "description": "Friendly description about the topic. This can be set by the publisher/partner to show custom description for the customer partner topic.\nThis will be helpful to remove any ambiguity of the origin of creation of the partner topic for the customer."
+        },
+        "messageForActivation": {
+          "type": "string",
+          "description": "Context or helpful message that can be used during the approval process by the subscriber."
+        }
+      }
+    },
+    "PartnerTopicProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the partner topic.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "IdleDueToMirroredChannelResourceDeletion"
+      ],
+      "x-ms-enum": {
+        "name": "PartnerTopicProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "IdleDueToMirroredChannelResourceDeletion",
+            "value": "IdleDueToMirroredChannelResourceDeletion",
+            "description": "IdleDueToMirroredChannelResourceDeletion"
+          }
+        ]
+      }
+    },
+    "PartnerTopicUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Partner Topic update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the Partner Topic resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the Partner Topic resource."
+        }
+      }
+    },
+    "PartnerTopicsListResult": {
+      "type": "object",
+      "description": "Result of the List Partner Topics operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PartnerTopic items on this page",
+          "items": {
+            "$ref": "#/definitions/PartnerTopic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PartnerUpdateDestinationInfo": {
+      "type": "object",
+      "description": "Properties of the corresponding partner destination of a Channel.",
+      "properties": {
+        "endpointType": {
+          "type": "string",
+          "description": "Type of the endpoint for the partner destination",
+          "default": "WebHook",
+          "enum": [
+            "WebHook"
+          ],
+          "x-ms-enum": {
+            "name": "PartnerEndpointType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "WebHook",
+                "value": "WebHook",
+                "description": "WebHook"
+              }
+            ]
+          }
+        }
+      },
+      "discriminator": "endpointType",
+      "required": [
+        "endpointType"
+      ]
+    },
+    "PartnerUpdateTopicInfo": {
+      "type": "object",
+      "description": "Update properties for the corresponding partner topic of a channel.",
+      "properties": {
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "Event type info for the partner topic"
+        }
+      }
+    },
+    "PermissionBinding": {
+      "type": "object",
+      "description": "The Permission binding resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PermissionBindingProperties",
+          "description": "The properties of permission binding.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PermissionBindingProperties": {
+      "type": "object",
+      "description": "The properties of permission binding.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description for the Permission Binding resource."
+        },
+        "topicSpaceName": {
+          "type": "string",
+          "description": "The name of the Topic Space resource that the permission is bound to.\nThe Topic space needs to be a resource under the same namespace the permission binding is a part of."
+        },
+        "permission": {
+          "$ref": "#/definitions/PermissionType",
+          "description": "The allowed permission."
+        },
+        "clientGroupName": {
+          "type": "string",
+          "description": "The name of the client group resource that the permission is bound to.\nThe client group needs to be a resource under the same namespace the permission binding is a part of."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PermissionBindingProvisioningState",
+          "description": "Provisioning state of the PermissionBinding resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "PermissionBindingProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the PermissionBinding resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "PermissionBindingProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          }
+        ]
+      }
+    },
+    "PermissionBindingsListResult": {
+      "type": "object",
+      "description": "Result of the List Permission Binding operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PermissionBinding items on this page",
+          "items": {
+            "$ref": "#/definitions/PermissionBinding"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PermissionType": {
+      "type": "string",
+      "description": "The allowed permission.",
+      "enum": [
+        "Publisher",
+        "Subscriber"
+      ],
+      "x-ms-enum": {
+        "name": "PermissionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Publisher",
+            "value": "Publisher",
+            "description": "Publisher"
+          },
+          {
+            "name": "Subscriber",
+            "value": "Subscriber",
+            "description": "Subscriber"
+          }
+        ]
+      }
+    },
+    "PersistedConnectionStatus": {
+      "type": "string",
+      "description": "Status of the connection.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PersistedConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PlatformCapabilities": {
+      "type": "object",
+      "description": "Platform capabilities properties of the resource.",
+      "properties": {
+        "confidentialCompute": {
+          "$ref": "#/definitions/ConfidentialCompute",
+          "description": "Represents the Azure Confidential Compute properties of the resource."
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "PrivateEndpoint information.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier for Private Endpoint."
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the PrivateEndpointConnection.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "Result of the list of all private endpoint connections operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection resource.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The Private Endpoint resource for this Connection."
+        },
+        "groupIds": {
+          "type": "array",
+          "description": "GroupIds from the private link service resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/ConnectionState",
+          "description": "Details about the state of the connection."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ResourceProvisioningState",
+          "description": "Provisioning state of the Private Endpoint Connection."
+        }
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "Information of the private link resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Properties of the private link resource.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of private link resource will be either topic, domain, partnerNamespace or namespace."
+        },
+        "type": {
+          "$ref": "#/definitions/Azure.Core.armResourceType",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\""
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "requiredMembers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourcesListResult": {
+      "type": "object",
+      "description": "Result of the List private link resources operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.DomainProperties.InboundIpRules\" />",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "SecuredByPerimeter"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "SecuredByPerimeter",
+            "value": "SecuredByPerimeter",
+            "description": "SecuredByPerimeter"
+          }
+        ]
+      }
+    },
+    "PublisherType": {
+      "type": "string",
+      "description": "Publisher type of the namespace topic.",
+      "enum": [
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "PublisherType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          }
+        ]
+      }
+    },
+    "PushInfo": {
+      "type": "object",
+      "description": "Properties of the destination info for event subscription supporting push.",
+      "properties": {
+        "maxDeliveryCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum delivery count of the events."
+        },
+        "eventTimeToLive": {
+          "type": "string",
+          "description": "Time span duration in ISO 8601 format that determines how long messages are available to the subscription from the time the message was published.\nThis duration value is expressed using the following format: \\'P(n)Y(n)M(n)DT(n)H(n)M(n)S\\', where:\n- (n) is replaced by the value of each time element that follows the (n).\n- P is the duration (or Period) designator and is always placed at the beginning of the duration.\n- Y is the year designator, and it follows the value for the number of years.\n- M is the month designator, and it follows the value for the number of months.\n- W is the week designator, and it follows the value for the number of weeks.\n- D is the day designator, and it follows the value for the number of days.\n- T is the time designator, and it precedes the time components.\n- H is the hour designator, and it follows the value for the number of hours.\n- M is the minute designator, and it follows the value for the number of minutes.\n- S is the second designator, and it follows the value for the number of seconds.\nThis duration value cannot be set greater than the topic’s EventRetentionInDays. It is is an optional field where its minimum value is 1 minute, and its maximum is determined\nby topic’s EventRetentionInDays value. The followings are examples of valid values:\n- \\'P0DT23H12M\\' or \\'PT23H12M\\': for duration of 23 hours and 12 minutes.\n- \\'P1D\\' or \\'P1DT0H0M0S\\': for duration of 1 day."
+        },
+        "deadLetterDestinationWithResourceIdentity": {
+          "$ref": "#/definitions/DeadLetterWithResourceIdentity",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses the managed identity setup on the parent resource (namely, namespace) to acquire the authentication tokens being used during dead-lettering."
+        },
+        "deliveryWithResourceIdentity": {
+          "$ref": "#/definitions/DeliveryWithResourceIdentity",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses the managed identity setup on the parent resource (namely, topic or domain) to acquire the authentication tokens being used during delivery."
+        },
+        "destination": {
+          "$ref": "#/definitions/EventSubscriptionDestination",
+          "description": "Information about the destination where events have to be delivered for the event subscription.\nUses Azure Event Grid's identity to acquire the authentication tokens being used during delivery."
+        }
+      }
+    },
+    "QueueInfo": {
+      "type": "object",
+      "description": "Properties of the Queue info for event subscription.",
+      "properties": {
+        "receiveLockDurationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum period in seconds in which once the message is in received (by the client) state and waiting to be accepted, released or rejected.\nIf this time elapsed after a message has been received by the client and not transitioned into accepted (not processed), released or rejected,\nthe message is available for redelivery. This is an optional field, where default is 60 seconds, minimum is 60 seconds and maximum is 300 seconds."
+        },
+        "maxDeliveryCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum delivery count of the events."
+        },
+        "deadLetterDestinationWithResourceIdentity": {
+          "$ref": "#/definitions/DeadLetterWithResourceIdentity",
+          "description": "The dead letter destination of the event subscription. Any event that cannot be delivered to its' destination is sent to the dead letter destination.\nUses the managed identity setup on the parent resource (namely, topic) to acquire the authentication tokens being used during delivery / dead-lettering."
+        },
+        "eventTimeToLive": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time span duration in ISO 8601 format that determines how long messages are available to the subscription from the time the message was published.\nThis duration value is expressed using the following format: \\'P(n)Y(n)M(n)DT(n)H(n)M(n)S\\', where:\n- (n) is replaced by the value of each time element that follows the (n).\n- P is the duration (or Period) designator and is always placed at the beginning of the duration.\n- Y is the year designator, and it follows the value for the number of years.\n- M is the month designator, and it follows the value for the number of months.\n- W is the week designator, and it follows the value for the number of weeks.\n- D is the day designator, and it follows the value for the number of days.\n- T is the time designator, and it precedes the time components.\n- H is the hour designator, and it follows the value for the number of hours.\n- M is the minute designator, and it follows the value for the number of minutes.\n- S is the second designator, and it follows the value for the number of seconds.\nThis duration value cannot be set greater than the topic’s EventRetentionInDays. It is is an optional field where its minimum value is 1 minute, and its maximum is determined\nby topic’s EventRetentionInDays value. The followings are examples of valid values:\n- \\'P0DT23H12M\\' or \\'PT23H12M\\': for duration of 23 hours and 12 minutes.\n- \\'P1D\\' or \\'P1DT0H0M0S\\': for duration of 1 day."
+        }
+      }
+    },
+    "ReadinessState": {
+      "type": "string",
+      "description": "The readiness state of the corresponding partner topic.",
+      "enum": [
+        "NeverActivated",
+        "Activated"
+      ],
+      "x-ms-enum": {
+        "name": "ReadinessState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NeverActivated",
+            "value": "NeverActivated",
+            "description": "NeverActivated"
+          },
+          {
+            "name": "Activated",
+            "value": "Activated",
+            "description": "Activated"
+          }
+        ]
+      }
+    },
+    "ResourceAssociation": {
+      "type": "object",
+      "description": "Nsp resource association",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Association name"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterAssociationAccessMode",
+          "description": "Network security perimeter access mode."
+        }
+      }
+    },
+    "ResourceMoveChangeHistory": {
+      "type": "object",
+      "description": "The change history of the resource move.",
+      "properties": {
+        "azureSubscriptionId": {
+          "type": "string",
+          "description": "Azure subscription ID of the resource."
+        },
+        "resourceGroupName": {
+          "type": "string",
+          "description": "Azure Resource Group of the resource."
+        },
+        "changedTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp of when the resource was changed."
+        }
+      }
+    },
+    "ResourceProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Private Endpoint Connection.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "ResourceRegionType": {
+      "type": "string",
+      "description": "Region type of the resource.",
+      "enum": [
+        "RegionalResource",
+        "GlobalResource"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceRegionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RegionalResource",
+            "value": "RegionalResource",
+            "description": "RegionalResource"
+          },
+          {
+            "name": "GlobalResource",
+            "value": "GlobalResource",
+            "description": "GlobalResource"
+          }
+        ]
+      }
+    },
+    "ResourceSku": {
+      "type": "object",
+      "description": "Describes an EventGrid Resource Sku.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Sku name of the resource. The possible values are: Basic or Premium.",
+          "default": "Basic",
+          "enum": [
+            "Basic",
+            "Premium"
+          ],
+          "x-ms-enum": {
+            "name": "Sku",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Basic",
+                "value": "Basic",
+                "description": "Basic"
+              },
+              {
+                "name": "Premium",
+                "value": "Premium",
+                "description": "Premium"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "description": "Information about the retry policy for an event subscription.",
+      "properties": {
+        "maxDeliveryAttempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of delivery retry attempts for events.",
+          "default": 30
+        },
+        "eventTimeToLiveInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Time To Live (in minutes) for events.",
+          "default": 1440
+        }
+      }
+    },
+    "RoutingEnrichments": {
+      "type": "object",
+      "properties": {
+        "static": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StaticRoutingEnrichment"
+          },
+          "x-ms-identifiers": []
+        },
+        "dynamic": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DynamicRoutingEnrichment"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "RoutingIdentityInfo": {
+      "type": "object",
+      "description": "Routing identity info for topic spaces configuration.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RoutingIdentityType",
+          "description": "Routing identity type for topic spaces configuration."
+        },
+        "userAssignedIdentity": {
+          "type": "string"
+        }
+      }
+    },
+    "RoutingIdentityType": {
+      "type": "string",
+      "description": "Routing identity type for topic spaces configuration.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          }
+        ]
+      }
+    },
+    "ServiceBusQueueEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the service bus destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceBusQueueEventSubscriptionDestinationProperties",
+          "description": "Service Bus Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "ServiceBusQueue"
+    },
+    "ServiceBusQueueEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties that represent the Service Bus destination of an event subscription.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/queues"
+              }
+            ]
+          }
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "ServiceBusTopicEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the service bus topic destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceBusTopicEventSubscriptionDestinationProperties",
+          "description": "Service Bus Topic Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "ServiceBusTopic"
+    },
+    "ServiceBusTopicEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties that represent the Service Bus Topic destination of an event subscription.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event subscription.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/topics"
+              }
+            ]
+          }
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        }
+      }
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "The name of the SKU.",
+      "enum": [
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          }
+        ]
+      }
+    },
+    "StaticDeliveryAttributeMapping": {
+      "type": "object",
+      "description": "Static delivery attribute mapping details.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StaticDeliveryAttributeMappingProperties",
+          "description": "Properties of static delivery attribute mapping.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeliveryAttributeMapping"
+        }
+      ],
+      "x-ms-discriminator-value": "Static"
+    },
+    "StaticDeliveryAttributeMappingProperties": {
+      "type": "object",
+      "description": "Properties of static delivery attribute mapping.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Value of the delivery attribute."
+        },
+        "isSecret": {
+          "type": "boolean",
+          "format": "password",
+          "description": "Boolean flag to tell if the attribute contains sensitive information .",
+          "default": false,
+          "x-ms-secret": true
+        }
+      }
+    },
+    "StaticRoutingEnrichment": {
+      "type": "object",
+      "description": "Static routing enrichment details.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Static routing enrichment key."
+        },
+        "valueType": {
+          "$ref": "#/definitions/StaticRoutingEnrichmentType",
+          "description": "Static routing enrichment value type. For e.g. this property value can be 'String'."
+        }
+      },
+      "discriminator": "valueType",
+      "required": [
+        "valueType"
+      ]
+    },
+    "StaticRoutingEnrichmentType": {
+      "type": "string",
+      "description": "Static routing enrichment value type. For e.g. this property value can be 'String'.",
+      "enum": [
+        "String"
+      ],
+      "x-ms-enum": {
+        "name": "StaticRoutingEnrichmentType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "String",
+            "value": "String",
+            "description": "String"
+          }
+        ]
+      }
+    },
+    "StaticStringRoutingEnrichment": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "String type routing enrichment value."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/StaticRoutingEnrichment"
+        }
+      ],
+      "x-ms-discriminator-value": "String"
+    },
+    "StorageBlobDeadLetterDestination": {
+      "type": "object",
+      "description": "Information about the storage blob based dead letter destination.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageBlobDeadLetterDestinationProperties",
+          "description": "The properties of the Storage Blob based deadletter destination",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeadLetterDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "StorageBlob"
+    },
+    "StorageBlobDeadLetterDestinationProperties": {
+      "type": "object",
+      "description": "Properties of the storage blob based dead letter destination.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID of the storage account that is the destination of the deadletter events",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        },
+        "blobContainerName": {
+          "type": "string",
+          "description": "The name of the Storage blob container that is the destination of the deadletter events"
+        }
+      }
+    },
+    "StorageQueueEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the storage queue destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageQueueEventSubscriptionDestinationProperties",
+          "description": "Storage Queue Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "StorageQueue"
+    },
+    "StorageQueueEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "The properties for a storage queue destination.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID of the storage account that contains the queue that is the destination of an event subscription.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts/queues"
+              }
+            ]
+          }
+        },
+        "queueName": {
+          "type": "string",
+          "description": "The name of the Storage queue under a storage account that is the destination of an event subscription."
+        },
+        "queueMessageTimeToLiveInSeconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Storage queue message time to live in seconds. This value cannot be zero or negative with the exception of using -1 to indicate that the Time To Live of the message is Infinite."
+        }
+      }
+    },
+    "StringBeginsWithAdvancedFilter": {
+      "type": "object",
+      "description": "StringBeginsWith Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringBeginsWith"
+    },
+    "StringBeginsWithFilter": {
+      "type": "object",
+      "description": "StringBeginsWith Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringBeginsWith"
+    },
+    "StringContainsAdvancedFilter": {
+      "type": "object",
+      "description": "StringContains Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringContains"
+    },
+    "StringContainsFilter": {
+      "type": "object",
+      "description": "StringContains Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringContains"
+    },
+    "StringEndsWithAdvancedFilter": {
+      "type": "object",
+      "description": "StringEndsWith Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringEndsWith"
+    },
+    "StringEndsWithFilter": {
+      "type": "object",
+      "description": "StringEndsWith Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringEndsWith"
+    },
+    "StringInAdvancedFilter": {
+      "type": "object",
+      "description": "StringIn Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringIn"
+    },
+    "StringInFilter": {
+      "type": "object",
+      "description": "StringIn Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringIn"
+    },
+    "StringNotBeginsWithAdvancedFilter": {
+      "type": "object",
+      "description": "StringNotBeginsWith Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotBeginsWith"
+    },
+    "StringNotBeginsWithFilter": {
+      "type": "object",
+      "description": "StringNotBeginsWith Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotBeginsWith"
+    },
+    "StringNotContainsAdvancedFilter": {
+      "type": "object",
+      "description": "StringNotContains Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotContains"
+    },
+    "StringNotContainsFilter": {
+      "type": "object",
+      "description": "StringNotContains Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotContains"
+    },
+    "StringNotEndsWithAdvancedFilter": {
+      "type": "object",
+      "description": "StringNotEndsWith Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotEndsWith"
+    },
+    "StringNotEndsWithFilter": {
+      "type": "object",
+      "description": "StringNotEndsWith Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotEndsWith"
+    },
+    "StringNotInAdvancedFilter": {
+      "type": "object",
+      "description": "StringNotIn Advanced Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvancedFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotIn"
+    },
+    "StringNotInFilter": {
+      "type": "object",
+      "description": "StringNotIn Filter.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The set of filter values.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ],
+      "x-ms-discriminator-value": "StringNotIn"
+    },
+    "Subscription": {
+      "type": "object",
+      "description": "Event Subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubscriptionProperties",
+          "description": "Properties of the event subscription.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SubscriptionFullUrl": {
+      "type": "object",
+      "description": "Full endpoint URL of an event subscription",
+      "properties": {
+        "endpointUrl": {
+          "type": "string",
+          "description": "The URL that represents the endpoint of the destination of an event subscription."
+        }
+      }
+    },
+    "SubscriptionProperties": {
+      "type": "object",
+      "description": "Properties of the event subscription.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/SubscriptionProvisioningState",
+          "description": "Provisioning state of the event subscription.",
+          "readOnly": true
+        },
+        "deliveryConfiguration": {
+          "$ref": "#/definitions/DeliveryConfiguration",
+          "description": "Information about the delivery configuration of the event subscription."
+        },
+        "eventDeliverySchema": {
+          "$ref": "#/definitions/DeliverySchema",
+          "description": "The event delivery schema for the event subscription."
+        },
+        "filtersConfiguration": {
+          "$ref": "#/definitions/FiltersConfiguration",
+          "description": "Information about the filter for the event subscription."
+        },
+        "expirationTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the event subscription."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tags relating to Event Subscription resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SubscriptionProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the event subscription.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "AwaitingManualAction",
+        "Deleted",
+        "DeleteFailed",
+        "CreateFailed",
+        "UpdatedFailed"
+      ],
+      "x-ms-enum": {
+        "name": "SubscriptionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "AwaitingManualAction",
+            "value": "AwaitingManualAction",
+            "description": "AwaitingManualAction"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          },
+          {
+            "name": "DeleteFailed",
+            "value": "DeleteFailed",
+            "description": "DeleteFailed"
+          },
+          {
+            "name": "CreateFailed",
+            "value": "CreateFailed",
+            "description": "CreateFailed"
+          },
+          {
+            "name": "UpdatedFailed",
+            "value": "UpdatedFailed",
+            "description": "UpdatedFailed"
+          }
+        ]
+      }
+    },
+    "SubscriptionUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Event Subscription update.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubscriptionUpdateParametersProperties",
+          "description": "Properties of the Event Subscription update parameters.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "SubscriptionUpdateParametersProperties": {
+      "type": "object",
+      "description": "Properties of the Event Subscription update parameters.",
+      "properties": {
+        "deliveryConfiguration": {
+          "$ref": "#/definitions/DeliveryConfiguration",
+          "description": "Information about the delivery configuration of the event subscription."
+        },
+        "eventDeliverySchema": {
+          "$ref": "#/definitions/DeliverySchema",
+          "description": "The event delivery schema for the event subscription."
+        },
+        "filtersConfiguration": {
+          "$ref": "#/definitions/FiltersConfiguration",
+          "description": "Information about the filter for the event subscription."
+        },
+        "expirationTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time of the event subscription."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tags relating to Event Subscription resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SubscriptionsListResult": {
+      "type": "object",
+      "description": "Result of the List event subscriptions operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Subscription items on this page",
+          "items": {
+            "$ref": "#/definitions/Subscription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SystemTopic": {
+      "type": "object",
+      "description": "EventGrid System Topic.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SystemTopicProperties",
+          "description": "Properties of the system topic.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "SystemTopicProperties": {
+      "type": "object",
+      "description": "Properties of the System Topic.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ResourceProvisioningState",
+          "description": "Provisioning state of the system topic.",
+          "readOnly": true
+        },
+        "source": {
+          "type": "string",
+          "description": "Source for the system topic."
+        },
+        "topicType": {
+          "type": "string",
+          "description": "TopicType for the system topic."
+        },
+        "metricResourceId": {
+          "type": "string",
+          "description": "Metric resource id for the system topic.",
+          "readOnly": true
+        },
+        "encryption": {
+          "$ref": "#/definitions/KeyEncryption",
+          "description": "Key encryption configuration properties of the system topic resource. This is an optional property. When not specified, no key encryption is used."
+        },
+        "platformCapabilities": {
+          "$ref": "#/definitions/PlatformCapabilities",
+          "description": "Represents the platform capabilities of the resource, including Azure Confidential Compute related properties."
+        }
+      }
+    },
+    "SystemTopicUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the System Topic update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the system topic.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Resource identity information."
+        }
+      }
+    },
+    "SystemTopicsListResult": {
+      "type": "object",
+      "description": "Result of the List System topics operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SystemTopic items on this page",
+          "items": {
+            "$ref": "#/definitions/SystemTopic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TlsVersion": {
+      "type": "string",
+      "description": "Minimum TLS version of the publisher allowed to publish to this domain",
+      "enum": [
+        "1.0",
+        "1.1",
+        "1.2"
+      ],
+      "x-ms-enum": {
+        "name": "TlsVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "1.0",
+            "value": "1.0",
+            "description": "1.0"
+          },
+          {
+            "name": "1.1",
+            "value": "1.1",
+            "description": "1.1"
+          },
+          {
+            "name": "1.2",
+            "value": "1.2",
+            "description": "1.2"
+          }
+        ]
+      }
+    },
+    "Topic": {
+      "type": "object",
+      "description": "EventGrid Topic",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TopicProperties",
+          "description": "Properties of the topic.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The Sku pricing tier for the topic."
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Identity information for the resource."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of the resource.",
+          "default": "Azure",
+          "enum": [
+            "Azure",
+            "AzureArc"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceKind",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Azure",
+                "value": "Azure",
+                "description": "Azure"
+              },
+              {
+                "name": "AzureArc",
+                "value": "AzureArc",
+                "description": "AzureArc"
+              }
+            ]
+          }
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "Extended location of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "TopicProperties": {
+      "type": "object",
+      "description": "Properties of the Topic.",
+      "properties": {
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/TopicProvisioningState",
+          "description": "Provisioning state of the topic.",
+          "readOnly": true
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint for the topic.",
+          "readOnly": true
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "Event Type Information for the user topic. This information is provided by the publisher and can be used by the\nsubscriber to view different types of events that are published."
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this topic"
+        },
+        "inputSchema": {
+          "type": "string",
+          "description": "This determines the format that Event Grid should expect for incoming events published to the topic.",
+          "default": "EventGridSchema",
+          "enum": [
+            "EventGridSchema",
+            "CustomEventSchema",
+            "CloudEventSchemaV1_0"
+          ],
+          "x-ms-enum": {
+            "name": "InputSchema",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "EventGridSchema",
+                "value": "EventGridSchema",
+                "description": "EventGridSchema"
+              },
+              {
+                "name": "CustomEventSchema",
+                "value": "CustomEventSchema",
+                "description": "CustomEventSchema"
+              },
+              {
+                "name": "CloudEventSchemaV1_0",
+                "value": "CloudEventSchemaV1_0",
+                "description": "CloudEventSchemaV1_0"
+              }
+            ]
+          }
+        },
+        "inputSchemaMapping": {
+          "$ref": "#/definitions/InputSchemaMapping",
+          "description": "This enables publishing using custom event schemas. An InputSchemaMapping can be specified to map various properties of a source schema to various required properties of the EventGridEvent schema."
+        },
+        "metricResourceId": {
+          "type": "string",
+          "description": "Metric resource id for the topic.",
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.TopicProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the topic.",
+          "default": false
+        },
+        "dataResidencyBoundary": {
+          "$ref": "#/definitions/DataResidencyBoundary",
+          "description": "Data Residency Boundary of the resource."
+        },
+        "encryption": {
+          "$ref": "#/definitions/KeyEncryption",
+          "description": "Key encryption configuration properties of the topic resource. This is an optional property. When not specified, no key encryption is used."
+        },
+        "platformCapabilities": {
+          "$ref": "#/definitions/PlatformCapabilities",
+          "description": "Represents the platform capabilities of the resource, including Azure Confidential Compute related properties."
+        }
+      }
+    },
+    "TopicProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the topic.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "TopicProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "TopicRegenerateKeyRequest": {
+      "type": "object",
+      "description": "Topic regenerate share access key request",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Key name to regenerate key1 or key2"
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "TopicSharedAccessKeys": {
+      "type": "object",
+      "description": "Shared access keys of the Topic",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "description": "Shared access key1 for the topic."
+        },
+        "key2": {
+          "type": "string",
+          "description": "Shared access key2 for the topic."
+        }
+      }
+    },
+    "TopicSpace": {
+      "type": "object",
+      "description": "The Topic space resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TopicSpaceProperties",
+          "description": "The properties of topic space.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TopicSpaceProperties": {
+      "type": "object",
+      "description": "The properties of topic space.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description for the Topic Space resource."
+        },
+        "topicTemplates": {
+          "type": "array",
+          "description": "The topic filters in the topic space.\nExample: \"topicTemplates\": [\n\"devices/foo/bar\",\n\"devices/topic1/+\",\n\"devices/${principal.name}/${principal.attributes.keyName}\" ].",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/TopicSpaceProvisioningState",
+          "description": "Provisioning state of the TopicSpace resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "TopicSpaceProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the TopicSpace resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "TopicSpaceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          }
+        ]
+      }
+    },
+    "TopicSpacesConfiguration": {
+      "type": "object",
+      "description": "Properties of the Topic Spaces Configuration.",
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "Indicate if Topic Spaces Configuration is enabled for the namespace. Default is Disabled.",
+          "default": "Disabled",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "x-ms-enum": {
+            "name": "TopicSpacesConfigurationState",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              }
+            ]
+          }
+        },
+        "routeTopicResourceId": {
+          "type": "string",
+          "description": "Fully qualified Azure Resource Id for the Event Grid Topic to which events will be routed to from TopicSpaces under a namespace.\nThis property should be in the following format '/subscriptions/{subId}/resourcegroups/{resourceGroupName}/providers/microsoft.EventGrid/topics/{topicName}'.\nThis topic should reside in the same region where namespace is located."
+        },
+        "hostname": {
+          "type": "string",
+          "description": "The endpoint for the topic spaces configuration. This is a read-only property.",
+          "readOnly": true
+        },
+        "routingEnrichments": {
+          "$ref": "#/definitions/RoutingEnrichments",
+          "description": "Routing enrichments for topic spaces configuration"
+        },
+        "clientAuthentication": {
+          "$ref": "#/definitions/ClientAuthenticationSettings",
+          "description": "Client authentication settings for topic spaces configuration."
+        },
+        "maximumSessionExpiryInHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum session expiry in hours. The property default value is 1 hour.\nMin allowed value is 1 hour and max allowed value is 8 hours."
+        },
+        "maximumClientSessionsPerAuthenticationName": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of sessions per authentication name. The property default value is 1.\nMin allowed value is 1 and max allowed value is 100."
+        },
+        "routingIdentityInfo": {
+          "$ref": "#/definitions/RoutingIdentityInfo",
+          "description": "Routing identity info for topic spaces configuration."
+        },
+        "customDomains": {
+          "type": "array",
+          "description": "List of custom domain configurations for the namespace.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "TopicSpacesConfigurationState": {
+      "type": "string",
+      "description": "Indicate if Topic Spaces Configuration is enabled for the namespace. Default is Disabled.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "TopicSpacesConfigurationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "TopicSpacesListResult": {
+      "type": "object",
+      "description": "Result of the List Topic Space operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TopicSpace items on this page",
+          "items": {
+            "$ref": "#/definitions/TopicSpace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TopicTypeAdditionalEnforcedPermission": {
+      "type": "object",
+      "properties": {
+        "permissionName": {
+          "type": "string"
+        },
+        "isDataAction": {
+          "type": "boolean"
+        }
+      }
+    },
+    "TopicTypeInfo": {
+      "type": "object",
+      "description": "Properties of a topic type info.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TopicTypeProperties",
+          "description": "Properties of the topic type info",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TopicTypeProperties": {
+      "type": "object",
+      "description": "Properties of a topic type.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Namespace of the provider of the topic type."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display Name for the topic type."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the topic type."
+        },
+        "resourceRegionType": {
+          "$ref": "#/definitions/ResourceRegionType",
+          "description": "Region type of the resource."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/TopicTypeProvisioningState",
+          "description": "Provisioning state of the topic type."
+        },
+        "supportedLocations": {
+          "type": "array",
+          "description": "List of locations supported by this topic type.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceResourceFormat": {
+          "type": "string",
+          "description": "Source resource format."
+        },
+        "supportedScopesForSource": {
+          "type": "array",
+          "description": "Supported source scopes.",
+          "items": {
+            "$ref": "#/definitions/TopicTypeSourceScope"
+          }
+        },
+        "areRegionalAndGlobalSourcesSupported": {
+          "type": "boolean",
+          "description": "Flag to indicate that a topic type can support both regional or global system topics."
+        },
+        "additionalEnforcedPermissions": {
+          "type": "array",
+          "description": "Permissions which are enforced for creating and updating system topics of this this topic type.",
+          "items": {
+            "$ref": "#/definitions/TopicTypeAdditionalEnforcedPermission"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "TopicTypeProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the topic type.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "TopicTypeProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "TopicTypeSourceScope": {
+      "type": "string",
+      "enum": [
+        "Resource",
+        "ResourceGroup",
+        "AzureSubscription",
+        "ManagementGroup"
+      ],
+      "x-ms-enum": {
+        "name": "TopicTypeSourceScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Resource",
+            "value": "Resource",
+            "description": "Resource"
+          },
+          {
+            "name": "ResourceGroup",
+            "value": "ResourceGroup",
+            "description": "ResourceGroup"
+          },
+          {
+            "name": "AzureSubscription",
+            "value": "AzureSubscription",
+            "description": "AzureSubscription"
+          },
+          {
+            "name": "ManagementGroup",
+            "value": "ManagementGroup",
+            "description": "ManagementGroup"
+          }
+        ]
+      }
+    },
+    "TopicTypesListResult": {
+      "type": "object",
+      "description": "Result of the List Topic Types operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A collection of topic types",
+          "items": {
+            "$ref": "#/definitions/TopicTypeInfo"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "TopicUpdateParameterProperties": {
+      "type": "object",
+      "description": "Information of topic update parameter properties.",
+      "properties": {
+        "publicNetworkAccess": {
+          "type": "string",
+          "description": "This determines if traffic is allowed over public network. By default it is enabled.\nYou can further restrict to specific IPs by configuring <seealso cref=\"P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.TopicUpdateParameterProperties.InboundIpRules\" />",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "SecuredByPerimeter"
+          ],
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "SecuredByPerimeter",
+                "value": "SecuredByPerimeter",
+                "description": "SecuredByPerimeter"
+              }
+            ]
+          }
+        },
+        "inboundIpRules": {
+          "type": "array",
+          "description": "This can be used to restrict traffic from specific IPs instead of all IPs. Note: These are considered only if PublicNetworkAccess is enabled.",
+          "items": {
+            "$ref": "#/definitions/InboundIpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version of the publisher allowed to publish to this domain"
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "This boolean is used to enable or disable local auth. Default value is false. When the property is set to true, only Microsoft Entra ID token will be used to authenticate if user is allowed to publish to the topic."
+        },
+        "dataResidencyBoundary": {
+          "$ref": "#/definitions/DataResidencyBoundary",
+          "description": "The data residency boundary for the topic."
+        },
+        "eventTypeInfo": {
+          "$ref": "#/definitions/EventTypeInfo",
+          "description": "The eventTypeInfo for the topic."
+        }
+      }
+    },
+    "TopicUpdateParameters": {
+      "type": "object",
+      "description": "Properties of the Topic update",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Tags of the Topic resource.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Topic resource identity information."
+        },
+        "properties": {
+          "$ref": "#/definitions/TopicUpdateParameterProperties",
+          "description": "Properties of the Topic resource.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The Sku pricing tier for the topic."
+        }
+      }
+    },
+    "TopicsConfiguration": {
+      "type": "object",
+      "description": "Properties of the Topics Configuration.",
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "The hostname for the topics configuration. This is a read-only property.",
+          "readOnly": true
+        },
+        "customDomains": {
+          "type": "array",
+          "description": "List of custom domain configurations for the namespace.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "TopicsListResult": {
+      "type": "object",
+      "description": "Result of the List Topics operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Topic items on this page",
+          "items": {
+            "$ref": "#/definitions/Topic"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "UpdateAutoScaleConfiguration": {
+      "type": "object",
+      "description": "UpdateAutoScaleConfiguration definition.",
+      "properties": {
+        "enableAutoScale": {
+          "type": "boolean",
+          "description": "Indicates whether auto-scaling is enabled for the namespace. When enabled, the namespace will automatically scale\nbetween minimumThroughputUnits and maximumThroughputUnits based on usage patterns."
+        },
+        "minimumThroughputUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of Throughput Units for auto-scaling. Valid only when EnableAutoScale is true."
+        },
+        "maximumThroughputUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of Throughput Units for auto-scaling. Valid only when EnableAutoScale is true."
+        }
+      }
+    },
+    "UpdateTopicSpacesConfigurationInfo": {
+      "type": "object",
+      "description": "Properties of the topic spaces configuration info of a namespace.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/TopicSpacesConfigurationState",
+          "description": "Indicate if Topic Spaces Configuration is enabled for the namespace. Default is Disabled."
+        },
+        "routeTopicResourceId": {
+          "type": "string",
+          "description": "This property is used to specify custom topic to which events will be routed to from topic spaces configuration under namespace."
+        },
+        "routingEnrichments": {
+          "$ref": "#/definitions/RoutingEnrichments",
+          "description": "Routing enrichments for topic spaces configuration."
+        },
+        "clientAuthentication": {
+          "$ref": "#/definitions/ClientAuthenticationSettings",
+          "description": "Client authentication settings for topic spaces configuration."
+        },
+        "maximumSessionExpiryInHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum session expiry in hours. The property default value is 1 hour.\nMin allowed value is 1 hour and max allowed value is 8 hours."
+        },
+        "maximumClientSessionsPerAuthenticationName": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of sessions per authentication name. The property default value is 1.\nMin allowed value is 1 and max allowed value is 100."
+        },
+        "routingIdentityInfo": {
+          "$ref": "#/definitions/RoutingIdentityInfo",
+          "description": "Routing identity info for topic spaces configuration."
+        },
+        "customDomains": {
+          "type": "array",
+          "description": "Custom domain info for topic spaces configuration.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "UpdateTopicsConfigurationInfo": {
+      "type": "object",
+      "description": "Properties of the topics configuration info of a namespace.",
+      "properties": {
+        "customDomains": {
+          "type": "array",
+          "description": "Custom domain info for topics configuration.",
+          "items": {
+            "$ref": "#/definitions/CustomDomainConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "UserIdentityProperties": {
+      "type": "object",
+      "description": "The information about the user identity.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of user assigned identity."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client id of user assigned identity."
+        }
+      }
+    },
+    "VerifiedPartner": {
+      "type": "object",
+      "description": "Verified partner information",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VerifiedPartnerProperties",
+          "description": "Properties of the verified partner.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "VerifiedPartnerProperties": {
+      "type": "object",
+      "description": "Properties of the verified partner.",
+      "properties": {
+        "partnerRegistrationImmutableId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "ImmutableId of the corresponding partner registration."
+        },
+        "organizationName": {
+          "type": "string",
+          "description": "Official name of the Partner."
+        },
+        "partnerDisplayName": {
+          "type": "string",
+          "description": "Display name of the verified partner."
+        },
+        "partnerTopicDetails": {
+          "$ref": "#/definitions/PartnerDetails",
+          "description": "Details of the partner topic scenario."
+        },
+        "partnerDestinationDetails": {
+          "$ref": "#/definitions/PartnerDetails",
+          "description": "Details of the partner destination scenario."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/VerifiedPartnerProvisioningState",
+          "description": "Provisioning state of the verified partner."
+        }
+      }
+    },
+    "VerifiedPartnerProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the verified partner.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "VerifiedPartnerProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "VerifiedPartnersListResult": {
+      "type": "object",
+      "description": "Result of the List Topic Types operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VerifiedPartner items on this page",
+          "items": {
+            "$ref": "#/definitions/VerifiedPartner"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WebHookEventSubscriptionDestination": {
+      "type": "object",
+      "description": "Information about the webhook destination for an event subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WebHookEventSubscriptionDestinationProperties",
+          "description": "WebHook Properties of the event subscription destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EventSubscriptionDestination"
+        }
+      ],
+      "x-ms-discriminator-value": "WebHook"
+    },
+    "WebHookEventSubscriptionDestinationProperties": {
+      "type": "object",
+      "description": "Information about the webhook destination properties for an event subscription.",
+      "properties": {
+        "endpointUrl": {
+          "type": "string",
+          "format": "password",
+          "description": "The URL that represents the endpoint of the destination of an event subscription.",
+          "x-ms-secret": true
+        },
+        "endpointBaseUrl": {
+          "type": "string",
+          "description": "The base URL that represents the endpoint of the destination of an event subscription.",
+          "readOnly": true
+        },
+        "maxEventsPerBatch": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events per batch.",
+          "default": 1
+        },
+        "preferredBatchSizeInKilobytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Preferred batch size in Kilobytes.",
+          "default": 64
+        },
+        "azureActiveDirectoryTenantId": {
+          "type": "string",
+          "description": "The Microsoft Entra ID Tenant ID to get the access token that will be included as the bearer token in delivery requests."
+        },
+        "azureActiveDirectoryApplicationIdOrUri": {
+          "type": "string",
+          "description": "The Microsoft Entra ID Application ID or URI to get the access token that will be included as the bearer token in delivery requests."
+        },
+        "deliveryAttributeMappings": {
+          "type": "array",
+          "description": "Delivery attribute details.",
+          "items": {
+            "$ref": "#/definitions/DeliveryAttributeMapping"
+          }
+        },
+        "minimumTlsVersionAllowed": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "Minimum TLS version that should be supported by webhook endpoint"
+        }
+      }
+    },
+    "WebhookAuthenticationSettings": {
+      "type": "object",
+      "description": "Authentication settings for a webhook endpoint within a Namespace resource.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/CustomWebhookAuthenticationManagedIdentity",
+          "description": "The identity configuration required for authenticating a custom webhook."
+        },
+        "endpointUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL endpoint where the Event Grid service sends authenticated webhook requests using the specified managed identity."
+        },
+        "endpointBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The base URL endpoint where the Event Grid service sends authenticated webhook requests using the specified managed identity."
+        },
+        "azureActiveDirectoryApplicationIdOrUri": {
+          "type": "string",
+          "description": "Microsoft Entra ID Application ID or URI to get the access token that will be included as the bearer token in delivery requests."
+        },
+        "azureActiveDirectoryTenantId": {
+          "type": "string",
+          "description": "Microsoft Entra ID Tenant ID to get the access token that will be included as the bearer token in delivery requests."
+        }
+      },
+      "required": [
+        "identity",
+        "endpointUrl",
+        "azureActiveDirectoryApplicationIdOrUri",
+        "azureActiveDirectoryTenantId"
+      ]
+    },
+    "WebhookPartnerDestinationInfo": {
+      "type": "object",
+      "description": "Information about the WebHook of the partner destination.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WebhookPartnerDestinationProperties",
+          "description": "WebHook Properties of the partner destination.",
+          "x-ms-client-flatten": true
+        },
+        "resourceMoveChangeHistory": {
+          "type": "array",
+          "description": "Change history of the resource move.",
+          "items": {
+            "$ref": "#/definitions/ResourceMoveChangeHistory"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartnerDestinationInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "WebHook"
+    },
+    "WebhookPartnerDestinationProperties": {
+      "type": "object",
+      "description": "Properties of a partner destination webhook.",
+      "properties": {
+        "endpointUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL that represents the endpoint of the partner destination."
+        },
+        "endpointBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The base URL that represents the endpoint of the partner destination."
+        },
+        "clientAuthentication": {
+          "$ref": "#/definitions/PartnerClientAuthentication",
+          "description": "Partner client authentication"
+        }
+      }
+    },
+    "WebhookUpdatePartnerDestinationInfo": {
+      "type": "object",
+      "description": "Information about the update of the WebHook of the partner destination.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WebhookPartnerDestinationProperties",
+          "description": "WebHook Properties of the partner destination.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartnerUpdateDestinationInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "WebHook"
+    }
+  },
+  "parameters": {}
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
@@ -19263,7 +19263,7 @@
           {
             "name": "1.3",
             "value": "1.3",
-            "description": "1.3"
+            "description": "TLS version 1.3."
           }
         ]
       }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/EventGrid.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "EventGridManagementClient",
-    "version": "2025-11-15-preview",
+    "version": "2026-06-15-preview",
     "description": "Azure EventGrid Management Client",
     "x-typespec-generated": [
       {
@@ -14967,6 +14967,30 @@
         ]
       }
     },
+    "IpAddressType": {
+      "type": "string",
+      "description": "Specifies the IP address type for the namespace.",
+      "enum": [
+        "IPv4",
+        "DualStack"
+      ],
+      "x-ms-enum": {
+        "name": "IpAddressType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "The namespace supports IPv4 only. This is the default."
+          },
+          {
+            "name": "DualStack",
+            "value": "DualStack",
+            "description": "The namespace supports both IPv4 and IPv6 (dual-stack)."
+          }
+        ]
+      }
+    },
     "IsNotNullAdvancedFilter": {
       "type": "object",
       "description": "IsNotNull Advanced Filter.",
@@ -15336,6 +15360,10 @@
           },
           "x-ms-identifiers": []
         },
+        "ipAddressType": {
+          "$ref": "#/definitions/IpAddressType",
+          "description": "This property specifies the IP address type for the namespace."
+        },
         "minimumTlsVersionAllowed": {
           "$ref": "#/definitions/TlsVersion",
           "description": "Minimum TLS version of the publisher allowed to publish to this namespace. Only TLS version 1.2 is supported."
@@ -15692,6 +15720,10 @@
             "$ref": "#/definitions/InboundIpRule"
           },
           "x-ms-identifiers": []
+        },
+        "ipAddressType": {
+          "$ref": "#/definitions/IpAddressType",
+          "description": "This property specifies the IP address type for the namespace."
         },
         "autoScaleConfiguration": {
           "$ref": "#/definitions/UpdateAutoScaleConfiguration",
@@ -19206,7 +19238,8 @@
       "enum": [
         "1.0",
         "1.1",
-        "1.2"
+        "1.2",
+        "1.3"
       ],
       "x-ms-enum": {
         "name": "TlsVersion",
@@ -19226,6 +19259,11 @@
             "name": "1.2",
             "value": "1.2",
             "description": "1.2"
+          },
+          {
+            "name": "1.3",
+            "value": "1.3",
+            "description": "1.3"
           }
         ]
       }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_CreateOrUpdate.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateInfo": {
+      "properties": {
+        "description": "This is a test certificate",
+        "encodedCertificate": "base64EncodePemFormattedCertificateString"
+      }
+    },
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "CaCertificates_CreateOrUpdate",
+  "title": "CaCertificates_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateInfo": {
       "properties": {
         "description": "This is a test certificate",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "CaCertificates_Delete",
+  "title": "CaCertificates_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateName": "exampleCACertificateName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "caCertificateName": "exampleCACertificateName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "caCertificateName": "exampleCACertificateName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleCACertificateName1",
+        "type": "Microsoft.EventGrid/namespaces/caCertificates",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+        "properties": {
+          "description": "This is a test Root certificate",
+          "encodedCertificate": "base64EncodePemFormattedCertificateString",
+          "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+          "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "CaCertificates_Get",
+  "title": "CaCertificates_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_ListByNamespace.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/caCertificates?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleCACertificateName1",
+            "type": "Microsoft.EventGrid/namespaces/caCertificates",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/caCertificates/exampleCACertificateName1",
+            "properties": {
+              "description": "This is a test Root certificate",
+              "encodedCertificate": "base64EncodePemFormattedCertificateString",
+              "expiryTimeInUtc": "2022-10-12T23:06:43+00:00",
+              "issueTimeInUtc": "2022-09-12T23:06:43+00:00",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CaCertificates_ListByNamespace",
+  "title": "CaCertificates_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/CaCertificates_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelInfo": {
       "properties": {
         "channelType": "PartnerTopic",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelInfo": {
+      "properties": {
+        "channelType": "PartnerTopic",
+        "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+        "messageForActivation": "Example message to approver",
+        "partnerTopicInfo": {
+          "name": "examplePartnerTopic1",
+          "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+          "resourceGroupName": "examplerg2",
+          "source": "ContosoCorp.Accounts.User1"
+        }
+      }
+    },
+    "channelName": "exampleChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Channels_CreateOrUpdate",
+  "title": "Channels_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleEventChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Channels_Delete",
+  "title": "Channels_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleEventChannelName1",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleChannelName1",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleChannelName1",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleChannelName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+        "properties": {
+          "channelType": "PartnerTopic",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Example message to approver",
+          "partnerTopicInfo": {
+            "name": "examplePartnerTopic1",
+            "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+            "resourceGroupName": "examplerg2",
+            "source": "ContosoCorp.Accounts.User1"
+          },
+          "provisioningState": "Succeeded",
+          "readinessState": "NeverActivated"
+        }
+      }
+    }
+  },
+  "operationId": "Channels_Get",
+  "title": "Channels_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "examplechannel",
     "partnerNamespaceName": "examplenamespace",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "examplechannel",
+    "partnerNamespaceName": "examplenamespace",
+    "resourceGroupName": "examplerg",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnernamespaces/examplenamespace",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "Channels_GetFullUrl",
+  "title": "Channels_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_ListByPartnerNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_ListByPartnerNamespace.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampleChannelName1",
+            "type": "Microsoft.EventGrid/partnerNamespaces/channels",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1/changes/exampleChannelName1",
+            "properties": {
+              "channelType": "PartnerTopic",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Example message to approver",
+              "partnerTopicInfo": {
+                "name": "examplePartnerTopic1",
+                "azureSubscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+                "resourceGroupName": "examplerg2",
+                "source": "ContosoCorp.Accounts.User1"
+              },
+              "provisioningState": "Succeeded",
+              "readinessState": "NeverActivated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Channels_ListByPartnerNamespace",
+  "title": "Channels_ListByPartnerNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_ListByPartnerNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_ListByPartnerNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "channelName": "exampleChannelName1",
     "channelUpdateParameters": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Channels_Update.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "channelName": "exampleChannelName1",
+    "channelUpdateParameters": {
+      "properties": {
+        "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:11.785Z"
+      }
+    },
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "Channels_Update",
+  "title": "Channels_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_CreateOrUpdate.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupInfo": {
+      "properties": {
+        "description": "This is a test client group",
+        "query": "attributes.b IN ['a', 'b', 'c']"
+      }
+    },
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    }
+  },
+  "operationId": "ClientGroups_CreateOrUpdate",
+  "title": "ClientGroups_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupInfo": {
       "properties": {
         "description": "This is a test client group",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ClientGroups_Delete",
+  "title": "ClientGroups_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupName": "exampleClientGroupName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientGroupName": "exampleClientGroupName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_Get.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientGroupName": "exampleClientGroupName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientGroupName1",
+        "type": "Microsoft.EventGrid/namespaces/clientGroups",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+        "properties": {
+          "description": "This is a test client group",
+          "query": "attributes.b IN ['a', 'b', 'c']"
+        }
+      }
+    }
+  },
+  "operationId": "ClientGroups_Get",
+  "title": "ClientGroups_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ClientGroups_ListByNamespace.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/clientGroups?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleClientGroupName1",
+            "type": "Microsoft.EventGrid/namespaces/clientGroups",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clientGroups/exampleClientGroupName1",
+            "properties": {
+              "description": "This is a test client group",
+              "query": "attributes.b IN ['a', 'b', 'c']"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ClientGroups_ListByNamespace",
+  "title": "ClientGroups_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientInfo": {
       "properties": {
         "description": "This is a test client",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_CreateOrUpdate.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientInfo": {
+      "properties": {
+        "description": "This is a test client",
+        "attributes": {
+          "deviceTypes": [
+            "Fan",
+            "Light",
+            "AC"
+          ],
+          "floor": 3,
+          "room": "345"
+        },
+        "clientCertificateAuthentication": {
+          "validationScheme": "SubjectMatchesAuthenticationName"
+        },
+        "state": "Enabled"
+      }
+    },
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "Clients_CreateOrUpdate",
+  "title": "Clients_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientName": "exampleClientName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Clients_Delete",
+  "title": "Clients_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "clientName": "exampleClientName1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_Get.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "clientName": "exampleClientName1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleClientName1",
+        "type": "Microsoft.EventGrid/namespaces/clients",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+        "properties": {
+          "description": "This is a test client",
+          "attributes": {
+            "deviceTypes": [
+              "Light",
+              "1"
+            ],
+            "floor": 3,
+            "room": "345a"
+          },
+          "clientCertificateAuthentication": {
+            "validationScheme": "SubjectMatchesAuthenticationName"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "Clients_Get",
+  "title": "Clients_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Clients_ListByNamespace.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/clients?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleClientName1",
+            "type": "Microsoft.EventGrid/namespaces/clients",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/clients/exampleClientName1",
+            "properties": {
+              "description": "This is a test client",
+              "attributes": {
+                "deviceTypes": [
+                  "Light",
+                  "1"
+                ],
+                "floor": 3,
+                "room": "345a"
+              },
+              "clientCertificateAuthentication": {
+                "validationScheme": "SubjectMatchesAuthenticationName"
+              },
+              "provisioningState": "Succeeded",
+              "state": "Enabled"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Clients_ListByNamespace",
+  "title": "Clients_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_CreateOrUpdate",
+  "title": "DomainEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainEventSubscriptions_Delete",
+  "title": "DomainEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_Get",
+  "title": "DomainEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_GetDeliveryAttributes",
+  "title": "DomainEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_GetFullUrl",
+  "title": "DomainEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_List.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_List",
+  "title": "DomainEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainEventSubscriptions_Update",
+  "title": "DomainEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_CreateOrUpdate",
+  "title": "DomainTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
@@ -11,8 +11,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainTopicEventSubscriptions_Delete",
+  "title": "DomainTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Get.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_Get",
+  "title": "DomainTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "DomainTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_GetFullUrl",
+  "title": "DomainTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_List.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_List",
+  "title": "DomainTopicEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Update.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampleDomain1",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/domains/domainTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampleDomain1/domainTopics/exampleDomainTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopicEventSubscriptions_Update",
+  "title": "DomainTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampleDomain1",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_CreateOrUpdate.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainTopicName": "exampledomaintopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampledomaintopic1",
+        "type": "Microsoft.EventGrid/domains/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1/topics/exampledomaintopic1",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopics_CreateOrUpdate",
+  "title": "DomainTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainTopicName": "exampledomaintopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainTopicName": "exampledomaintopic1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainTopicName": "exampledomaintopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DomainTopics_Delete",
+  "title": "DomainTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Get.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "domainTopicName": "topic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "topic1",
+        "type": "Microsoft.EventGrid/domains/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2/topics/topic1",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "DomainTopics_Get",
+  "title": "DomainTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "domainTopicName": "topic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_ListByDomain.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_ListByDomain.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_ListByDomain.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/DomainTopics_ListByDomain.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "domainCli100topic1",
+            "type": "Microsoft.EventGrid/domains/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/devexprg/providers/Microsoft.EventGrid/domains/domainCli100/topics/domainCli100topic1",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "domainCli100topic2",
+            "type": "Microsoft.EventGrid/domains/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/devexprg/providers/Microsoft.EventGrid/domains/domainCli100/topics/domainCli100topic2",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DomainTopics_ListByDomain",
+  "title": "DomainTopics_ListByDomain"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_CreateOrUpdate.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainInfo": {
+      "location": "westus2",
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "domainName": "exampledomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampledomain1",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_CreateOrUpdate",
+  "title": "Domains_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainInfo": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Domains_Delete",
+  "title": "Domains_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampledomain2",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+        "location": "westcentralus",
+        "properties": {
+          "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_Get",
+  "title": "Domains_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListByResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampledomain1",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampledomain2",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Domains_ListByResourceGroup",
+  "title": "Domains_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListBySubscription.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampledomain1",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampledomain2",
+            "type": "Microsoft.EventGrid/domains",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampledomain2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Domains_ListBySubscription",
+  "title": "Domains_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Domains_ListSharedAccessKeys",
+  "title": "Domains_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain2",
     "regenerateKeyRequest": {
       "keyName": "key1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain2",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Domains_RegenerateKey",
+  "title": "Domains_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "domainName": "exampledomain1",
     "domainUpdateParameters": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Domains_Update.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "domainName": "exampledomain1",
+    "domainUpdateParameters": {
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "exampledomain1",
+        "type": "Microsoft.EventGrid/domains",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/exampledomain1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampledomain1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Domains_Update",
+  "title": "Domains_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "AzureFunction",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "HybridConnection",
+          "properties": {
+            "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "ServiceBusQueue",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "ServiceBusTopic",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deadLetterDestination": {
+          "endpointType": "StorageBlob",
+          "properties": {
+            "blobContainerName": "contosocontainer",
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "destination": {
+          "endpointType": "StorageQueue",
+          "properties": {
+            "queueMessageTimeToLiveInSeconds": 300,
+            "queueName": "queue1",
+            "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "EventHub",
+          "properties": {
+            "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResource.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription10",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription10",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResourceGroup.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForSubscription.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false
+        }
+      }
+    },
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "",
+            "subjectEndsWith": ""
+          },
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_CreateOrUpdate",
+  "title": "EventSubscriptions_CreateOrUpdateForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_CreateOrUpdateForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForCustomTopic.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription10",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResource.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription10",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForResourceGroup.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_DeleteForSubscription.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "EventSubscriptions_Delete",
+  "title": "EventSubscriptions_DeleteForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetDeliveryAttributes",
+  "title": "EventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_EventHubDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResource.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetForSubscription.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Get",
+  "title": "EventSubscriptions_GetForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForCustomTopic.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResource.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResourceGroup.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_GetFullUrlForSubscription.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_GetFullUrl",
+  "title": "EventSubscriptions_GetFullUrlForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByDomainTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByDomainTopic.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "examplerg",
     "domainName": "domain1",
     "topicName": "topic1",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByDomainTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByDomainTopic.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "domainName": "domain1",
+    "topicName": "topic1",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/domains/domain1/topics/topic1"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/domains/domain1/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListByDomainTopic",
+  "title": "EventSubscriptions_ListByDomainTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByResource.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "providerNamespace": "Microsoft.EventGrid",
+    "resourceTypeName": "topics",
+    "resourceName": "exampletopic2",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListByResource",
+  "title": "EventSubscriptions_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListByResource.json
@@ -5,7 +5,7 @@
     "providerNamespace": "Microsoft.EventGrid",
     "resourceTypeName": "topics",
     "resourceName": "exampletopic2",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "resourceGroupName": "examplerg",
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          },
+          {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                },
+                "endpointType": "WebHook"
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            },
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription4",
+            "name": "examplesubscription4",
+            "type": "Microsoft.EventGrid/eventSubscriptions"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalByResourceGroup",
+  "title": "EventSubscriptions_ListGlobalByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroup.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "resourceGroupName": "examplerg",
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.Resources.ResourceGroups"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalByResourceGroupForTopicType.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.Resources.ResourceGroups"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalByResourceGroupForTopicType",
+  "title": "EventSubscriptions_ListGlobalByResourceGroupForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          },
+          {
+            "name": "examplesubscription4",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription4",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalBySubscription",
+  "title": "EventSubscriptions_ListGlobalBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.Resources.Subscriptions"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListGlobalBySubscriptionForTopicType.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.Resources.Subscriptions"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription3",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListGlobalBySubscriptionForTopicType",
+  "title": "EventSubscriptions_ListGlobalBySubscriptionForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroup.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalByResourceGroup",
+  "title": "EventSubscriptions_ListRegionalByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.EventHub.namespaces"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalByResourceGroupForTopicType",
+  "title": "EventSubscriptions_ListRegionalByResourceGroupForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalByResourceGroupForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscription.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "EventHub",
+                "properties": {
+                  "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalBySubscription",
+  "title": "EventSubscriptions_ListRegionalBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "location": "westus2",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicTypeName": "Microsoft.EventHub.namespaces"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription10",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription10",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          },
+          {
+            "name": "examplesubscription11",
+            "type": "Microsoft.EventGrid/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription11",
+            "properties": {
+              "destination": {
+                "endpointType": "WebHook",
+                "properties": {
+                  "endpointBaseUrl": "https://requestb.in/15ksip71"
+                }
+              },
+              "filter": {
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "Finance",
+                "HR"
+              ],
+              "provisioningState": "Succeeded",
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventhub/namespaces/examplenamespace1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_ListRegionalBySubscriptionForTopicType",
+  "title": "EventSubscriptions_ListRegionalBySubscriptionForTopicType"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_ListRegionalBySubscriptionForTopicType.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "location": "westus2",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicTypeName": "Microsoft.EventHub.namespaces"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "AzureFunction",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "AzureFunction",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Web/sites/ContosoSite/funtions/ContosoFunc"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_AzureFunctionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_EventHubDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "EventHub",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "EventHub",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_EventHubDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "HybridConnection",
+        "properties": {
+          "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "HybridConnection",
+            "properties": {
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Relay/namespaces/ContosoNamespace/hybridConnections/HC1"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_HybridConnectionDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "ServiceBusQueue",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "ServiceBusQueue",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/queues/SBQ"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_ServiceBusQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "ServiceBusTopic",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "ServiceBusTopic",
+            "properties": {
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.ServiceBus/namespaces/ContosoNamespace/topics/SBT"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_ServiceBusTopicDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "deadLetterDestination": {
+        "endpointType": "StorageBlob",
+        "properties": {
+          "blobContainerName": "contosocontainer",
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "destination": {
+        "endpointType": "StorageQueue",
+        "properties": {
+          "queueMessageTimeToLiveInSeconds": 300,
+          "queueName": "queue1",
+          "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": false,
+        "subjectBeginsWith": "ExamplePrefix",
+        "subjectEndsWith": "ExampleSuffix"
+      }
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+              "blobContainerName": "contosocontainer",
+              "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueMessageTimeToLiveInSeconds": 300,
+              "queueName": "queue1",
+              "resourceId": "/subscriptions/d33c5f7a-02ea-40f4-bf52-07f17e84d6a8/resourceGroups/TestRG/providers/Microsoft.Storage/storageAccounts/contosostg"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Creating",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_StorageQueueDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "deadLetterDestination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForCustomTopic_WebhookDestination.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/topics/exampletopic2"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForCustomTopic_WebhookDestination"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResource.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventHub/namespaces/examplenamespace1"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription2",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForResourceGroup.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription2",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "EventHub",
+        "properties": {
+          "resourceId": "/subscriptions/55f3dcd4-cac7-43b4-990b-a139d62a1eb2/resourceGroups/TestRG/providers/Microsoft.EventHub/namespaces/ContosoNamespace/eventhubs/EH1"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription2",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription2",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForSubscription.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription3",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplesubscription3",
+        "type": "Microsoft.EventGrid/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/Microsoft.EventGrid/topics/exampletopic2/providers/Microsoft.EventGrid/eventSubscriptions/examplesubscription3",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [],
+          "provisioningState": "Succeeded",
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+        }
+      }
+    }
+  },
+  "operationId": "EventSubscriptions_Update",
+  "title": "EventSubscriptions_UpdateForSubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForSubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/EventSubscriptions_UpdateForSubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription3",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ExtensionTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ExtensionTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "providerNamespace": "microsoft.storage",
     "resourceGroupName": "examplerg",
     "resourceName": "exampleResourceName",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ExtensionTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/ExtensionTopics_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "providerNamespace": "microsoft.storage",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceTypeName": "storageaccounts",
+    "scope": "subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "providers/Microsoft.EventGrid/extensionTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default",
+        "properties": {
+          "description": "Extension topic for /subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.storage/storageaccounts/exampleResourceName/providers/Microsoft.eventgrid/extensionTopics/default that can be used to obtain metrics",
+          "systemTopic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleResourceName-2a41650f-00dd-4790-b3ab-dabd12d227cb"
+        }
+      }
+    }
+  },
+  "operationId": "ExtensionTopics_Get",
+  "title": "ExtensionTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "deliveryConfiguration": {
+          "deliveryMode": "Queue",
+          "queue": {
+            "eventTimeToLive": "P1D",
+            "maxDeliveryCount": 4,
+            "receiveLockDurationInSeconds": 60
+          }
+        },
+        "eventDeliverySchema": "CloudEventSchemaV1_0"
+      }
+    },
+    "eventSubscriptionName": "examplenamespacetopicEventSub2",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_CreateOrUpdate",
+  "title": "NamespaceTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "deliveryConfiguration": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplenamespacetopicEventSub2",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Delete",
+  "title": "NamespaceTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplenamespacetopicEventSub2",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
@@ -11,8 +11,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplenamespacetopicEventSub1",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplenamespacetopicEventSub1",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopicEventSub2",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 4,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Get",
+  "title": "NamespaceTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName",
+    "namespaceName": "exampleNamespace",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopic"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "NamespaceTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName",
     "namespaceName": "exampleNamespace",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleDomainTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_GetFullUrl",
+  "title": "NamespaceTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_ListByNamespaceTopic.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplenamespacetopicEventSub1",
+            "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub1",
+            "properties": {
+              "deliveryConfiguration": {
+                "deliveryMode": "Queue",
+                "queue": {
+                  "eventTimeToLive": "P1D",
+                  "maxDeliveryCount": 5,
+                  "receiveLockDurationInSeconds": 50
+                }
+              },
+              "eventDeliverySchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": null
+          },
+          {
+            "name": "examplenamespacetopicEventSub2",
+            "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2/eventSubscriptions/examplenamespacetopicEventSub2",
+            "properties": {
+              "deliveryConfiguration": {
+                "deliveryMode": "Queue",
+                "queue": {
+                  "eventTimeToLive": "P1D",
+                  "maxDeliveryCount": 4,
+                  "receiveLockDurationInSeconds": 60
+                }
+              },
+              "eventDeliverySchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_ListByNamespaceTopic",
+  "title": "NamespaceTopicEventSubscriptions_ListByNamespaceTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Update.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleNamespaceTopicEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "properties": {
+        "deliveryConfiguration": {
+          "deliveryMode": "Queue",
+          "queue": {
+            "eventTimeToLive": "P1D",
+            "maxDeliveryCount": 3,
+            "receiveLockDurationInSeconds": 60
+          }
+        },
+        "eventDeliverySchema": "CloudEventSchemaV1_0"
+      }
+    },
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopicName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceTopicEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 3,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": null
+      }
+    },
+    "202": {
+      "body": {
+        "name": "exampleNamespaceTopicEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/namespaces/topics/eventsubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1",
+        "properties": {
+          "deliveryConfiguration": {
+            "deliveryMode": "Queue",
+            "queue": {
+              "eventTimeToLive": "P1D",
+              "maxDeliveryCount": 3,
+              "receiveLockDurationInSeconds": 60
+            }
+          },
+          "eventDeliverySchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Updating"
+        },
+        "systemData": null
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "NamespaceTopicEventSubscriptions_Update",
+  "title": "NamespaceTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleNamespaceTopicEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "properties": {
@@ -61,8 +61,8 @@
         "systemData": null
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/eventSubscriptions/exampleNamespaceTopicEventSubscriptionName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_CreateOrUpdate.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "namespaceTopicInfo": {
+      "properties": {
+        "eventRetentionInDays": 1,
+        "inputSchema": "CloudEventSchemaV1_0",
+        "publisherType": "Custom"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Creating",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_CreateOrUpdate",
+  "title": "NamespaceTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "namespaceTopicInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NamespaceTopics_Delete",
+  "title": "NamespaceTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e41",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e41/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_Get",
+  "title": "NamespaceTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e41",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListByNamespace.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplenamespacetopic2",
+            "type": "Microsoft.EventGrid/namespaces/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic2",
+            "properties": {
+              "eventRetentionInDays": 1,
+              "inputSchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded",
+              "publisherType": "Custom"
+            },
+            "systemData": null
+          },
+          {
+            "name": "examplenamespacetopic4",
+            "type": "Microsoft.EventGrid/namespaces/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/examplenamespace2/topics/examplenamespacetopic4",
+            "properties": {
+              "eventRetentionInDays": 1,
+              "inputSchema": "CloudEventSchemaV1_0",
+              "provisioningState": "Succeeded",
+              "publisherType": "Custom"
+            },
+            "systemData": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_ListByNamespace",
+  "title": "NamespaceTopics_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_ListSharedAccessKeys.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_ListSharedAccessKeys",
+  "title": "NamespaceTopics_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "examplenamespace2",
     "regenerateKeyRequest": {
       "keyName": "key1"
@@ -18,8 +18,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_RegenerateKey.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "examplenamespace2",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "examplenamespacetopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_RegenerateKey",
+  "title": "NamespaceTopics_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "namespaceTopicUpdateParameters": {
       "properties": {
@@ -40,8 +40,8 @@
         "systemData": null
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NamespaceTopics_Update.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "namespaceTopicUpdateParameters": {
+      "properties": {
+        "eventRetentionInDays": 1
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleNamespaceTopicName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplenamespacetopic2",
+        "type": "Microsoft.EventGrid/namespaces/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1",
+        "properties": {
+          "eventRetentionInDays": 1,
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded",
+          "publisherType": "Custom"
+        },
+        "systemData": null
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topics/exampleNamespaceTopicName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "NamespaceTopics_Update",
+  "title": "NamespaceTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceInfo": {
       "location": "westus",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_CreateOrUpdate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceInfo": {
+      "location": "westus",
+      "properties": {
+        "topicSpacesConfiguration": {
+          "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+          "state": "Enabled"
+        }
+      },
+      "tags": {
+        "tag1": "value11",
+        "tag2": "value22"
+      }
+    },
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/Namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Creating",
+          "topicSpacesConfiguration": {
+            "hostname": null,
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value11",
+          "key2": "value22"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/Namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Creating",
+          "topicSpacesConfiguration": {
+            "hostname": null,
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value11",
+          "key2": "value22"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_CreateOrUpdate",
+  "title": "Namespaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Namespaces_Delete",
+  "title": "Namespaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "West US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2",
+          "key3": "value3"
+        }
+      }
+    }
+  },
+  "operationId": "Namespaces_Get",
+  "title": "Namespaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListByResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/microsoft.eventgrid/namespaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleNamespaceName1",
+            "type": "Microsoft.EventGrid/namespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+            "location": "West US",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicSpacesConfiguration": {
+                "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+                "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+                "state": "Enabled"
+              }
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListByResourceGroup",
+  "title": "Namespaces_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListBySubscription.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleNamespaceName1",
+            "type": "Microsoft.EventGrid/namespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+            "location": "West US",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicSpacesConfiguration": {
+                "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+                "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+                "state": "Enabled"
+              }
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Namespaces_ListBySubscription",
+  "title": "Namespaces_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Namespaces_ListSharedAccessKeys",
+  "title": "Namespaces_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_RegenerateKey.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_RegenerateKey",
+  "title": "Namespaces_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "regenerateKeyRequest": {
       "keyName": "key1"
@@ -17,8 +17,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "namespaceUpdateParameters": {
       "tags": {
@@ -46,8 +46,8 @@
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
-        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2026-06-15-preview",
         "Retry-After": "60"
       }
     }

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_Update.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "namespaceUpdateParameters": {
+      "tags": {
+        "tag1": "value1Updated"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "exampleNamespaceName1",
+        "type": "Microsoft.EventGrid/namespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1",
+        "location": "West US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicSpacesConfiguration": {
+            "hostname": "exampleNamespaceName1.westus-1.mqtt.eventgrid-int.azure.net",
+            "routeTopicResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1",
+            "state": "Enabled"
+          }
+        },
+        "tags": {
+          "key1": "value1Updated"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationStatus/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Location": "https://management.windowsazure.com/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/exampleNamespaceName1/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/operationResults/7B023877-A473-457B-B462-562F97048FB6?api-version=2025-04-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "Namespaces_Update",
+  "title": "Namespaces_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ValidateCustomDomainOwnership.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ValidateCustomDomainOwnership.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -36,8 +36,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ValidateCustomDomainOwnership.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Namespaces_ValidateCustomDomainOwnership.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "customDomainsForTopicSpacesConfiguration": [
+          {
+            "certificateUrl": "string",
+            "expectedTxtRecordName": "txt-record-name-2",
+            "expectedTxtRecordValue": "txt-record-value-2",
+            "fullyQualifiedDomainName": "custom-domain-name-2",
+            "identity": {
+              "type": "SystemAssigned"
+            },
+            "validationState": "Pending"
+          }
+        ],
+        "customDomainsForTopicsConfiguration": [
+          {
+            "certificateUrl": "string",
+            "expectedTxtRecordName": "txt-record-name-1",
+            "expectedTxtRecordValue": "txt-record-value-1",
+            "fullyQualifiedDomainName": "custom-domain-name-1",
+            "identity": {
+              "type": "SystemAssigned"
+            },
+            "validationState": "Pending"
+          }
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Namespaces_ValidateCustomDomainOwnership",
+  "title": "Namespaces_ValidateCustomDomainOwnership"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "associationName": "someAssociation",
     "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "associationName": "someAssociation",
+    "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+            "location": "West US",
+            "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+          },
+          "profile": {
+            "name": "someProfile",
+            "accessRules": [
+              {
+                "name": "ipRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "1",
+            "diagnosticSettingsVersion": "1",
+            "enabledLogCategories": [
+              "NspOutbound"
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "someAssociation",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "title": "NetworkSecurityPerimeterConfigurations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_List.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+            "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+                "location": "West US",
+                "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+              },
+              "profile": {
+                "name": "someProfile",
+                "accessRules": [
+                  {
+                    "name": "ipRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": "1",
+                "diagnosticSettingsVersion": "1",
+                "enabledLogCategories": [
+                  "NspOutbound"
+                ]
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "someAssociation",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "title": "NetworkSecurityPerimeterConfigurations_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "resourceName": "exampleResourceName",
     "resourceType": "topics",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Reconcile.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Reconcile.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "associationName": "someAssociation",
     "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
     "resourceGroupName": "examplerg",
@@ -49,8 +49,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Reconcile.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/NetworkSecurityPerimeterConfigurations_Reconcile.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "associationName": "someAssociation",
+    "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter",
+    "resourceGroupName": "examplerg",
+    "resourceName": "exampleResourceName",
+    "resourceType": "topics",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "type": "Microsoft.EventGrid/topics/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/paasrg/providers/Microsoft.EventGrid/topics/egtopic/networkSecurityPerimeterConfigurations/8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter.someAssociation",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/perimeterrg/providers/Microsoft.Network/networkSecurityPerimeters/somePerimeter",
+            "location": "West US",
+            "perimeterGuid": "8f6b6269-84f2-4d09-9e31-1127efcd1e40perimeter"
+          },
+          "profile": {
+            "name": "someProfile",
+            "accessRules": [
+              {
+                "name": "ipRule",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": "1",
+            "diagnosticSettingsVersion": "1",
+            "enabledLogCategories": [
+              "NspOutbound"
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "someAssociation",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurations_Reconcile"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Operations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Operations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Operations_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Operations_List.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.EventGrid/register/action",
+            "display": {
+              "description": "Registers the eventSubscription for the EventGrid resource provider and enables the creation of Event Grid subscriptions.",
+              "operation": "Registers the EventGrid Resource Provider",
+              "provider": "Microsoft Event Grid",
+              "resource": "EventGrid Resource Provider"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/write",
+            "display": {
+              "description": "Create or update a eventSubscription",
+              "operation": "Write EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/read",
+            "display": {
+              "description": "Read a eventSubscription",
+              "operation": "Read EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/eventSubscriptions/delete",
+            "display": {
+              "description": "Delete a eventSubscription",
+              "operation": "Delete EventSubscription",
+              "provider": "Microsoft Event Grid",
+              "resource": "eventSubscriptions"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/write",
+            "display": {
+              "description": "Create or update a topic",
+              "operation": "Write Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/read",
+            "display": {
+              "description": "Read a topic",
+              "operation": "Read Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          },
+          {
+            "name": "Microsoft.EventGrid/topics/delete",
+            "display": {
+              "description": "Delete a topic",
+              "operation": "Delete Topic",
+              "provider": "Microsoft Event Grid",
+              "resource": "topics"
+            },
+            "origin": "UserAndSystem"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "Operations_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_AuthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_AuthorizePartner.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerInfo": {
+      "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+      "partnerName": "Contoso.Finance",
+      "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_AuthorizePartner",
+  "title": "PartnerConfigurations_AuthorizePartner"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_AuthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_AuthorizePartner.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerInfo": {
       "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
       "partnerName": "Contoso.Finance",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerConfigurationInfo": {
       "properties": {
         "partnerAuthorization": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_CreateOrUpdate.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerConfigurationInfo": {
+      "properties": {
+        "partnerAuthorization": {
+          "authorizedPartnersList": [
+            {
+              "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+              "partnerName": "Contoso.Finance",
+              "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+            },
+            {
+              "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+              "partnerName": "fabrikam.HR",
+              "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+            }
+          ],
+          "defaultMaximumExpirationTimeInDays": 10
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_CreateOrUpdate",
+  "title": "PartnerConfigurations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerConfigurations_Delete",
+  "title": "PartnerConfigurations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
@@ -8,8 +8,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_Get",
+  "title": "PartnerConfigurations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListByResourceGroup.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventGrid/partnerConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+            "location": "global",
+            "properties": {
+              "partnerAuthorization": {
+                "authorizedPartnersList": [
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                    "partnerName": "Contoso.Finance",
+                    "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+                  },
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                    "partnerName": "fabrikam.HR",
+                    "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+                  }
+                ],
+                "defaultMaximumExpirationTimeInDays": 10
+              }
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_ListByResourceGroup",
+  "title": "PartnerConfigurations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListBySubscription.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.EventGrid/partnerConfigurations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+            "location": "global",
+            "properties": {
+              "partnerAuthorization": {
+                "authorizedPartnersList": [
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                    "partnerName": "Contoso.Finance",
+                    "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+                  },
+                  {
+                    "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                    "partnerName": "fabrikam.HR",
+                    "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+                  }
+                ],
+                "defaultMaximumExpirationTimeInDays": 10
+              }
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_ListBySubscription",
+  "title": "PartnerConfigurations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_UnauthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_UnauthorizePartner.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerInfo": {
+      "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+      "partnerName": "Contoso.Finance",
+      "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 10
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_UnauthorizePartner",
+  "title": "PartnerConfigurations_UnauthorizePartner"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_UnauthorizePartner.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_UnauthorizePartner.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerInfo": {
       "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
       "partnerName": "Contoso.Finance",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Update.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerConfigurationUpdateParameters": {
+      "properties": {
+        "defaultMaximumExpirationTimeInDays": 100
+      },
+      "tags": {
+        "tag1": "value11",
+        "tag2": "value22"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 100
+          }
+        },
+        "tags": {
+          "tag1": "value11",
+          "tag2": "value22"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.EventGrid/partnerConfigurations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerConfigurations/default",
+        "location": "global",
+        "properties": {
+          "partnerAuthorization": {
+            "authorizedPartnersList": [
+              {
+                "authorizationExpirationTimeInUtc": "2022-01-28T01:20:55.142Z",
+                "partnerName": "Contoso.Finance",
+                "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71"
+              },
+              {
+                "authorizationExpirationTimeInUtc": "2022-02-20T01:00:00.142Z",
+                "partnerName": "fabrikam.HR",
+                "partnerRegistrationImmutableId": "5362bdb6-ce3e-4d0d-9a5b-3eb92c8aab38"
+              }
+            ],
+            "defaultMaximumExpirationTimeInDays": 100
+          }
+        },
+        "tags": {
+          "tag1": "value11",
+          "tag2": "value22"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerConfigurations_Update",
+  "title": "PartnerConfigurations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerConfigurations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerConfigurationUpdateParameters": {
       "properties": {
         "defaultMaximumExpirationTimeInDays": 100

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Activate.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestination1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Activated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Activate",
+  "title": "PartnerDestinations_Activate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Activate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestination1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_CreateOrUpdate.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestination": {
+      "location": "westus2",
+      "properties": {
+        "endpointBaseUrl": "https://www.example/endpoint",
+        "endpointServiceContext": "This is an example",
+        "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+        "messageForActivation": "Sample Activation message",
+        "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404"
+      }
+    },
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "tags": {
+      "tag1": "value1",
+      "tag2": "value2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "westus2",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://www.example/endpoint",
+          "endpointServiceContext": "string",
+          "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+          "messageForActivation": "Sample Activation message",
+          "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "westus2",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://www.example/endpoint",
+          "endpointServiceContext": "string",
+          "expirationTimeIfNotActivatedUtc": "2022-03-14T19:33:43.430Z",
+          "messageForActivation": "Sample Activation message",
+          "partnerRegistrationImmutableId": "0bd70ee2-7d95-447e-ab1f-c4f320019404",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_CreateOrUpdate",
+  "title": "PartnerDestinations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestination": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerDestinations_Delete",
+  "title": "PartnerDestinations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Get",
+  "title": "PartnerDestinations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListByResourceGroup.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerDestinationName1",
+            "type": "Microsoft.EventGrid/partnerDestinations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "endpointBaseUrl": "https://somepartnerhostname",
+              "endpointServiceContext": "ContosoCorp.Accounts.User1",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Some message to the approver",
+              "provisioningState": "Succeeded"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_ListByResourceGroup",
+  "title": "PartnerDestinations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListBySubscription.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerDestinationName1",
+            "type": "Microsoft.EventGrid/partnerDestinations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "endpointBaseUrl": "https://somepartnerhostname",
+              "endpointServiceContext": "ContosoCorp.Accounts.User1",
+              "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+              "messageForActivation": "Some message to the approver",
+              "provisioningState": "Succeeded"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_ListBySubscription",
+  "title": "PartnerDestinations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerDestinationName": "examplePartnerDestinationName1",
     "partnerDestinationUpdateParameters": {
       "tags": {
@@ -72,8 +72,8 @@
         }
       },
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerDestinations_Update.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerDestinationName": "examplePartnerDestinationName1",
+    "partnerDestinationUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplePartnerDestinationName1",
+        "type": "Microsoft.EventGrid/partnerDestinations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerDestinations/examplePartnerDestinationName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "endpointBaseUrl": "https://somepartnerhostname",
+          "endpointServiceContext": "ContosoCorp.Accounts.User1",
+          "expirationTimeIfNotActivatedUtc": "2021-10-21T22:50:25.410433Z",
+          "messageForActivation": "Some message to the approver",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "PartnerDestinations_Update",
+  "title": "PartnerDestinations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceInfo": {
       "location": "westus",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_CreateOrUpdate.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceInfo": {
+      "location": "westus",
+      "properties": {
+        "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_CreateOrUpdate",
+  "title": "PartnerNamespaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerNamespaces_Delete",
+  "title": "PartnerNamespaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "Central US EUAP",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2",
+          "key3": "value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_Get",
+  "title": "PartnerNamespaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListByResourceGroup.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "partnerNamespace123",
+            "type": "Microsoft.EventGrid/partnerNamespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/partnerNamespace123",
+            "location": "Central US EUAP",
+            "properties": {
+              "endpoint": "https://partnernamespace123.centraluseuap-1.eventgrid.azure.net/api/events",
+              "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListByResourceGroup",
+  "title": "PartnerNamespaces_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListBySubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "partnerNamespace123",
+            "type": "Microsoft.EventGrid/partnerNamespaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerNamespaces/partnerNamespace123",
+            "location": "Central US EUAP",
+            "properties": {
+              "endpoint": "https://partnernamespace123.centraluseuap-1.eventgrid.azure.net/api/events",
+              "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2",
+              "key3": "value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListBySubscription",
+  "title": "PartnerNamespaces_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_ListSharedAccessKeys",
+  "title": "PartnerNamespaces_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "regenerateKeyRequest": {
       "keyName": "key1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_RegenerateKey",
+  "title": "PartnerNamespaces_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Update.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerNamespaceName": "examplePartnerNamespaceName1",
+    "partnerNamespaceUpdateParameters": {
+      "tags": {
+        "tag1": "value1"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerNamespaceName1",
+        "type": "Microsoft.EventGrid/partnerNamespaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerNamespaces/examplePartnerNamespaceName1",
+        "location": "Central US EUAP",
+        "properties": {
+          "endpoint": "https://examplePartnerNamespaceName1.centraluseuap-1.eventgrid.azure.net/api/events",
+          "partnerRegistrationFullyQualifiedId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerNamespaces_Update",
+  "title": "PartnerNamespaces_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerNamespaces_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerNamespaceName": "examplePartnerNamespaceName1",
     "partnerNamespaceUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationInfo": {
       "location": "global",
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationInfo": {
+      "location": "global",
+      "tags": {
+        "key1": "value1",
+        "key2": "Value2",
+        "key3": "Value3"
+      }
+    },
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_CreateOrUpdate",
+  "title": "PartnerRegistrations_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerRegistrations_Delete",
+  "title": "PartnerRegistrations_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "Value2",
+          "key3": "Value3"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_Get",
+  "title": "PartnerRegistrations_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListByResourceGroup.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ContosoCorpAccount1",
+            "type": "Microsoft.EventGrid/partnerRegistrations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+            "location": "global",
+            "properties": {
+              "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "Value2",
+              "key3": "Value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_ListByResourceGroup",
+  "title": "PartnerRegistrations_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListBySubscription.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ContosoCorpAccount1",
+            "type": "Microsoft.EventGrid/partnerRegistrations",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerRegistrations/ContosoCorpAccount1",
+            "location": "global",
+            "properties": {
+              "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "Value2",
+              "key3": "Value3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_ListBySubscription",
+  "title": "PartnerRegistrations_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Update.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerRegistrationName": "examplePartnerRegistrationName1",
+    "partnerRegistrationUpdateParameters": {
+      "tags": {
+        "NewKey": "NewValue"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerRegistrationName1",
+        "type": "Microsoft.EventGrid/partnerRegistrations",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerRegistrations/examplePartnerRegistrationName1",
+        "location": "global",
+        "properties": {
+          "partnerRegistrationImmutableId": "cda82399-79fe-4d5a-bc6d-b05a437204d9",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "NewKey": "NewValue"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerRegistrations_Update",
+  "title": "PartnerRegistrations_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerRegistrations_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerRegistrationName": "examplePartnerRegistrationName1",
     "partnerRegistrationUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_CreateOrUpdate",
+  "title": "PartnerTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Delete",
+  "title": "PartnerTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Get",
+  "title": "PartnerTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "PartnerTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_GetFullUrl",
+  "title": "PartnerTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 10
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+            }
+          },
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_ListByPartnerTopic",
+  "title": "PartnerTopicEventSubscriptions_ListByPartnerTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_ListByPartnerTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/partnerTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopicEventSubscriptions_Update",
+  "title": "PartnerTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Activate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Activate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Activate.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Activated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Activate",
+  "title": "PartnerTopics_Activate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicInfo": {
       "location": "westus2",
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_CreateOrUpdate.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicInfo": {
+      "location": "westus2",
+      "properties": {
+        "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+        "messageForActivation": "Example message for activation",
+        "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+        "partnerTopicFriendlyDescription": "Example description",
+        "source": "ContosoCorp.Accounts.User1"
+      }
+    },
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "tags": {
+      "tag1": "value1",
+      "tag2": "value2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+          "messageForActivation": "Example message for activation",
+          "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+          "partnerTopicFriendlyDescription": "Example description",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "expirationTimeIfNotActivatedUtc": "2022-03-23T23:06:13.109Z",
+          "messageForActivation": "Example message for activation",
+          "partnerRegistrationImmutableId": "6f541064-031d-4cc8-9ec3-a3b4fc0f7185",
+          "partnerTopicFriendlyDescription": "Example description",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopics_CreateOrUpdate",
+  "title": "PartnerTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Deactivate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Deactivate.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopic1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "Deactivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Deactivate",
+  "title": "PartnerTopics_Deactivate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Deactivate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Deactivate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopic1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PartnerTopics_Delete",
+  "title": "PartnerTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePartnerTopicName1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopicName1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Get",
+  "title": "PartnerTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListByResourceGroup.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerTopic1",
+            "type": "Microsoft.EventGrid/partnerTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "provisioningState": "Succeeded",
+              "source": "ContosoCorp.Accounts.User1"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopics_ListByResourceGroup",
+  "title": "PartnerTopics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListBySubscription.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplePartnerTopic1",
+            "type": "Microsoft.EventGrid/partnerTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+            "location": "centraluseuap",
+            "properties": {
+              "activationState": "NeverActivated",
+              "provisioningState": "Succeeded",
+              "source": "ContosoCorp.Accounts.User1"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PartnerTopics_ListBySubscription",
+  "title": "PartnerTopics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Update.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "partnerTopicName": "examplePartnerTopicName1",
+    "partnerTopicUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "examplePartnerTopic1",
+        "type": "Microsoft.EventGrid/partnerTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/partnerTopics/examplePartnerTopic1",
+        "location": "centraluseuap",
+        "properties": {
+          "activationState": "NeverActivated",
+          "provisioningState": "Succeeded",
+          "source": "ContosoCorp.Accounts.User1"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "PartnerTopics_Update",
+  "title": "PartnerTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PartnerTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "partnerTopicName": "examplePartnerTopicName1",
     "partnerTopicUpdateParameters": {
       "tags": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_CreateOrUpdate.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingInfo": {
+      "properties": {
+        "clientGroupName": "exampleClientGroupName1",
+        "permission": "Publisher",
+        "topicSpaceName": "exampleTopicSpaceName1"
+      }
+    },
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    }
+  },
+  "operationId": "PermissionBindings_CreateOrUpdate",
+  "title": "PermissionBindings_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingInfo": {
       "properties": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingName": "examplePermissionBindingName1",
     "resourceGroupName": "examplerg",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PermissionBindings_Delete",
+  "title": "PermissionBindings_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "permissionBindingName": "examplePermissionBindingName1",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "permissionBindingName": "examplePermissionBindingName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplePermissionBindingName1",
+        "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+        "properties": {
+          "clientGroupName": "exampleClientGroupName1",
+          "permission": "Publisher",
+          "provisioningState": "Succeeded",
+          "topicSpaceName": "exampleTopicSpaceName1"
+        }
+      }
+    }
+  },
+  "operationId": "PermissionBindings_Get",
+  "title": "PermissionBindings_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PermissionBindings_ListByNamespace.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/permissionBindings?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "examplePermissionBindingName1",
+            "type": "Microsoft.EventGrid/namespaces/permissionBindings",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/permissionBindings/examplePermissionBindingName1",
+            "properties": {
+              "clientGroupName": "exampleClientGroupName1",
+              "permission": "Publisher",
+              "provisioningState": "Succeeded",
+              "topicSpaceName": "exampleTopicSpaceName1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PermissionBindings_ListByNamespace",
+  "title": "PermissionBindings_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "PrivateEndpointConnections_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Test",
+            "actionsRequired": "None",
+            "status": "Pending"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "PrivateEndpointConnections_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_ListByResource.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+            "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+            "properties": {
+              "groupIds": [
+                "topic"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Test",
+                "actionsRequired": "None",
+                "status": "Pending"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_ListByResource",
+  "title": "PrivateEndpointConnections_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_ListByResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Update.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "approving connection",
+          "actionsRequired": "None",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approving connection",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "type": "Microsoft.EventGrid/topics/privateEndpointConnections",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1/privateEndpointConnections/BMTPE5.8A30D251-4C61-489D-A1AA-B37C4A329B8B",
+        "properties": {
+          "groupIds": [
+            "topic"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/bmtpe5"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "approving connection",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Update",
+  "title": "PrivateEndpointConnections_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateEndpointConnections_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateEndpointConnection": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "privateLinkResourceName": "topic",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "privateLinkResourceName": "topic",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "topic",
+        "type": "Microsoft.EventGrid/topics/privateLinkResources",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/topics/exampletopic1/privateLinkResources/topic",
+        "properties": {
+          "displayName": "Event Grid topic",
+          "groupId": "topic",
+          "requiredMembers": [
+            "topic"
+          ],
+          "requiredZoneNames": [
+            "privatelink.eventgrid.azure.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_Get",
+  "title": "PrivateLinkResources_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_ListByResource.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "parentName": "exampletopic1",
+    "parentType": "topics",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "topic",
+            "type": "Microsoft.EventGrid/topics/privateLinkResources",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/amh/providers/Microsoft.EventGrid/topics/exampletopic1/privateLinkResources/topic",
+            "properties": {
+              "displayName": "Event Grid topic",
+              "groupId": "topic",
+              "requiredMembers": [
+                "topic"
+              ],
+              "requiredZoneNames": [
+                "privatelink.eventgrid.azure.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByResource",
+  "title": "PrivateLinkResources_ListByResource"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_ListByResource.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/PrivateLinkResources_ListByResource.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "parentName": "exampletopic1",
     "parentType": "topics",
     "resourceGroupName": "examplerg",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_CreateOrUpdate",
+  "title": "SystemTopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SystemTopicEventSubscriptions_Delete",
+  "title": "SystemTopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_Get",
+  "title": "SystemTopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "SystemTopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_GetFullUrl",
+  "title": "SystemTopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_ListBySystemTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_ListBySystemTopic.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_ListBySystemTopic.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_ListBySystemTopic.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "subjectBeginsWith": "",
+                "subjectEndsWith": ""
+              },
+              "labels": [],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 10
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+            }
+          },
+          {
+            "name": "examplesubscription2",
+            "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/examplesubscription2",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_ListBySystemTopic",
+  "title": "SystemTopicEventSubscriptions_ListBySystemTopic"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopicEventSubscriptions_Update",
+  "title": "SystemTopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_CreateOrUpdate.json
@@ -1,0 +1,127 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicInfo": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {}
+        }
+      },
+      "location": "centraluseuap",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": [
+            {
+              "keyEncryptionKeyIdentity": {
+                "type": "UserAssigned",
+                "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+              },
+              "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+            }
+          ]
+        },
+        "platformCapabilities": {
+          "confidentialCompute": {
+            "mode": "Enabled"
+          }
+        },
+        "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+        "topicType": "microsoft.storage.storageaccounts"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic1",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleSystemTopic1",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopics_CreateOrUpdate",
+  "title": "SystemTopics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1"
@@ -9,8 +9,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SystemTopics_Delete",
+  "title": "SystemTopics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        }
+      }
+    }
+  },
+  "operationId": "SystemTopics_Get",
+  "title": "SystemTopics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListByResourceGroup.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "pubstgrunnerb71cd29e-86fad330-7bac-4238-8cab-9e46b75165aa",
+            "type": "Microsoft.EventGrid/systemTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/pubstgrunnerb71cd29e-86fad330-7bac-4238-8cab-9e46b75165aa",
+            "location": "centraluseuap",
+            "properties": {
+              "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+              "provisioningState": "Succeeded",
+              "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+              "topicType": "microsoft.storage.storageaccounts"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopics_ListByResourceGroup",
+  "title": "SystemTopics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListBySubscription.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampleSystemTopic2",
+            "type": "Microsoft.EventGrid/systemTopics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+            "location": "centraluseuap",
+            "properties": {
+              "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+              "provisioningState": "Succeeded",
+              "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+              "topicType": "microsoft.storage.storageaccounts"
+            },
+            "tags": null
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SystemTopics_ListBySubscription",
+  "title": "SystemTopics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Update.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "systemTopicName": "exampleSystemTopic1",
+    "systemTopicUpdateParameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "location": "centraluseuap",
+        "properties": {
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        },
+        "tags": null
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleSystemTopic2",
+        "type": "Microsoft.EventGrid/systemTopics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/systemTopics/exampleSystemTopic2",
+        "location": "centraluseuap",
+        "properties": {
+          "metricResourceId": "183c0fb1-17ff-47b6-ac77-5a47420ab01e",
+          "provisioningState": "Succeeded",
+          "source": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/microsoft.storage/storageaccounts/pubstgrunnerb71cd29e",
+          "topicType": "microsoft.storage.storageaccounts"
+        },
+        "tags": null
+      }
+    }
+  },
+  "operationId": "SystemTopics_Update",
+  "title": "SystemTopics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/SystemTopics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "systemTopicName": "exampleSystemTopic1",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionInfo": {
       "properties": {
         "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionInfo": {
+      "properties": {
+        "destination": {
+          "endpointType": "WebHook",
+          "properties": {
+            "endpointUrl": "https://requestb.in/15ksip71"
+          }
+        },
+        "filter": {
+          "isSubjectCaseSensitive": false,
+          "subjectBeginsWith": "ExamplePrefix",
+          "subjectEndsWith": "ExampleSuffix"
+        }
+      }
+    },
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": null,
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_CreateOrUpdate",
+  "title": "TopicEventSubscriptions_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "TopicEventSubscriptions_Delete",
+  "title": "TopicEventSubscriptions_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplesubscription1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/examplesubscription1",
+        "properties": {
+          "destination": {
+            "endpointType": "StorageQueue",
+            "properties": {
+              "queueName": "que",
+              "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "includedEventTypes": [
+              "Microsoft.Storage.BlobCreated",
+              "Microsoft.Storage.BlobDeleted"
+            ],
+            "isSubjectCaseSensitive": false,
+            "subjectBeginsWith": "ExamplePrefix",
+            "subjectEndsWith": "ExampleSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_Get",
+  "title": "TopicEventSubscriptions_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "header1",
+            "type": "Static",
+            "properties": {
+              "isSecret": false,
+              "value": "NormalValue"
+            }
+          },
+          {
+            "name": "header2",
+            "type": "Dynamic",
+            "properties": {
+              "sourceField": "data.foo"
+            }
+          },
+          {
+            "name": "header3",
+            "type": "Static",
+            "properties": {
+              "isSecret": true,
+              "value": "mySecretValue"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_GetDeliveryAttributes",
+  "title": "TopicEventSubscriptions_GetDeliveryAttributes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetDeliveryAttributes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetDeliveryAttributes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetFullUrl.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "endpointUrl": "https://requestb.in/15ksip71"
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_GetFullUrl",
+  "title": "TopicEventSubscriptions_GetFullUrl"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetFullUrl.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_GetFullUrl.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_List.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "examplesubscription1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "examplesubscription1",
+            "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/examplesubscription1",
+            "properties": {
+              "destination": {
+                "endpointType": "StorageQueue",
+                "properties": {
+                  "queueName": "que",
+                  "resourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.Storage/storageAccounts/testtrackedsource"
+                }
+              },
+              "eventDeliverySchema": "EventGridSchema",
+              "filter": {
+                "includedEventTypes": [
+                  "Microsoft.Storage.BlobCreated",
+                  "Microsoft.Storage.BlobDeleted"
+                ],
+                "isSubjectCaseSensitive": false,
+                "subjectBeginsWith": "ExamplePrefix",
+                "subjectEndsWith": "ExampleSuffix"
+              },
+              "labels": [
+                "label1",
+                "label2"
+              ],
+              "provisioningState": "Succeeded",
+              "retryPolicy": {
+                "eventTimeToLiveInMinutes": 1440,
+                "maxDeliveryAttempts": 30
+              },
+              "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_List",
+  "title": "TopicEventSubscriptions_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "examplesubscription1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "eventSubscriptionName": "exampleEventSubscriptionName1",
+    "eventSubscriptionUpdateParameters": {
+      "destination": {
+        "endpointType": "WebHook",
+        "properties": {
+          "endpointUrl": "https://requestb.in/15ksip71"
+        }
+      },
+      "filter": {
+        "isSubjectCaseSensitive": true,
+        "subjectBeginsWith": "existingPrefix",
+        "subjectEndsWith": "newSuffix"
+      },
+      "labels": [
+        "label1",
+        "label2"
+      ]
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampleTopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampleEventSubscriptionName1",
+        "type": "Microsoft.EventGrid/topics/eventSubscriptions",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1/eventSubscriptions/exampleEventSubscriptionName1",
+        "properties": {
+          "destination": {
+            "endpointType": "WebHook",
+            "properties": {
+              "endpointBaseUrl": "https://requestb.in/15ksip71"
+            }
+          },
+          "eventDeliverySchema": "EventGridSchema",
+          "filter": {
+            "isSubjectCaseSensitive": true,
+            "subjectBeginsWith": "existingPrefix",
+            "subjectEndsWith": "newSuffix"
+          },
+          "labels": [
+            "label1",
+            "label2"
+          ],
+          "provisioningState": "Succeeded",
+          "retryPolicy": {
+            "eventTimeToLiveInMinutes": 1440,
+            "maxDeliveryAttempts": 30
+          },
+          "topic": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampleTopic1"
+        }
+      }
+    }
+  },
+  "operationId": "TopicEventSubscriptions_Update",
+  "title": "TopicEventSubscriptions_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicEventSubscriptions_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "eventSubscriptionName": "exampleEventSubscriptionName1",
     "eventSubscriptionUpdateParameters": {
       "destination": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_CreateOrUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceInfo": {
+      "properties": {
+        "topicTemplates": [
+          "filter1",
+          "filter2"
+        ]
+      }
+    },
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "TopicSpaces_CreateOrUpdate",
+  "title": "TopicSpaces_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
@@ -10,8 +10,8 @@
     "200": {},
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "TopicSpaces_Delete",
+  "title": "TopicSpaces_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "exampleNamespaceName1",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "exampleNamespaceName1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicSpaceName": "exampleTopicSpaceName1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleTopicSpaceName1",
+        "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "topicTemplates": [
+            "filter1",
+            "filter2"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "TopicSpaces_Get",
+  "title": "TopicSpaces_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_ListByNamespace.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "namespaceName": "namespace123",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_ListByNamespace.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicSpaces_ListByNamespace.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "namespaceName": "namespace123",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://xyz.net/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/providers/microsoft.eventgrid/namespaces/namespace123/topicSpaces?2025-04-01-preview&%24skiptoken=7ZjtaqQwFIbvRWp%2f1dHJ6GgHypK1yro707F%2bdOn%2bUxPdMJhIkmqh9N43cYfeg6CE%2bB45mI%2bHlxz9MCh%2bl0dCL8I4fBi%2fo7woc%2bNg%2fJVyEAfbrgZiIda1jKENx4K98QaLzUQoYpOwCJUbiqUt3mrRcDJIwqiwkRt4%2b30VWMAFgeVW%2b8YKdq5v3e99Dzn3bR14W3vgbCQIc2H3pOFMsFZu8Iip7DhBtmQDacQ3PfqoctRrH4ADgLV1rK1nDRyPBE%2b3N%2bKixmQXTB9Mrzb92gRgDtXd3FW6B3WWPGrt49F5fYS%2ffP7SJxf4dZk7pBvYZYVK2ypRZKFSwFEyyV%2b01Co6K7X3PE%2bnPIexigKl4lQnwy7SL%2bxgeIIlDKGcTslrB6cu5SZoJ6dpwziCbqqC8ll1QQtDeqp5k81zbFTPK9rh67znhfSEXkO9DNV0Vl%2b9fz2MYy19pJuHbm%2fUnqlNMu6uEMFKcdEU83NZ%2fAijpyKDx9WSC7fk9wz%2bSY4z0tWWi7alPiGjMjun0Qpy0SAjqEud9ZTUBc5ya53%2fFFcrLh4izBO4Ylw0xrm80YZcWS7%2bG%2fInTOGTrnVWTy7Yk593RsV72HUcd5XEqND%2fShRRmJ2Mz38%3d",
+        "value": [
+          {
+            "name": "exampleTopicSpaceName1",
+            "type": "Microsoft.EventGrid/namespaces/topicSpaces",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/namespaces/exampleNamespaceName1/topicSpaces/exampleTopicSpaceName1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "topicTemplates": [
+                "filter1",
+                "filter2"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicSpaces_ListByNamespace",
+  "title": "TopicSpaces_ListByNamespace"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "topicTypeName": "Microsoft.Storage.StorageAccounts"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_Get.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "topicTypeName": "Microsoft.Storage.StorageAccounts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft.Storage.StorageAccounts",
+        "type": "Microsoft.EventGrid/topicTypes",
+        "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts",
+        "properties": {
+          "description": "Microsoft Storage service events.",
+          "displayName": "Storage Accounts",
+          "provider": "Microsoft.Storage",
+          "provisioningState": "Succeeded",
+          "resourceRegionType": "RegionalResource"
+        }
+      }
+    }
+  },
+  "operationId": "TopicTypes_Get",
+  "title": "TopicTypes_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_List.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Eventhub.Namespaces",
+            "type": "Microsoft.EventGrid/topicTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Eventhub.Namespaces",
+            "properties": {
+              "description": "Microsoft EventHubs service events.",
+              "displayName": "EventHubs Namespace",
+              "provider": "Microsoft.Eventhub",
+              "provisioningState": "Succeeded",
+              "resourceRegionType": "RegionalResource"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.StorageAccounts",
+            "type": "Microsoft.EventGrid/topicTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts",
+            "properties": {
+              "description": "Microsoft Storage service events.",
+              "displayName": "Storage Accounts",
+              "provider": "Microsoft.Storage",
+              "provisioningState": "Succeeded",
+              "resourceRegionType": "RegionalResource"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicTypes_List",
+  "title": "TopicTypes_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_ListEventTypes.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "topicTypeName": "Microsoft.Storage.StorageAccounts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage.BlobCreated",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobCreated",
+            "properties": {
+              "description": "Raised when a blob is created.",
+              "displayName": "Blob Created",
+              "schemaUrl": "tbd"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.BlobDeleted",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobDeleted",
+            "properties": {
+              "description": "Raised when a blob is deleted.",
+              "displayName": "Blob Deleted",
+              "schemaUrl": "tbd"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TopicTypes_ListEventTypes",
+  "title": "TopicTypes_ListEventTypes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/TopicTypes_ListEventTypes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "topicTypeName": "Microsoft.Storage.StorageAccounts"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdate.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicInfo": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {}
+        }
+      },
+      "location": "westus2",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": [
+            {
+              "keyEncryptionKeyIdentity": {
+                "type": "UserAssigned",
+                "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+              },
+              "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+            }
+          ]
+        },
+        "platformCapabilities": {
+          "confidentialCompute": {
+            "mode": "Enabled"
+          }
+        }
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "westus2",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "Topics_CreateOrUpdate"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdate.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdate.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdateForAzureArc.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdateForAzureArc.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicInfo": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdateForAzureArc.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_CreateOrUpdateForAzureArc.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicInfo": {
+      "extendedLocation": {
+        "name": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourcegroups/examplerg/providers/Microsoft.ExtendedLocation/CustomLocations/exampleCustomLocation",
+        "type": "CustomLocation"
+      },
+      "kind": "AzureArc",
+      "location": "westus2",
+      "properties": {
+        "inputSchema": "CloudEventSchemaV1_0"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "extendedLocation": {
+          "name": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourcegroups/examplerg/providers/Microsoft.ExtendedLocation/CustomLocations/exampleCustomLocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "kind": "AzureArc",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "inputSchema": "CloudEventSchemaV1_0",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_CreateOrUpdate",
+  "title": "Topics_CreateOrUpdateForAzureArc"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg1",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic1"
@@ -8,8 +8,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     },
     "204": {}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Delete.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg1",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Topics_Delete",
+  "title": "Topics_Delete"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampletopic2",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id": {
+              "clientId": "11af827c-d951-4766-9c41-15565fa13157",
+              "principalId": "a5435982-c82d-453b-b244-3115b7c8789c"
+            }
+          }
+        },
+        "location": "westcentralus",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": [
+              {
+                "keyEncryptionKeyIdentity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentityResourceId": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/azureeventgridrunnerrgcentraluseuap/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-assigned-id"
+                },
+                "keyEncryptionKeyStatus": "Active",
+                "keyEncryptionKeyStatusFriendlyDescription": "Customer Managed Key (CMK) Encryption is 'Active' and running normally.",
+                "keyEncryptionKeyUrl": "https://ege2ekeyvault.vault.azure.net/keys/ValidKey1"
+              }
+            ]
+          },
+          "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Get",
+  "title": "Topics_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListByResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampletopic1",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampletopic2",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListByResourceGroup",
+  "title": "Topics_ListByResourceGroup"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListByResourceGroup.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListBySubscription.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "exampletopic1",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+            "location": "westus2",
+            "properties": {
+              "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          },
+          {
+            "name": "exampletopic2",
+            "type": "Microsoft.EventGrid/topics",
+            "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic2",
+            "location": "westcentralus",
+            "properties": {
+              "endpoint": "https://exampletopic2.westcentralus-1.eventgrid.azure.net/api/events",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListBySubscription",
+  "title": "Topics_ListBySubscription"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListBySubscription.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListEventTypes.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "providerNamespace": "Microsoft.Storage",
+    "resourceGroupName": "examplerg",
+    "resourceName": "ExampleStorageAccount",
+    "resourceTypeName": "storageAccounts",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage.BlobCreated",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobCreated",
+            "properties": {
+              "description": "Raised when a blob is created.",
+              "displayName": "Blob Created",
+              "schemaUrl": "tbd"
+            }
+          },
+          {
+            "name": "Microsoft.Storage.BlobDeleted",
+            "type": "Microsoft.EventGrid/topicTypes/eventTypes",
+            "id": "/providers/Microsoft.EventGrid/topicTypes/Microsoft.Storage.StorageAccounts/eventTypes/Microsoft.Storage.BlobDeleted",
+            "properties": {
+              "description": "Raised when a blob is deleted.",
+              "displayName": "Blob Deleted",
+              "schemaUrl": "tbd"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Topics_ListEventTypes",
+  "title": "Topics_ListEventTypes"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListEventTypes.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListEventTypes.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "providerNamespace": "Microsoft.Storage",
     "resourceGroupName": "examplerg",
     "resourceName": "ExampleStorageAccount",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListSharedAccessKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    }
+  },
+  "operationId": "Topics_ListSharedAccessKeys",
+  "title": "Topics_ListSharedAccessKeys"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListSharedAccessKeys.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_ListSharedAccessKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic2"

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_RegenerateKey.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "regenerateKeyRequest": {
       "keyName": "key1"
     },
@@ -17,8 +17,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2026-06-15-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-06-15-preview"
       }
     }
   },

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_RegenerateKey.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_RegenerateKey.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "regenerateKeyRequest": {
+      "keyName": "key1"
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "testKey1Value",
+        "key2": "testKey2Value"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000/Spring/default?api-version=2025-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.EventGrid/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-04-01-preview"
+      }
+    }
+  },
+  "operationId": "Topics_RegenerateKey",
+  "title": "Topics_RegenerateKey"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Update.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "resourceGroupName": "examplerg",
     "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
     "topicName": "exampletopic1",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Update.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/Topics_Update.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8f6b6269-84f2-4d09-9e31-1127efcd1e40",
+    "topicName": "exampletopic1",
+    "topicUpdateParameters": {
+      "properties": {
+        "inboundIpRules": [
+          {
+            "action": "Allow",
+            "ipMask": "12.18.30.15"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "12.18.176.1"
+          }
+        ],
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {},
+    "201": {
+      "body": {
+        "name": "exampletopic1",
+        "type": "Microsoft.EventGrid/topics",
+        "id": "/subscriptions/8f6b6269-84f2-4d09-9e31-1127efcd1e40/resourceGroups/examplerg/providers/Microsoft.EventGrid/topics/exampletopic1",
+        "location": "westus2",
+        "properties": {
+          "endpoint": "https://exampletopic1.westus2-1.eventgrid.azure.net/api/events",
+          "inboundIpRules": [
+            {
+              "action": "Allow",
+              "ipMask": "12.18.30.15"
+            },
+            {
+              "action": "Allow",
+              "ipMask": "12.18.176.1"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "Topics_Update",
+  "title": "Topics_Update"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview",
+    "api-version": "2026-06-15-preview",
     "verifiedPartnerName": "Contoso.Finance"
   },
   "responses": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_Get.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_Get.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "verifiedPartnerName": "Contoso.Finance"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Contoso.Finance",
+        "type": "Microsoft.EventGrid/verifiedPartners",
+        "id": "/providers/Microsoft.EventGrid/verifiedPartners/Contoso.Finance",
+        "properties": {
+          "organizationName": "Contoso",
+          "partnerDestinationDetails": {
+            "description": "This is custom description",
+            "longDescription": "This is long custom description",
+            "setupUri": "https://www.example.com/"
+          },
+          "partnerDisplayName": "Contoso - Finance Department",
+          "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71",
+          "partnerTopicDetails": {
+            "description": "This is short description",
+            "longDescription": "This is really long long... long description",
+            "setupUri": "https://www.example.com/"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VerifiedPartners_Get",
+  "title": "VerifiedPartners_Get"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-11-15-preview"
+    "api-version": "2026-06-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_List.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2026-06-15-preview/examples/VerifiedPartners_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2025-11-15-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Contoso.Finance",
+            "type": "Microsoft.EventGrid/verifiedPartners",
+            "id": "/providers/Microsoft.EventGrid/verifiedPartners/Contoso.Finance",
+            "properties": {
+              "organizationName": "Contoso",
+              "partnerDestinationDetails": {
+                "description": "This is custom description",
+                "longDescription": "This is long custom description",
+                "setupUri": "https://www.example.com/"
+              },
+              "partnerDisplayName": "Contoso - Finance Department",
+              "partnerRegistrationImmutableId": "941892bc-f5d0-4d1c-8fb5-477570fc2b71",
+              "partnerTopicDetails": {
+                "description": "This is short description",
+                "longDescription": "This is really long long... long description",
+                "setupUri": "https://www.example.com/"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VerifiedPartners_List",
+  "title": "VerifiedPartners_List"
+}

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
@@ -27,7 +27,16 @@ These are the global settings for the Azure EventGrid API.
 ```yaml
 openapi-type: arm
 
-tag: package-2025-11-preview
+tag: package-2026-06-preview
+```
+
+### Tag: package-2026-06-preview
+
+These settings apply only when `--tag=package-2026-06-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-06-preview'
+input-file:
+- preview/2026-06-15-preview/EventGrid.json
 ```
 
 ### Tag: package-2025-11-preview

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
@@ -37,6 +37,923 @@ These settings apply only when `--tag=package-2026-06-preview` is specified on t
 ```yaml $(tag) == 'package-2026-06-preview'
 input-file:
 - preview/2026-06-15-preview/EventGrid.json
+
+suppressions:
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'eventSubscriptionName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[3].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'eventSubscriptionName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'eventSubscriptionName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}"].get.responses[200].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventTypes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'verifiedPartnerName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/providers/Microsoft.EventGrid/verifiedPartners/{verifiedPartnerName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/providers/Microsoft.EventGrid/verifiedPartners/{verifiedPartnerName}"].get.responses[200].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/locations/{location}/topicTypes/{topicTypeName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'resourceTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceTypeName}/{resourceName}/providers/Microsoft.EventGrid/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'resourceTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceTypeName}/{resourceName}/providers/Microsoft.EventGrid/eventTypes"]
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations"]
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}"]
+
+  - code: PathResourceTypeNameCamelCase
+    reason: "Resource type naming must follow camel case. Path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}'"
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}"].get.responses[200].schema
+
+  - code: PathForResourceAction
+    reason: "Path for 'post' method on a resource type MUST follow valid resource naming."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}/reconcile"]
+
+  - code: PathResourceTypeNameCamelCase
+    reason: "Resource type naming must follow camel case. Path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}/reconcile'"
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}/reconcile"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{resourceType}/{resourceName}/networkSecurityPerimeterConfigurations/{perimeterGuid}.{associationName}/reconcile"].post.responses[200].schema
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'parentName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections"]
+
+  - code: EvenSegmentedPathForPutOperation
+    reason: "API path with PUT operation defined MUST have even number of segments (i.e. end in {resourceType}/{resourceName} segments)."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"]
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'parentName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}"].put.responses[201].schema
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'parentName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources"]
+
+  - code: PathContainsResourceType
+    reason: "The path for the CURD methods do not contain a resource type."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources/{privateLinkResourceName}"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'parentName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateLinkResources/{privateLinkResourceName}"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[5].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/listKeys"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/regenerateKey"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}"].put.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[6].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'domainName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/providers/Microsoft.EventGrid/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/locations/{location}/topicTypes/{topicTypeName}/eventSubscriptions"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}"].patch.responses[202].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}"].patch.responses[202].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[202].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'properties.defaultMaximumExpirationTimeInDays' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].patch.parameters[3].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default"].patch.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default/authorizePartner"].post.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default/unauthorizePartner"].post.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].put.responses[201].schema
+
+  - code: PatchResponseCodes
+    reason: "Long-running PATCH operations must have responses with 200, 202 and default return codes. They also must not have other response codes."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].patch
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].patch.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].patch.responses[202].schema
+
+  - code: DeleteResponseCodes
+    reason: "Long-running delete operations must have responses with 202, 204 and default return codes. They also must have no other response codes."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}"].delete
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerDestinations/{partnerDestinationName}/activate"].post.responses[200].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}"].put.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/listKeys"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerNamespaceName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/regenerateKey"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerRegistrationName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}"].put.responses[202].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/activate"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/activate"].post.responses[200].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/deactivate"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/deactivate"].post.responses[200].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[5].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'partnerTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'systemTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"].patch.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'systemTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'systemTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[5].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'systemTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'systemTopicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicTypeName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topicTypes/{topicTypeName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}"].put.responses[201].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"]
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].get.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[200].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].put.responses[201].schema
+
+  - code: ConsistentPatchProperties
+    reason: "The property 'destination' in the request body either not apppear in the resource model or has the wrong level."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.parameters[5].schema
+
+  - code: ProvisioningStateMustBeReadOnly
+    reason: "provisioningState property must be set to readOnly."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}"].patch.responses[201].schema
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getDeliveryAttributes"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}/getFullUrl"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/listKeys"]
+
+  - code: ResourceNameRestriction
+    reason: "The resource name parameter 'topicName' should be defined with a 'pattern' restriction."
+    from: EventGrid.json
+    where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/regenerateKey"]
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.FederatedIdentityCredentialInfo.properties.federatedClientId.format
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.Partner.properties.partnerRegistrationImmutableId.format
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.PartnerDestinationProperties.properties.partnerRegistrationImmutableId.format
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.PartnerRegistrationProperties.properties.partnerRegistrationImmutableId.format
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProperties.properties.partnerRegistrationImmutableId.format
+
+  - code: GuidUsage
+    reason: "Usage of Guid is not recommended. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board."
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProperties.properties.partnerRegistrationImmutableId.format
+
 ```
 
 ### Tag: package-2025-11-preview

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/readme.md
@@ -954,6 +954,556 @@ suppressions:
     from: EventGrid.json
     where: $.definitions.VerifiedPartnerProperties.properties.partnerRegistrationImmutableId.format
 
+  - code: RequiredPropertiesMissingInResourceModel
+    reason: "Model definition 'OperationsListResult' must have the properties 'name', 'id' and 'type' in its hierarchy and these properties must be marked as readonly."
+    from: EventGrid.json
+    where: $.definitions.OperationsListResult
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.PartnerRegistrationProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.PartnerRegistrationProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.PartnerRegistrationProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.PartnerRegistrationProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'NeverActivated' Description:'NeverActivated'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicActivationState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Activated' Description:'Activated'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicActivationState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deactivated' Description:'Deactivated'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicActivationState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'IdleDueToMirroredChannelResourceDeletion' Description:'IdleDueToMirroredChannelResourceDeletion'"
+    from: EventGrid.json
+    where: $.definitions.PartnerTopicProvisioningState.x-ms-enum.values[6].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'WebHook' Description:'WebHook'"
+    from: EventGrid.json
+    where: $.definitions.PartnerUpdateDestinationInfo.properties.endpointType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleted' Description:'Deleted'"
+    from: EventGrid.json
+    where: $.definitions.PermissionBindingProvisioningState.x-ms-enum.values[6].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Publisher' Description:'Publisher'"
+    from: EventGrid.json
+    where: $.definitions.PermissionType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Subscriber' Description:'Subscriber'"
+    from: EventGrid.json
+    where: $.definitions.PermissionType.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Pending' Description:'Pending'"
+    from: EventGrid.json
+    where: $.definitions.PersistedConnectionStatus.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Approved' Description:'Approved'"
+    from: EventGrid.json
+    where: $.definitions.PersistedConnectionStatus.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Rejected' Description:'Rejected'"
+    from: EventGrid.json
+    where: $.definitions.PersistedConnectionStatus.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disconnected' Description:'Disconnected'"
+    from: EventGrid.json
+    where: $.definitions.PersistedConnectionStatus.x-ms-enum.values[3].description
+
+  - code: RequiredPropertiesMissingInResourceModel
+    reason: "Model definition 'PrivateLinkResource' must have the properties 'name', 'id' and 'type' in its hierarchy and these properties must be marked as readonly."
+    from: EventGrid.json
+    where: $.definitions.PrivateLinkResource
+
+  - code: RequiredPropertiesMissingInResourceModel
+    reason: "Model definition 'PrivateLinkResourcesListResult' must have the properties 'name', 'id' and 'type' in its hierarchy and these properties must be marked as readonly."
+    from: EventGrid.json
+    where: $.definitions.PrivateLinkResourcesListResult
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Enabled' Description:'Enabled'"
+    from: EventGrid.json
+    where: $.definitions.PublicNetworkAccess.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disabled' Description:'Disabled'"
+    from: EventGrid.json
+    where: $.definitions.PublicNetworkAccess.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'SecuredByPerimeter' Description:'SecuredByPerimeter'"
+    from: EventGrid.json
+    where: $.definitions.PublicNetworkAccess.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Custom' Description:'Custom'"
+    from: EventGrid.json
+    where: $.definitions.PublisherType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'NeverActivated' Description:'NeverActivated'"
+    from: EventGrid.json
+    where: $.definitions.ReadinessState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Activated' Description:'Activated'"
+    from: EventGrid.json
+    where: $.definitions.ReadinessState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.ResourceProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'RegionalResource' Description:'RegionalResource'"
+    from: EventGrid.json
+    where: $.definitions.ResourceRegionType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'GlobalResource' Description:'GlobalResource'"
+    from: EventGrid.json
+    where: $.definitions.ResourceRegionType.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Basic' Description:'Basic'"
+    from: EventGrid.json
+    where: $.definitions.ResourceSku.properties.name.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Premium' Description:'Premium'"
+    from: EventGrid.json
+    where: $.definitions.ResourceSku.properties.name.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'None' Description:'None'"
+    from: EventGrid.json
+    where: $.definitions.RoutingIdentityType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'SystemAssigned' Description:'SystemAssigned'"
+    from: EventGrid.json
+    where: $.definitions.RoutingIdentityType.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'UserAssigned' Description:'UserAssigned'"
+    from: EventGrid.json
+    where: $.definitions.RoutingIdentityType.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Standard' Description:'Standard'"
+    from: EventGrid.json
+    where: $.definitions.SkuName.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'String' Description:'String'"
+    from: EventGrid.json
+    where: $.definitions.StaticRoutingEnrichmentType.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'AwaitingManualAction' Description:'AwaitingManualAction'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[6].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleted' Description:'Deleted'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[7].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'DeleteFailed' Description:'DeleteFailed'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[8].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'CreateFailed' Description:'CreateFailed'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[9].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'UpdatedFailed' Description:'UpdatedFailed'"
+    from: EventGrid.json
+    where: $.definitions.SubscriptionProvisioningState.x-ms-enum.values[10].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'1.0' Description:'1.0'"
+    from: EventGrid.json
+    where: $.definitions.TlsVersion.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'1.1' Description:'1.1'"
+    from: EventGrid.json
+    where: $.definitions.TlsVersion.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'1.2' Description:'1.2'"
+    from: EventGrid.json
+    where: $.definitions.TlsVersion.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Azure' Description:'Azure'"
+    from: EventGrid.json
+    where: $.definitions.Topic.properties.kind.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'AzureArc' Description:'AzureArc'"
+    from: EventGrid.json
+    where: $.definitions.Topic.properties.kind.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'EventGridSchema' Description:'EventGridSchema'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.inputSchema.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'CustomEventSchema' Description:'CustomEventSchema'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.inputSchema.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'CloudEventSchemaV1_0' Description:'CloudEventSchemaV1_0'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.inputSchema.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Enabled' Description:'Enabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.publicNetworkAccess.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disabled' Description:'Disabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.publicNetworkAccess.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'SecuredByPerimeter' Description:'SecuredByPerimeter'"
+    from: EventGrid.json
+    where: $.definitions.TopicProperties.properties.publicNetworkAccess.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.TopicProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleted' Description:'Deleted'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpaceProvisioningState.x-ms-enum.values[6].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disabled' Description:'Disabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpacesConfiguration.properties.state.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Enabled' Description:'Enabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpacesConfiguration.properties.state.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disabled' Description:'Disabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpacesConfigurationState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Enabled' Description:'Enabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicSpacesConfigurationState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeProvisioningState.x-ms-enum.values[5].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Resource' Description:'Resource'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeSourceScope.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'ResourceGroup' Description:'ResourceGroup'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeSourceScope.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'AzureSubscription' Description:'AzureSubscription'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeSourceScope.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'ManagementGroup' Description:'ManagementGroup'"
+    from: EventGrid.json
+    where: $.definitions.TopicTypeSourceScope.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Enabled' Description:'Enabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicUpdateParameterProperties.properties.publicNetworkAccess.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Disabled' Description:'Disabled'"
+    from: EventGrid.json
+    where: $.definitions.TopicUpdateParameterProperties.properties.publicNetworkAccess.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'SecuredByPerimeter' Description:'SecuredByPerimeter'"
+    from: EventGrid.json
+    where: $.definitions.TopicUpdateParameterProperties.properties.publicNetworkAccess.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Creating' Description:'Creating'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[0].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Updating' Description:'Updating'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[1].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Deleting' Description:'Deleting'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[2].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Succeeded' Description:'Succeeded'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[3].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Canceled' Description:'Canceled'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[4].description
+
+  - code: DescriptionMustNotBeNodeName
+    reason: "Description must not match the name of the node it is supposed to describe. Node name:'Failed' Description:'Failed'"
+    from: EventGrid.json
+    where: $.definitions.VerifiedPartnerProvisioningState.x-ms-enum.values[5].description
+
 ```
 
 ### Tag: package-2025-11-preview


### PR DESCRIPTION
# Event Grid - Add Control Plane API Version 2026-06-15-preview

Adds the `2026-06-15-preview` control plane API version for Microsoft.EventGrid with two features.

## Features

### NamespaceIpv6Support
- New `IpAddressType` enum (`IPv4`, `DualStack`; `modelAsString: true`).
- New `ipAddressType` property on `NamespaceProperties` and `NamespaceUpdateParameterProperties` (mutable), `$ref` to `IpAddressType`.

### Tls1.3
- New `1.3` value added to the shared `TlsVersion` enum (now `1.0`, `1.1`, `1.2`, `1.3`), used by `minimumTlsVersionAllowed`.

## Versioning
- Added `v2026_06_15_preview` to the `Versions` enum in `main.tsp`.
- All additions guarded with `@added(Versions.v2026_06_15_preview)`; the prior `2025-11-15-preview` swagger is unchanged.

## Commit structure
1. `EventGrid RP - Baseline commit 2025-11-15-preview` (last released swagger copied as-is for clean diffs)
2. `EventGrid RP - Updated swagger 2026-06-15-preview` (this version's changes)

## Validation
- `tsp compile .` -- 0 warnings, 0 errors.
- Mapper Validator -- 40/42 checks PASS, 0 failures, 0 breaking changes.
- `oav validate-spec` -- valid.

- [ ] All AI-generated changes have been reviewed and validated by the author.
