### PR TITLE
Add shared voice agent tool choice

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38781,7 +38781,7 @@
             "description": "The Handlebars prompt that guides the opening turn."
           },
           "tool_choice": {
-            "$ref": "#/components/schemas/VoiceGreetingToolChoice",
+            "$ref": "#/components/schemas/VoiceAgentToolChoice",
             "description": "The tool-selection policy for the opening response. Defaults to `none`.",
             "default": "none"
           }
@@ -82142,6 +82142,11 @@
             },
             "description": "The tools the voice agent may use. Supported tool kinds are `function` (executed by the client), `mcp`,\n`system` (service-managed session controls), and `toolbox`. Server-side tools such as `web_search`,\n`azure_ai_search`, and `openapi` are provided through a toolbox rather than declared directly."
           },
+          "tool_choice": {
+            "$ref": "#/components/schemas/VoiceAgentToolChoice",
+            "description": "How the model chooses tools for generated responses. `none` prevents tool calls, `auto` lets the model decide,\n`required` requires at least one tool call, and a specific function or MCP tool can be selected with an object.\nDefaults to `auto`.",
+            "default": "auto"
+          },
           "structured_inputs": {
             "type": "object",
             "unevaluatedProperties": {
@@ -82395,6 +82400,25 @@
           }
         ],
         "description": "A tool usable by a voice agent. Supported kinds are native `function` tools (executed by the client), `mcp`,\nservice-managed `system` controls, and `toolbox` references. Server-side tools such as `web_search` and\n`azure_ai_search` are provided through a toolbox.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentToolChoice": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceFunction"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceMCP"
+          }
+        ],
+        "description": "Tool-selection behavior for a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -83496,20 +83520,6 @@
           }
         },
         "description": "Session-start greeting configuration for a voice agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "VoiceGreetingToolChoice": {
-        "type": "string",
-        "enum": [
-          "none",
-          "auto",
-          "required"
-        ],
-        "description": "The tool-selection policy for an LLM-generated greeting.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46891,7 +46891,7 @@ components:
           minLength: 1
           description: The Handlebars prompt that guides the opening turn.
         tool_choice:
-          $ref: '#/components/schemas/VoiceGreetingToolChoice'
+          $ref: '#/components/schemas/VoiceAgentToolChoice'
           description: The tool-selection policy for the opening response. Defaults to `none`.
           default: none
       allOf:
@@ -78237,6 +78237,13 @@ components:
             The tools the voice agent may use. Supported tool kinds are `function` (executed by the client), `mcp`,
             `system` (service-managed session controls), and `toolbox`. Server-side tools such as `web_search`,
             `azure_ai_search`, and `openapi` are provided through a toolbox rather than declared directly.
+        tool_choice:
+          $ref: '#/components/schemas/VoiceAgentToolChoice'
+          description: |-
+            How the model chooses tools for generated responses. `none` prevents tool calls, `auto` lets the model decide,
+            `required` requires at least one tool call, and a specific function or MCP tool can be selected with an object.
+            Defaults to `auto`.
+          default: auto
         structured_inputs:
           type: object
           unevaluatedProperties:
@@ -78410,6 +78417,15 @@ components:
         A tool usable by a voice agent. Supported kinds are native `function` tools (executed by the client), `mcp`,
         service-managed `system` controls, and `toolbox` references. Server-side tools such as `web_search` and
         `azure_ai_search` are provided through a toolbox.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentToolChoice:
+      oneOf:
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceFunction'
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceMCP'
+      description: Tool-selection behavior for a voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -79166,16 +79182,6 @@ components:
           template: '#/components/schemas/TemplateVoiceGreetingConfig'
           llm_generated: '#/components/schemas/LlmGeneratedVoiceGreetingConfig'
       description: Session-start greeting configuration for a voice agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    VoiceGreetingToolChoice:
-      type: string
-      enum:
-        - none
-        - auto
-        - required
-      description: The tool-selection policy for an LLM-generated greeting.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -43126,7 +43126,7 @@
             "description": "The Handlebars prompt that guides the opening turn."
           },
           "tool_choice": {
-            "$ref": "#/components/schemas/VoiceGreetingToolChoice",
+            "$ref": "#/components/schemas/VoiceAgentToolChoice",
             "description": "The tool-selection policy for the opening response. Defaults to `none`.",
             "default": "none"
           }
@@ -86801,6 +86801,11 @@
             },
             "description": "The tools the voice agent may use. Supported tool kinds are `function` (executed by the client), `mcp`,\n`system` (service-managed session controls), and `toolbox`. Server-side tools such as `web_search`,\n`azure_ai_search`, and `openapi` are provided through a toolbox rather than declared directly."
           },
+          "tool_choice": {
+            "$ref": "#/components/schemas/VoiceAgentToolChoice",
+            "description": "How the model chooses tools for generated responses. `none` prevents tool calls, `auto` lets the model decide,\n`required` requires at least one tool call, and a specific function or MCP tool can be selected with an object.\nDefaults to `auto`.",
+            "default": "auto"
+          },
           "structured_inputs": {
             "type": "object",
             "unevaluatedProperties": {
@@ -87054,6 +87059,25 @@
           }
         ],
         "description": "A tool usable by a voice agent. Supported kinds are native `function` tools (executed by the client), `mcp`,\nservice-managed `system` controls, and `toolbox` references. Server-side tools such as `web_search` and\n`azure_ai_search` are provided through a toolbox.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentToolChoice": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceFunction"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAI.ToolChoiceMCP"
