### PR TITLE
[Translation] Customize Document Translation SDK client names

### DIFF
--- a/specification/translation/data-plane/DocumentTranslation/client.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/client.tsp
@@ -320,6 +320,18 @@ interface SingleDocumentTranslationClient {
 );
 
 @@clientName(
+  DocumentTranslation.DocumentStatus.imageCharged,
+  "imagesCharged",
+  "csharp"
+);
+
+@@clientName(
+  DocumentTranslation.DocumentStatus.imageCharacterDetected,
+  "imageCharactersDetected",
+  "csharp"
+);
+
+@@clientName(
   DocumentTranslation.StatusSummary.totalCharacterCharged,
   "total_characters_charged",
   "python"

--- a/specification/translation/data-plane/DocumentTranslation/client.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/client.tsp
@@ -164,6 +164,18 @@ interface SingleDocumentTranslationClient {
 );
 
 @@clientName(
+  DocumentTranslationClient.getDocumentsStatus,
+  "listDocumentStatuses",
+  "javascript"
+);
+
+@@clientName(
+  DocumentTranslationClient.getTranslationsStatus,
+  "listTranslationStatuses",
+  "javascript"
+);
+
+@@clientName(
   DocumentTranslation.TranslationStatus.createdDateTimeUtc,
   "created_on",
   "python"
@@ -183,7 +195,7 @@ interface SingleDocumentTranslationClient {
 
 @@clientName(
   DocumentTranslation.TranslationStatus.lastActionDateTimeUtc,
-  "lastActionAt",
+  "updatedAt",
   "javascript"
 );
 


### PR DESCRIPTION
## Summary

- customize JavaScript list operation names and translation status timestamp naming
- customize C# image charge and image character detection property names

## TypeSpec project

`specification/translation/data-plane/DocumentTranslation`