### PR TITLE
Add DeltaSnap snapshot generation system event

### DIFF
--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/DeltaSnapExample.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/DeltaSnapExample.tsp
@@ -1,0 +1,18 @@
+import "./Storage.tsp";
+
+namespace Microsoft.EventGrid.SystemEvents;
+
+const MicrosoftStorageDeltaSnapSnapshotGenerationSucceededExample: StorageDeltaSnapSnapshotGenerationSucceededEventData = #{
+  jobId: "",
+  accountName: "p0uxscnsat12pe01gx",
+  status: "Succeeded",
+  dataRecordCount: "81",
+  totalSizeBytes: "27459",
+  snapshotCommitDurationMs: "670848",
+  snapshotCreateTime: utcDateTime.fromISO("2026-07-23T19:06:24.0794200Z"),
+  snapshotFinalizeTime: utcDateTime.fromISO("2026-07-23T19:17:34.9283110Z"),
+  snapshotId: "130",
+  operationType: "FULL_OVERWRITE",
+  dataFileCount: "1",
+  manifestCount: "1",
+};

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/DeltaSnapExample.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/DeltaSnapExample.tsp
@@ -4,7 +4,7 @@ namespace Microsoft.EventGrid.SystemEvents;
 
 const MicrosoftStorageDeltaSnapSnapshotGenerationSucceededExample: StorageDeltaSnapSnapshotGenerationSucceededEventData = #{
   jobId: "",
-  accountName: "p0uxscnsat12pe01gx",
+  accountName: "deltasnapstorageaccount",
   status: "Succeeded",
   dataRecordCount: "81",
   totalSizeBytes: "27459",

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
@@ -1,3 +1,4 @@
+import "./DeltaSnapExample.tsp";
 import "@typespec/versioning";
 using TypeSpec.Versioning;
 /** Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent. */
@@ -311,6 +312,46 @@ namespace Microsoft.EventGrid.SystemEvents {
     manifestBlobUrl?: string;
   }
 
+  /** Schema of the Data property of an EventGridEvent for a Microsoft.Storage.DeltaSnapSnapshotGenerationSucceeded event. */
+  @example(MicrosoftStorageDeltaSnapSnapshotGenerationSucceededExample)
+  model StorageDeltaSnapSnapshotGenerationSucceededEventData {
+    /** The identifier of the DeltaSnap job. The value is an empty string when no job identifier is assigned. */
+    jobId: string;
+
+    /** The name of the storage account for which the snapshot was generated. */
+    accountName: string;
+
+    /** The status of the snapshot generation operation. */
+    status: StorageDeltaSnapSnapshotGenerationStatus;
+
+    /** The number of records in data files added by the snapshot operation, encoded as a decimal string. */
+    dataRecordCount: string;
+
+    /** The total size, in bytes, of data files added by the snapshot operation, encoded as a decimal string. */
+    totalSizeBytes: string;
+
+    /** The elapsed time, in milliseconds, between the logical snapshot creation time and finalization time, encoded as a decimal string. */
+    snapshotCommitDurationMs: string;
+
+    /** The logical creation time of the snapshot. */
+    snapshotCreateTime: utcDateTime;
+
+    /** The time at which the snapshot was finalized and published. */
+    snapshotFinalizeTime: utcDateTime;
+
+    /** The decimal identifier of the generated snapshot. */
+    snapshotId: string;
+
+    /** The Iceberg operation used to generate the snapshot. */
+    operationType: StorageDeltaSnapSnapshotOperationType;
+
+    /** The number of data files added by the snapshot operation, encoded as a decimal string. */
+    dataFileCount: string;
+
+    /** The number of manifests attributed to data files added by the snapshot operation, encoded as a decimal string. */
+    manifestCount: string;
+  }
+
   /** Schema of the Data property of an EventGridEvent for an Microsoft.Storage.StorageTaskCompleted event. */
   model StorageTaskCompletedEventData {
     /** The status for a storage task. */
@@ -383,6 +424,31 @@ namespace Microsoft.EventGrid.SystemEvents {
 
     /** Incomplete */
     "Incomplete",
+
+    string,
+  }
+
+  /** The status of a DeltaSnap snapshot generation operation. */
+  union StorageDeltaSnapSnapshotGenerationStatus {
+    /** The snapshot was generated successfully. */
+    "Succeeded",
+
+    string,
+  }
+
+  /** The Iceberg operation used to generate a DeltaSnap snapshot. */
+  union StorageDeltaSnapSnapshotOperationType {
+    /** Appends data files to create the initial snapshot. */
+    "APPEND",
+
+    /** Replaces selected data files in an existing snapshot. */
+    "OVERWRITE",
+
+    /** Replaces all data files in an existing snapshot. */
+    "FULL_OVERWRITE",
+
+    /** The snapshot operation is not recognized. */
+    "UNKNOWN",
 
     string,
   }

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
@@ -96,6 +96,14 @@ using Azure.ClientGenerator.Core;
   Access.public
 );
 @@usage(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotGenerationSucceededEventData,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotGenerationSucceededEventData,
+  Access.public
+);
+@@usage(
   Microsoft.EventGrid.SystemEvents.StorageTaskCompletedEventData,
   Usage.output | Usage.json
 );
