### PR TITLE
Service Bus: add 2024-05 data-plane API version with topic filter-count runtime properties

### DIFF
--- a/specification/servicebus/data-plane/ServiceBus/readme.md
+++ b/specification/servicebus/data-plane/ServiceBus/readme.md
@@ -26,7 +26,16 @@ These are the global settings for the [ServiceBus].
 
 ```yaml
 openapi-type: data-plane
-tag: package-2021-05
+tag: package-2024-05
+```
+
+### Tag: package-2024-05
+
+These settings apply only when `--tag=package-2024-05` is specified on the command line.
+
+```yaml $(tag) == 'package-2024-05'
+input-file:
+  - ./stable/2024-05/servicebus.json
 ```
 
 ### Tag: package-2021-05

--- a/specification/servicebus/data-plane/ServiceBus/stable/2024-05/servicebus.json
+++ b/specification/servicebus/data-plane/ServiceBus/stable/2024-05/servicebus.json
@@ -1,0 +1,2609 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2024-05",
+    "title": "ServiceBusManagementClient",
+    "description": "Azure Service Bus client for managing Queues, Topics, and Subscriptions.",
+    "x-ms-code-generation-settings": {
+      "internalConstructors": true,
+      "name": "ServiceBusManagementClient"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "parameters": [
+      {
+        "$ref": "#/parameters/Endpoint"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/xml",
+    "application/atom+xml"
+  ],
+  "consumes": [
+    "application/atom+xml"
+  ],
+  "tags": [
+    {
+      "name": "Namespace Operations"
+    },
+    {
+      "name": "Queue Operations"
+    },
+    {
+      "name": "Topic Operations"
+    },
+    {
+      "name": "Subscription Operations"
+    },
+    {
+      "name": "Rule Operations"
+    }
+  ],
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API Version.",
+      "x-ms-parameter-location": "client"
+    },
+    "Endpoint": {
+      "in": "path",
+      "name": "endpoint",
+      "description": "The Service Bus fully qualified domain name.",
+      "required": true,
+      "type": "string",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "client"
+    },
+    "Enrich": {
+      "name": "enrich",
+      "in": "query",
+      "description": "A query parameter that sets enrich to true or false.",
+      "type": "boolean",
+      "default": false,
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "definitions": {
+    "AccessRights": {
+      "description": "Access rights of an authorization",
+      "type": "string",
+      "xml": {
+        "name": "AccessRights",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Manage",
+        "Send",
+        "Listen"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRights",
+        "modelAsString": true
+      }
+    },
+    "AuthorizationRule": {
+      "description": "Authorization rule of an entity",
+      "type": "object",
+      "xml": {
+        "name": "AuthorizationRule",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The authorization type.",
+          "xml": {
+            "attribute": true,
+            "prefix": "i",
+            "namespace": "http://www.w3.org/2001/XMLSchema-instance"
+          }
+        },
+        "claimType": {
+          "description": "The claim type.",
+          "type": "string",
+          "xml": {
+            "name": "ClaimType",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "claimValue": {
+          "description": "The claim value.",
+          "type": "string",
+          "xml": {
+            "name": "ClaimValue",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "rights": {
+          "description": "Access rights of the entity. Values are 'Send', 'Listen', or 'Manage'",
+          "type": "array",
+          "xml": {
+            "wrapped": true,
+            "name": "Rights",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          },
+          "items": {
+            "type": "object",
+            "xml": {
+              "name": "AccessRights",
+              "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+            },
+            "$ref": "#/definitions/AccessRights"
+          }
+        },
+        "createdTime": {
+          "description": "The date and time when the authorization rule was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedTime",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "modifiedTime": {
+          "description": "The date and time when the authorization rule was modified.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "ModifiedTime",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "keyName": {
+          "description": "The authorization rule key name",
+          "type": "string",
+          "xml": {
+            "name": "KeyName",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "primaryKey": {
+          "description": "The primary key of the authorization rule",
+          "type": "string",
+          "xml": {
+            "name": "PrimaryKey",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "secondaryKey": {
+          "description": "The primary key of the authorization rule",
+          "type": "string",
+          "xml": {
+            "name": "SecondaryKey",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "CreateQueueBody": {
+      "description": "The request body for creating a queue.",
+      "type": "object",
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "content": {
+          "description": "QueueDescription for the new queue.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "MIME type of content.",
+              "type": "string",
+              "default": "application/xml",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "queueDescription": {
+              "description": "Properties of the new queue.",
+              "$ref": "#/definitions/QueueDescription"
+            }
+          }
+        }
+      }
+    },
+    "CreateTopicBody": {
+      "description": "The request body for creating a topic.",
+      "type": "object",
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "content": {
+          "description": "TopicDescription for the new topic.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "MIME type of content.",
+              "type": "string",
+              "default": "application/xml",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "topicDescription": {
+              "description": "Topic information to create.",
+              "$ref": "#/definitions/TopicDescription"
+            }
+          }
+        }
+      }
+    },
+    "CreateSubscriptionBody": {
+      "description": "The request body for creating a subscription.",
+      "type": "object",
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "content": {
+          "description": "SubscriptionDescription for the new subscription.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "MIME type of content.",
+              "type": "string",
+              "default": "application/xml",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "subscriptionDescription": {
+              "description": "Subscription information to create.",
+              "$ref": "#/definitions/SubscriptionDescription"
+            }
+          }
+        }
+      }
+    },
+    "CreateRuleBody": {
+      "description": "The request body for creating a rule.",
+      "type": "object",
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "content": {
+          "description": "RuleDescription for the new Rule.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "MIME type of content.",
+              "type": "string",
+              "default": "application/xml",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "ruleDescription": {
+              "description": "Rule information to create.",
+              "$ref": "#/definitions/RuleDescription"
+            }
+          }
+        }
+      }
+    },
+    "EntityAvailabilityStatus": {
+      "description": "Availability status of the entity",
+      "type": "string",
+      "xml": {
+        "name": "EntityAvailabilityStatus",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Available",
+        "Limited",
+        "Renaming",
+        "Restoring",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "EntityAvailabilityStatus",
+        "modelAsString": true
+      }
+    },
+    "EntityStatus": {
+      "description": "Status of a Service Bus resource",
+      "type": "string",
+      "xml": {
+        "name": "Status",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Active",
+        "Creating",
+        "Deleting",
+        "Disabled",
+        "ReceiveDisabled",
+        "Renaming",
+        "Restoring",
+        "SendDisabled",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "EntityStatus",
+        "modelAsString": true
+      }
+    },
+    "MessageCountDetails": {
+      "description": "Details about the message counts in entity.",
+      "type": "object",
+      "properties": {
+        "activeMessageCount": {
+          "description": "Number of active messages in the queue, topic, or subscription.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "ActiveMessageCount",
+            "prefix": "d2p1",
+            "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
+          }
+        },
+        "deadLetterMessageCount": {
+          "description": "Number of messages that are dead lettered.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "DeadLetterMessageCount",
+            "prefix": "d2p1",
+            "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
+          }
+        },
+        "scheduledMessageCount": {
+          "description": "Number of scheduled messages.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "ScheduledMessageCount",
+            "prefix": "d2p1",
+            "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
+          }
+        },
+        "transferDeadLetterMessageCount": {
+          "description": "Number of messages transferred into dead letters.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "TransferDeadLetterMessageCount",
+            "prefix": "d2p1",
+            "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
+          }
+        },
+        "transferMessageCount": {
+          "description": "Number of messages transferred to another queue, topic, or subscription.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "TransferMessageCount",
+            "prefix": "d2p1",
+            "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
+          }
+        }
+      },
+      "xml": {
+        "name": "CountDetails",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      }
+    },
+    "MessagingSku": {
+      "description": "The SKU for the messaging entity.",
+      "type": "string",
+      "xml": {
+        "name": "MessagingSKU",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "MessagingSku",
+        "modelAsString": true
+      }
+    },
+    "NamespaceProperties": {
+      "description": "The metadata related to a Service Bus namespace.",
+      "type": "object",
+      "xml": {
+        "name": "NamespaceInfo",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "alias": {
+          "description": "Alias for the geo-disaster recovery Service Bus namespace.",
+          "type": "string",
+          "xml": {
+            "name": "Alias",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "createdTime": {
+          "description": "The exact time the namespace was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedTime",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messagingSku": {
+          "$ref": "#/definitions/MessagingSku"
+        },
+        "messagingUnits": {
+          "description": "The number of messaging units allocated to the namespace.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "MessagingUnits",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "modifiedTime": {
+          "description": "The exact time the namespace was last modified.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "ModifiedTime",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "name": {
+          "description": "Name of the namespace",
+          "type": "string",
+          "xml": {
+            "name": "Name",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "namespaceType": {
+          "$ref": "#/definitions/NamespaceType"
+        }
+      }
+    },
+    "NamespacePropertiesEntry": {
+      "description": "Represents an entry in the feed when querying namespace info",
+      "type": "object",
+      "required": [
+        "title"
+      ],
+      "properties": {
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the namespace.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "The timestamp for when this namespace was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "author": {
+          "$ref": "#/definitions/ResponseAuthor"
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "Information about the namespace.",
+          "type": "object",
+          "required": [
+            "type",
+            "NamespaceProperties"
+          ],
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in namespace info response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "NamespaceProperties": {
+              "$ref": "#/definitions/NamespaceProperties"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "NamespaceType": {
+      "description": "The type of entities the namespace can contain.",
+      "type": "string",
+      "xml": {
+        "name": "NamespaceType",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Messaging",
+        "NotificationHub",
+        "Mixed",
+        "EventHub",
+        "Relay"
+      ],
+      "x-ms-enum": {
+        "name": "NamespaceType",
+        "modelAsString": true
+      }
+    },
+    "QueueDescription": {
+      "description": "Description of a Service Bus queue resource.",
+      "type": "object",
+      "xml": {
+        "name": "QueueDescription",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "lockDuration": {
+          "description": "ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "LockDuration",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxSizeInMegabytes": {
+          "description": "The maximum size of the queue in megabytes, which is the size of memory allocated for the queue.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "MaxSizeInMegabytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "requiresDuplicateDetection": {
+          "description": "A value indicating if this queue requires duplicate detection.",
+          "type": "boolean",
+          "xml": {
+            "name": "RequiresDuplicateDetection",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "requiresSession": {
+          "description": "A value that indicates whether the queue supports the concept of sessions.",
+          "type": "boolean",
+          "xml": {
+            "name": "RequiresSession",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "defaultMessageTimeToLive": {
+          "description": "ISO 8601 default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "DefaultMessageTimeToLive",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "deadLetteringOnMessageExpiration": {
+          "description": "A value that indicates whether this queue has dead letter support when a message expires.",
+          "type": "boolean",
+          "xml": {
+            "name": "DeadLetteringOnMessageExpiration",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "duplicateDetectionHistoryTimeWindow": {
+          "description": "ISO 8601 timeSpan structure that defines the duration of the duplicate detection history. The default value is 10 minutes.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "DuplicateDetectionHistoryTimeWindow",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxDeliveryCount": {
+          "description": "The maximum delivery count. A message is automatically deadlettered after this number of deliveries. Default value is 10.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "MaxDeliveryCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableBatchedOperations": {
+          "description": "Value that indicates whether server-side batched operations are enabled.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableBatchedOperations",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "sizeInBytes": {
+          "description": "The size of the queue, in bytes.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "SizeInBytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messageCount": {
+          "description": "The number of messages in the queue.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "MessageCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "isAnonymousAccessible": {
+          "description": "A value indicating if the resource can be accessed without authorization.",
+          "type": "boolean",
+          "xml": {
+            "name": "IsAnonymousAccessible",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "authorizationRules": {
+          "description": "Authorization rules for resource.",
+          "type": "array",
+          "xml": {
+            "name": "AuthorizationRules",
+            "wrapped": true,
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          },
+          "items": {
+            "$ref": "#/definitions/AuthorizationRule"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus"
+        },
+        "forwardTo": {
+          "description": "The name of the recipient entity to which all the messages sent to the queue are forwarded to.",
+          "type": "string",
+          "xml": {
+            "name": "ForwardTo",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "userMetadata": {
+          "description": "Custom metadata that user can associate with the description. Max length is 1024 chars.",
+          "type": "string",
+          "xml": {
+            "name": "UserMetadata",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "createdAt": {
+          "description": "The exact time the queue was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "updatedAt": {
+          "description": "The exact time the entity description was last updated.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "UpdatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "accessedAt": {
+          "description": "Last time a message was sent, or the last time there was a receive request to this queue.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "AccessedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "supportOrdering": {
+          "description": "Indicates if messages are received in the same order they are sent. For queues, defaults to true and setting it to false has no effect.",
+          "type": "boolean",
+          "xml": {
+            "name": "SupportOrdering",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messageCountDetails": {
+          "$ref": "#/definitions/MessageCountDetails"
+        },
+        "autoDeleteOnIdle": {
+          "description": "ISO 8601 timeSpan idle interval after which the queue is automatically deleted. The minimum duration is 5 minutes.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "AutoDeleteOnIdle",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enablePartitioning": {
+          "description": "A value that indicates whether the queue is to be partitioned across multiple message brokers.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnablePartitioning",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "entityAvailabilityStatus": {
+          "$ref": "#/definitions/EntityAvailabilityStatus"
+        },
+        "forwardDeadLetteredMessagesTo": {
+          "description": "The name of the recipient entity to which all the dead-lettered messages of this subscription are forwarded to.",
+          "type": "string",
+          "xml": {
+            "name": "ForwardDeadLetteredMessagesTo",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableExpress": {
+          "description": "A value that indicates whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableExpress",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxMessageSizeInKilobytes": {
+          "description": "The maximum size in kilobytes of message payload that can be accepted by the queue.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "MaxMessageSizeInKilobytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "QueueDescriptionEntry": {
+      "description": "Represents an entry in the feed when querying queues",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Base URL for the query.",
+          "type": "string",
+          "xml": {
+            "name": "base",
+            "attribute": true,
+            "prefix": "xml"
+          }
+        },
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the queue",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "published": {
+          "description": "The timestamp for when this queue was published",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "The timestamp for when this queue was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "author": {
+          "$ref": "#/definitions/ResponseAuthor"
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "The QueueDescription",
+          "type": "object",
+          "required": [
+            "type",
+            "QueueDescription"
+          ],
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in queue response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "QueueDescription": {
+              "$ref": "#/definitions/QueueDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "QueueDescriptionFeed": {
+      "description": "Response from listing Service Bus queues.",
+      "type": "object",
+      "xml": {
+        "name": "feed",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "id": {
+          "description": "URL of the list queues query.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The entity type for the feed.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "Datetime of the query.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "description": "Links to paginated response.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResponseLink"
+          }
+        },
+        "entry": {
+          "description": "Queue entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueDescriptionEntry"
+          }
+        }
+      }
+    },
+    "ResponseAuthor": {
+      "description": "The author that created this resource",
+      "type": "object",
+      "xml": {
+        "name": "author",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "name": {
+          "description": "The Service Bus namespace",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        }
+      }
+    },
+    "ResponseLink": {
+      "description": "The URL for the HTTP request",
+      "type": "object",
+      "properties": {
+        "href": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        },
+        "rel": {
+          "description": "What the link href is relative to",
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        }
+      },
+      "xml": {
+        "name": "link",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "ServiceBusManagementError": {
+      "description": "The error response from Service Bus.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The service error code.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "Code"
+          }
+        },
+        "detail": {
+          "description": "The service error message.",
+          "type": "string",
+          "xml": {
+            "name": "Detail"
+          }
+        }
+      }
+    },
+    "TopicDescription": {
+      "description": "Description of a Service Bus topic resource.",
+      "type": "object",
+      "xml": {
+        "name": "TopicDescription",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "defaultMessageTimeToLive": {
+          "description": "ISO 8601 default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "DefaultMessageTimeToLive",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxSizeInMegabytes": {
+          "description": "The maximum size of the topic in megabytes, which is the size of memory allocated for the topic.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "MaxSizeInMegabytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "requiresDuplicateDetection": {
+          "description": "A value indicating if this topic requires duplicate detection.",
+          "type": "boolean",
+          "xml": {
+            "name": "RequiresDuplicateDetection",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "duplicateDetectionHistoryTimeWindow": {
+          "description": "ISO 8601 timeSpan structure that defines the duration of the duplicate detection history. The default value is 10 minutes.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "DuplicateDetectionHistoryTimeWindow",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableBatchedOperations": {
+          "description": "Value that indicates whether server-side batched operations are enabled.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableBatchedOperations",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "sizeInBytes": {
+          "description": "The size of the topic, in bytes.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "SizeInBytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "filteringMessagesBeforePublishing": {
+          "description": "Filter messages before publishing.",
+          "type": "boolean",
+          "xml": {
+            "name": "FilteringMessagesBeforePublishing",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "isAnonymousAccessible": {
+          "description": "A value indicating if the resource can be accessed without authorization.",
+          "type": "boolean",
+          "xml": {
+            "name": "IsAnonymousAccessible",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "authorizationRules": {
+          "description": "Authorization rules for resource.",
+          "type": "array",
+          "xml": {
+            "name": "AuthorizationRules",
+            "wrapped": true,
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          },
+          "items": {
+            "$ref": "#/definitions/AuthorizationRule"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus"
+        },
+        "createdAt": {
+          "description": "The exact time the topic was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "updatedAt": {
+          "description": "The exact time a message was updated in the topic.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "UpdatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "accessedAt": {
+          "description": "Last time a message was sent, or the last time there was a receive request to this topic.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "AccessedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "supportOrdering": {
+          "description": "Indicates if messages are received in the same order they are sent. If partitioned topics, defaults to false, and setting it to true has no effect. For unpartitioned topics, setting it to false will improve perf, but messages may not be received in the order they are sent.",
+          "type": "boolean",
+          "xml": {
+            "name": "SupportOrdering",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messageCountDetails": {
+          "$ref": "#/definitions/MessageCountDetails"
+        },
+        "subscriptionCount": {
+          "description": "The number of subscriptions in the topic.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "SubscriptionCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "sqlFilterCount": {
+          "description": "The total number of SQL filters across all subscriptions of the topic.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "SqlFilterCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "correlationFilterCount": {
+          "description": "The total number of correlation filters across all subscriptions of the topic.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "CorrelationFilterCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "autoDeleteOnIdle": {
+          "description": "ISO 8601 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "AutoDeleteOnIdle",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enablePartitioning": {
+          "description": "A value that indicates whether the topic is to be partitioned across multiple message brokers.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnablePartitioning",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "entityAvailabilityStatus": {
+          "$ref": "#/definitions/EntityAvailabilityStatus"
+        },
+        "enableSubscriptionPartitioning": {
+          "description": "A value that indicates whether the topic's subscription is to be partitioned.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableSubscriptionPartitioning",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableExpress": {
+          "description": "A value that indicates whether Express Entities are enabled. An express topic holds a message in memory temporarily before writing it to persistent storage.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableExpress",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "userMetadata": {
+          "description": "Metadata associated with the topic.",
+          "type": "string",
+          "xml": {
+            "name": "UserMetadata",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxMessageSizeInKilobytes": {
+          "description": "The maximum size in kilobytes of message payload that can be accepted by the topic.",
+          "type": "integer",
+          "format": "int64",
+          "xml": {
+            "name": "MaxMessageSizeInKilobytes",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "TopicDescriptionEntry": {
+      "description": "Represents an entry in the feed when querying topics",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Base URL for the query.",
+          "type": "string",
+          "xml": {
+            "name": "base",
+            "attribute": true,
+            "prefix": "xml"
+          }
+        },
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the topic",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "published": {
+          "description": "The timestamp for when this topic was published",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "The timestamp for when this topic was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "author": {
+          "$ref": "#/definitions/ResponseAuthor"
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "The TopicDescription",
+          "type": "object",
+          "required": [
+            "type",
+            "TopicDescription"
+          ],
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in topic response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "TopicDescription": {
+              "$ref": "#/definitions/TopicDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "TopicDescriptionFeed": {
+      "description": "Response from listing Service Bus topics.",
+      "type": "object",
+      "xml": {
+        "name": "feed",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "id": {
+          "description": "URL of the list topics query.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The entity type for the feed.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "Datetime of the query.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "description": "Links to paginated response.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResponseLink"
+          }
+        },
+        "entry": {
+          "description": "Topic entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TopicDescriptionEntry"
+          }
+        }
+      }
+    },
+    "SubscriptionDescription": {
+      "description": "Description of a Service Bus subscription resource.",
+      "type": "object",
+      "xml": {
+        "name": "SubscriptionDescription",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "lockDuration": {
+          "description": "ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "LockDuration",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "requiresSession": {
+          "description": "A value that indicates whether the subscription supports the concept of sessions.",
+          "type": "boolean",
+          "xml": {
+            "name": "RequiresSession",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "defaultMessageTimeToLive": {
+          "description": "ISO 8601 default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "DefaultMessageTimeToLive",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "deadLetteringOnMessageExpiration": {
+          "description": "A value that indicates whether this subscription has dead letter support when a message expires.",
+          "type": "boolean",
+          "xml": {
+            "name": "DeadLetteringOnMessageExpiration",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "deadLetteringOnFilterEvaluationExceptions": {
+          "description": "A value that indicates whether this subscription has dead letter support when a message expires.",
+          "type": "boolean",
+          "xml": {
+            "name": "DeadLetteringOnFilterEvaluationExceptions",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "defaultRuleDescription": {
+          "description": "The default rule description.",
+          "$ref": "#/definitions/RuleDescription",
+          "xml": {
+            "name": "DefaultRuleDescription",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messageCount": {
+          "description": "The number of messages in the subscription.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "MessageCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "maxDeliveryCount": {
+          "description": "The maximum delivery count. A message is automatically deadlettered after this number of deliveries. Default value is 10.",
+          "type": "integer",
+          "format": "int32",
+          "xml": {
+            "name": "MaxDeliveryCount",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableBatchedOperations": {
+          "description": "Value that indicates whether server-side batched operations are enabled.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableBatchedOperations",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/EntityStatus"
+        },
+        "forwardTo": {
+          "description": "The name of the recipient entity to which all the messages sent to the subscription are forwarded to.",
+          "type": "string",
+          "xml": {
+            "name": "ForwardTo",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "createdAt": {
+          "description": "The exact time the subscription was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "updatedAt": {
+          "description": "The exact time a message was updated in the subscription.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "UpdatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "accessedAt": {
+          "description": "Last time a message was sent, or the last time there was a receive request to this subscription.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "AccessedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "messageCountDetails": {
+          "$ref": "#/definitions/MessageCountDetails"
+        },
+        "userMetadata": {
+          "description": "Metadata associated with the subscription. Maximum number of characters is 1024.",
+          "type": "string",
+          "xml": {
+            "name": "UserMetadata",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "forwardDeadLetteredMessagesTo": {
+          "description": "The name of the recipient entity to which all the messages sent to the subscription are forwarded to.",
+          "type": "string",
+          "xml": {
+            "name": "ForwardDeadLetteredMessagesTo",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "autoDeleteOnIdle": {
+          "description": "ISO 8601 timeSpan idle interval after which the subscription is automatically deleted. The minimum duration is 5 minutes.",
+          "type": "string",
+          "format": "duration",
+          "xml": {
+            "name": "AutoDeleteOnIdle",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "entityAvailabilityStatus": {
+          "$ref": "#/definitions/EntityAvailabilityStatus"
+        }
+      }
+    },
+    "SubscriptionDescriptionEntry": {
+      "description": "Represents an entry in the feed when querying subscriptions.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the subscription",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "published": {
+          "description": "The timestamp for when this subscription was published",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "The timestamp for when this subscription was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "The SubscriptionDescription.",
+          "type": "object",
+          "required": [
+            "type",
+            "SubscriptionDescription"
+          ],
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in subscription response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "SubscriptionDescription": {
+              "$ref": "#/definitions/SubscriptionDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "SubscriptionDescriptionFeed": {
+      "description": "Response from listing Service Bus subscriptions.",
+      "type": "object",
+      "xml": {
+        "name": "feed",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "id": {
+          "description": "URL of the list subscriptions query.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The entity type for the feed.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "Datetime of the query.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "description": "Links to paginated response.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResponseLink"
+          }
+        },
+        "entry": {
+          "description": "Subscription entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubscriptionDescriptionEntry"
+          }
+        }
+      }
+    },
+    "KeyValue": {
+      "description": "Key Values of custom properties",
+      "type": "object",
+      "xml": {
+        "name": "KeyValueOfstringanyType",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "key": {
+          "type": "string",
+          "xml": {
+            "name": "Key",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "value": {
+          "type": "string",
+          "xml": {
+            "name": "Value",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "KeyObjectValue": {
+      "description": "Key Values of custom properties",
+      "type": "object",
+      "xml": {
+        "name": "KeyValueOfObjectType",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "key": {
+          "type": "string",
+          "xml": {
+            "name": "Key",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "value": {
+          "type": "object",
+          "xml": {
+            "name": "Value",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "RuleFilter": {
+      "type": "object",
+      "discriminator": "type",
+      "required": [
+        "type"
+      ],
+      "xml": {
+        "name": "Filter",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "xml": {
+            "attribute": true,
+            "prefix": "xsi",
+            "namespace": "http://www.w3.org/2001/XMLSchema-instance"
+          }
+        }
+      }
+    },
+    "CorrelationFilter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RuleFilter"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "correlationId": {
+              "type": "string",
+              "xml": {
+                "name": "CorrelationId",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "messageId": {
+              "type": "string",
+              "xml": {
+                "name": "MessageId",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "to": {
+              "type": "string",
+              "xml": {
+                "name": "To",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "replyTo": {
+              "type": "string",
+              "xml": {
+                "name": "ReplyTo",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "label": {
+              "type": "string",
+              "xml": {
+                "name": "Label",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "sessionId": {
+              "type": "string",
+              "xml": {
+                "name": "SessionId",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "replyToSessionId": {
+              "type": "string",
+              "xml": {
+                "name": "ReplyToSessionId",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "contentType": {
+              "type": "string",
+              "xml": {
+                "name": "ContentType",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "properties": {
+              "type": "array",
+              "xml": {
+                "name": "Properties",
+                "wrapped": true,
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              },
+              "items": {
+                "$ref": "#/definitions/KeyObjectValue"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "SqlFilter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RuleFilter"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "sqlExpression": {
+              "type": "string",
+              "xml": {
+                "name": "SqlExpression",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "compatibilityLevel": {
+              "type": "string",
+              "default": "20",
+              "xml": {
+                "name": "CompatibilityLevel",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "parameters": {
+              "type": "array",
+              "xml": {
+                "name": "Parameters",
+                "wrapped": true,
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              },
+              "items": {
+                "$ref": "#/definitions/KeyValue"
+              }
+            },
+            "requiresPreprocessing": {
+              "type": "boolean",
+              "xml": {
+                "name": "RequiresPreprocessing",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "TrueFilter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SqlFilter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "FalseFilter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SqlFilter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "RuleAction": {
+      "type": "object",
+      "discriminator": "type",
+      "required": [
+        "type"
+      ],
+      "xml": {
+        "name": "Action",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "xml": {
+            "attribute": true,
+            "prefix": "xsi",
+            "namespace": "http://www.w3.org/2001/XMLSchema-instance"
+          }
+        }
+      }
+    },
+    "SqlRuleAction": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RuleAction"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "sqlExpression": {
+              "type": "string",
+              "xml": {
+                "name": "SqlExpression",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "compatibilityLevel": {
+              "type": "string",
+              "default": "20",
+              "xml": {
+                "name": "CompatibilityLevel",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            },
+            "parameters": {
+              "type": "array",
+              "xml": {
+                "name": "Parameters",
+                "wrapped": true,
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              },
+              "items": {
+                "$ref": "#/definitions/KeyValue"
+              }
+            },
+            "requiresPreprocessing": {
+              "type": "boolean",
+              "xml": {
+                "name": "RequiresPreprocessing",
+                "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "EmptyRuleAction": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RuleAction"
+        }
+      ]
+    },
+    "RuleDescription": {
+      "type": "object",
+      "xml": {
+        "name": "RuleDescription",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/RuleFilter"
+        },
+        "action": {
+          "$ref": "#/definitions/RuleAction"
+        },
+        "createdAt": {
+          "description": "The exact time the rule was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "name": "CreatedAt",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "name": {
+          "type": "string",
+          "xml": {
+            "name": "Name",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        }
+      }
+    },
+    "RuleDescriptionEntry": {
+      "description": "Represents an entry in the feed when querying rules",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the rule",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "published": {
+          "description": "The timestamp for when this rule was published",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "The timestamp for when this rule was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "The RuleDescription",
+          "type": "object",
+          "required": [
+            "type",
+            "RuleDescription"
+          ],
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in rule response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "RuleDescription": {
+              "$ref": "#/definitions/RuleDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "RuleDescriptionFeed": {
+      "description": "Response from listing Service Bus rules.",
+      "type": "object",
+      "xml": {
+        "name": "feed",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "id": {
+          "description": "URL of the list rules query.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The entity type for the feed.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "updated": {
+          "description": "Datetime of the query.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "link": {
+          "description": "Links to paginated response.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResponseLink"
+          }
+        },
+        "entry": {
+          "description": "Rules entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RuleDescriptionEntry"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "ServiceBusManagementErrorResponse": {
+      "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
+      "headers": {
+        "x-ms-request-id": {
+          "description": "A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.",
+          "pattern": "^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$",
+          "type": "string"
+        },
+        "x-ms-version": {
+          "description": "The version of the REST protocol used to process the request.",
+          "type": "string"
+        }
+      },
+      "schema": {
+        "$ref": "#/definitions/ServiceBusManagementError"
+      }
+    }
+  },
+  "paths": {
+    "/{entityName}": {
+      "parameters": [
+        {
+          "name": "entityName",
+          "in": "path",
+          "description": "The name of the queue or topic relative to the Service Bus namespace.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "Entity_Get",
+        "summary": "Get Queue or Topic",
+        "description": "Get the details about the Queue or Topic with the given entityName.",
+        "tags": [
+          "Queue Operations",
+          "Topic Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Enrich"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Queue Operations",
+          "Topic Operations"
+        ],
+        "operationId": "Entity_Put",
+        "description": "Create or update a queue or topic at the provided entityName",
+        "parameters": [
+          {
+            "name": "requestBody",
+            "in": "body",
+            "schema": {
+              "type": "object"
+            },
+            "required": true,
+            "description": "Parameters required to make or edit a queue or topic.",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found.",
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update -- Update Queue/Topic operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "201": {
+            "description": "Created -- Create Queue/Topic operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Entity_Delete",
+        "summary": "Delete Queue or Topic",
+        "description": "Delete the Queue or Topic with the given entityName.",
+        "tags": [
+          "Queue Operations",
+          "Topic Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/{topicName}/subscriptions": {
+      "parameters": [
+        {
+          "name": "topicName",
+          "in": "path",
+          "description": "name of the topic.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "listSubscriptions",
+        "summary": "Get subscriptions",
+        "description": "Get the details about the subscriptions of the given topic.",
+        "tags": [
+          "Subscription Operations"
+        ],
+        "parameters": [
+          {
+            "name": "$skip",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 0
+          },
+          {
+            "name": "$top",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 100
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/{topicName}/subscriptions/{subscriptionName}": {
+      "parameters": [
+        {
+          "name": "topicName",
+          "in": "path",
+          "description": "name of the topic.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "subscriptionName",
+          "in": "path",
+          "description": "name of the subscription.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "Subscription_Get",
+        "summary": "Get Subscription",
+        "description": "Get the details about the subscription of a topic.",
+        "tags": [
+          "Subscription Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Enrich"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Subscription Operations"
+        ],
+        "operationId": "Subscription_Put",
+        "description": "Create or update a subscription",
+        "parameters": [
+          {
+            "name": "requestBody",
+            "in": "body",
+            "schema": {
+              "type": "object"
+            },
+            "required": true,
+            "description": "Parameters required to make or edit a subscription.",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found.",
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update -- Update Subscription operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "201": {
+            "description": "Created -- Create Subscription operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Subscription_Delete",
+        "summary": "Delete Subscription",
+        "description": "Delete the subscription with the given topicName and subscriptionName.",
+        "tags": [
+          "Subscription Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/{topicName}/subscriptions/{subscriptionName}/rules": {
+      "parameters": [
+        {
+          "name": "topicName",
+          "in": "path",
+          "description": "name of the topic.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "subscriptionName",
+          "in": "path",
+          "description": "name of the subscription.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "listRules",
+        "summary": "Get rules of a topic subscription",
+        "description": "Get the details about the rules of the given topic subscription.",
+        "tags": [
+          "Subscription Operations"
+        ],
+        "parameters": [
+          {
+            "name": "$skip",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 0
+          },
+          {
+            "name": "$top",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 100
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/{topicName}/subscriptions/{subscriptionName}/rules/{ruleName}": {
+      "parameters": [
+        {
+          "name": "topicName",
+          "in": "path",
+          "description": "name of the topic.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "subscriptionName",
+          "in": "path",
+          "description": "name of the subscription.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "ruleName",
+          "in": "path",
+          "description": "name of the filter.",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "Rule_Get",
+        "summary": "Get Rule",
+        "description": "Get the details about the rule of a subscription of a topic.",
+        "tags": [
+          "Rule Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Enrich"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Rule Operations"
+        ],
+        "operationId": "Rule_Put",
+        "description": "Create or update a rule",
+        "parameters": [
+          {
+            "name": "requestBody",
+            "in": "body",
+            "schema": {
+              "type": "object"
+            },
+            "required": true,
+            "description": "Parameters required to make or edit a rule.",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found.",
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update -- Update Rule operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "201": {
+            "description": "Created -- Create Rule operation completed successfully.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Rule_Delete",
+        "summary": "Delete Subscription",
+        "description": "Delete the rule with the given topicName, subscriptionName and ruleName.",
+        "tags": [
+          "Rule Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/$namespaceinfo": {
+      "get": {
+        "operationId": "Namespace_Get",
+        "summary": "Get Namespace Properties",
+        "description": "Get the details about the Service Bus namespace.",
+        "tags": [
+          "Namespace Operations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/NamespacePropertiesEntry"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    },
+    "/$Resources/{entityType}": {
+      "parameters": [
+        {
+          "name": "entityType",
+          "in": "path",
+          "description": "List all queues or all topics of the service bus. Value can be \"queues\" or \"topics\" ",
+          "minLength": 1,
+          "x-ms-parameter-location": "method",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "listEntities",
+        "summary": "Get Queues or topics",
+        "description": "Get the details about the entities of the given Service Bus namespace.",
+        "tags": [
+          "Queue Operations",
+          "Topic Operations"
+        ],
+        "parameters": [
+          {
+            "name": "$skip",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 0
+          },
+          {
+            "name": "$top",
+            "type": "integer",
+            "format": "int32",
+            "in": "query",
+            "default": 100
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ServiceBusManagementErrorResponse"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new `2024-05` stable data-plane API version for the Service Bus ATOM management surface.

The only delta from `2021-05` is two read-only runtime properties on `TopicDescription`:

- `SqlFilterCount` — the total number of SQL filters across all of a topic's subscriptions.
- `CorrelationFilterCount` — the total number of correlation filters across all of a topic's subscriptions.

These are served by the service at `api-version=2024-05` (the current `MaxSupportedApiVersion`) and mirror the existing `SubscriptionCount` shape exactly (integer / int32 / XML name + namespace).

## Context

The Service Bus data-plane swagger had been frozen at `2021-05`. The intervening service versions (`2021-10`, `2022-10`, `2023-07-01`) added SchemaRegistry / Event Hubs / Kafka / ARM surfaces that are not part of this ATOM management spec, so `2021-05` + these two fields is the accurate `2024-05` contract for this surface.

## Change is additive-only

- No definitions removed.
- No property types changed.
- No new required fields.
- Two new **optional** read-only response properties on `TopicDescription`.

The `package-2024-05` tag is added to the readme and set as the default (standard for a new stable version).
