### PR TITLE
ContentSafety: remove the Java emitter api-version pin

### DIFF
--- a/specification/cognitiveservices/ContentSafety/tspconfig.yaml
+++ b/specification/cognitiveservices/ContentSafety/tspconfig.yaml
@@ -45,4 +45,4 @@ options:
     namespace: com.azure.ai.contentsafety
     partial-update: true
     flavor: azure
-    api-version: "2023-10-01"
+    api-version: "2026-07-01-preview"

--- a/specification/cognitiveservices/ContentSafety/tspconfig.yaml
+++ b/specification/cognitiveservices/ContentSafety/tspconfig.yaml
@@ -45,4 +45,3 @@ options:
     namespace: com.azure.ai.contentsafety
     partial-update: true
     flavor: azure
-    api-version: "2026-07-01-preview"


### PR DESCRIPTION
### Summary

Removes the `@azure-tools/typespec-java` `api-version` pin for ContentSafety.

One-line `tspconfig.yaml` change. No `.tsp` files change and the generated `contentsafety.json` is byte-identical (verified by recompiling with the pinned toolchain — `git status` stayed clean apart from `tspconfig.yaml`).

### The bug this fixes

The Java emitter has been pinned to `2023-10-01` since [#29084](https://github.com/Azure/azure-rest-api-specs/pull/29084) (May 2024). That pin drives the generated `ContentSafetyServiceVersion` enum, which today contains a single value:

```java
V2023_10_01("2023-10-01");
public static ContentSafetyServiceVersion getLatest() { return V2023_10_01; }
```

The `2026-07-01-preview` generation ([azure-sdk-for-java#49999](https://github.com/Azure/azure-sdk-for-java/pull/49999)) **did** emit the new Content Provenance classes, but it did **not** update that enum. `ContentProvenanceClientBuilder` falls back to `getLatest()`, and `ContentProvenanceClientImpl` passes it straight through as the `api-version` query parameter:

```java
service.detectSync(this.getEndpoint(), this.getServiceVersion().getVersion(), contentType, accept, ...)
```

So every Java provenance call is sent as `api-version=2023-10-01`, in which `/provenance:detect` does not exist. A caller cannot work around it, because the enum has no other value to pass.

Verified against the live service:

| api-version | Response |
|---|---|
| `2023-10-01` | `404` — `{"error":{"code":"404","message":"Resource not found"}}` |
| `2026-07-01-preview` | `400` — `{"error":{"code":"BadRequest","message":"Failed to connect to the blob."}}` |

The `400` is a deliberately invalid blob URI failing body validation, i.e. the route was reached. The Java PR adds no provenance tests, so nothing in CI catches this.

### The pin has also cost Java two years of features

This is not only about provenance. Java `azure-ai-contentsafety` has been GA since 2023-12-12 and is now at **1.0.19** — every one of those releases generated from `2023-10-01`. It never picked up `2024-09-01`.

Measured on `main`, Java's `ContentSafetyClient` exposes only `analyzeText` and `analyzeImage`:

| | `shieldPrompt` | `detectTextProtectedMaterial` |
|---|---|---|
| Java (`ContentSafetyClient.java`) | 0 | 0 |
| .NET (`Azure.AI.ContentSafety.net8.0.cs`) | 40 | 40 |

Removing the pin catches Java up on `2024-09-01` as well as enabling provenance.

### Why remove rather than re-pin

Removing the pin and setting it to `2026-07-01-preview` have the **same immediate effect** — with no pin the emitter uses the latest api-version in the spec. They differ only in future behaviour:

- **Keep a pin:** every future api-version needs another PR. That is precisely how Java came to sit on `2023-10-01` for two years while the service shipped `2024-09-01` and `2026-07-01-preview`.
- **No pin:** Java tracks the spec, exactly like this service's `csharp`, `python` and `ts` emitters, none of which pin.

This also matches the wider repo: of 607 `tspconfig.yaml` files, 336 configure `typespec-java` and only 18 (5%) pin `api-version`.

If the service team would rather keep an explicit pin, I'm happy to change this back to `api-version: "2026-07-01-preview"` — say so in review and I'll push it.

### Follow-up

Once merged, `azure-sdk-for-java` needs regeneration so `ContentSafetyServiceVersion` picks up the newer versions. Note that its three currently-failing blocklist tests are a **separate** issue (the emitter dropped the `accept` argument from void-returning operations, so recordings expecting `Accept: application/json` no longer match) and will need re-recording after that regeneration.

### Related

- Spec that added provenance: #45038
- Route fix: #45164
- CODEOWNERS: #45187
