### PR TITLE
Add Ray Client remote access to MachineLearningServices 2026-07-15-preview

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-07-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-07-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -12,7 +12,8 @@
           "distributionType": "Ray",
           "port": 6379,
           "includeDashboard": true,
-          "dashboardPort": 8265
+          "dashboardPort": 8265,
+          "enableRemoteAccessClientServer": true
         },
         "environmentId": "string",
         "environmentVariables": {
@@ -57,7 +58,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {
@@ -103,7 +105,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {

--- a/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
@@ -15447,6 +15447,12 @@ model Ray extends DistributionConfiguration {
   workerNodeAdditionalArgs?: string | null;
 
   /**
+   * Whether to expose the Ray Client server through the AML proxy on the default port 10001.
+   */
+  @added(Versions.v2026_07_15_preview)
+  enableRemoteAccessClientServer?: boolean;
+
+  /**
    * [Required] Specifies the type of distribution framework.
    */
   distributionType: "Ray";

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-07-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-07-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -12,7 +12,8 @@
           "distributionType": "Ray",
           "port": 6379,
           "includeDashboard": true,
-          "dashboardPort": 8265
+          "dashboardPort": 8265,
+          "enableRemoteAccessClientServer": true
         },
         "environmentId": "string",
         "environmentVariables": {
@@ -57,7 +58,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {
@@ -103,7 +105,8 @@
             "includeDashboard": true,
             "dashboardPort": 8265,
             "headNodeAdditionalArgs": null,
-            "workerNodeAdditionalArgs": null
+            "workerNodeAdditionalArgs": null,
+            "enableRemoteAccessClientServer": true
           },
           "environmentId": "string",
           "environmentVariables": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-07-15-preview/openapi.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-07-15-preview/openapi.json
@@ -39313,6 +39313,10 @@
           "type": "string",
           "description": "Additional arguments passed to ray start in worker node.",
           "x-nullable": true
+        },
+        "enableRemoteAccessClientServer": {
+          "type": "boolean",
+          "description": "Whether to expose the Ray Client server through the AML proxy on the default port 10001."
         }
       },
       "allOf": [


### PR DESCRIPTION
## Summary

- Add the optional `enableRemoteAccessClientServer` property to the Ray distribution, gated to `2026-07-15-preview`.
- Update the Ray command-job request/response example and generated OpenAPI contract.

## Validation

- `npm exec -- tsp compile specification/machinelearningservices/MachineLearningServices.Management --warn-as-error`
- Parsed the changed JSON examples and OpenAPI document with Node.js.
- `git diff --check`

## Dependencies

- Stacked on #44335, which introduces the MachineLearningServices `2026-07-15-preview` contract.

## Related

- Vienna service switch: https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2034747