### PR TITLE
Add Ray Client remote access to MachineLearningServices 2026-05-15-preview

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-05-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-05-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -12,7 +12,8 @@
           "distributionType": "Ray",
           "port": 6379,
           "includeDashboard": true,
-          "dashboardPort": 8265
+          "dashboardPort": 8265,
+          "enableRemoteAccessClientServer": true
         },
         "environmentId": "string",
         "environmentVariables": {
@@ -57,7 +58,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {
@@ -103,7 +105,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {

--- a/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
@@ -15422,6 +15422,12 @@ model Ray extends DistributionConfiguration {
   workerNodeAdditionalArgs?: string | null;
 
   /**
+   * Whether to expose the Ray Client server through the AML proxy on the default port 10001.
+   */
+  @added(Versions.v2026_05_15_preview)
+  enableRemoteAccessClientServer?: boolean;
+
+  /**
    * [Required] Specifies the type of distribution framework.
    */
   distributionType: "Ray";

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-05-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-05-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -12,7 +12,8 @@
           "distributionType": "Ray",
           "port": 6379,
           "includeDashboard": true,
-          "dashboardPort": 8265
+          "dashboardPort": 8265,
+          "enableRemoteAccessClientServer": true
         },
         "environmentId": "string",
         "environmentVariables": {
@@ -57,7 +58,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {
@@ -103,7 +105,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-05-15-preview/openapi.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-05-15-preview/openapi.json
@@ -39343,6 +39343,10 @@
           "type": "string",
           "description": "Additional arguments passed to ray start in worker node.",
           "x-nullable": true
+        },
+        "enableRemoteAccessClientServer": {
+          "type": "boolean",
+          "description": "Whether to expose the Ray Client server through the AML proxy on the default port 10001."
         }
       },
       "allOf": [


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [x] Other, please clarify:
  - Additively expose an existing Ray backend capability in the MachineLearningServices `2026-05-15-preview` API, as requested by the service owner.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [ ] I have reviewed the Resource Provider and REST guidelines referenced by the PR template.
- [ ] A release plan has been created or confirmed for this update.

## Summary

Adds the optional `enableRemoteAccessClientServer` property to the Ray distribution configuration in `2026-05-15-preview`.

- `true` exposes the Ray Client server through the AML proxy.
- The API intentionally does not expose `clientServerPort`; the service uses the existing default port `10001`.
- The property is gated to `2026-05-15-preview`; `2026-03-15-preview` and stable API versions are unchanged.
- Updates the Ray command-job request/response example and regenerates OpenAPI from TypeSpec.

The Execution backend support was previously merged in Vienna PR 2034747. A companion MFE PR will map this ARM property through both the classic job path and the FoundryTrainingJob route.

## Validation

- `npx tsp compile .` succeeded.
- `npx tsp format --check models.tsp` succeeded.
- Repository Prettier checks passed for all changed JSON files.
- `oav validate-example` completed without errors.
- `oav validate-spec` completed without errors.
- Generated version check: property occurrences are `0` in `2026-03-15-preview`, `1` in `2026-05-15-preview`, and `0` in stable versions.