@@ -129,6 +137,22 @@ using Azure.ClientGenerator.Core;
 );
 //Enums
 @@usage(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotGenerationStatus,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotGenerationStatus,
+  Access.public
+);
+@@usage(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotOperationType,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotOperationType,
+  Access.public
+);
+@@usage(
   Microsoft.EventGrid.SystemEvents.StorageTaskAssignmentCompletedStatus,
   Usage.output | Usage.json
 );
@@ -160,6 +184,10 @@ using Azure.ClientGenerator.Core;
 );
 @@useSystemTextJsonConverter(
   Microsoft.EventGrid.SystemEvents.StorageBlobInventoryPolicyCompletedEventData,
+  "csharp"
+);
+@@useSystemTextJsonConverter(
+  Microsoft.EventGrid.SystemEvents.StorageDeltaSnapSnapshotGenerationSucceededEventData,
   "csharp"
 );
 @@useSystemTextJsonConverter(

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
@@ -8790,6 +8790,130 @@
         "storageDiagnostics"
       ]
     },
+    "StorageDeltaSnapSnapshotGenerationStatus": {
+      "type": "string",
+      "description": "The status of a DeltaSnap snapshot generation operation.",
+      "enum": [
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "StorageDeltaSnapSnapshotGenerationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The snapshot was generated successfully."
+          }
+        ]
+      }
+    },
+    "StorageDeltaSnapSnapshotGenerationSucceededEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.DeltaSnapSnapshotGenerationSucceeded event.",
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "The identifier of the DeltaSnap job. The value is an empty string when no job identifier is assigned."
+        },
+        "accountName": {
+          "type": "string",
+          "description": "The name of the storage account for which the snapshot was generated."
+        },
+        "status": {
+          "$ref": "#/definitions/StorageDeltaSnapSnapshotGenerationStatus",
+          "description": "The status of the snapshot generation operation."
+        },
+        "dataRecordCount": {
+          "type": "string",
+          "description": "The number of records in data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "totalSizeBytes": {
+          "type": "string",
+          "description": "The total size, in bytes, of data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "snapshotCommitDurationMs": {
+          "type": "string",
+          "description": "The elapsed time, in milliseconds, between the logical snapshot creation time and finalization time, encoded as a decimal string."
+        },
+        "snapshotCreateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The logical creation time of the snapshot."
+        },
+        "snapshotFinalizeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the snapshot was finalized and published."
+        },
+        "snapshotId": {
+          "type": "string",
+          "description": "The decimal identifier of the generated snapshot."
+        },
+        "operationType": {
+          "$ref": "#/definitions/StorageDeltaSnapSnapshotOperationType",
+          "description": "The Iceberg operation used to generate the snapshot."
+        },
+        "dataFileCount": {
+          "type": "string",
+          "description": "The number of data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "manifestCount": {
+          "type": "string",
+          "description": "The number of manifests attributed to data files added by the snapshot operation, encoded as a decimal string."
+        }
+      },
+      "required": [
+        "jobId",
+        "accountName",
+        "status",
+        "dataRecordCount",
+        "totalSizeBytes",
+        "snapshotCommitDurationMs",
+        "snapshotCreateTime",
+        "snapshotFinalizeTime",
+        "snapshotId",
+        "operationType",
+        "dataFileCount",
+        "manifestCount"
+      ]
+    },
+    "StorageDeltaSnapSnapshotOperationType": {
+      "type": "string",
+      "description": "The Iceberg operation used to generate a DeltaSnap snapshot.",
+      "enum": [
+        "APPEND",
+        "OVERWRITE",
+        "FULL_OVERWRITE",
+        "UNKNOWN"
+      ],
+      "x-ms-enum": {
+        "name": "StorageDeltaSnapSnapshotOperationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "APPEND",
+            "value": "APPEND",
+            "description": "Appends data files to create the initial snapshot."
+          },
+          {
+            "name": "OVERWRITE",
+            "value": "OVERWRITE",
+            "description": "Replaces selected data files in an existing snapshot."
+          },
+          {
+            "name": "FULL_OVERWRITE",
+            "value": "FULL_OVERWRITE",
+            "description": "Replaces all data files in an existing snapshot."
+          },
+          {
+            "name": "UNKNOWN",
+            "value": "UNKNOWN",
+            "description": "The snapshot operation is not recognized."
+          }
+        ]
+      }
+    },
     "StorageDirectoryCreatedEventData": {
       "type": "object",
       "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.DirectoryCreated event.",

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
@@ -8936,6 +8936,130 @@
         "storageDiagnostics"
       ]
     },
