### PR TITLE
[wip] Improve suppressions.yaml support for swagger checks

### DIFF
--- a/.github/tsconfig.json
+++ b/.github/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "checkJs": true,
     // Avoid generating tsconfig.tsbuildinfo file, which isn't useful for our scenario
     "incremental": false,

--- a/.github/workflows/_reusable-set-check-status.yaml
+++ b/.github/workflows/_reusable-set-check-status.yaml
@@ -53,6 +53,14 @@ jobs:
           # or the repo default branch (other triggers).
           sparse-checkout: |
             .github
+            eng/tools/suppressions
+
+      - name: Install suppressions dependencies
+        if: |
+          startsWith(inputs.required_check_name, 'Swagger ') ||
+          inputs.required_check_name == 'Breaking Change(Cross-Version)'
+        working-directory: eng/tools/suppressions
+        run: npm install --omit dev --no-package-lock --no-audit --no-fund --ignore-scripts
 
       - name: "Set Status"
         uses: actions/github-script@v8

--- a/.github/workflows/_reusable-set-check-status.yaml
+++ b/.github/workflows/_reusable-set-check-status.yaml
@@ -55,15 +55,15 @@ jobs:
             .github
             eng/tools/suppressions
 
-      - name: Checkout PR suppression files
+      - name: Checkout base suppression files
         if: |
           startsWith(inputs.required_check_name, 'Swagger ') ||
           inputs.required_check_name == 'Breaking Change(Cross-Version)'
         uses: actions/checkout@v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
-          path: pull-request-head
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.event.workflow_run.pull_requests[0].base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || github.event.repository.default_branch }}
+          path: pull-request-base
           persist-credentials: false
           sparse-checkout-cone-mode: false
           sparse-checkout: |

--- a/.github/workflows/_reusable-set-check-status.yaml
+++ b/.github/workflows/_reusable-set-check-status.yaml
@@ -55,6 +55,21 @@ jobs:
             .github
             eng/tools/suppressions
 
+      - name: Checkout PR suppression files
+        if: |
+          startsWith(inputs.required_check_name, 'Swagger ') ||
+          inputs.required_check_name == 'Breaking Change(Cross-Version)'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          path: pull-request-head
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            specification/suppressions.yaml
+            specification/**/suppressions.yaml
+
       - name: Install suppressions dependencies
         if: |
           startsWith(inputs.required_check_name, 'Swagger ') ||

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -8,6 +8,7 @@ import {
 } from "../../shared/src/github.js";
 import { byDate, invert } from "../../shared/src/sort.js";
 import { extractInputs } from "./context.js";
+import { getSwaggerCheckSuppression, isSwaggerCheck } from "./swagger-check-suppressions.js";
 
 // TODO: Add tests
 /* v8 ignore start */
