### PR TITLE
ContainerService: GA nodePublicIPPrefixIDs on stable 2026-07-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -856,7 +856,7 @@ model AgentPoolNetworkProfile {
   nodePublicIPTags?: IPTag[];
 
   /**
-   * The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip
+   * Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_07_01)

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -856,7 +856,7 @@ model AgentPoolNetworkProfile {
   nodePublicIPTags?: IPTag[];
 
   /**
-   * Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip
+   * Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). For more information, see https://aka.ms/aks/ipv6-ilpip
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_07_01)

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -859,7 +859,7 @@ model AgentPoolNetworkProfile {
    * The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
-  @added(Versions.v2026_07_02_preview)
+  @added(Versions.v2026_07_01)
   @maxItems(2)
   nodePublicIPPrefixIDs?: Azure.Core.armResourceIdentifier<[
     {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -231,7 +231,7 @@ model ManagedClusterAgentPoolProfileProperties {
   enableNodePublicIP?: boolean;
 
   /**
-   * The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+   * The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   nodePublicIPPrefixID?: Azure.Core.armResourceIdentifier<[

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -11734,7 +11734,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -7578,7 +7578,7 @@
         },
         "nodePublicIPPrefixIDs": {
           "type": "array",
-          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip",
+          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). For more information, see https://aka.ms/aks/ipv6-ilpip",
           "maxItems": 2,
           "items": {
             "type": "string",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -7578,7 +7578,7 @@
         },
         "nodePublicIPPrefixIDs": {
           "type": "array",
-          "description": "The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip",
+          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip",
           "maxItems": 2,
           "items": {
             "type": "string",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
@@ -6711,7 +6711,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
@@ -6767,7 +6767,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
@@ -6791,7 +6791,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
@@ -6801,7 +6801,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
@@ -7284,7 +7284,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
@@ -7307,7 +7307,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-06-01/managedClusters.json
@@ -7331,7 +7331,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
@@ -4909,7 +4909,7 @@
         },
         "nodePublicIPPrefixIDs": {
           "type": "array",
-          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip",
+          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). For more information, see https://aka.ms/aks/ipv6-ilpip",
           "maxItems": 2,
           "items": {
             "type": "string",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
@@ -7348,7 +7348,7 @@
         "nodePublicIPPrefixID": {
           "type": "string",
           "format": "arm-id",
-          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "description": "The resource ID of a public IP prefix for node public IPs (IPv4 only). Retained for backward compatibility. Use nodePublicIPPrefixIDs via API version 2026-07-01 or newer instead. This field cannot be updated once set. If both nodePublicIPPrefixID and nodePublicIPPrefixIDs are set, nodePublicIPPrefixIDs wins.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
@@ -4907,6 +4907,23 @@
           },
           "x-ms-identifiers": []
         },
+        "nodePublicIPPrefixIDs": {
+          "type": "array",
+          "description": "The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip",
+          "maxItems": 2,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Network/publicIPPrefixes"
+                }
+              ]
+            }
+          }
+        },
         "allowedHostPorts": {
           "type": "array",
           "description": "The port ranges that are allowed to access. The specified ranges are allowed to overlap.",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
@@ -4909,7 +4909,7 @@
         },
         "nodePublicIPPrefixIDs": {
           "type": "array",
-          "description": "The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip",
+          "description": "Resource IDs of public IP prefixes (Microsoft.Network/publicIPPrefixes) used to assign instance-level public IPs to nodes. At most two entries: one IPv4 prefix and one IPv6 prefix. The IPv6 prefix requires a dual-stack cluster (ipFamilies contains IPv6). Immutable after node-pool creation. For more information, see https://aka.ms/aks/ipv6-ilpip",
           "maxItems": 2,
           "items": {
             "type": "string",


### PR DESCRIPTION
## Summary

Promote the dual-stack node public IP prefix array **`nodePublicIPPrefixIDs`** (on `AgentPoolNetworkProfile`) from preview to the **`2026-07-01` stable** API version. This is the API-surface GA of the IPv6 ILPIP dual-stack node public IP feature; `2026-07-01` is the target GA stable version (public announcement planned for September).

## Change

- `aks/AgentPoolModels.tsp`: `@added(Versions.v2026_07_02_preview)` → `@added(Versions.v2026_07_01)`.
- Regenerated `aks/stable/2026-07-01/managedClusters.json` — the property now appears in the stable swagger (+17 lines).

The property is an `armResourceIdentifier` array (`Microsoft.Network/publicIPPrefixes`, `maxItems: 2`), already shipped in `2026-07-02-preview`.

## Breaking change?

**No.** Additive, optional property graduated into the existing, still-open `2026-07-01` stable version. No existing shapes change.

## Validation (local)

- `tsp compile` (TypeSpec 1.14.0 / `@azure-tools/typespec-autorest` 0.70.0): clean.
- LintDiff: **0 new** errors/warnings (all findings pre-existing; none on the added property).
- avocado: **0 new** issues (2680 before = 2680 after).