+    "StorageDeltaSnapSnapshotGenerationStatus": {
+      "type": "string",
+      "description": "The status of a DeltaSnap snapshot generation operation.",
+      "enum": [
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "StorageDeltaSnapSnapshotGenerationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The snapshot was generated successfully."
+          }
+        ]
+      }
+    },
+    "StorageDeltaSnapSnapshotGenerationSucceededEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.DeltaSnapSnapshotGenerationSucceeded event.",
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "The identifier of the DeltaSnap job. The value is an empty string when no job identifier is assigned."
+        },
+        "accountName": {
+          "type": "string",
+          "description": "The name of the storage account for which the snapshot was generated."
+        },
+        "status": {
+          "$ref": "#/definitions/StorageDeltaSnapSnapshotGenerationStatus",
+          "description": "The status of the snapshot generation operation."
+        },
+        "dataRecordCount": {
+          "type": "string",
+          "description": "The number of records in data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "totalSizeBytes": {
+          "type": "string",
+          "description": "The total size, in bytes, of data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "snapshotCommitDurationMs": {
+          "type": "string",
+          "description": "The elapsed time, in milliseconds, between the logical snapshot creation time and finalization time, encoded as a decimal string."
+        },
+        "snapshotCreateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The logical creation time of the snapshot."
+        },
+        "snapshotFinalizeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the snapshot was finalized and published."
+        },
+        "snapshotId": {
+          "type": "string",
+          "description": "The decimal identifier of the generated snapshot."
+        },
+        "operationType": {
+          "$ref": "#/definitions/StorageDeltaSnapSnapshotOperationType",
+          "description": "The Iceberg operation used to generate the snapshot."
+        },
+        "dataFileCount": {
+          "type": "string",
+          "description": "The number of data files added by the snapshot operation, encoded as a decimal string."
+        },
+        "manifestCount": {
+          "type": "string",
+          "description": "The number of manifests attributed to data files added by the snapshot operation, encoded as a decimal string."
+        }
+      },
+      "required": [
+        "jobId",
+        "accountName",
+        "status",
+        "dataRecordCount",
+        "totalSizeBytes",
+        "snapshotCommitDurationMs",
+        "snapshotCreateTime",
+        "snapshotFinalizeTime",
+        "snapshotId",
+        "operationType",
+        "dataFileCount",
+        "manifestCount"
+      ]
+    },
+    "StorageDeltaSnapSnapshotOperationType": {
+      "type": "string",
+      "description": "The Iceberg operation used to generate a DeltaSnap snapshot.",
+      "enum": [
+        "APPEND",
+        "OVERWRITE",
+        "FULL_OVERWRITE",
+        "UNKNOWN"
+      ],
+      "x-ms-enum": {
+        "name": "StorageDeltaSnapSnapshotOperationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "APPEND",
+            "value": "APPEND",
+            "description": "Appends data files to create the initial snapshot."
+          },
+          {
+            "name": "OVERWRITE",
+            "value": "OVERWRITE",
+            "description": "Replaces selected data files in an existing snapshot."
+          },
+          {
+            "name": "FULL_OVERWRITE",
+            "value": "FULL_OVERWRITE",
+            "description": "Replaces all data files in an existing snapshot."
+          },
+          {
+            "name": "UNKNOWN",
+            "value": "UNKNOWN",
+            "description": "The snapshot operation is not recognized."
+          }
+        ]
+      }
+    },
     "StorageDirectoryCreatedEventData": {
       "type": "object",
       "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.DirectoryCreated event.",


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Onboard the `Microsoft.Storage.DeltaSnapSnapshotGenerationSucceeded` Azure Event Grid system event so its public data contract is available in generated Swagger and Event Grid SDK models.

## API Info: The Basics

* Link to API Spec engagement record issue: TBD - Azure SDK Architecture Board / Event Grid system-event review

Is this review for:

- [ ] a private preview
- [ ] a public preview
- [x] GA release

The Event Grid system-events guidance treats a merged event contract as GA. Production delivery must remain disabled until Architecture Board review is complete and this PR is merged.

### Change Scope

* Design Document: DeltaSnap snapshot-generation Event Grid schema, validated against the service's emitted payload.
* Previous API Spec Doc: N/A - new system event.
* Updated paths:
  * `specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/`
  * `specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json`
  * `specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json`

## Event contract

* Event type: `Microsoft.Storage.DeltaSnapSnapshotGenerationSucceeded`
* Model: `StorageDeltaSnapSnapshotGenerationSucceededEventData`
* All twelve fields are required because the service always emits them.
* Count and duration fields remain strings to match the existing JSON wire contract.
* Snapshot timestamps are modeled as `utcDateTime`.
* Status and operation type are public extensible unions.
* Includes a sanitized typed TypeSpec example based on a captured service event.

## Validation

* Repository-pinned dependencies installed with `npm ci`.
* TypeSpec source formatted with the repository Prettier plugin.
* `npx tsp compile .` completed successfully.
* Both supported generated Swagger versions contain the same required model and types.
* `git diff --check` passed.
