### PR TITLE
Fix .NET SDK naming for SkuMixPlacement (RESINFIX001, DATETIME001)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Recommender/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Recommender/client.tsp
@@ -58,5 +58,6 @@ using Microsoft.Compute;
   "csharp"
 );
 @@clientName(SkuMixPlacementItem, "ComputeSkuMixPlacementItem", "csharp");
-@@clientName(SkuMixPlacementBase, "ComputeSkuMixPlacementResource", "csharp");
+@@clientName(SkuMixPlacementBase, "ComputeSkuMixPlacement", "csharp");
+@@clientName(SkuMixPlacementResponse.validUntil, "ValidUntilOn", "csharp");
 @@clientName(SkuMixPlacementScores.post, "generate", "csharp");


### PR DESCRIPTION
## Purpose

Fix two blocking .NET SDK naming-convention violations flagged on the auto-generated .NET SDK PR ([Azure/azure-sdk-for-net#61669](https://github.com/Azure/azure-sdk-for-net/pull/61669)) for `Azure.ResourceManager.Compute.Recommender`. Both are addressed entirely through csharp client customizations in `Recommender/client.tsp` (no API surface / swagger change).

### Details

| Rule | Before | After |
|------|--------|-------|
| **RESINFIX001** | Data type generated as `ComputeSkuMixPlacementResourceData` (illegal `Resource` infix) | `ComputeSkuMixPlacementData` |
| **DATETIME001** | `DateTimeOffset` property `ValidUntil` | `ValidUntilOn` |

Change:
- Rename the `SkuMixPlacementBase` csharp client name from `ComputeSkuMixPlacementResource` to `ComputeSkuMixPlacement`. The mgmt emitter derives the data type as `<base>Data` and the resource class as `<base>Resource`, so this yields `ComputeSkuMixPlacementData` + `ComputeSkuMixPlacementResource` (resource class name unchanged). This mirrors the sibling `ComputeDiagnosticBase` -> `ComputeRecommenderDiagnostic` mapping already in this project.
- Add `@@clientName(SkuMixPlacementResponse.validUntil, "ValidUntilOn", "csharp")` so the `DateTimeOffset` property ends with `On`.

Scope is csharp-only; other language SDKs are unaffected.

### Validation

- `tsp compile` on the Recommender project: succeeds.
- `tsp format`: no changes.
- Only `client.tsp` is modified; generated swagger is unchanged.