+          }
+        ],
+        "description": "Tool-selection behavior for a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -88155,20 +88179,6 @@
           }
         },
         "description": "Session-start greeting configuration for a voice agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "VoiceGreetingToolChoice": {
-        "type": "string",
-        "enum": [
-          "none",
-          "auto",
-          "required"
-        ],
-        "description": "The tool-selection policy for an LLM-generated greeting.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49876,7 +49876,7 @@ components:
           minLength: 1
           description: The Handlebars prompt that guides the opening turn.
         tool_choice:
-          $ref: '#/components/schemas/VoiceGreetingToolChoice'
+          $ref: '#/components/schemas/VoiceAgentToolChoice'
           description: The tool-selection policy for the opening response. Defaults to `none`.
           default: none
       allOf:
@@ -81445,6 +81445,13 @@ components:
             The tools the voice agent may use. Supported tool kinds are `function` (executed by the client), `mcp`,
             `system` (service-managed session controls), and `toolbox`. Server-side tools such as `web_search`,
             `azure_ai_search`, and `openapi` are provided through a toolbox rather than declared directly.
+        tool_choice:
+          $ref: '#/components/schemas/VoiceAgentToolChoice'
+          description: |-
+            How the model chooses tools for generated responses. `none` prevents tool calls, `auto` lets the model decide,
+            `required` requires at least one tool call, and a specific function or MCP tool can be selected with an object.
+            Defaults to `auto`.
+          default: auto
         structured_inputs:
           type: object
           unevaluatedProperties:
@@ -81618,6 +81625,15 @@ components:
         A tool usable by a voice agent. Supported kinds are native `function` tools (executed by the client), `mcp`,
         service-managed `system` controls, and `toolbox` references. Server-side tools such as `web_search` and
         `azure_ai_search` are provided through a toolbox.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentToolChoice:
+      oneOf:
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceFunction'
+        - $ref: '#/components/schemas/OpenAI.ToolChoiceMCP'
+      description: Tool-selection behavior for a voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -82374,16 +82390,6 @@ components:
           template: '#/components/schemas/TemplateVoiceGreetingConfig'
           llm_generated: '#/components/schemas/LlmGeneratedVoiceGreetingConfig'
       description: Session-start greeting configuration for a voice agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    VoiceGreetingToolChoice:
-      type: string
-      enum:
-        - none
-        - auto
-        - required
-      description: The tool-selection policy for an LLM-generated greeting.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -72,6 +72,13 @@ model VoiceAgentDefinition {
     """)
   tools?: VoiceAgentTool[];
 
+  @doc("""
+    How the model chooses tools for generated responses. `none` prevents tool calls, `auto` lets the model decide,
+    `required` requires at least one tool call, and a specific function or MCP tool can be selected with an object.
+    Defaults to `auto`.
+    """)
+  tool_choice?: VoiceAgentToolChoice = OpenAI.ToolChoiceOptions.auto;
+
   @doc("Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.")
   structured_inputs?: Record<StructuredInputDefinition>;
 
@@ -114,20 +121,7 @@ model LlmGeneratedVoiceGreetingConfig extends VoiceGreetingConfig {
   prompt: string;
 
   @doc("The tool-selection policy for the opening response. Defaults to `none`.")
-  tool_choice?: VoiceGreetingToolChoice = VoiceGreetingToolChoice.none;
-}
-
-@doc("The tool-selection policy for an LLM-generated greeting.")
-@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-union VoiceGreetingToolChoice {
-  @doc("Do not use tools for the opening response.")
-  none: "none",
-
-  @doc("Allow the model to select configured tools for the opening response.")
-  auto: "auto",
-
-  @doc("Require the opening response to use a configured tool.")
-  required: "required",
+  tool_choice?: VoiceAgentToolChoice = OpenAI.ToolChoiceOptions.none;
 }
 
 @doc("""
@@ -163,6 +157,16 @@ union VoiceAgentTool {
 
   @doc("A reference to a Foundry toolbox executed through its MCP endpoint.")
   toolbox: VoiceToolboxTool,
+}
+
+#suppress "@azure-tools/typespec-autorest/union-unsupported" "Tool choice may be a mode, a forced function, or an MCP tool."
+@doc("Tool-selection behavior for a voice agent.")
+@oneOf
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union VoiceAgentToolChoice {
+  mode: OpenAI.ToolChoiceOptions,
+  function: OpenAI.ToolChoiceFunction,
+  mcp: OpenAI.ToolChoiceMCP,
 }
 
 @doc("When an MCP invocation creates a follow-up response. Additional values may be added over time.")


### PR DESCRIPTION
## Summary

- add `tool_choice` to `VoiceAgentDefinition`, defaulting to `auto`
- define the shared mode-or-function `VoiceAgentToolChoice` shape used by the voice WebSocket contract in #45143
- reuse the shared definition for LLM-generated greetings, defaulting to `none`
- regenerate the v1 and virtual preview OpenAPI projections

This PR targets the review branch for #45185 so the change can be incorporated without including unrelated Foundry history.

## Validation

- `tsp compile . --warn-as-error`
- C# voice client TypeSpec compile with `--no-emit --warn-as-error`
- JavaScript voice client TypeSpec compile with `--no-emit --warn-as-error`
- Python voice client TypeSpec compile with `--no-emit --warn-as-error`