@@ -58,6 +59,7 @@ export default async function setStatus(
  * @param {string} params.monitoredWorkflowName
  * @param {string} params.requiredStatusName
  * @param {string} params.overridingLabel
+ * @param {typeof getSwaggerCheckSuppression} [params.swaggerCheckSuppressionResolver]
  * @returns {Promise<void>}
  */
 export async function setStatusImpl({
@@ -71,6 +73,7 @@ export async function setStatusImpl({
   monitoredWorkflowName,
   requiredStatusName,
   overridingLabel,
+  swaggerCheckSuppressionResolver = getSwaggerCheckSuppression,
 }) {
   if (!isFullGitSha(head_sha)) {
     throw new Error(`head_sha is not a valid full git SHA: '${head_sha}'`);
@@ -122,6 +125,35 @@ export async function setStatusImpl({
     });
 
     return;
+  }
+
+  if (isSwaggerCheck(requiredStatusName)) {
+    const suppression = await swaggerCheckSuppressionResolver({
+      github,
+      owner,
+      repo,
+      pullNumber: issue_number,
+      checkName: requiredStatusName,
+    });
+
+    if (suppression.skip) {
+      const description = truncateStatusDescription(
+        `Skipped via suppressions.yaml: ${suppression.reason}`,
+      );
+      core.info(description);
+
+      await github.rest.repos.createCommitStatus({
+        owner,
+        repo,
+        sha: head_sha,
+        state: CommitStatusState.SUCCESS,
+        context: requiredStatusName,
+        description,
+        target_url,
+      });
+
+      return;
+    }
   }
 
   const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
@@ -238,4 +270,14 @@ export async function setStatusImpl({
       target_url,
     });
   }
+}
+
+/**
+ * Commit status descriptions have a maximum length of 140 characters.
+ *
+ * @param {string} description
+ * @returns {string}
+ */
+function truncateStatusDescription(description) {
+  return description.length <= 140 ? description : `${description.slice(0, 137)}...`;
 }

--- a/.github/workflows/src/swagger-check-suppressions.js
+++ b/.github/workflows/src/swagger-check-suppressions.js
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { PER_PAGE_MAX } from "../../shared/src/github.js";
 
-const PR_HEAD_ROOT = "pull-request-head";
+const PR_BASE_ROOT = "pull-request-base";
 
 export const SWAGGER_ALL_SUPPRESSION_TOOL = "SwaggerAll";
 
@@ -52,6 +52,7 @@ export async function resolveSwaggerCheckSuppression({
     return { skip: false };
   }
 
+  /** @type {Set<string>} */
   const reasons = new Set();
   for (const path of specificationPaths) {
     const toolSuppressions = await getSuppressionsForPath(
@@ -77,7 +78,7 @@ export async function resolveSwaggerCheckSuppression({
 }
 
 /**
- * Resolve a Swagger check suppression from the sparse PR-head checkout.
+ * Resolve a Swagger check suppression from the sparse PR-base checkout.
  *
  * @param {Object} params
  * @param {import('@actions/github-script').AsyncFunctionArguments["github"]} params.github
@@ -85,7 +86,7 @@ export async function resolveSwaggerCheckSuppression({
  * @param {string} params.repo
  * @param {number} params.pullNumber
  * @param {string} params.checkName
- * @param {(tool: string, path: string, context?: Record<string, unknown>, options?: {allowMissingPath?: boolean, evaluateIf?: boolean}) => Promise<SwaggerSuppression[]>} [params.getSuppressionsImpl]
+ * @param {(tool: string, path: string, context?: Record<string, unknown>, options?: {allowMissingPath?: boolean}) => Promise<SwaggerSuppression[]>} [params.getSuppressionsImpl]
  * @returns {Promise<{skip: false} | {skip: true, reason: string}>}
  */
 export async function getSwaggerCheckSuppression({
@@ -115,11 +116,10 @@ export async function getSwaggerCheckSuppression({
     getSuppressionsForPath: async (tool, path) =>
       await getSuppressionsImpl(
         tool,
-        resolve(PR_HEAD_ROOT, path),
+        resolve(PR_BASE_ROOT, path),
         {},
         {
           allowMissingPath: true,
-          evaluateIf: false,
         },
       ),
   });

--- a/.github/workflows/src/swagger-check-suppressions.js
+++ b/.github/workflows/src/swagger-check-suppressions.js
@@ -1,5 +1,7 @@
-import { dirname } from "node:path/posix";
+import { resolve } from "node:path";
 import { PER_PAGE_MAX } from "../../shared/src/github.js";
+
+const PR_HEAD_ROOT = "pull-request-head";
 
 export const SWAGGER_ALL_SUPPRESSION_TOOL = "SwaggerAll";
 
@@ -24,22 +26,18 @@ export function isSwaggerCheck(checkName) {
 }
 
 /**
- * Resolve a Swagger check exemption using the same ancestor-file semantics as
- * `@azure-tools/suppressions`.
- *
- * Conditional entries are deliberately ignored because this resolver runs in a privileged
- * workflow without the tool-specific context needed to evaluate them.
+ * Determine whether every changed specification path has a whole-check suppression.
  *
  * @param {Object} params
  * @param {string[]} params.changedPaths
  * @param {string} params.checkName
- * @param {(path: string) => Promise<string | undefined>} params.loadSuppressionsFile
+ * @param {(tool: string, path: string) => Promise<SwaggerSuppression[]>} params.getSuppressionsForPath
  * @returns {Promise<{skip: false} | {skip: true, reason: string}>}
  */
 export async function resolveSwaggerCheckSuppression({
   changedPaths,
   checkName,
-  loadSuppressionsFile,
+  getSuppressionsForPath,
 }) {
   if (!isSwaggerCheck(checkName)) {
     return { skip: false };
@@ -50,65 +48,25 @@ export async function resolveSwaggerCheckSuppression({
       changedPaths.map(normalizeRepoPath).filter((path) => path.startsWith("specification/")),
     ),
   ];
-
   if (specificationPaths.length === 0) {
     return { skip: false };
   }
 
-  const suppressionTools = [SWAGGER_SUPPRESSION_TOOLS[checkName], SWAGGER_ALL_SUPPRESSION_TOOL];
-  const { getSuppressionsFromYaml } =
-    await import("../../../eng/tools/suppressions/src/suppressions.ts");
-  /** @type {Map<string, Promise<string | undefined>>} */
-  const contentCache = new Map();
-  /** @type {Set<string>} */
   const reasons = new Set();
+  for (const path of specificationPaths) {
+    const toolSuppressions = await getSuppressionsForPath(
+      SWAGGER_SUPPRESSION_TOOLS[checkName],
+      path,
+    );
+    const allSuppressions = await getSuppressionsForPath(SWAGGER_ALL_SUPPRESSION_TOOL, path);
+    const suppression = [...toolSuppressions, ...allSuppressions].find(
+      (item) => !item.rules?.length && !item.subRules?.length,
+    );
 
-  for (const changedPath of specificationPaths) {
-    /** @type {SwaggerSuppression | undefined} */
-    let matchedSuppression;
-
-    for (const suppressionsFile of getAncestorSuppressionsFiles(changedPath)) {
-      let contentPromise = contentCache.get(suppressionsFile);
-      if (!contentPromise) {
-        contentPromise = loadSuppressionsFile(suppressionsFile);
-        contentCache.set(suppressionsFile, contentPromise);
-      }
-
-      const content = await contentPromise;
-      if (content === undefined) {
-        continue;
-      }
-
-      for (const tool of suppressionTools) {
-        const suppressions = /** @type {SwaggerSuppression[]} */ (
-          getSuppressionsFromYaml(
-            tool,
-            changedPath,
-            suppressionsFile,
-            content,
-            {},
-            { evaluateIf: false },
-          )
-        );
-        matchedSuppression = suppressions.find(
-          (suppression) => !suppression.rules?.length && !suppression.subRules?.length,
-        );
-
-        if (matchedSuppression) {
-          break;
-        }
-      }
-
-      if (matchedSuppression) {
-        break;
-      }
-    }
-
-    if (!matchedSuppression) {
+    if (!suppression) {
       return { skip: false };
     }
-
-    reasons.add(matchedSuppression.reason);
+    reasons.add(suppression.reason);
   }
 
   return {
@@ -119,9 +77,7 @@ export async function resolveSwaggerCheckSuppression({
 }
 
 /**
- * Resolve a Swagger check exemption from `suppressions.yaml` files in the pull request base.
- *
- * Reading the reviewed base policy prevents an untrusted pull request from exempting itself.
+ * Resolve a Swagger check suppression from the sparse PR-head checkout.
  *
  * @param {Object} params
  * @param {import('@actions/github-script').AsyncFunctionArguments["github"]} params.github
@@ -129,11 +85,17 @@ export async function resolveSwaggerCheckSuppression({
  * @param {string} params.repo
  * @param {number} params.pullNumber
  * @param {string} params.checkName
+ * @param {(tool: string, path: string, context?: Record<string, unknown>, options?: {allowMissingPath?: boolean, evaluateIf?: boolean}) => Promise<SwaggerSuppression[]>} [params.getSuppressionsImpl]
  * @returns {Promise<{skip: false} | {skip: true, reason: string}>}
  */
-export async function getSwaggerCheckSuppression({ github, owner, repo, pullNumber, checkName }) {
-  /** @type {Promise<{baseOwner: string, baseRepo: string, baseSha: string}> | undefined} */
-  let pullRequestBasePromise;
+export async function getSwaggerCheckSuppression({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  checkName,
+  getSuppressionsImpl,
+}) {
   const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
     owner,
     repo,
@@ -144,58 +106,23 @@ export async function getSwaggerCheckSuppression({ github, owner, repo, pullNumb
     file.previous_filename ? [file.filename, file.previous_filename] : [file.filename],
   );
 
+  getSuppressionsImpl ??= (await import("../../../eng/tools/suppressions/src/suppressions.ts"))
+    .getSuppressions;
+
   return await resolveSwaggerCheckSuppression({
     changedPaths,
     checkName,
-    loadSuppressionsFile: async (path) => {
-      pullRequestBasePromise ??= getPullRequestBase(github, owner, repo, pullNumber);
-      const { baseOwner, baseRepo, baseSha } = await pullRequestBasePromise;
-
-      try {
-        const { data } = await github.rest.repos.getContent({
-          owner: baseOwner,
-          repo: baseRepo,
-          path,
-          ref: baseSha,
-        });
-
-        if (Array.isArray(data) || data.type !== "file" || !("content" in data)) {
-          throw new Error(`Expected '${path}' to be a file`);
-        }
-
-        return Buffer.from(data.content, "base64").toString("utf8");
-      } catch (error) {
-        if (error instanceof Error && "status" in error && error.status === 404) {
-          return undefined;
-        }
-        throw error;
-      }
-    },
+    getSuppressionsForPath: async (tool, path) =>
+      await getSuppressionsImpl(
+        tool,
+        resolve(PR_HEAD_ROOT, path),
+        {},
+        {
+          allowMissingPath: true,
+          evaluateIf: false,
+        },
+      ),
   });
-}
-
-/**
- * @param {import('@actions/github-script').AsyncFunctionArguments["github"]} github
- * @param {string} owner
- * @param {string} repo
- * @param {number} pullNumber
- * @returns {Promise<{baseOwner: string, baseRepo: string, baseSha: string}>}
- */
-async function getPullRequestBase(github, owner, repo, pullNumber) {
-  const { data: pullRequest } = await github.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: pullNumber,
-  });
-  const baseOwner = pullRequest.base.repo.owner.login;
-  const baseRepo = pullRequest.base.repo.name;
-  const baseSha = pullRequest.base.sha;
-
-  if (!baseOwner || !baseRepo || !baseSha) {
-    throw new Error(`Pull request ${pullNumber} has no accessible base repository`);
-  }
-
-  return { baseOwner, baseRepo, baseSha };
 }
 
 /**
@@ -204,23 +131,4 @@ async function getPullRequestBase(github, owner, repo, pullNumber) {
  */
 function normalizeRepoPath(path) {
   return path.replaceAll("\\", "/").replace(/^\.\/+/, "");
-}
-
-/**
- * @param {string} changedPath
- * @returns {string[]}
- */
-function getAncestorSuppressionsFiles(changedPath) {
-  const files = [];
-  let directory = dirname(changedPath);
-
-  while (directory === "specification" || directory.startsWith("specification/")) {
-    files.push(`${directory}/suppressions.yaml`);
-    if (directory === "specification") {
-      break;
-    }
-    directory = dirname(directory);
-  }
-
-  return files;
 }

--- a/.github/workflows/src/swagger-check-suppressions.js
+++ b/.github/workflows/src/swagger-check-suppressions.js
@@ -1,0 +1,226 @@
+import { dirname } from "node:path/posix";
+import { PER_PAGE_MAX } from "../../shared/src/github.js";
+
+export const SWAGGER_ALL_SUPPRESSION_TOOL = "SwaggerAll";
+
+export const SWAGGER_SUPPRESSION_TOOLS = Object.freeze({
+  "Swagger Avocado": "SwaggerAvocado",
+  "Swagger LintDiff": "SwaggerLintDiff",
+  "Swagger ModelValidation": "SwaggerModelValidation",
+  "Swagger SemanticValidation": "SwaggerSemanticValidation",
+  "Swagger BreakingChange": "SwaggerBreakingChange",
+  "Breaking Change(Cross-Version)": "SwaggerBreakingChangeCrossVersion",
+});
+
+/** @typedef {keyof typeof SWAGGER_SUPPRESSION_TOOLS} SwaggerCheckName */
+/** @typedef {{rules?: string[], subRules?: string[], reason: string}} SwaggerSuppression */
+
+/**
+ * @param {string} checkName
+ * @returns {checkName is SwaggerCheckName}
+ */
+export function isSwaggerCheck(checkName) {
+  return Object.hasOwn(SWAGGER_SUPPRESSION_TOOLS, checkName);
+}
+
+/**
+ * Resolve a Swagger check exemption using the same ancestor-file semantics as
+ * `@azure-tools/suppressions`.
+ *
+ * Conditional entries are deliberately ignored because this resolver runs in a privileged
+ * workflow without the tool-specific context needed to evaluate them.
+ *
+ * @param {Object} params
+ * @param {string[]} params.changedPaths
+ * @param {string} params.checkName
+ * @param {(path: string) => Promise<string | undefined>} params.loadSuppressionsFile
+ * @returns {Promise<{skip: false} | {skip: true, reason: string}>}
+ */
+export async function resolveSwaggerCheckSuppression({
+  changedPaths,
+  checkName,
+  loadSuppressionsFile,
+}) {
+  if (!isSwaggerCheck(checkName)) {
+    return { skip: false };
+  }
+
+  const specificationPaths = [
+    ...new Set(
+      changedPaths.map(normalizeRepoPath).filter((path) => path.startsWith("specification/")),
+    ),
+  ];
+
+  if (specificationPaths.length === 0) {
+    return { skip: false };
+  }
+
+  const suppressionTools = [SWAGGER_SUPPRESSION_TOOLS[checkName], SWAGGER_ALL_SUPPRESSION_TOOL];
+  const { getSuppressionsFromYaml } =
+    await import("../../../eng/tools/suppressions/src/suppressions.ts");
+  /** @type {Map<string, Promise<string | undefined>>} */
+  const contentCache = new Map();
+  /** @type {Set<string>} */
+  const reasons = new Set();
+
+  for (const changedPath of specificationPaths) {
+    /** @type {SwaggerSuppression | undefined} */
+    let matchedSuppression;
+
+    for (const suppressionsFile of getAncestorSuppressionsFiles(changedPath)) {
+      let contentPromise = contentCache.get(suppressionsFile);
+      if (!contentPromise) {
+        contentPromise = loadSuppressionsFile(suppressionsFile);
+        contentCache.set(suppressionsFile, contentPromise);
+      }
+
+      const content = await contentPromise;
+      if (content === undefined) {
+        continue;
+      }
+
+      for (const tool of suppressionTools) {
+        const suppressions = /** @type {SwaggerSuppression[]} */ (
+          getSuppressionsFromYaml(
+            tool,
+            changedPath,
+            suppressionsFile,
+            content,
+            {},
+            { evaluateIf: false },
+          )
+        );
+        matchedSuppression = suppressions.find(
+          (suppression) => !suppression.rules?.length && !suppression.subRules?.length,
+        );
+
+        if (matchedSuppression) {
+          break;
+        }
+      }
+
+      if (matchedSuppression) {
+        break;
+      }
+    }
+
+    if (!matchedSuppression) {
+      return { skip: false };
+    }
+
+    reasons.add(matchedSuppression.reason);
+  }
+
+  return {
+    skip: true,
+    reason:
+      reasons.size === 1 ? [...reasons][0] : `Matched ${reasons.size} Swagger check suppressions`,
+  };
+}
+
+/**
+ * Resolve a Swagger check exemption from `suppressions.yaml` files in the pull request base.
+ *
+ * Reading the reviewed base policy prevents an untrusted pull request from exempting itself.
+ *
+ * @param {Object} params
+ * @param {import('@actions/github-script').AsyncFunctionArguments["github"]} params.github
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {number} params.pullNumber
+ * @param {string} params.checkName
+ * @returns {Promise<{skip: false} | {skip: true, reason: string}>}
+ */
+export async function getSwaggerCheckSuppression({ github, owner, repo, pullNumber, checkName }) {
+  /** @type {Promise<{baseOwner: string, baseRepo: string, baseSha: string}> | undefined} */
+  let pullRequestBasePromise;
+  const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: PER_PAGE_MAX,
+  });
+  const changedPaths = changedFiles.flatMap((file) =>
+    file.previous_filename ? [file.filename, file.previous_filename] : [file.filename],
+  );
+
+  return await resolveSwaggerCheckSuppression({
+    changedPaths,
+    checkName,
+    loadSuppressionsFile: async (path) => {
+      pullRequestBasePromise ??= getPullRequestBase(github, owner, repo, pullNumber);
+      const { baseOwner, baseRepo, baseSha } = await pullRequestBasePromise;
+
+      try {
+        const { data } = await github.rest.repos.getContent({
+          owner: baseOwner,
+          repo: baseRepo,
+          path,
+          ref: baseSha,
+        });
+
+        if (Array.isArray(data) || data.type !== "file" || !("content" in data)) {
+          throw new Error(`Expected '${path}' to be a file`);
+        }
+
+        return Buffer.from(data.content, "base64").toString("utf8");
+      } catch (error) {
+        if (error instanceof Error && "status" in error && error.status === 404) {
+          return undefined;
+        }
+        throw error;
+      }
+    },
+  });
+}
+
+/**
+ * @param {import('@actions/github-script').AsyncFunctionArguments["github"]} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} pullNumber
+ * @returns {Promise<{baseOwner: string, baseRepo: string, baseSha: string}>}
+ */
+async function getPullRequestBase(github, owner, repo, pullNumber) {
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  const baseOwner = pullRequest.base.repo.owner.login;
+  const baseRepo = pullRequest.base.repo.name;
+  const baseSha = pullRequest.base.sha;
+
+  if (!baseOwner || !baseRepo || !baseSha) {
+    throw new Error(`Pull request ${pullNumber} has no accessible base repository`);
+  }
+
+  return { baseOwner, baseRepo, baseSha };
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizeRepoPath(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+/**
+ * @param {string} changedPath
+ * @returns {string[]}
+ */
+function getAncestorSuppressionsFiles(changedPath) {
+  const files = [];
+  let directory = dirname(changedPath);
+
+  while (directory === "specification" || directory.startsWith("specification/")) {
+    files.push(`${directory}/suppressions.yaml`);
+    if (directory === "specification") {
+      break;
+    }
+    directory = dirname(directory);
+  }
+
+  return files;
+}

--- a/.github/workflows/test/mocks.js
+++ b/.github/workflows/test/mocks.js
@@ -62,7 +62,6 @@ function createMockGithubImpl() {
       },
       repos: {
         createCommitStatus: vi.fn(),
-        getContent: vi.fn(),
         listCommitStatusesForRef: vi.fn().mockResolvedValue({ data: [] }),
         listPullRequestsAssociatedWithCommit: vi.fn().mockResolvedValue({
           data: [],

--- a/.github/workflows/test/mocks.js
+++ b/.github/workflows/test/mocks.js
@@ -58,9 +58,11 @@ function createMockGithubImpl() {
       },
       pulls: {
         get: vi.fn(),
+        listFiles: vi.fn().mockResolvedValue({ data: [] }),
       },
       repos: {
         createCommitStatus: vi.fn(),
+        getContent: vi.fn(),
         listCommitStatusesForRef: vi.fn().mockResolvedValue({ data: [] }),
         listPullRequestsAssociatedWithCommit: vi.fn().mockResolvedValue({
           data: [],

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CheckConclusion, CheckStatus, CommitStatusState } from "../../shared/src/github.js";
 import { fullGitSha } from "../../shared/test/examples.js";
 import { setStatusImpl } from "../src/set-status.js";
@@ -250,6 +250,80 @@ describe("setStatusImpl", () => {
       sha: fullGitSha,
       state: CommitStatusState.PENDING,
       context: "Swagger BreakingChange",
+      target_url: "https://test.com/set_status_url",
+    });
+  });
+
+  it("sets success when all changed specification paths have a configured exemption", async () => {
+    const swaggerCheckSuppressionResolver = vi.fn().mockResolvedValue({
+      skip: true,
+      reason: "Swagger validation is not applicable",
+    });
+
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: fullGitSha,
+        issue_number: 123,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "Swagger Avocado - Analyze Code",
+        requiredStatusName: "Swagger Avocado",
+        overridingLabel: "Approved-Avocado",
+        swaggerCheckSuppressionResolver,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      sha: fullGitSha,
+      state: CommitStatusState.SUCCESS,
+      context: "Swagger Avocado",
+      description: "Skipped via suppressions.yaml: Swagger validation is not applicable",
+      target_url: "https://test.com/set_status_url",
+    });
+    expect(swaggerCheckSuppressionResolver).toHaveBeenCalledWith({
+      github,
+      owner: "test-owner",
+      repo: "test-repo",
+      pullNumber: 123,
+      checkName: "Swagger Avocado",
+    });
+    expect(github.rest.actions.listWorkflowRunsForRepo).not.toHaveBeenCalled();
+  });
+
+  it("does not consult exemptions for a non-Swagger check", async () => {
+    const swaggerCheckSuppressionResolver = vi.fn();
+    github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+      data: [],
+    });
+
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: fullGitSha,
+        issue_number: 123,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "TypeSpec Suppressions - Analyze Code",
+        requiredStatusName: "TypeSpec Suppressions",
+        overridingLabel: "",
+        swaggerCheckSuppressionResolver,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(swaggerCheckSuppressionResolver).not.toHaveBeenCalled();
+    expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      sha: fullGitSha,
+      state: CommitStatusState.PENDING,
+      context: "TypeSpec Suppressions",
       target_url: "https://test.com/set_status_url",
     });
   });

--- a/.github/workflows/test/swagger-check-suppressions.test.js
+++ b/.github/workflows/test/swagger-check-suppressions.test.js
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SWAGGER_ALL_SUPPRESSION_TOOL,
+  SWAGGER_SUPPRESSION_TOOLS,
+  getSwaggerCheckSuppression,
+  resolveSwaggerCheckSuppression,
+} from "../src/swagger-check-suppressions.js";
+import { createMockGithub } from "./mocks.js";
+
+const changedPath =
+  "specification/contoso/resource-manager/Microsoft.Contoso/stable/2025-01-01/foo.json";
+
+describe("resolveSwaggerCheckSuppression", () => {
+  it.each(Object.keys(SWAGGER_SUPPRESSION_TOOLS))(
+    "supports SwaggerAll for %s",
+    async (checkName) => {
+      const loadSuppressionsFile = vi.fn((path) =>
+        Promise.resolve(
+          path === "specification/suppressions.yaml"
+            ? `
+- tool: ${SWAGGER_ALL_SUPPRESSION_TOOL}
+  path: contoso/**
+  reason: Swagger checks are not applicable
+`
+            : undefined,
+        ),
+      );
+
+      await expect(
+        resolveSwaggerCheckSuppression({
+          changedPaths: [changedPath],
+          checkName,
+          loadSuppressionsFile,
+        }),
+      ).resolves.toEqual({
+        skip: true,
+        reason: "Swagger checks are not applicable",
+      });
+    },
+  );
+
+  it("supports a suppression for one Swagger check", async () => {
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [changedPath],
+        checkName: "Swagger LintDiff",
+        loadSuppressionsFile: (path) =>
+          Promise.resolve(
+            path === "specification/contoso/suppressions.yaml"
+              ? `
+- tool: SwaggerLintDiff
+  path: resource-manager/**
+  reason: LintDiff is not applicable
+`
+              : undefined,
+          ),
+      }),
+    ).resolves.toEqual({
+      skip: true,
+      reason: "LintDiff is not applicable",
+    });
+  });
+
+  it("falls back to specification/suppressions.yaml when no nearer file exists", async () => {
+    const loadSuppressionsFile = vi.fn((path) =>
+      Promise.resolve(
+        path === "specification/suppressions.yaml"
+          ? `
+- tool: SwaggerAll
+  path: contoso/**
+  reason: Central exemption
+`
+          : undefined,
+      ),
+    );
+
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [changedPath],
+        checkName: "Swagger Avocado",
+        loadSuppressionsFile,
+      }),
+    ).resolves.toEqual({ skip: true, reason: "Central exemption" });
+    expect(loadSuppressionsFile).toHaveBeenCalledWith("specification/contoso/suppressions.yaml");
+    expect(loadSuppressionsFile).toHaveBeenCalledWith("specification/suppressions.yaml");
+  });
+
+  it("uses a nearer project suppression before the central file", async () => {
+    const loadSuppressionsFile = vi.fn((path) => {
+      if (path === "specification/contoso/suppressions.yaml") {
+        return Promise.resolve(`
+- tool: SwaggerAll
+  path: resource-manager/**
+  reason: Project exemption
+`);
+      }
+      if (path === "specification/suppressions.yaml") {
+        return Promise.resolve(`
+- tool: SwaggerAll
+  path: contoso/**
+  reason: Central exemption
+`);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [changedPath],
+        checkName: "Swagger Avocado",
+        loadSuppressionsFile,
+      }),
+    ).resolves.toEqual({ skip: true, reason: "Project exemption" });
+    expect(loadSuppressionsFile).not.toHaveBeenCalledWith("specification/suppressions.yaml");
+  });
+
+  it("does not skip unless all changed specification paths are suppressed", async () => {
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [
+          changedPath,
+          "specification/fabrikam/resource-manager/Microsoft.Fabrikam/foo.json",
+        ],
+        checkName: "Swagger Avocado",
+        loadSuppressionsFile: (path) =>
+          Promise.resolve(
+            path === "specification/suppressions.yaml"
+              ? `
+- tool: SwaggerAll
+  path: contoso/**
+  reason: Contoso exemption
+`
+              : undefined,
+          ),
+      }),
+    ).resolves.toEqual({ skip: false });
+  });
+
+  it("ignores rule-scoped and conditional suppressions", async () => {
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [changedPath],
+        checkName: "Swagger Avocado",
+        loadSuppressionsFile: (path) =>
+          Promise.resolve(
+            path === "specification/suppressions.yaml"
+              ? `
+- tool: SwaggerAll
+  path: contoso/**
+  rules: [SomeRule]
+  reason: Rule only
+- tool: SwaggerAll
+  path: contoso/**
+  if: "true"
+  reason: Conditional
+`
+              : undefined,
+          ),
+      }),
+    ).resolves.toEqual({ skip: false });
+  });
+
+  it("does not skip non-Swagger checks or PRs without specification changes", async () => {
+    const loadSuppressionsFile = vi.fn();
+
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [changedPath],
+        checkName: "TypeSpec Suppressions",
+        loadSuppressionsFile,
+      }),
+    ).resolves.toEqual({ skip: false });
+    await expect(
+      resolveSwaggerCheckSuppression({
+        changedPaths: [".github/workflows/avocado-code.yaml"],
+        checkName: "Swagger Avocado",
+        loadSuppressionsFile,
+      }),
+    ).resolves.toEqual({ skip: false });
+    expect(loadSuppressionsFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("getSwaggerCheckSuppression", () => {
+  it("loads suppression files from the pull request base commit", async () => {
+    const github = createMockGithub();
+    github.rest.pulls.get.mockResolvedValue({
+      data: {
+        base: {
+          sha: "b".repeat(40),
+          repo: {
+            name: "azure-rest-api-specs",
+            owner: { login: "Azure" },
+          },
+        },
+      },
+    });
+    github.rest.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: changedPath }],
+    });
+    github.rest.repos.getContent.mockImplementation(({ path }) => {
+      if (path !== "specification/suppressions.yaml") {
+        const error = new Error("Not Found");
+        Object.assign(error, { status: 404 });
+        return Promise.reject(error);
+      }
+      return Promise.resolve({
+        data: {
+          type: "file",
+          content: Buffer.from(
+            `
+- tool: SwaggerAll
+  path: contoso/**
+  reason: Central exemption
+`,
+          ).toString("base64"),
+        },
+      });
+    });
+
+    await expect(
+      getSwaggerCheckSuppression({
+        github,
+        owner: "Azure",
+        repo: "azure-rest-api-specs",
+        pullNumber: 123,
+        checkName: "Swagger Avocado",
+      }),
+    ).resolves.toEqual({ skip: true, reason: "Central exemption" });
+
+    expect(github.rest.repos.getContent).toHaveBeenCalledWith({
+      owner: "Azure",
+      repo: "azure-rest-api-specs",
+      path: "specification/suppressions.yaml",
+      ref: "b".repeat(40),
+    });
+    expect(github.rest.pulls.listFiles).toHaveBeenCalledWith({
+      owner: "Azure",
+      repo: "azure-rest-api-specs",
+      pull_number: 123,
+      per_page: 100,
+    });
+  });
+});

