### PR TITLE
Remove `managedOnBehalfOfConfiguration`, add `properties.encryption.status`

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -77,6 +77,7 @@ using Azure.ClientGenerator.Core;
   "AppConfigurationStoreEncryptionProperties",
   "csharp"
 );
+@@clientName(EncryptionStatus, "AppConfigurationEncryptionStatus", "csharp");
 @@clientName(
   NameAvailabilityStatus,
   "AppConfigurationNameAvailabilityResult",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/models.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/models.tsp
@@ -127,6 +127,69 @@ union PrivateLinkDelegation {
 }
 
 /**
+ * The status of customer-managed key encryption for a configuration store.
+ */
+@added(Versions.v2026_09_01_preview)
+union EncryptionStatus {
+  string,
+
+  /**
+   * The customer-managed key is accessible and encryption is functioning as expected.
+   */
+  Succeeded: "Succeeded",
+
+  /**
+   * The managed identity configured to access the customer-managed key could not be found.
+   */
+  IdentityNotFound: "IdentityNotFound",
+
+  /**
+   * The customer-managed key is in a state that does not permit encryption operations.
+   */
+  InvalidKeyState: "InvalidKeyState",
+
+  /**
+   * The length of the customer-managed key is not supported for encryption.
+   */
+  InvalidKeyLength: "InvalidKeyLength",
+
+  /**
+   * The customer-managed key is disabled in the key vault.
+   */
+  KeyDisabled: "KeyDisabled",
+
+  /**
+   * The customer-managed key has passed its expiration date.
+   */
+  KeyExpired: "KeyExpired",
+
+  /**
+   * The customer-managed key could not be found at the configured key identifier.
+   */
+  KeyNotFound: "KeyNotFound",
+
+  /**
+   * The algorithm of the customer-managed key is not supported for encryption.
+   */
+  UnsupportedKeyAlgorithm: "UnsupportedKeyAlgorithm",
+
+  /**
+   * The configured identity is not authorized to perform encryption operations with the customer-managed key.
+   */
+  Unauthorized: "Unauthorized",
+
+  /**
+   * The customer-managed key is not yet valid because its activation date is in the future.
+   */
+  KeyNotValidYet: "KeyNotValidYet",
+
+  /**
+   * Access to the customer-managed key is blocked by a network security perimeter configuration.
+   */
+  ForbiddenByNetworkSecurityPerimeter: "ForbiddenByNetworkSecurityPerimeter",
+}
+
+/**
  * The type of identity that created the resource.
  */
 union CreatedByType {
@@ -344,6 +407,13 @@ model EncryptionProperties {
    * Key vault properties.
    */
   keyVaultProperties?: KeyVaultProperties;
+
+  /**
+   * The status of customer-managed key encryption for the configuration store.
+   */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_09_01_preview)
+  status?: EncryptionStatus;
 }
 
 /**

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/models.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/models.tsp
@@ -326,6 +326,7 @@ model ConfigurationStoreProperties {
    * Managed On Behalf Of Configuration.
    */
   @visibility(Lifecycle.Read)
+  @removed(Versions.v2026_09_01_preview)
   managedOnBehalfOfConfiguration?: CommonTypes.ManagedOnBehalfOfConfiguration;
 
   /**

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -2326,11 +2326,6 @@
           "$ref": "#/definitions/TelemetryProperties",
           "description": "Property specifying the configuration of telemetry for this configuration store"
         },
-        "managedOnBehalfOfConfiguration": {
-          "$ref": "../../../../../../common-types/resource-management/v5/mobo.json#/definitions/ManagedOnBehalfOfConfiguration",
-          "description": "Managed On Behalf Of Configuration.",
-          "readOnly": true
-        },
         "azureFrontDoor": {
           "$ref": "#/definitions/AzureFrontDoorProperties",
           "description": "Property specifying the configuration of Azure Front Door for this configuration store"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -2540,7 +2540,90 @@
         "keyVaultProperties": {
           "$ref": "#/definitions/KeyVaultProperties",
           "description": "Key vault properties."
+        },
+        "status": {
+          "$ref": "#/definitions/EncryptionStatus",
+          "description": "The status of customer-managed key encryption for the configuration store.",
+          "readOnly": true
         }
+      }
+    },
+    "EncryptionStatus": {
+      "type": "string",
+      "description": "The status of customer-managed key encryption for a configuration store.",
+      "enum": [
+        "Succeeded",
+        "IdentityNotFound",
+        "InvalidKeyState",
+        "InvalidKeyLength",
+        "KeyDisabled",
+        "KeyExpired",
+        "KeyNotFound",
+        "UnsupportedKeyAlgorithm",
+        "Unauthorized",
+        "KeyNotValidYet",
+        "ForbiddenByNsp"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The customer-managed key is accessible and encryption is functioning as expected."
+          },
+          {
+            "name": "IdentityNotFound",
+            "value": "IdentityNotFound",
+            "description": "The managed identity configured to access the customer-managed key could not be found."
+          },
+          {
+            "name": "InvalidKeyState",
+            "value": "InvalidKeyState",
+            "description": "The customer-managed key is in a state that does not permit encryption operations."
+          },
+          {
+            "name": "InvalidKeyLength",
+            "value": "InvalidKeyLength",
+            "description": "The length of the customer-managed key is not supported for encryption."
+          },
+          {
+            "name": "KeyDisabled",
+            "value": "KeyDisabled",
+            "description": "The customer-managed key is disabled in the key vault."
+          },
+          {
+            "name": "KeyExpired",
+            "value": "KeyExpired",
+            "description": "The customer-managed key has passed its expiration date."
+          },
+          {
+            "name": "KeyNotFound",
+            "value": "KeyNotFound",
+            "description": "The customer-managed key could not be found at the configured key identifier."
+          },
+          {
+            "name": "UnsupportedKeyAlgorithm",
+            "value": "UnsupportedKeyAlgorithm",
+            "description": "The algorithm of the customer-managed key is not supported for encryption."
+          },
+          {
+            "name": "Unauthorized",
+            "value": "Unauthorized",
+            "description": "The configured identity is not authorized to perform encryption operations with the customer-managed key."
+          },
+          {
+            "name": "KeyNotValidYet",
+            "value": "KeyNotValidYet",
+            "description": "The customer-managed key is not yet valid because its activation date is in the future."
+          },
+          {
+            "name": "ForbiddenByNsp",
+            "value": "ForbiddenByNsp",
+            "description": "Access to the customer-managed key is blocked by a network security perimeter configuration."
+          }
+        ]
       }
     },
     "IdentityType": {

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -2562,7 +2562,7 @@
         "UnsupportedKeyAlgorithm",
         "Unauthorized",
         "KeyNotValidYet",
-        "ForbiddenByNsp"
+        "ForbiddenByNetworkSecurityPerimeter"
       ],
       "x-ms-enum": {
         "name": "EncryptionStatus",
@@ -2619,8 +2619,8 @@
             "description": "The customer-managed key is not yet valid because its activation date is in the future."
           },
           {
-            "name": "ForbiddenByNsp",
-            "value": "ForbiddenByNsp",
+            "name": "ForbiddenByNetworkSecurityPerimeter",
+            "value": "ForbiddenByNetworkSecurityPerimeter",
             "description": "Access to the customer-managed key is blocked by a network security perimeter configuration."
           }
         ]


### PR DESCRIPTION
This PR contains all of the changes in the `2026-09-01-preview` API version that aren't related to enhanced feature flags. Namely:
- Removes `managedOnBehalfOfConfiguration`
- Adds CMK encryption status as a control plane level property