--- a/.github/workflows/test/swagger-check-suppressions.test.js
+++ b/.github/workflows/test/swagger-check-suppressions.test.js
@@ -9,32 +9,28 @@ import { createMockGithub } from "./mocks.js";
 
 const changedPath =
   "specification/contoso/resource-manager/Microsoft.Contoso/stable/2025-01-01/foo.json";
+const suppression = {
+  paths: ["contoso/**"],
+  reason: "Swagger checks are not applicable",
+};
 
 describe("resolveSwaggerCheckSuppression", () => {
   it.each(Object.keys(SWAGGER_SUPPRESSION_TOOLS))(
     "supports SwaggerAll for %s",
     async (checkName) => {
-      const loadSuppressionsFile = vi.fn((path) =>
-        Promise.resolve(
-          path === "specification/suppressions.yaml"
-            ? `
-- tool: ${SWAGGER_ALL_SUPPRESSION_TOOL}
-  path: contoso/**
-  reason: Swagger checks are not applicable
-`
-            : undefined,
-        ),
+      const getSuppressionsForPath = vi.fn((tool) =>
+        Promise.resolve(tool === SWAGGER_ALL_SUPPRESSION_TOOL ? [suppression] : []),
       );
 
       await expect(
         resolveSwaggerCheckSuppression({
           changedPaths: [changedPath],
           checkName,
-          loadSuppressionsFile,
+          getSuppressionsForPath,
         }),
       ).resolves.toEqual({
         skip: true,
-        reason: "Swagger checks are not applicable",
+        reason: suppression.reason,
       });
     },
   );
@@ -44,74 +40,13 @@ describe("resolveSwaggerCheckSuppression", () => {
       resolveSwaggerCheckSuppression({
         changedPaths: [changedPath],
         checkName: "Swagger LintDiff",
-        loadSuppressionsFile: (path) =>
-          Promise.resolve(
-            path === "specification/contoso/suppressions.yaml"
-              ? `
-- tool: SwaggerLintDiff
-  path: resource-manager/**
-  reason: LintDiff is not applicable
-`
-              : undefined,
-          ),
+        getSuppressionsForPath: (tool) =>
+          Promise.resolve(tool === "SwaggerLintDiff" ? [suppression] : []),
       }),
     ).resolves.toEqual({
       skip: true,
-      reason: "LintDiff is not applicable",
+      reason: suppression.reason,
     });
-  });
-
-  it("falls back to specification/suppressions.yaml when no nearer file exists", async () => {
-    const loadSuppressionsFile = vi.fn((path) =>
-      Promise.resolve(
-        path === "specification/suppressions.yaml"
-          ? `
-- tool: SwaggerAll
-  path: contoso/**
-  reason: Central exemption
-`
-          : undefined,
-      ),
-    );
-
-    await expect(
-      resolveSwaggerCheckSuppression({
-        changedPaths: [changedPath],
-        checkName: "Swagger Avocado",
-        loadSuppressionsFile,
-      }),
-    ).resolves.toEqual({ skip: true, reason: "Central exemption" });
-    expect(loadSuppressionsFile).toHaveBeenCalledWith("specification/contoso/suppressions.yaml");
-    expect(loadSuppressionsFile).toHaveBeenCalledWith("specification/suppressions.yaml");
-  });
-
-  it("uses a nearer project suppression before the central file", async () => {
-    const loadSuppressionsFile = vi.fn((path) => {
-      if (path === "specification/contoso/suppressions.yaml") {
-        return Promise.resolve(`
-- tool: SwaggerAll
-  path: resource-manager/**
-  reason: Project exemption
-`);
-      }
-      if (path === "specification/suppressions.yaml") {
-        return Promise.resolve(`
-- tool: SwaggerAll
-  path: contoso/**
-  reason: Central exemption
-`);
-      }
-      return Promise.resolve(undefined);
-    });
-
-    await expect(
-      resolveSwaggerCheckSuppression({
-        changedPaths: [changedPath],
-        checkName: "Swagger Avocado",
-        loadSuppressionsFile,
-      }),
-    ).resolves.toEqual({ skip: true, reason: "Project exemption" });
-    expect(loadSuppressionsFile).not.toHaveBeenCalledWith("specification/suppressions.yaml");
   });
 
   it("does not skip unless all changed specification paths are suppressed", async () => {
@@ -122,101 +57,51 @@ describe("resolveSwaggerCheckSuppression", () => {
           "specification/fabrikam/resource-manager/Microsoft.Fabrikam/foo.json",
         ],
         checkName: "Swagger Avocado",
-        loadSuppressionsFile: (path) =>
-          Promise.resolve(
-            path === "specification/suppressions.yaml"
-              ? `
-- tool: SwaggerAll
-  path: contoso/**
-  reason: Contoso exemption
-`
-              : undefined,
-          ),
+        getSuppressionsForPath: (_tool, path) =>
+          Promise.resolve(path === changedPath ? [suppression] : []),
       }),
     ).resolves.toEqual({ skip: false });
   });
 
-  it("ignores rule-scoped and conditional suppressions", async () => {
+  it("ignores rule-scoped suppressions", async () => {
     await expect(
       resolveSwaggerCheckSuppression({
         changedPaths: [changedPath],
         checkName: "Swagger Avocado",
-        loadSuppressionsFile: (path) =>
-          Promise.resolve(
-            path === "specification/suppressions.yaml"
-              ? `
-- tool: SwaggerAll
-  path: contoso/**
-  rules: [SomeRule]
-  reason: Rule only
-- tool: SwaggerAll
-  path: contoso/**
-  if: "true"
-  reason: Conditional
-`
-              : undefined,
-          ),
+        getSuppressionsForPath: () => Promise.resolve([{ ...suppression, rules: ["SomeRule"] }]),
       }),
     ).resolves.toEqual({ skip: false });
   });
 
   it("does not skip non-Swagger checks or PRs without specification changes", async () => {
-    const loadSuppressionsFile = vi.fn();
+    const getSuppressionsForPath = vi.fn();
 
     await expect(
       resolveSwaggerCheckSuppression({
         changedPaths: [changedPath],
         checkName: "TypeSpec Suppressions",
-        loadSuppressionsFile,
+        getSuppressionsForPath,
       }),
     ).resolves.toEqual({ skip: false });
     await expect(
       resolveSwaggerCheckSuppression({
         changedPaths: [".github/workflows/avocado-code.yaml"],
         checkName: "Swagger Avocado",
-        loadSuppressionsFile,
+        getSuppressionsForPath,
       }),
     ).resolves.toEqual({ skip: false });
-    expect(loadSuppressionsFile).not.toHaveBeenCalled();
+    expect(getSuppressionsForPath).not.toHaveBeenCalled();
   });
 });
 
 describe("getSwaggerCheckSuppression", () => {
-  it("loads suppression files from the pull request base commit", async () => {
+  it("uses getSuppressions for current and previous paths", async () => {
     const github = createMockGithub();
-    github.rest.pulls.get.mockResolvedValue({
-      data: {
-        base: {
-          sha: "b".repeat(40),
-          repo: {
-            name: "azure-rest-api-specs",
-            owner: { login: "Azure" },
-          },
-        },
-      },
-    });
+    const previousPath = changedPath.replace("foo.json", "old.json");
     github.rest.pulls.listFiles.mockResolvedValue({
-      data: [{ filename: changedPath }],
+      data: [{ filename: changedPath, previous_filename: previousPath }],
     });
-    github.rest.repos.getContent.mockImplementation(({ path }) => {
-      if (path !== "specification/suppressions.yaml") {
-        const error = new Error("Not Found");
-        Object.assign(error, { status: 404 });
-        return Promise.reject(error);
-      }
-      return Promise.resolve({
-        data: {
-          type: "file",
-          content: Buffer.from(
-            `
-- tool: SwaggerAll
-  path: contoso/**
-  reason: Central exemption
-`,
-          ).toString("base64"),
-        },
-      });
-    });
+    const getSuppressionsImpl = vi.fn(() => Promise.resolve([suppression]));
 
     await expect(
       getSwaggerCheckSuppression({
@@ -225,20 +110,30 @@ describe("getSwaggerCheckSuppression", () => {
         repo: "azure-rest-api-specs",
         pullNumber: 123,
         checkName: "Swagger Avocado",
+        getSuppressionsImpl,
       }),
-    ).resolves.toEqual({ skip: true, reason: "Central exemption" });
-
-    expect(github.rest.repos.getContent).toHaveBeenCalledWith({
-      owner: "Azure",
-      repo: "azure-rest-api-specs",
-      path: "specification/suppressions.yaml",
-      ref: "b".repeat(40),
+    ).resolves.toEqual({
+      skip: true,
+      reason: suppression.reason,
     });
+
     expect(github.rest.pulls.listFiles).toHaveBeenCalledWith({
       owner: "Azure",
       repo: "azure-rest-api-specs",
       pull_number: 123,
       per_page: 100,
     });
+    expect(getSuppressionsImpl).toHaveBeenCalledWith(
+      "SwaggerAvocado",
+      expect.stringMatching(/pull-request-head[\\/]specification[\\/]contoso[\\/]resource-manager/),
+      {},
+      { allowMissingPath: true, evaluateIf: false },
+    );
+    expect(getSuppressionsImpl).toHaveBeenCalledWith(
+      "SwaggerAll",
+      expect.stringContaining("old.json"),
+      {},
+      { allowMissingPath: true, evaluateIf: false },
+    );
   });
 });

--- a/.github/workflows/test/swagger-check-suppressions.test.js
+++ b/.github/workflows/test/swagger-check-suppressions.test.js
@@ -125,15 +125,15 @@ describe("getSwaggerCheckSuppression", () => {
     });
     expect(getSuppressionsImpl).toHaveBeenCalledWith(
       "SwaggerAvocado",
-      expect.stringMatching(/pull-request-head[\\/]specification[\\/]contoso[\\/]resource-manager/),
+      expect.stringMatching(/pull-request-base[\\/]specification[\\/]contoso[\\/]resource-manager/),
       {},
-      { allowMissingPath: true, evaluateIf: false },
+      { allowMissingPath: true },
     );
     expect(getSuppressionsImpl).toHaveBeenCalledWith(
       "SwaggerAll",
       expect.stringContaining("old.json"),
       {},
-      { allowMissingPath: true, evaluateIf: false },
+      { allowMissingPath: true },
     );
   });
 });

--- a/eng/tools/suppressions/README.md
+++ b/eng/tools/suppressions/README.md
@@ -111,9 +111,7 @@ For example, an entry in `specification/suppressions.yaml` can cover a specifica
 The status gate walks from every changed specification path up to
 `specification/suppressions.yaml`, matching the existing closest-file-first behavior. Every changed
 specification path must have a matching suppression or the check runs normally. It reads
-`suppressions.yaml` from a sparse checkout of the pull request head, consistent with other
-suppression consumers. Conditional `if` entries are not evaluated by the privileged status
-workflow.
+`suppressions.yaml` from a sparse checkout of the trusted pull request base.
 
 ## Folder structure & contributing
 

--- a/eng/tools/suppressions/README.md
+++ b/eng/tools/suppressions/README.md
@@ -110,8 +110,10 @@ For example, an entry in `specification/suppressions.yaml` can cover a specifica
 
 The status gate walks from every changed specification path up to
 `specification/suppressions.yaml`, matching the existing closest-file-first behavior. Every changed
-specification path must have a matching suppression or the check runs normally. The gate reads
-suppression policy from the pull request base commit, so new exemptions become active after merge.
+specification path must have a matching suppression or the check runs normally. It reads
+`suppressions.yaml` from a sparse checkout of the pull request head, consistent with other
+suppression consumers. Conditional `if` entries are not evaluated by the privileged status
+workflow.
 
 ## Folder structure & contributing
 

--- a/eng/tools/suppressions/README.md
+++ b/eng/tools/suppressions/README.md
@@ -85,6 +85,34 @@ const suppressions: Suppression[] = await getSuppressions(
 `getSuppressions(tool, path)` resolves `path`, throws if it does not exist, walks up the directory
 tree collecting `suppressions.yaml` files, and returns the matching `Suppression[]`.
 
+### Skipping Swagger checks
+
+Swagger status checks recognize whole-check suppressions with no `rules` or `sub-rules`. Use
+`SwaggerAll` to skip every Swagger check, or one of the per-check tool names below:
+
+| Required check name            | Suppression tool                    |
+| ------------------------------ | ----------------------------------- |
+| Swagger Avocado                | `SwaggerAvocado`                    |
+| Swagger LintDiff               | `SwaggerLintDiff`                   |
+| Swagger ModelValidation        | `SwaggerModelValidation`            |
+| Swagger SemanticValidation     | `SwaggerSemanticValidation`         |
+| Swagger BreakingChange         | `SwaggerBreakingChange`             |
+| Breaking Change(Cross-Version) | `SwaggerBreakingChangeCrossVersion` |
+| All Swagger checks             | `SwaggerAll`                        |
+
+For example, an entry in `specification/suppressions.yaml` can cover a specification centrally:
+
+```yaml
+- tool: SwaggerAll
+  path: contoso/**
+  reason: Swagger checks are not applicable to this specification.
+```
+
+The status gate walks from every changed specification path up to
+`specification/suppressions.yaml`, matching the existing closest-file-first behavior. Every changed
+specification path must have a matching suppression or the check runs normally. The gate reads
+suppression policy from the pull request base commit, so new exemptions become active after merge.
+
 ## Folder structure & contributing
 
 ```

--- a/eng/tools/suppressions/src/suppressions.ts
+++ b/eng/tools/suppressions/src/suppressions.ts
@@ -24,7 +24,7 @@ const suppressionSchema = z.array(
     .object({
       tool: z.string(),
       if: z.string().optional(),
-      // For now, input allows "path" alongside "paths".  Lather, may deprecate "path".
+      // For now, input allows "path" alongside "paths".  Later, may deprecate "path".
       path: z.string().optional(),
       paths: z.array(z.string()).optional(),
       rules: z.array(z.string()).optional(),
@@ -105,30 +105,15 @@ export async function getSuppressions(
 
 /**
  * Returns the suppressions for a tool applicable to a path, given the path and content of the suppressions.yaml.
- * Extracted for unit testing.
- *
- * @internal
+ * Extracted for unit testing and API-backed consumers.
  *
  * @param tool Name of tool. Matched against property "tool" in suppressions.yaml.
  * @param path Path to file under analysis.
  * @param suppressionsFile Path to suppressions.yaml file.
  * @param suppressionsYaml Content of suppressions.yaml file.
+ * @param context Values available to conditional suppressions.
+ * @param options Matching options.
  * @returns Array of suppressions matching tool and path (may be empty).
- * @example
- * ```
- * // Prints
- * // '[{
- * //    "tool":"TypeSpecRequirement",
- * //    "path":"data-plane/foo/stable/2024-01-01/*.json",
- * //    "reason":"foo"
- * // }]':
- * console.log(JSON.stringify(_getSuppressionsFromYaml(
- *  "TypeSpecRequirement",
- *  "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json",
- *  "specification/foo/suppressions.yaml",
- *  '- tool: TypeSpecRequirement\n paths: ["data-plane/foo/stable/2024-01-01/*.json"]\n reason: foo'
- * )));
- * ```
  */
 export function getSuppressionsFromYaml(
   tool: string,
@@ -136,6 +121,7 @@ export function getSuppressionsFromYaml(
   suppressionsFile: string,
   suppressionsYaml: string,
   context: Record<string, unknown> = {},
+  options: { evaluateIf?: boolean } = {},
 ): Suppression[] {
   path = resolve(path);
   suppressionsFile = resolve(suppressionsFile);
@@ -155,6 +141,7 @@ export function getSuppressionsFromYaml(
     throw finalErr;
   }
 
+  const evaluateIf = options.evaluateIf ?? true;
   // Make "require" available inside sandbox for CJS imports
   const sandbox = { ...context, require: createRequire(import.meta.url) };
 
@@ -175,7 +162,9 @@ export function getSuppressionsFromYaml(
         });
       })
       // If
-      .filter((s) => s.if === undefined || vm.runInNewContext(s.if, sandbox))
+      .filter(
+        (s) => s.if === undefined || (evaluateIf && Boolean(vm.runInNewContext(s.if, sandbox))),
+      )
   );
 }
 

--- a/eng/tools/suppressions/src/suppressions.ts
+++ b/eng/tools/suppressions/src/suppressions.ts
@@ -79,7 +79,7 @@ export async function getSuppressions(
   tool: string,
   path: string,
   context: Record<string, unknown> = {},
-  options: { allowMissingPath?: boolean; evaluateIf?: boolean } = {},
+  options: { allowMissingPath?: boolean } = {},
 ): Promise<Suppression[]> {
   path = resolve(path);
 
@@ -99,7 +99,6 @@ export async function getSuppressions(
         suppressionsFile,
         await readFile(suppressionsFile, { encoding: "utf8" }),
         context,
-        { evaluateIf: options.evaluateIf },
       ),
     );
   }
@@ -116,7 +115,6 @@ export async function getSuppressions(
  * @param suppressionsFile Path to suppressions.yaml file.
  * @param suppressionsYaml Content of suppressions.yaml file.
  * @param context Values available to conditional suppressions.
- * @param options Matching options.
  * @returns Array of suppressions matching tool and path (may be empty).
  */
 export function getSuppressionsFromYaml(
@@ -125,7 +123,6 @@ export function getSuppressionsFromYaml(
   suppressionsFile: string,
   suppressionsYaml: string,
   context: Record<string, unknown> = {},
-  options: { evaluateIf?: boolean } = {},
 ): Suppression[] {
   path = resolve(path);
   suppressionsFile = resolve(suppressionsFile);
@@ -145,7 +142,6 @@ export function getSuppressionsFromYaml(
     throw finalErr;
   }
 
-  const evaluateIf = options.evaluateIf ?? true;
   // Make "require" available inside sandbox for CJS imports
   const sandbox = { ...context, require: createRequire(import.meta.url) };
 
@@ -166,9 +162,7 @@ export function getSuppressionsFromYaml(
         });
       })
       // If
-      .filter(
-        (s) => s.if === undefined || (evaluateIf && Boolean(vm.runInNewContext(s.if, sandbox))),
-      )
+      .filter((s) => s.if === undefined || vm.runInNewContext(s.if, sandbox))
   );
 }
 

--- a/eng/tools/suppressions/src/suppressions.ts
+++ b/eng/tools/suppressions/src/suppressions.ts
@@ -79,13 +79,16 @@ export async function getSuppressions(
   tool: string,
   path: string,
   context: Record<string, unknown> = {},
+  options: { allowMissingPath?: boolean; evaluateIf?: boolean } = {},
 ): Promise<Suppression[]> {
   path = resolve(path);
 
   // If path doesn't exist, throw instead of returning "[]" to prevent confusion
-  await access(path, constants.R_OK);
+  if (!options.allowMissingPath) {
+    await access(path, constants.R_OK);
+  }
 
-  const suppressionsFiles: string[] = await findSuppressionsFiles(path);
+  const suppressionsFiles: string[] = await findSuppressionsFiles(path, options.allowMissingPath);
   let suppressions: Suppression[] = [];
 
   for (const suppressionsFile of suppressionsFiles) {
@@ -96,6 +99,7 @@ export async function getSuppressions(
         suppressionsFile,
         await readFile(suppressionsFile, { encoding: "utf8" }),
         context,
+        { evaluateIf: options.evaluateIf },
       ),
     );
   }
@@ -184,13 +188,18 @@ export function getSuppressionsFromYaml(
  * ));
  * ```
  */
-async function findSuppressionsFiles(path: string): Promise<string[]> {
+async function findSuppressionsFiles(path: string, assumeFile: boolean = false): Promise<string[]> {
   const suppressionsFiles: string[] = [];
 
   path = resolve(path);
 
-  const stats: Stats = await lstat(path);
-  let currentDirectory: string = stats.isDirectory() ? path : dirname(path);
+  let currentDirectory: string;
+  if (assumeFile) {
+    currentDirectory = dirname(path);
+  } else {
+    const stats: Stats = await lstat(path);
+    currentDirectory = stats.isDirectory() ? path : dirname(path);
+  }
 
   while (true) {
     const suppressionsFile: string = join(currentDirectory, "suppressions.yaml");

--- a/eng/tools/suppressions/test/suppressions.e2e.test.ts
+++ b/eng/tools/suppressions/test/suppressions.e2e.test.ts
@@ -21,6 +21,30 @@ test.concurrent("no suppressions.yaml", async () => {
   expect(suppressions).toEqual([]);
 });
 
+test.concurrent("missing path allowed", async () => {
+  const path = join(__dirname, "e2e", "merge", "foo", "missing.json");
+  const suppressions = await getSuppressions("TestTool", path, {}, { allowMissingPath: true });
+
+  expect(suppressions.map(({ paths, reason }) => ({ paths, reason }))).toEqual([
+    {
+      paths: ["**"],
+      reason: "foo-globstar",
+    },
+    {
+      paths: ["*"],
+      reason: "foo-star",
+    },
+    {
+      paths: ["foo/**"],
+      reason: "root-foo-globstar",
+    },
+    {
+      paths: ["foo/*"],
+      reason: "root-foo-star",
+    },
+  ]);
+});
+
 test.concurrent("empty suppressions.yaml", async () => {
   const suppressions: Suppression[] = await getTestSuppressions("emptySuppressionsYaml");
   expect(suppressions).toEqual([]);

--- a/eng/tools/suppressions/test/suppressions.test.ts
+++ b/eng/tools/suppressions/test/suppressions.test.ts
@@ -210,18 +210,6 @@ test("tool matching", () => {
   ]);
 });
 
-test("conditional suppression evaluation can be disabled", () => {
-  const suppressions: Suppression[] = getSuppressionsFromYaml(
-    "TestTool",
-    "foo.json",
-    "suppressions.yaml",
-    '- tool: TestTool\n  path: "foo.json"\n  if: "true"\n  reason: test',
-    {},
-    { evaluateIf: false },
-  );
-  expect(suppressions).toEqual([]);
-});
-
 test("suppression path relative to suppressions file", () => {
   let suppressions: Suppression[] = getSuppressionsFromYaml(
     "TestTool",

--- a/eng/tools/suppressions/test/suppressions.test.ts
+++ b/eng/tools/suppressions/test/suppressions.test.ts
@@ -210,6 +210,18 @@ test("tool matching", () => {
   ]);
 });
 
+test("conditional suppression evaluation can be disabled", () => {
+  const suppressions: Suppression[] = getSuppressionsFromYaml(
+    "TestTool",
+    "foo.json",
+    "suppressions.yaml",
+    '- tool: TestTool\n  path: "foo.json"\n  if: "true"\n  reason: test',
+    {},
+    { evaluateIf: false },
+  );
+  expect(suppressions).toEqual([]);
+});
+
 test("suppression path relative to suppressions file", () => {
   let suppressions: Suppression[] = getSuppressionsFromYaml(
     "TestTool",


### PR DESCRIPTION
This PR uses the common set-status flow to see if swagger checks have been suppressed through suppressions.yaml. Also note that it supports a `SwaggerAll` value to skip all swagger checks for services that do not use swagger, such as Foundry. 